### PR TITLE
chore: converts server core namespaces to file-scoped namespaces

### DIFF
--- a/Intersect.Server.Core/Collections/Indexing/LookupKey.cs
+++ b/Intersect.Server.Core/Collections/Indexing/LookupKey.cs
@@ -1,55 +1,54 @@
 ﻿using System.ComponentModel;
 using System.Globalization;
 
-namespace Intersect.Server.Web.RestApi.Payloads
+namespace Intersect.Server.Web.RestApi.Payloads;
+
+
+[TypeConverter(typeof(Converter))]
+public partial struct LookupKey
 {
 
-    [TypeConverter(typeof(Converter))]
-    public partial struct LookupKey
+    public bool HasName => !string.IsNullOrWhiteSpace(Name);
+
+    public bool HasId => Guid.Empty != Id;
+
+    public bool IsNameInvalid => !HasId && Name != null;
+
+    public bool IsIdInvalid => !HasId && Name == null;
+
+    public bool IsInvalid => !HasId && !HasName;
+
+    public Guid Id { get; private set; }
+
+    public string Name { get; private set; }
+
+    public override string ToString()
+    {
+        return HasId ? Id.ToString() : Name;
+    }
+
+    public partial class Converter : TypeConverter
     {
 
-        public bool HasName => !string.IsNullOrWhiteSpace(Name);
-
-        public bool HasId => Guid.Empty != Id;
-
-        public bool IsNameInvalid => !HasId && Name != null;
-
-        public bool IsIdInvalid => !HasId && Name == null;
-
-        public bool IsInvalid => !HasId && !HasName;
-
-        public Guid Id { get; private set; }
-
-        public string Name { get; private set; }
-
-        public override string ToString()
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
         {
-            return HasId ? Id.ToString() : Name;
+            return typeof(string) == sourceType || typeof(Guid) == sourceType;
         }
 
-        public partial class Converter : TypeConverter
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
         {
-
-            public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+            if (Guid.TryParse(value as string, out var guid))
             {
-                return typeof(string) == sourceType || typeof(Guid) == sourceType;
-            }
-
-            public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
-            {
-                if (Guid.TryParse(value as string, out var guid))
-                {
-                    return new LookupKey
-                    {
-                        Id = guid
-                    };
-                }
-
                 return new LookupKey
                 {
-                    Name = value as string
+                    Id = guid
                 };
             }
+
+            return new LookupKey
+            {
+                Name = value as string
+            };
         }
     }
 }

--- a/Intersect.Server.Core/Collections/Sorting/Sort.cs
+++ b/Intersect.Server.Core/Collections/Sorting/Sort.cs
@@ -1,40 +1,34 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿namespace Intersect.Server.Web.RestApi.Payloads;
 
-namespace Intersect.Server.Web.RestApi.Payloads
+
+public partial struct Sort
 {
 
-    public partial struct Sort
+    public string By { get; set; }
+
+    public SortDirection Direction { get; set; }
+
+    public static Sort From(string sortBy, SortDirection sortDirection)
     {
-
-        public string By { get; set; }
-
-        public SortDirection Direction { get; set; }
-
-        public static Sort From(string sortBy, SortDirection sortDirection)
+        return new Sort
         {
-            return new Sort
-            {
-                By = sortBy,
-                Direction = sortDirection
-            };
-        }
+            By = sortBy,
+            Direction = sortDirection
+        };
+    }
 
-        public static Sort[] From(string[] sortBy, SortDirection[] sortDirections)
-        {
-            var filteredBy =
-                sortBy?.Where(by => !string.IsNullOrWhiteSpace(by)).Take(sortDirections?.Length ?? 0).ToList() ??
-                new List<string>();
+    public static Sort[] From(string[] sortBy, SortDirection[] sortDirections)
+    {
+        var filteredBy =
+            sortBy?.Where(by => !string.IsNullOrWhiteSpace(by)).Take(sortDirections?.Length ?? 0).ToList() ??
+            new List<string>();
 
-            var filteredDirections = sortDirections?.Take(filteredBy.Count).ToList() ?? new List<SortDirection>();
+        var filteredDirections = sortDirections?.Take(filteredBy.Count).ToList() ?? new List<SortDirection>();
 
-            return filteredBy.Select(
-                    (by, index) => From(by ?? throw new InvalidOperationException(), filteredDirections[index])
-                )
-                .ToArray();
-        }
-
+        return filteredBy.Select(
+                (by, index) => From(by ?? throw new InvalidOperationException(), filteredDirections[index])
+            )
+            .ToArray();
     }
 
 }

--- a/Intersect.Server.Core/Collections/Sorting/SortDirection.cs
+++ b/Intersect.Server.Core/Collections/Sorting/SortDirection.cs
@@ -1,13 +1,11 @@
-﻿namespace Intersect.Server.Web.RestApi.Payloads
+﻿namespace Intersect.Server.Web.RestApi.Payloads;
+
+
+public enum SortDirection
 {
 
-    public enum SortDirection
-    {
+    Ascending,
 
-        Ascending,
-
-        Descending
-
-    }
+    Descending
 
 }

--- a/Intersect.Server.Core/Core/Bootstrapper.cs
+++ b/Intersect.Server.Core/Core/Bootstrapper.cs
@@ -22,497 +22,496 @@ using Intersect.Server.Networking;
 using Intersect.Threading;
 using Intersect.Utilities;
 
-namespace Intersect.Server.Core
+namespace Intersect.Server.Core;
+
+internal static class Bootstrapper
 {
-    internal static class Bootstrapper
+    static Bootstrapper()
     {
-        static Bootstrapper()
+        Console.CancelKeyPress += OnConsoleCancelKeyPress;
+    }
+
+    internal static event Action OnPostContextSetupCompleted;
+
+    public static IServerContext Context { get; private set; }
+
+    public static LockingActionQueue MainThread { get; private set; }
+
+    public static void Start(params string[] args)
+    {
+        (string[] Args, Parser Parser, ServerCommandLineOptions CommandLineOptions) parsedArguments =
+            ParseCommandLineArgs(args);
+        if (!string.IsNullOrWhiteSpace(parsedArguments.CommandLineOptions.WorkingDirectory))
         {
-            Console.CancelKeyPress += OnConsoleCancelKeyPress;
+            var workingDirectory = parsedArguments.CommandLineOptions.WorkingDirectory.Trim();
+            if (Directory.Exists(workingDirectory))
+            {
+                Directory.SetCurrentDirectory(workingDirectory);
+            }
         }
 
-        internal static event Action OnPostContextSetupCompleted;
-
-        public static IServerContext Context { get; private set; }
-
-        public static LockingActionQueue MainThread { get; private set; }
-
-        public static void Start(params string[] args)
+        if (!PreContextSetup(args))
         {
-            (string[] Args, Parser Parser, ServerCommandLineOptions CommandLineOptions) parsedArguments =
-                ParseCommandLineArgs(args);
-            if (!string.IsNullOrWhiteSpace(parsedArguments.CommandLineOptions.WorkingDirectory))
-            {
-                var workingDirectory = parsedArguments.CommandLineOptions.WorkingDirectory.Trim();
-                if (Directory.Exists(workingDirectory))
-                {
-                    Directory.SetCurrentDirectory(workingDirectory);
-                }
-            }
+            Console.Error.WriteLine("[FATAL] Pre-context setup failed.");
+            return;
+        }
 
-            if (!PreContextSetup(args))
-            {
-                Console.Error.WriteLine("[FATAL] Pre-context setup failed.");
-                return;
-            }
+        Console.WriteLine("Pre-context setup finished.");
 
-            Console.WriteLine("Pre-context setup finished.");
+        var logger = Log.Default;
+        var packetTypeRegistry = new PacketTypeRegistry(logger);
+        if (!packetTypeRegistry.TryRegisterBuiltIn())
+        {
+            logger.Error("[FATAL] Failed to load built-in packet types.");
+            return;
+        }
 
-            var logger = Log.Default;
-            var packetTypeRegistry = new PacketTypeRegistry(logger);
-            if (!packetTypeRegistry.TryRegisterBuiltIn())
-            {
-                logger.Error("[FATAL] Failed to load built-in packet types.");
-                return;
-            }
+        Console.WriteLine("Built-in packets registered to the packet type registry.");
 
-            Console.WriteLine("Built-in packets registered to the packet type registry.");
+        var packetHandlerRegistry = new PacketHandlerRegistry(packetTypeRegistry, logger);
+        var packetHelper = new PacketHelper(packetTypeRegistry, packetHandlerRegistry);
 
-            var packetHandlerRegistry = new PacketHandlerRegistry(packetTypeRegistry, logger);
-            var packetHelper = new PacketHelper(packetTypeRegistry, packetHandlerRegistry);
-
-            FactoryRegistry<IPluginBootstrapContext>.RegisterFactory(
-                PluginBootstrapContext.CreateFactory(
-                    parsedArguments.Args ?? Array.Empty<string>(),
-                    parsedArguments.Parser,
-                    packetHelper
-                )
-            );
-
-            Console.WriteLine("Creating server context...");
-
-            Context = ServerContext.ServerContextFactory.Invoke(
-                parsedArguments.CommandLineOptions,
-                logger,
+        FactoryRegistry<IPluginBootstrapContext>.RegisterFactory(
+            PluginBootstrapContext.CreateFactory(
+                parsedArguments.Args ?? Array.Empty<string>(),
+                parsedArguments.Parser,
                 packetHelper
-            );
-            var noHaltOnError = Context?.StartupOptions.DoNotHaltOnError ?? false;
+            )
+        );
 
-            if (!PostContextSetup())
-            {
-                Console.Error.WriteLine("[FATAL] Post-context setup failed.");
-                return;
-            }
+        Console.WriteLine("Creating server context...");
 
-            OnPostContextSetupCompleted?.Invoke();
+        Context = ServerContext.ServerContextFactory.Invoke(
+            parsedArguments.CommandLineOptions,
+            logger,
+            packetHelper
+        );
+        var noHaltOnError = Context?.StartupOptions.DoNotHaltOnError ?? false;
 
-            Console.WriteLine("Finished post-context setup.");
-
-            Console.WriteLine("Starting main thread...");
-            MainThread = Context.StartWithActionQueue();
-            Action action;
-            while (null != (action = MainThread.NextAction))
-            {
-                action.Invoke();
-            }
-
-            Log.Diagnostic("Bootstrapper exited.");
-
-            // At this point dbs should be saved and all threads should be killed. Give a message saying that the server has shutdown and to press any key to exit.
-            // Having the message and the console.readline() allows the server to exit properly if the console has crashed, and it allows us to know that the server context has shutdown.
-            if (Context.HasErrors)
-            {
-                if (noHaltOnError)
-                {
-                    Console.WriteLine(Strings.Errors.errorservercrashnohalt);
-                }
-                else
-                {
-                    Console.WriteLine(Strings.Errors.errorservercrash);
-                    Console.ReadLine();
-                }
-            }
+        if (!PostContextSetup())
+        {
+            Console.Error.WriteLine("[FATAL] Post-context setup failed.");
+            return;
         }
 
-        private static ValueTuple<string[], Parser, ServerCommandLineOptions> ParseCommandLineArgs(params string[] args)
+        OnPostContextSetupCompleted?.Invoke();
+
+        Console.WriteLine("Finished post-context setup.");
+
+        Console.WriteLine("Starting main thread...");
+        MainThread = Context.StartWithActionQueue();
+        Action action;
+        while (null != (action = MainThread.NextAction))
         {
-            var parser = new Parser(
-                parserSettings =>
-                {
-                    if (parserSettings == null)
-                    {
-                        throw new ArgumentNullException(
-                            nameof(parserSettings),
-                            @"If this is null the CommandLineParser dependency is likely broken."
-                        );
-                    }
-
-                    parserSettings.AutoHelp = true;
-                    parserSettings.AutoVersion = true;
-                    parserSettings.IgnoreUnknownArguments = true;
-                    parserSettings.MaximumDisplayWidth = Console.BufferWidth;
-                }
-            );
-
-            var options = parser.ParseArguments<ServerCommandLineOptions>(args)
-                .MapResult(commandLineOptions => commandLineOptions, errors => default);
-
-            return (args, parser, options);
+            action.Invoke();
         }
 
-        #region System Console
+        Log.Diagnostic("Bootstrapper exited.");
 
-        private static void OnConsoleCancelKeyPress(object sender, ConsoleCancelEventArgs cancelEvent)
+        // At this point dbs should be saved and all threads should be killed. Give a message saying that the server has shutdown and to press any key to exit.
+        // Having the message and the console.readline() allows the server to exit properly if the console has crashed, and it allows us to know that the server context has shutdown.
+        if (Context.HasErrors)
         {
-            ServerContext.Instance.RequestShutdown(true);
-
-            //Shutdown();
-            cancelEvent.Cancel = true;
+            if (noHaltOnError)
+            {
+                Console.WriteLine(Strings.Errors.errorservercrashnohalt);
+            }
+            else
+            {
+                Console.WriteLine(Strings.Errors.errorservercrash);
+                Console.ReadLine();
+            }
         }
+    }
 
-        #endregion
-
-        #region Pre-Context
-
-        private static bool PreContextSetup(params string[] args)
-        {
-            if (RunningOnWindows())
+    private static ValueTuple<string[], Parser, ServerCommandLineOptions> ParseCommandLineArgs(params string[] args)
+    {
+        var parser = new Parser(
+            parserSettings =>
             {
-                SetConsoleCtrlHandler(ConsoleCtrlHandler, true);
-            }
-
-            if (!Strings.Load())
-            {
-                Console.WriteLine(Strings.Errors.ErrorLoadingStrings);
-                Console.ReadKey();
-
-                return false;
-            }
-
-            if (!Options.LoadFromDisk())
-            {
-                Console.WriteLine(Strings.Errors.errorloadingconfig);
-                Console.ReadKey();
-
-                return false;
-            }
-
-            if (ServerContext.IsDefaultResourceDirectory)
-            {
-                if (!Directory.Exists(Path.Combine(ServerContext.ResourceDirectory, "notifications")))
+                if (parserSettings == null)
                 {
-                    Directory.CreateDirectory(Path.Combine(ServerContext.ResourceDirectory, "notifications"));
-                }
-
-                if (!File.Exists(Path.Combine(ServerContext.ResourceDirectory, "notifications", "PasswordReset.html")))
-                {
-                    ReflectionUtils.ExtractResource(
-                        "Intersect.Server.Resources.notifications.PasswordReset.html",
-                        Path.Combine(ServerContext.ResourceDirectory, "notifications", "PasswordReset.html")
+                    throw new ArgumentNullException(
+                        nameof(parserSettings),
+                        @"If this is null the CommandLineParser dependency is likely broken."
                     );
                 }
+
+                parserSettings.AutoHelp = true;
+                parserSettings.AutoVersion = true;
+                parserSettings.IgnoreUnknownArguments = true;
+                parserSettings.MaximumDisplayWidth = Console.BufferWidth;
             }
+        );
 
-            DbInterface.InitializeDbLoggers();
-            DbInterface.CheckDirectories();
+        var options = parser.ParseArguments<ServerCommandLineOptions>(args)
+            .MapResult(commandLineOptions => commandLineOptions, errors => default);
 
-            PrintIntroduction();
-
-            ExportDependencies(args);
-
-            Formulas.LoadFormulas();
-
-            CustomColors.Load();
-
-            if (Options.Instance.Metrics.Enable)
-            {
-                MetricsRoot.Init();
-            }
-
-            return true;
-        }
-
-        private static bool PostContextSetup()
-        {
-            Console.WriteLine("Starting post-context setup...");
-
-            if (Context == null)
-            {
-                Console.Error.WriteLine("No context?");
-                throw new ArgumentNullException(nameof(Context));
-            }
-
-            Console.WriteLine("Configuring thread pool...");
-
-            //Configure System Threadpool
-            ThreadPool.GetMaxThreads(out var maxWorkerThreads, out var maxCompletionPortThreads);
-            ThreadPool.GetMinThreads(out var minWorkerThreads, out var minCompletionPortThreads);
-            if (Options.Instance.Processing.MaxSystemThreadpoolWorkerThreads >= Environment.ProcessorCount)
-            {
-                maxWorkerThreads = Options.Instance.Processing.MaxSystemThreadpoolWorkerThreads;
-            }
-
-            if (Options.Instance.Processing.MaxSystemThreadpoolIOThreads >= Environment.ProcessorCount)
-            {
-                maxCompletionPortThreads = Options.Instance.Processing.MaxSystemThreadpoolIOThreads;
-            }
-
-            ThreadPool.SetMaxThreads(maxWorkerThreads, maxCompletionPortThreads);
-            if (Options.Instance.Processing.MinSystemThreadpoolWorkerThreads >= Environment.ProcessorCount)
-            {
-                minWorkerThreads = Options.Instance.Processing.MinSystemThreadpoolWorkerThreads;
-            }
-
-            if (Options.Instance.Processing.MinSystemThreadpoolIOThreads >= Environment.ProcessorCount)
-            {
-                minCompletionPortThreads = Options.Instance.Processing.MinSystemThreadpoolIOThreads;
-            }
-
-            ThreadPool.SetMinThreads(minWorkerThreads, minCompletionPortThreads);
-
-            if (!DbInterface.InitDatabase(Context))
-            {
-                Console.Error.WriteLine("Failed to initialize the database.");
-
-                Console.ReadKey();
-
-                return false;
-            }
-
-            Time.Update();
-
-            Console.WriteLine();
-            Console.WriteLine(Strings.Commandoutput.ServerInfo);
-            Console.WriteLine(Strings.Commandoutput.AccountCount.ToString(Database.PlayerData.User.Count()));
-            Console.WriteLine(Strings.Commandoutput.CharacterCount.ToString(Player.Count()));
-            Console.WriteLine(Strings.Commandoutput.NpcCount.ToString(NpcBase.Lookup.Count));
-            Console.WriteLine(Strings.Commandoutput.SpellCount.ToString(SpellBase.Lookup.Count));
-            Console.WriteLine(Strings.Commandoutput.MapCount.ToString(MapBase.Lookup.Count));
-            Console.WriteLine(Strings.Commandoutput.EventCount.ToString(EventBase.Lookup.Count));
-            Console.WriteLine(Strings.Commandoutput.ItemCount.ToString(ItemBase.Lookup.Count));
-            Console.WriteLine();
-            Console.WriteLine(Strings.Commandoutput.gametime.ToString(Time.GetTime().ToString("F")));
-            Console.WriteLine();
-
-            PacketSender.CacheGameDataPacket();
-
-            if (Options.Instance.Guild.DeleteStaleGuildsAfterDays > 0)
-            {
-                Guild.WipeStaleGuilds();
-            }
-
-            return true;
-        }
-
-        private static void PrintIntroduction()
-        {
-            Console.Clear();
-            Console.WriteLine();
-            Console.WriteLine(@"  _____       _                          _   ");
-            Console.WriteLine(@" |_   _|     | |                        | |  ");
-            Console.WriteLine(@"   | |  _ __ | |_ ___ _ __ ___  ___  ___| |_ ");
-            Console.WriteLine(@"   | | | '_ \| __/ _ \ '__/ __|/ _ \/ __| __|");
-            Console.WriteLine(@"  _| |_| | | | ||  __/ |  \__ \  __/ (__| |_ ");
-            Console.WriteLine(@" |_____|_| |_|\__\___|_|  |___/\___|\___|\__|");
-            Console.WriteLine(Strings.Intro.tagline);
-            Console.WriteLine(@"Copyright (C) 2020 Ascension Game Dev");
-            Console.WriteLine(Strings.Intro.version.ToString(Assembly.GetExecutingAssembly().GetName().Version));
-            Console.WriteLine(Strings.Intro.support);
-            Console.WriteLine();
-            Console.WriteLine(Strings.Intro.loading);
-        }
-
-        #endregion
-
-        #region Dependencies
-
-        private static void ClearDlls()
-        {
-            Console.WriteLine("Deleting old dependencies...");
-
-            DeleteIfExists("libe_sqlite3.so");
-            DeleteIfExists("e_sqlite3.dll");
-            DeleteIfExists("libe_sqlite3.dylib");
-        }
-
-        private static string ReadProcessOutput(string name)
-        {
-            try
-            {
-                Debug.Assert(name != null, "name != null");
-                var p = new Process
-                {
-                    StartInfo =
-                    {
-                        UseShellExecute = false,
-                        RedirectStandardOutput = true,
-                        FileName = name
-                    }
-                };
-
-                p.Start();
-
-                // Do not wait for the child process to exit before
-                // reading to the end of its redirected stream.
-                // p.WaitForExit();
-                // Read the output stream first and then wait.
-                var output = p.StandardOutput.ReadToEnd();
-                p.WaitForExit();
-                output = output.Trim();
-
-                return output;
-            }
-            catch
-            {
-                return "";
-            }
-        }
-
-        internal static bool DeleteIfExists(string filename)
-        {
-            try
-            {
-                Debug.Assert(filename != null, "filename != null");
-                if (File.Exists(filename))
-                {
-                    File.Delete(filename);
-                }
-
-                return true;
-            }
-            catch
-            {
-                return false;
-            }
-        }
-
-        private static void ExportDependencies(params string[] args)
-        {
-            Console.WriteLine("Exporting dependencies...");
-
-            ClearDlls();
-
-            var platformId = Environment.OSVersion.Platform;
-            if (platformId == PlatformID.Unix)
-            {
-                var unixName = ReadProcessOutput("uname") ?? "";
-                if (unixName.Contains("Darwin"))
-                {
-                    platformId = PlatformID.MacOSX;
-                }
-            }
-
-            var platformBaseRid = "unknown";
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                platformBaseRid = "linux";
-            }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                platformBaseRid = "osx";
-            }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                platformBaseRid = "win";
-            }
-
-            platformBaseRid = $"{platformBaseRid}_{RuntimeInformation.OSArchitecture.ToString().ToLowerInvariant()}";
-
-            var assembly = typeof(Bootstrapper).Assembly;
-            var resourceNameRoot = $"Intersect.Server.Resources.runtimes.{platformBaseRid}";
-            var resourceNames = assembly.GetManifestResourceNames();
-            var matchingResourceNames = resourceNames
-                .Where(name => name.StartsWith(resourceNameRoot) && name.Contains("e_sqlite3"))
-                .ToArray();
-
-            var sqliteResourceName = matchingResourceNames.FirstOrDefault();
-            if (string.IsNullOrWhiteSpace(sqliteResourceName))
-            {
-                throw new MissingManifestResourceException($"No matching manifest resource found for e_sqlite3");
-            }
-
-            var sqliteFileName = string.Join(
-                '.',
-                sqliteResourceName.Split('.').SkipWhile(part => !part.Contains("e_sqlite3"))
-            );
-
-            if (ReflectionUtils.ExtractResource(sqliteResourceName, sqliteFileName, assembly))
-            {
-                return;
-            }
-
-            Log.Error($"Failed to extract {sqliteFileName} library, terminating startup.");
-            Environment.Exit(-0x1000);
-        }
-
-        #endregion
-
-        #region Unmanaged
-
-        // Declare the SetConsoleCtrlHandler function
-        // as external and receiving a delegate.
-
-        [DllImport("Kernel32")]
-        public static extern bool SetConsoleCtrlHandler(HandlerRoutine handler, bool add);
-
-        // A delegate type to be used as the handler routine
-        // for SetConsoleCtrlHandler.
-        public delegate bool HandlerRoutine(CtrlTypes ctrlType);
-
-        // An enumerated type for the control messages
-        // sent to the handler routine.
-        public enum CtrlTypes
-        {
-            CtrlCEvent = 0,
-
-            CtrlBreakEvent,
-
-            CtrlCloseEvent,
-
-            CtrlLogoffEvent = 5,
-
-            CtrlShutdownEvent
-        }
-
-        private static readonly HandlerRoutine ConsoleCtrlHandler = ConsoleCtrlCheck;
-
-        private static bool ConsoleCtrlCheck(CtrlTypes ctrlType)
-        {
-            switch (ctrlType)
-            {
-                case CtrlTypes.CtrlCEvent:
-                case CtrlTypes.CtrlBreakEvent:
-                    // Handled Elsewhere
-                    break;
-
-                case CtrlTypes.CtrlCloseEvent:
-                case CtrlTypes.CtrlLogoffEvent:
-                case CtrlTypes.CtrlShutdownEvent:
-                    // We can't just request a shutdown -- from testing the
-                    // Dispose() task never actually runs soon enough so the
-                    // operating system kills the application before it
-                    // actually does any clean-up and data persistence.
-                    ServerContext.Instance.Dispose();
-
-                    break;
-
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(ctrlType), ctrlType, null);
-            }
-
-            return true;
-        }
-
-        private static bool RunningOnWindows()
-        {
-            switch (Environment.OSVersion.Platform)
-            {
-                case PlatformID.Win32NT:
-                case PlatformID.Win32S:
-                case PlatformID.Win32Windows:
-                case PlatformID.WinCE:
-                    return true;
-
-                case PlatformID.MacOSX:
-                case PlatformID.Unix:
-                case PlatformID.Xbox:
-                    return false;
-
-                default:
-                    throw new ArgumentOutOfRangeException();
-            }
-        }
-
-        #endregion
+        return (args, parser, options);
     }
+
+    #region System Console
+
+    private static void OnConsoleCancelKeyPress(object sender, ConsoleCancelEventArgs cancelEvent)
+    {
+        ServerContext.Instance.RequestShutdown(true);
+
+        //Shutdown();
+        cancelEvent.Cancel = true;
+    }
+
+    #endregion
+
+    #region Pre-Context
+
+    private static bool PreContextSetup(params string[] args)
+    {
+        if (RunningOnWindows())
+        {
+            SetConsoleCtrlHandler(ConsoleCtrlHandler, true);
+        }
+
+        if (!Strings.Load())
+        {
+            Console.WriteLine(Strings.Errors.ErrorLoadingStrings);
+            Console.ReadKey();
+
+            return false;
+        }
+
+        if (!Options.LoadFromDisk())
+        {
+            Console.WriteLine(Strings.Errors.errorloadingconfig);
+            Console.ReadKey();
+
+            return false;
+        }
+
+        if (ServerContext.IsDefaultResourceDirectory)
+        {
+            if (!Directory.Exists(Path.Combine(ServerContext.ResourceDirectory, "notifications")))
+            {
+                Directory.CreateDirectory(Path.Combine(ServerContext.ResourceDirectory, "notifications"));
+            }
+
+            if (!File.Exists(Path.Combine(ServerContext.ResourceDirectory, "notifications", "PasswordReset.html")))
+            {
+                ReflectionUtils.ExtractResource(
+                    "Intersect.Server.Resources.notifications.PasswordReset.html",
+                    Path.Combine(ServerContext.ResourceDirectory, "notifications", "PasswordReset.html")
+                );
+            }
+        }
+
+        DbInterface.InitializeDbLoggers();
+        DbInterface.CheckDirectories();
+
+        PrintIntroduction();
+
+        ExportDependencies(args);
+
+        Formulas.LoadFormulas();
+
+        CustomColors.Load();
+
+        if (Options.Instance.Metrics.Enable)
+        {
+            MetricsRoot.Init();
+        }
+
+        return true;
+    }
+
+    private static bool PostContextSetup()
+    {
+        Console.WriteLine("Starting post-context setup...");
+
+        if (Context == null)
+        {
+            Console.Error.WriteLine("No context?");
+            throw new ArgumentNullException(nameof(Context));
+        }
+
+        Console.WriteLine("Configuring thread pool...");
+
+        //Configure System Threadpool
+        ThreadPool.GetMaxThreads(out var maxWorkerThreads, out var maxCompletionPortThreads);
+        ThreadPool.GetMinThreads(out var minWorkerThreads, out var minCompletionPortThreads);
+        if (Options.Instance.Processing.MaxSystemThreadpoolWorkerThreads >= Environment.ProcessorCount)
+        {
+            maxWorkerThreads = Options.Instance.Processing.MaxSystemThreadpoolWorkerThreads;
+        }
+
+        if (Options.Instance.Processing.MaxSystemThreadpoolIOThreads >= Environment.ProcessorCount)
+        {
+            maxCompletionPortThreads = Options.Instance.Processing.MaxSystemThreadpoolIOThreads;
+        }
+
+        ThreadPool.SetMaxThreads(maxWorkerThreads, maxCompletionPortThreads);
+        if (Options.Instance.Processing.MinSystemThreadpoolWorkerThreads >= Environment.ProcessorCount)
+        {
+            minWorkerThreads = Options.Instance.Processing.MinSystemThreadpoolWorkerThreads;
+        }
+
+        if (Options.Instance.Processing.MinSystemThreadpoolIOThreads >= Environment.ProcessorCount)
+        {
+            minCompletionPortThreads = Options.Instance.Processing.MinSystemThreadpoolIOThreads;
+        }
+
+        ThreadPool.SetMinThreads(minWorkerThreads, minCompletionPortThreads);
+
+        if (!DbInterface.InitDatabase(Context))
+        {
+            Console.Error.WriteLine("Failed to initialize the database.");
+
+            Console.ReadKey();
+
+            return false;
+        }
+
+        Time.Update();
+
+        Console.WriteLine();
+        Console.WriteLine(Strings.Commandoutput.ServerInfo);
+        Console.WriteLine(Strings.Commandoutput.AccountCount.ToString(Database.PlayerData.User.Count()));
+        Console.WriteLine(Strings.Commandoutput.CharacterCount.ToString(Player.Count()));
+        Console.WriteLine(Strings.Commandoutput.NpcCount.ToString(NpcBase.Lookup.Count));
+        Console.WriteLine(Strings.Commandoutput.SpellCount.ToString(SpellBase.Lookup.Count));
+        Console.WriteLine(Strings.Commandoutput.MapCount.ToString(MapBase.Lookup.Count));
+        Console.WriteLine(Strings.Commandoutput.EventCount.ToString(EventBase.Lookup.Count));
+        Console.WriteLine(Strings.Commandoutput.ItemCount.ToString(ItemBase.Lookup.Count));
+        Console.WriteLine();
+        Console.WriteLine(Strings.Commandoutput.gametime.ToString(Time.GetTime().ToString("F")));
+        Console.WriteLine();
+
+        PacketSender.CacheGameDataPacket();
+
+        if (Options.Instance.Guild.DeleteStaleGuildsAfterDays > 0)
+        {
+            Guild.WipeStaleGuilds();
+        }
+
+        return true;
+    }
+
+    private static void PrintIntroduction()
+    {
+        Console.Clear();
+        Console.WriteLine();
+        Console.WriteLine(@"  _____       _                          _   ");
+        Console.WriteLine(@" |_   _|     | |                        | |  ");
+        Console.WriteLine(@"   | |  _ __ | |_ ___ _ __ ___  ___  ___| |_ ");
+        Console.WriteLine(@"   | | | '_ \| __/ _ \ '__/ __|/ _ \/ __| __|");
+        Console.WriteLine(@"  _| |_| | | | ||  __/ |  \__ \  __/ (__| |_ ");
+        Console.WriteLine(@" |_____|_| |_|\__\___|_|  |___/\___|\___|\__|");
+        Console.WriteLine(Strings.Intro.tagline);
+        Console.WriteLine(@"Copyright (C) 2020 Ascension Game Dev");
+        Console.WriteLine(Strings.Intro.version.ToString(Assembly.GetExecutingAssembly().GetName().Version));
+        Console.WriteLine(Strings.Intro.support);
+        Console.WriteLine();
+        Console.WriteLine(Strings.Intro.loading);
+    }
+
+    #endregion
+
+    #region Dependencies
+
+    private static void ClearDlls()
+    {
+        Console.WriteLine("Deleting old dependencies...");
+
+        DeleteIfExists("libe_sqlite3.so");
+        DeleteIfExists("e_sqlite3.dll");
+        DeleteIfExists("libe_sqlite3.dylib");
+    }
+
+    private static string ReadProcessOutput(string name)
+    {
+        try
+        {
+            Debug.Assert(name != null, "name != null");
+            var p = new Process
+            {
+                StartInfo =
+                {
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    FileName = name
+                }
+            };
+
+            p.Start();
+
+            // Do not wait for the child process to exit before
+            // reading to the end of its redirected stream.
+            // p.WaitForExit();
+            // Read the output stream first and then wait.
+            var output = p.StandardOutput.ReadToEnd();
+            p.WaitForExit();
+            output = output.Trim();
+
+            return output;
+        }
+        catch
+        {
+            return "";
+        }
+    }
+
+    internal static bool DeleteIfExists(string filename)
+    {
+        try
+        {
+            Debug.Assert(filename != null, "filename != null");
+            if (File.Exists(filename))
+            {
+                File.Delete(filename);
+            }
+
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static void ExportDependencies(params string[] args)
+    {
+        Console.WriteLine("Exporting dependencies...");
+
+        ClearDlls();
+
+        var platformId = Environment.OSVersion.Platform;
+        if (platformId == PlatformID.Unix)
+        {
+            var unixName = ReadProcessOutput("uname") ?? "";
+            if (unixName.Contains("Darwin"))
+            {
+                platformId = PlatformID.MacOSX;
+            }
+        }
+
+        var platformBaseRid = "unknown";
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            platformBaseRid = "linux";
+        }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            platformBaseRid = "osx";
+        }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            platformBaseRid = "win";
+        }
+
+        platformBaseRid = $"{platformBaseRid}_{RuntimeInformation.OSArchitecture.ToString().ToLowerInvariant()}";
+
+        var assembly = typeof(Bootstrapper).Assembly;
+        var resourceNameRoot = $"Intersect.Server.Resources.runtimes.{platformBaseRid}";
+        var resourceNames = assembly.GetManifestResourceNames();
+        var matchingResourceNames = resourceNames
+            .Where(name => name.StartsWith(resourceNameRoot) && name.Contains("e_sqlite3"))
+            .ToArray();
+
+        var sqliteResourceName = matchingResourceNames.FirstOrDefault();
+        if (string.IsNullOrWhiteSpace(sqliteResourceName))
+        {
+            throw new MissingManifestResourceException($"No matching manifest resource found for e_sqlite3");
+        }
+
+        var sqliteFileName = string.Join(
+            '.',
+            sqliteResourceName.Split('.').SkipWhile(part => !part.Contains("e_sqlite3"))
+        );
+
+        if (ReflectionUtils.ExtractResource(sqliteResourceName, sqliteFileName, assembly))
+        {
+            return;
+        }
+
+        Log.Error($"Failed to extract {sqliteFileName} library, terminating startup.");
+        Environment.Exit(-0x1000);
+    }
+
+    #endregion
+
+    #region Unmanaged
+
+    // Declare the SetConsoleCtrlHandler function
+    // as external and receiving a delegate.
+
+    [DllImport("Kernel32")]
+    public static extern bool SetConsoleCtrlHandler(HandlerRoutine handler, bool add);
+
+    // A delegate type to be used as the handler routine
+    // for SetConsoleCtrlHandler.
+    public delegate bool HandlerRoutine(CtrlTypes ctrlType);
+
+    // An enumerated type for the control messages
+    // sent to the handler routine.
+    public enum CtrlTypes
+    {
+        CtrlCEvent = 0,
+
+        CtrlBreakEvent,
+
+        CtrlCloseEvent,
+
+        CtrlLogoffEvent = 5,
+
+        CtrlShutdownEvent
+    }
+
+    private static readonly HandlerRoutine ConsoleCtrlHandler = ConsoleCtrlCheck;
+
+    private static bool ConsoleCtrlCheck(CtrlTypes ctrlType)
+    {
+        switch (ctrlType)
+        {
+            case CtrlTypes.CtrlCEvent:
+            case CtrlTypes.CtrlBreakEvent:
+                // Handled Elsewhere
+                break;
+
+            case CtrlTypes.CtrlCloseEvent:
+            case CtrlTypes.CtrlLogoffEvent:
+            case CtrlTypes.CtrlShutdownEvent:
+                // We can't just request a shutdown -- from testing the
+                // Dispose() task never actually runs soon enough so the
+                // operating system kills the application before it
+                // actually does any clean-up and data persistence.
+                ServerContext.Instance.Dispose();
+
+                break;
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(ctrlType), ctrlType, null);
+        }
+
+        return true;
+    }
+
+    private static bool RunningOnWindows()
+    {
+        switch (Environment.OSVersion.Platform)
+        {
+            case PlatformID.Win32NT:
+            case PlatformID.Win32S:
+            case PlatformID.Win32Windows:
+            case PlatformID.WinCE:
+                return true;
+
+            case PlatformID.MacOSX:
+            case PlatformID.Unix:
+            case PlatformID.Xbox:
+                return false;
+
+            default:
+                throw new ArgumentOutOfRangeException();
+        }
+    }
+
+    #endregion
 }

--- a/Intersect.Server.Core/Core/CommandParsing/CommandParserErrorsNamespace.cs
+++ b/Intersect.Server.Core/Core/CommandParsing/CommandParserErrorsNamespace.cs
@@ -2,111 +2,109 @@ using Intersect.Localization;
 
 using Newtonsoft.Json;
 
-namespace Intersect.Server.Core.CommandParsing
+namespace Intersect.Server.Core.CommandParsing;
+
+
+public sealed partial class CommandParserErrorsNamespace : LocaleNamespace
 {
 
-    public sealed partial class CommandParserErrorsNamespace : LocaleNamespace
-    {
+    /// <summary>
+    /// Argument matches neither the short nor long argument name format and is not positional.
+    /// </summary>
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+    public readonly LocalizedString BadArgumentFormat =
+        @"The argument '{00}' is not a valid short or long-form argument.";
 
-        /// <summary>
-        /// Argument matches neither the short nor long argument name format and is not positional.
-        /// </summary>
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-        public readonly LocalizedString BadArgumentFormat =
-            @"The argument '{00}' is not a valid short or long-form argument.";
+    /// <summary>
+    /// Command not found for the given name.
+    /// </summary>
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+    public readonly LocalizedString CommandNotFound =
+        @"The command '{00}' is not recoginized. Enter '{01}' for a list of commands.";
 
-        /// <summary>
-        /// Command not found for the given name.
-        /// </summary>
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-        public readonly LocalizedString CommandNotFound =
-            @"The command '{00}' is not recoginized. Enter '{01}' for a list of commands.";
+    /// <summary>
+    /// Named argument was specified multiple times.
+    /// </summary>
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString DuplicateNamedArgument = @"The argument '{00}' was specified more than once.";
 
-        /// <summary>
-        /// Named argument was specified multiple times.
-        /// </summary>
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString DuplicateNamedArgument = @"The argument '{00}' was specified more than once.";
+    /// <summary>
+    /// Flag argument is provided a value, but they do not accept them.
+    /// </summary>
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+    public readonly LocalizedString FlagArgumentsIgnoreValue =
+        @"'{00}' is a flag argument and will ignore provided values.";
 
-        /// <summary>
-        /// Flag argument is provided a value, but they do not accept them.
-        /// </summary>
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-        public readonly LocalizedString FlagArgumentsIgnoreValue =
-            @"'{00}' is a flag argument and will ignore provided values.";
+    /// <summary>
+    /// Generic parser error message.
+    /// </summary>
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString GenericError = @"An error occurred while trying to parse the command.";
 
-        /// <summary>
-        /// Generic parser error message.
-        /// </summary>
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString GenericError = @"An error occurred while trying to parse the command.";
+    /// <summary>
+    /// Argument matches both the short and long argument name formats.
+    ///
+    /// Note that should not actually be possible.
+    /// </summary>
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+    public readonly LocalizedString IllegalArgumentFormat =
+        @"The argument '{00}' matches both the short and long-form argument formats (e.g. '{01}h' and '{02}help').";
 
-        /// <summary>
-        /// Argument matches both the short and long argument name formats.
-        ///
-        /// Note that should not actually be possible.
-        /// </summary>
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-        public readonly LocalizedString IllegalArgumentFormat =
-            @"The argument '{00}' matches both the short and long-form argument formats (e.g. '{01}h' and '{02}help').";
+    /// <summary>
+    /// The value provided is not valid for this argument.
+    /// </summary>
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+    public readonly LocalizedString
+        InvalidArgumentValue = @"The value '{00}' is not valid for the argument '{01}'.";
 
-        /// <summary>
-        /// The value provided is not valid for this argument.
-        /// </summary>
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-        public readonly LocalizedString
-            InvalidArgumentValue = @"The value '{00}' is not valid for the argument '{01}'.";
+    /// <summary>
+    /// The value provided is not valid for this argument, expected one of the specified type.
+    /// </summary>
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+    public readonly LocalizedString InvalidArgumentValueWithType =
+        @"The value '{00}' is not valid for the argument '{01}' (expected type '{02}').";
 
-        /// <summary>
-        /// The value provided is not valid for this argument, expected one of the specified type.
-        /// </summary>
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-        public readonly LocalizedString InvalidArgumentValueWithType =
-            @"The value '{00}' is not valid for the argument '{01}' (expected type '{02}').";
+    /// <summary>
+    /// Required arguments were missing.
+    /// </summary>
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString MissingArguments = @"Missing one or more arguments: {00}";
 
-        /// <summary>
-        /// Required arguments were missing.
-        /// </summary>
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString MissingArguments = @"Missing one or more arguments: {00}";
+    /// <summary>
+    /// List delimeter for missing arguments.
+    /// </summary>
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString MissingArgumentsDelimeter = @", ";
 
-        /// <summary>
-        /// List delimeter for missing arguments.
-        /// </summary>
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString MissingArgumentsDelimeter = @", ";
+    /// <summary>
+    /// Named argument is required but missing for the given command.
+    /// </summary>
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+    public readonly LocalizedString MissingNamedArgument =
+        @"The argument '{00}{01}' is required for the command '{02}' but is missing.";
 
-        /// <summary>
-        /// Named argument is required but missing for the given command.
-        /// </summary>
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-        public readonly LocalizedString MissingNamedArgument =
-            @"The argument '{00}{01}' is required for the command '{02}' but is missing.";
+    /// <summary>
+    /// Positional argument is required but missing for the given command.
+    /// </summary>
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+    public readonly LocalizedString MissingPositionalArgument =
+        @"The argument '{00}' is required for the command '{01}' but is missing.";
 
-        /// <summary>
-        /// Positional argument is required but missing for the given command.
-        /// </summary>
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-        public readonly LocalizedString MissingPositionalArgument =
-            @"The argument '{00}' is required for the command '{01}' but is missing.";
+    /// <summary>
+    /// No input was provided.
+    /// </summary>
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+    public readonly LocalizedString NoInput =
+        @"No input was provided. If this is not the case, please report this error.";
 
-        /// <summary>
-        /// No input was provided.
-        /// </summary>
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-        public readonly LocalizedString NoInput =
-            @"No input was provided. If this is not the case, please report this error.";
+    /// <summary>
+    /// Named argument is not valid for the given command.
+    /// </summary>
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+    public readonly LocalizedString UnhandledNamedArgument =
+        @"The argument '{00}' is not accepted for the command '{01}'.";
 
-        /// <summary>
-        /// Named argument is not valid for the given command.
-        /// </summary>
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-        public readonly LocalizedString UnhandledNamedArgument =
-            @"The argument '{00}' is not accepted for the command '{01}'.";
-
-        /// <summary>
-        /// Positional argument is not valid for the given command.
-        /// </summary>
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-        public readonly LocalizedString UnhandledPositionalArgument =
-            @"The argument '{00}' in position {01} is not accepted for the command '{02}'.";
-
-    }
+    /// <summary>
+    /// Positional argument is not valid for the given command.
+    /// </summary>
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+    public readonly LocalizedString UnhandledPositionalArgument =
+        @"The argument '{00}' in position {01} is not accepted for the command '{02}'.";
 
 }

--- a/Intersect.Server.Core/Core/CommandParsing/CommandParserFormattingNamespace.cs
+++ b/Intersect.Server.Core/Core/CommandParsing/CommandParserFormattingNamespace.cs
@@ -2,18 +2,16 @@
 
 using Newtonsoft.Json;
 
-namespace Intersect.Server.Core.CommandParsing
+namespace Intersect.Server.Core.CommandParsing;
+
+
+public sealed partial class CommandParserFormattingNamespace : LocaleNamespace
 {
 
-    public sealed partial class CommandParserFormattingNamespace : LocaleNamespace
-    {
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]        public readonly LocalizedString Optional = @"[{00}]";
 
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]        public readonly LocalizedString Optional = @"[{00}]";
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]        public readonly LocalizedString Type = @":{00}";
 
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]        public readonly LocalizedString Type = @":{00}";
-
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]        public readonly LocalizedString Usage = @"Usage: {00}";
-
-    }
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]        public readonly LocalizedString Usage = @"Usage: {00}";
 
 }

--- a/Intersect.Server.Core/Core/CommandParsing/CommandParsingNamespace.cs
+++ b/Intersect.Server.Core/Core/CommandParsing/CommandParsingNamespace.cs
@@ -1,44 +1,42 @@
 ﻿using Intersect.Localization;
 using Newtonsoft.Json;
 
-namespace Intersect.Server.Core.CommandParsing
+namespace Intersect.Server.Core.CommandParsing;
+
+
+public sealed partial class CommandParsingNamespace : LocaleNamespace
 {
 
-    public sealed partial class CommandParsingNamespace : LocaleNamespace
-    {
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]        public readonly CommandParserErrorsNamespace Errors = new CommandParserErrorsNamespace();
 
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]        public readonly CommandParserErrorsNamespace Errors = new CommandParserErrorsNamespace();
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]        public readonly CommandParserFormattingNamespace Formatting = new CommandParserFormattingNamespace();
 
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]        public readonly CommandParserFormattingNamespace Formatting = new CommandParserFormattingNamespace();
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]        public readonly LocaleDictionary<string, LocalizedString> TypeNames =
+        new LocaleDictionary<string, LocalizedString>(
+            new Dictionary<string, LocalizedString>
+            {
+                {typeof(bool).Name, "bool"},
+                {typeof(byte).Name, "byte"},
+                {typeof(sbyte).Name, "sbyte"},
+                {typeof(short).Name, "short"},
+                {typeof(ushort).Name, "ushort"},
+                {typeof(int).Name, "int"},
+                {typeof(uint).Name, "uint"},
+                {typeof(long).Name, "long"},
+                {typeof(ulong).Name, "ulong"},
+                {typeof(float).Name, "float"},
+                {typeof(double).Name, "double"},
+                {typeof(decimal).Name, "decimal"},
+                {typeof(object).Name, "object"},
+                {typeof(char).Name, "char"},
+                {typeof(string).Name, "string"}
+            }
+        );
 
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]        public readonly LocaleDictionary<string, LocalizedString> TypeNames =
-            new LocaleDictionary<string, LocalizedString>(
-                new Dictionary<string, LocalizedString>
-                {
-                    {typeof(bool).Name, "bool"},
-                    {typeof(byte).Name, "byte"},
-                    {typeof(sbyte).Name, "sbyte"},
-                    {typeof(short).Name, "short"},
-                    {typeof(ushort).Name, "ushort"},
-                    {typeof(int).Name, "int"},
-                    {typeof(uint).Name, "uint"},
-                    {typeof(long).Name, "long"},
-                    {typeof(ulong).Name, "ulong"},
-                    {typeof(float).Name, "float"},
-                    {typeof(double).Name, "double"},
-                    {typeof(decimal).Name, "decimal"},
-                    {typeof(object).Name, "object"},
-                    {typeof(char).Name, "char"},
-                    {typeof(string).Name, "string"}
-                }
-            );
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]        public readonly LocalizedString TypeUnknown = @"unknown";
 
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]        public readonly LocalizedString TypeUnknown = @"unknown";
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]        public readonly LocalizedString ValueFalse = @"false";
 
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]        public readonly LocalizedString ValueFalse = @"false";
-
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]        public readonly LocalizedString ValueTrue = @"true";
-
-    }
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]        public readonly LocalizedString ValueTrue = @"true";
 
 }

--- a/Intersect.Server.Core/Core/ExperimentalFeatures/Experiments.cs
+++ b/Intersect.Server.Core/Core/ExperimentalFeatures/Experiments.cs
@@ -1,40 +1,36 @@
-﻿using System;
-
-using Intersect.Core.ExperimentalFeatures;
+﻿using Intersect.Core.ExperimentalFeatures;
 
 using Newtonsoft.Json;
 
-namespace Intersect.Server.Core.ExperimentalFeatures
+namespace Intersect.Server.Core.ExperimentalFeatures;
+
+
+public sealed partial class Experiments : CommonExperiments<Experiments>
 {
 
-    public sealed partial class Experiments : CommonExperiments<Experiments>
+    private static readonly Guid NamespaceId = Guid.Parse("4a6db511-7d5c-4a23-a096-5d61baa58cd7");
+
+    static Experiments()
     {
-
-        private static readonly Guid NamespaceId = Guid.Parse("4a6db511-7d5c-4a23-a096-5d61baa58cd7");
-
-        static Experiments()
-        {
-            Instance = new Experiments();
-            Instance.Load();
-        }
-
-        private Experiments()
-        {
-            PostgreSQL = new ExperimentalFlag(nameof(PostgreSQL), NamespaceId, parentFlag: All);
-        }
-
-        public static Experiments Instance
-        {
-            get => CommonExperiments<Experiments>.Instance;
-            private set => CommonExperiments<Experiments>.Instance = value;
-        }
-
-        [JsonProperty(
-            DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate,
-            ObjectCreationHandling = ObjectCreationHandling.Reuse
-        )]
-        public ExperimentalFlag PostgreSQL { get; private set; }
-
+        Instance = new Experiments();
+        Instance.Load();
     }
+
+    private Experiments()
+    {
+        PostgreSQL = new ExperimentalFlag(nameof(PostgreSQL), NamespaceId, parentFlag: All);
+    }
+
+    public static Experiments Instance
+    {
+        get => CommonExperiments<Experiments>.Instance;
+        private set => CommonExperiments<Experiments>.Instance = value;
+    }
+
+    [JsonProperty(
+        DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate,
+        ObjectCreationHandling = ObjectCreationHandling.Reuse
+    )]
+    public ExperimentalFlag PostgreSQL { get; private set; }
 
 }

--- a/Intersect.Server.Core/Core/IServerContext.cs
+++ b/Intersect.Server.Core/Core/IServerContext.cs
@@ -2,29 +2,28 @@
 using Intersect.Network;
 using Intersect.Server.Core.Services;
 
-namespace Intersect.Server.Core
+namespace Intersect.Server.Core;
+
+/// <summary>
+/// Declares the API surface of server contexts.
+/// </summary>
+internal interface IServerContext : IApplicationContext<ServerCommandLineOptions>
 {
+    #region Services
+
     /// <summary>
-    /// Declares the API surface of server contexts.
+    /// The server's core logic service.
     /// </summary>
-    internal interface IServerContext : IApplicationContext<ServerCommandLineOptions>
-    {
-        #region Services
+    ILogicService LogicService { get; }
 
-        /// <summary>
-        /// The server's core logic service.
-        /// </summary>
-        ILogicService LogicService { get; }
+    /// <summary>
+    /// The server's network processing service.
+    /// </summary>
+    INetwork Network { get; }
 
-        /// <summary>
-        /// The server's network processing service.
-        /// </summary>
-        INetwork Network { get; }
+    #endregion Services
 
-        #endregion Services
+    void WaitForConsole();
 
-        void WaitForConsole();
-
-        void RequestShutdown(bool join = false);
-    }
+    void RequestShutdown(bool join = false);
 }

--- a/Intersect.Server.Core/Core/LogicService.LogicThread.cs
+++ b/Intersect.Server.Core/Core/LogicService.LogicThread.cs
@@ -13,395 +13,394 @@ using Intersect.Utilities;
 using Intersect.Server.Database.PlayerData.Api;
 using Intersect.Server.Core.MapInstancing;
 
-namespace Intersect.Server.Core
+namespace Intersect.Server.Core;
+
+internal sealed partial class LogicService
 {
-    internal sealed partial class LogicService
+    internal static INetworkPoolDataProvider NetworkPoolDataProvider { get; set; } =
+        new SinglePlayerNetworkPoolDataProvider();
+
+    internal sealed partial class LogicThread : Threaded<ServerContext>
     {
-        internal static INetworkPoolDataProvider NetworkPoolDataProvider { get; set; } =
-            new SinglePlayerNetworkPoolDataProvider();
+        private long _nextClearExpiredTokens;
 
-        internal sealed partial class LogicThread : Threaded<ServerContext>
-        {
-            private long _nextClearExpiredTokens;
+        /// <summary>
+        /// We lock on this in order to stop maps from entering the update queue. This is only done when the editor is saving/modifying game maps or the map grids are being rebuilt.
+        /// </summary>
+        public readonly object LogicLock = new object();
 
-            /// <summary>
-            /// We lock on this in order to stop maps from entering the update queue. This is only done when the editor is saving/modifying game maps or the map grids are being rebuilt.
-            /// </summary>
-            public readonly object LogicLock = new object();
-
-            /// <summary>
-            /// This is our thread pool for handling server/game logic. This includes npcs, event processing, map updating, projectiles, spell casting, etc. 
-            /// Min/Max Number of Threads & Idle Timeouts are set via server config.
-            /// </summary>
-            public readonly SmartThreadPool LogicPool = new SmartThreadPool(
-                new STPStartInfo()
-                {
-                    ThreadPoolName = "LogicPool",
-                    IdleTimeout = 20000,
-                    MinWorkerThreads = Options.Instance.Processing.MinLogicThreads,
-                    MaxWorkerThreads = Options.Instance.Processing.MaxLogicThreads
-                }
-            );
-
-            public LogicThread() : base("ServerLogic")
+        /// <summary>
+        /// This is our thread pool for handling server/game logic. This includes npcs, event processing, map updating, projectiles, spell casting, etc. 
+        /// Min/Max Number of Threads & Idle Timeouts are set via server config.
+        /// </summary>
+        public readonly SmartThreadPool LogicPool = new SmartThreadPool(
+            new STPStartInfo()
             {
+                ThreadPoolName = "LogicPool",
+                IdleTimeout = 20000,
+                MinWorkerThreads = Options.Instance.Processing.MinLogicThreads,
+                MaxWorkerThreads = Options.Instance.Processing.MaxLogicThreads
+            }
+        );
+
+        public LogicThread() : base("ServerLogic")
+        {
+        }
+
+        /// <summary>
+        /// Queue of active maps which maps are added to after being updated. Once a map makes it to the front of the queue they are updated again.
+        /// </summary>
+        public readonly ConcurrentQueue<MapInstance> MapInstanceUpdateQueue = new ConcurrentQueue<MapInstance>();
+
+        /// <summary>
+        /// Queue of active maps which maps are added to after being updated. Once a map makes it to the front of the queue they are updated again. 
+        /// This queue is only used for projectile updates if the projectile update interval does not match the map update interval in the server config.
+        /// </summary>
+        public readonly ConcurrentQueue<MapInstance> MapInstanceProjectileQueue = new ConcurrentQueue<MapInstance>();
+
+        /// <summary>
+        /// This is the set of maps determined to be 'active' based on player locations in the game. Our logic recalculates this hashset every 250ms.
+        /// When maps are updated they are not added back into the map update queues unless they exist in this hash set.
+        /// </summary>
+        public readonly Dictionary<Guid, MapInstance> ActiveMapInstances = new Dictionary<Guid, MapInstance>();
+
+        protected override void ThreadStart(ServerContext serverContext)
+        {
+            if (serverContext == null)
+            {
+                throw new ArgumentNullException(nameof(serverContext));
             }
 
-            /// <summary>
-            /// Queue of active maps which maps are added to after being updated. Once a map makes it to the front of the queue they are updated again.
-            /// </summary>
-            public readonly ConcurrentQueue<MapInstance> MapInstanceUpdateQueue = new ConcurrentQueue<MapInstance>();
-
-            /// <summary>
-            /// Queue of active maps which maps are added to after being updated. Once a map makes it to the front of the queue they are updated again. 
-            /// This queue is only used for projectile updates if the projectile update interval does not match the map update interval in the server config.
-            /// </summary>
-            public readonly ConcurrentQueue<MapInstance> MapInstanceProjectileQueue = new ConcurrentQueue<MapInstance>();
-
-            /// <summary>
-            /// This is the set of maps determined to be 'active' based on player locations in the game. Our logic recalculates this hashset every 250ms.
-            /// When maps are updated they are not added back into the map update queues unless they exist in this hash set.
-            /// </summary>
-            public readonly Dictionary<Guid, MapInstance> ActiveMapInstances = new Dictionary<Guid, MapInstance>();
-
-            protected override void ThreadStart(ServerContext serverContext)
+            try
             {
-                if (serverContext == null)
+                var swCpsTimer = Timing.Global.Milliseconds + 1000;
+                var lastCpuTime = Process.GetCurrentProcess().TotalProcessorTime;
+                var saveServerVariablesTimer = Timing.Global.Milliseconds + Options.Instance.Processing.DatabaseSaveServerVariablesInterval;
+                var metricsTimer = 0l;
+                long swCps = 0;
+
+                long updateTimer = 0;
+
+                var processedMapInstances = new HashSet<Guid>();
+                var sourceMapInstances = new HashSet<Guid>();
+                var players = 0;
+
+                while (ServerContext.Instance.IsRunning)
                 {
-                    throw new ArgumentNullException(nameof(serverContext));
-                }
+                    var startTime = Timing.Global.Milliseconds;
 
-                try
-                {
-                    var swCpsTimer = Timing.Global.Milliseconds + 1000;
-                    var lastCpuTime = Process.GetCurrentProcess().TotalProcessorTime;
-                    var saveServerVariablesTimer = Timing.Global.Milliseconds + Options.Instance.Processing.DatabaseSaveServerVariablesInterval;
-                    var metricsTimer = 0l;
-                    long swCps = 0;
-
-                    long updateTimer = 0;
-
-                    var processedMapInstances = new HashSet<Guid>();
-                    var sourceMapInstances = new HashSet<Guid>();
-                    var players = 0;
-
-                    while (ServerContext.Instance.IsRunning)
+                    // Cron-clear expired refresh tokens
+                    if (startTime > _nextClearExpiredTokens)
                     {
-                        var startTime = Timing.Global.Milliseconds;
-
-                        // Cron-clear expired refresh tokens
-                        if (startTime > _nextClearExpiredTokens)
-                        {
 #pragma warning disable CA2008 // Do not create tasks without passing a TaskScheduler
-                            _ = RefreshToken
-                                .RemoveExpiredAsync(250)
-                                /* Make it speed up the next call if we definitely have more expired tokens */
-                                .ContinueWith(remainingCount => _nextClearExpiredTokens -= remainingCount.Result > 0 ? 60000 : 0, TaskContinuationOptions.RunContinuationsAsynchronously);
+                        _ = RefreshToken
+                            .RemoveExpiredAsync(250)
+                            /* Make it speed up the next call if we definitely have more expired tokens */
+                            .ContinueWith(remainingCount => _nextClearExpiredTokens -= remainingCount.Result > 0 ? 60000 : 0, TaskContinuationOptions.RunContinuationsAsynchronously);
 #pragma warning restore CA2008 // Do not create tasks without passing a TaskScheduler
-                            _nextClearExpiredTokens = startTime + 60000;
-                        }
+                        _nextClearExpiredTokens = startTime + 60000;
+                    }
 
 
-                        if (startTime > updateTimer)
+                    if (startTime > updateTimer)
+                    {
+                        //Resync Active Maps By Scanning Players and Their Surrounding Maps
+                        players = 0;
+                        processedMapInstances.Clear();
+                        sourceMapInstances.Clear();
+
+                        //Metrics
+                        var globalEntities = 0;
+                        var events = 0;
+                        var eventsProcessing = 0;
+                        var autorunEvents = 0;
+
+                        foreach (var player in Player.OnlineList)
                         {
-                            //Resync Active Maps By Scanning Players and Their Surrounding Maps
-                            players = 0;
-                            processedMapInstances.Clear();
-                            sourceMapInstances.Clear();
-
-                            //Metrics
-                            var globalEntities = 0;
-                            var events = 0;
-                            var eventsProcessing = 0;
-                            var autorunEvents = 0;
-
-                            foreach (var player in Player.OnlineList)
+                            if (player != null)
                             {
-                                if (player != null)
+                                players++;
+                                if (Options.Instance.Metrics.Enable)
                                 {
-                                    players++;
-                                    if (Options.Instance.Metrics.Enable)
-                                    {
-                                        events += player.EventLookup.Count;
-                                        eventsProcessing += player.EventLookup.Values.Where(e => e.CallStack?.Count > 0).Count();
-                                        autorunEvents += player.CommonAutorunEvents + player.MapAutorunEvents;
-                                    }
+                                    events += player.EventLookup.Count;
+                                    eventsProcessing += player.EventLookup.Values.Where(e => e.CallStack?.Count > 0).Count();
+                                    autorunEvents += player.CommonAutorunEvents + player.MapAutorunEvents;
                                 }
+                            }
 
-                                var plyrMap = player?.MapId ?? Guid.Empty;
-                                if (plyrMap != Guid.Empty 
-                                    && !sourceMapInstances.Contains(plyrMap))
-                                {
-                                    // Queue up each surrounding map instance of the given player
-                                    MapController.GetSurroundingMapInstances(plyrMap, player.MapInstanceId, true)
-                                        .ForEach(instance =>
+                            var plyrMap = player?.MapId ?? Guid.Empty;
+                            if (plyrMap != Guid.Empty 
+                                && !sourceMapInstances.Contains(plyrMap))
+                            {
+                                // Queue up each surrounding map instance of the given player
+                                MapController.GetSurroundingMapInstances(plyrMap, player.MapInstanceId, true)
+                                    .ForEach(instance =>
+                                    {
+                                        if (!processedMapInstances.Contains(instance.Id))
                                         {
-                                            if (!processedMapInstances.Contains(instance.Id))
+                                            if (!ActiveMapInstances.Keys.Contains(instance.Id))
                                             {
-                                                if (!ActiveMapInstances.Keys.Contains(instance.Id))
-                                                {
-                                                    AddToQueue(instance);
-                                                }
-
-                                                globalEntities += instance.GetCachedEntities().Length;
-
-                                                processedMapInstances.Add(instance.Id);
+                                                AddToQueue(instance);
                                             }
-                                            sourceMapInstances.Add(instance.Id);
-                                        });
-                                }
+
+                                            globalEntities += instance.GetCachedEntities().Length;
+
+                                            processedMapInstances.Add(instance.Id);
+                                        }
+                                        sourceMapInstances.Add(instance.Id);
+                                    });
                             }
-
-                            //Refresh list of active maps & their instances
-                            foreach (var (instanceId, mapInstance) in ActiveMapInstances.ToArray())
-                            {
-                                if (processedMapInstances.Contains(instanceId) || mapInstance.ShouldBeActive())
-                                {
-                                    continue;
-                                }
-
-                                if (mapInstance != default)
-                                {
-                                    if (mapInstance.ShouldBeCleaned())
-                                    {
-                                        mapInstance.RemoveLayerFromController();
-                                    }
-                                    else if (!mapInstance.ShouldBeActive())
-                                    {
-                                        mapInstance.ResetNpcSpawns();
-                                    }
-                                }
-
-                                ActiveMapInstances.Remove(instanceId);
-                            }
-
-                            // Allow our instance controllers to keep their instances up to date
-                            InstanceProcessor.UpdateInstanceControllers(ActiveMapInstances.Values.ToArray());
-
-                            if (Options.Instance.Metrics.Enable)
-                            {
-                                MetricsRoot.Instance.Game.ActiveEntities.Record(globalEntities);
-                                MetricsRoot.Instance.Game.ActiveEvents.Record(events);
-                                MetricsRoot.Instance.Game.ProcessingEvents.Record(eventsProcessing);
-                                MetricsRoot.Instance.Game.AutorunEvents.Record(autorunEvents);
-                                MetricsRoot.Instance.Game.ActiveMaps.Record(ActiveMapInstances.Count);
-                                MetricsRoot.Instance.Game.Players.Record(players);
-                                MetricsRoot.Instance.Network.Clients.Record(Globals.Clients?.Count ?? 0);
-                            }
-
-                            //End Resync of Active Maps
-                            updateTimer = startTime + 250;
                         }
 
-                        //Check our map update queues. If maps are ready to be updated based on our update intervals set in the server config then tell our thread pool to queue the map update as a work item.
-                        lock (LogicLock)
+                        //Refresh list of active maps & their instances
+                        foreach (var (instanceId, mapInstance) in ActiveMapInstances.ToArray())
                         {
-                            if (Options.Instance.Processing.MapUpdateInterval != Options.Instance.Processing.ProjectileUpdateInterval)
+                            if (processedMapInstances.Contains(instanceId) || mapInstance.ShouldBeActive())
                             {
-                                while (MapInstanceProjectileQueue.TryPeek(out MapInstance result) && result.LastProjectileUpdateTime + Options.Instance.Processing.ProjectileUpdateInterval <= startTime)
+                                continue;
+                            }
+
+                            if (mapInstance != default)
+                            {
+                                if (mapInstance.ShouldBeCleaned())
                                 {
-                                    if (MapInstanceProjectileQueue.TryDequeue(out MapInstance sameResult))
-                                    {
-                                        LogicPool.QueueWorkItem(UpdateMap, sameResult, true);
-                                    }
+                                    mapInstance.RemoveLayerFromController();
+                                }
+                                else if (!mapInstance.ShouldBeActive())
+                                {
+                                    mapInstance.ResetNpcSpawns();
                                 }
                             }
 
-                            while (MapInstanceUpdateQueue.TryPeek(out MapInstance result) && result.LastRequestedUpdateTime + Options.Instance.Processing.MapUpdateInterval <= startTime)
-                            {
-                                if (MapInstanceUpdateQueue.TryDequeue(out MapInstance sameResult))
-                                {
-                                    if (Options.Instance.Metrics.Enable)
-                                    {
-                                        var delay = Timing.Global.Milliseconds - (result.LastRequestedUpdateTime + Options.Instance.Processing.MapUpdateInterval);
-                                        MetricsRoot.Instance.Game.MapQueueUpdateOffset.Record(delay);
-                                        result.UpdateQueueStart = Timing.Global.Milliseconds;
-                                    }
-                                    LogicPool.QueueWorkItem(UpdateMap, sameResult, false);
-                                }
-                            }                            
+                            ActiveMapInstances.Remove(instanceId);
                         }
 
-                        Time.Update();
-                        swCps++;
-
-                        var endTime = Timing.Global.Milliseconds;
-                        if (Timing.Global.Milliseconds > swCpsTimer)
-                        {
-                            Globals.Cps = swCps;
-                            swCps = 0;
-                            
-                            Console.Title = $"Intersect Server - CPS: {Globals.Cps}, Players: {players}, Active Maps: {ActiveMapInstances.Count}, Logic Threads: {LogicPool.ActiveThreads} ({LogicPool.InUseThreads} In Use), Pool Queue: {LogicPool.CurrentWorkItemsCount}, Idle: {LogicPool.IsIdle}";
-
-                            if (Options.Instance.Metrics.Enable)
-                            {
-                                //Get Average CPU Usage for the last second
-                                var currentCpuTime = Process.GetCurrentProcess().TotalProcessorTime;
-                                var cpuUsedMs = (currentCpuTime - lastCpuTime).TotalMilliseconds;
-                                var totalMsPassed = Timing.Global.Milliseconds - (swCpsTimer - 1000);
-                                var cpuUsageTotal = (cpuUsedMs / (Environment.ProcessorCount * totalMsPassed)) * 100f;
-                                lastCpuTime = currentCpuTime;
-
-                                MetricsRoot.Instance.Application.Cpu.Record((int)cpuUsageTotal);
-                                MetricsRoot.Instance.Application.Memory.Record(Process.GetCurrentProcess().PrivateMemorySize64);
-
-                                MetricsRoot.Instance.Game.Cps.Record(Globals.Cps);
-
-
-                                //Also Update Networking Metrics
-                                MetricsRoot.Instance.Network.TotalBandwidth.Record(PacketHandler.ReceivedBytes + PacketSender.SentBytes);
-                                MetricsRoot.Instance.Network.SentBytes.Record(PacketSender.SentBytes);
-                                MetricsRoot.Instance.Network.SentPackets.Record(PacketSender.SentPackets);
-                                MetricsRoot.Instance.Network.ReceivedBytes.Record(PacketHandler.ReceivedBytes);
-                                MetricsRoot.Instance.Network.ReceivedPackets.Record(PacketHandler.ReceivedPackets);
-                                MetricsRoot.Instance.Network.AcceptedBytes.Record(PacketHandler.AcceptedBytes);
-                                MetricsRoot.Instance.Network.AcceptedPackets.Record(PacketHandler.AcceptedPackets);
-                                MetricsRoot.Instance.Network.DroppedBytes.Record(PacketHandler.DroppedBytes);
-                                MetricsRoot.Instance.Network.DroppedPackets.Record(PacketHandler.DroppedPackets);
-
-                                PacketSender.ResetMetrics();
-                                PacketHandler.ResetMetrics();
-                            }
-
-                            //Should we send out guild updates?
-                            foreach (var guild in Guild.Guilds)
-                            {
-                                if (guild.Value.LastUpdateTime + Options.Instance.Guild.GuildUpdateInterval < Timing.Global.Milliseconds)
-                                {
-                                    LogicPool.QueueWorkItem(guild.Value.Update);
-                                }
-                            }
-
-                            swCpsTimer = Timing.Global.Milliseconds + 1000;
-                        }
+                        // Allow our instance controllers to keep their instances up to date
+                        InstanceProcessor.UpdateInstanceControllers(ActiveMapInstances.Values.ToArray());
 
                         if (Options.Instance.Metrics.Enable)
                         {
-                            //Record how our Thread Pools are Operating
-                            MetricsRoot.Instance.Threading.LogicPoolActiveThreads.Record(LogicPool.ActiveThreads);
-                            MetricsRoot.Instance.Threading.LogicPoolInUseThreads.Record(LogicPool.InUseThreads);
-                            MetricsRoot.Instance.Threading.LogicPoolWorkItemsCount.Record(LogicPool.CurrentWorkItemsCount);
-                            MetricsRoot.Instance.Threading.NetworkPoolActiveThreads.Record(NetworkPoolDataProvider.ActiveThreads);
-                            MetricsRoot.Instance.Threading.NetworkPoolInUseThreads.Record(NetworkPoolDataProvider.InUseThreads);
-                            MetricsRoot.Instance.Threading.NetworkPoolWorkItemsCount.Record(NetworkPoolDataProvider.CurrentWorkItemsCount);
-                            MetricsRoot.Instance.Threading.DatabasePoolActiveThreads.Record(DbInterface.Pool.ActiveThreads);
-                            MetricsRoot.Instance.Threading.DatabasePoolInUseThreads.Record(DbInterface.Pool.InUseThreads);
-                            MetricsRoot.Instance.Threading.DatabasePoolWorkItemsCount.Record(DbInterface.Pool.CurrentWorkItemsCount);
+                            MetricsRoot.Instance.Game.ActiveEntities.Record(globalEntities);
+                            MetricsRoot.Instance.Game.ActiveEvents.Record(events);
+                            MetricsRoot.Instance.Game.ProcessingEvents.Record(eventsProcessing);
+                            MetricsRoot.Instance.Game.AutorunEvents.Record(autorunEvents);
+                            MetricsRoot.Instance.Game.ActiveMaps.Record(ActiveMapInstances.Count);
+                            MetricsRoot.Instance.Game.Players.Record(players);
+                            MetricsRoot.Instance.Network.Clients.Record(Globals.Clients?.Count ?? 0);
+                        }
 
-                            ThreadPool.GetMaxThreads(out int maxWorkerThreads, out int maxIOThreads);
-                            ThreadPool.GetAvailableThreads(out int availableWorkerThreads, out int availableIOThreads);
-                            MetricsRoot.Instance.Threading.SystemPoolInUseWorkerThreads.Record(maxWorkerThreads - availableWorkerThreads);
-                            MetricsRoot.Instance.Threading.SystemPoolInUseIOThreads.Record(maxIOThreads - availableIOThreads);
+                        //End Resync of Active Maps
+                        updateTimer = startTime + 250;
+                    }
 
-                            if (Timing.Global.Milliseconds > metricsTimer)
+                    //Check our map update queues. If maps are ready to be updated based on our update intervals set in the server config then tell our thread pool to queue the map update as a work item.
+                    lock (LogicLock)
+                    {
+                        if (Options.Instance.Processing.MapUpdateInterval != Options.Instance.Processing.ProjectileUpdateInterval)
+                        {
+                            while (MapInstanceProjectileQueue.TryPeek(out MapInstance result) && result.LastProjectileUpdateTime + Options.Instance.Processing.ProjectileUpdateInterval <= startTime)
                             {
-                                MetricsRoot.Instance.Capture();
-
-                                foreach (var key in PacketSender.SentPacketTypes.Keys)
+                                if (MapInstanceProjectileQueue.TryDequeue(out MapInstance sameResult))
                                 {
-                                    PacketSender.SentPacketTypes[key] = 0;
+                                    LogicPool.QueueWorkItem(UpdateMap, sameResult, true);
                                 }
-
-                                foreach (var key in PacketHandler.AcceptedPacketTypes.Keys)
-                                {
-                                    PacketHandler.AcceptedPacketTypes[key] = 0;
-                                }
-
-                                metricsTimer = Timing.Global.Milliseconds + 5000;
                             }
                         }
 
-                        if (saveServerVariablesTimer < endTime)
+                        while (MapInstanceUpdateQueue.TryPeek(out MapInstance result) && result.LastRequestedUpdateTime + Options.Instance.Processing.MapUpdateInterval <= startTime)
                         {
-                            DbInterface.Pool.QueueWorkItem(DbInterface.SaveUpdatedServerVariables);
-                            saveServerVariablesTimer = Timing.Global.Milliseconds + Options.Instance.Processing.DatabaseSaveServerVariablesInterval;
-                        }
-
-                        if (Options.Instance.Processing.CpsLock)
-                        {
-                            Thread.Sleep(1);
-                        }
-            
+                            if (MapInstanceUpdateQueue.TryDequeue(out MapInstance sameResult))
+                            {
+                                if (Options.Instance.Metrics.Enable)
+                                {
+                                    var delay = Timing.Global.Milliseconds - (result.LastRequestedUpdateTime + Options.Instance.Processing.MapUpdateInterval);
+                                    MetricsRoot.Instance.Game.MapQueueUpdateOffset.Record(delay);
+                                    result.UpdateQueueStart = Timing.Global.Milliseconds;
+                                }
+                                LogicPool.QueueWorkItem(UpdateMap, sameResult, false);
+                            }
+                        }                            
                     }
-                    LogicPool.Shutdown();
-                }
-                catch (Exception exception)
-                {
-                    ServerContext.DispatchUnhandledException(exception);
-                }
-                finally
-                {
-                    ServerContext.Instance.RequestShutdown();
-                }
-            }
 
-            /// <summary>
-            /// Adds a map instance to the map update queues for our logic loop to start processing.
-            /// </summary>
-            /// <param name="mapInstance">The map instance in which to process in our queues.</param>
-            private void AddToQueue(MapInstance mapInstance)
-            {
-                if (Options.Instance.Processing.MapUpdateInterval != Options.Instance.Processing.ProjectileUpdateInterval)
-                {
-                    MapInstanceProjectileQueue.Enqueue(mapInstance);
-                }
-                MapInstanceUpdateQueue.Enqueue(mapInstance);
-                ActiveMapInstances.Add(mapInstance.Id, mapInstance);
-                mapInstance.LastRequestedUpdateTime = Timing.Global.Milliseconds - Options.Instance.Processing.MapUpdateInterval;
-            }
+                    Time.Update();
+                    swCps++;
 
-            /// <summary>
-            /// This function actually runs our map update function on the logic thread pool, and then re-queues our map for future updates if the map is still considered active.
-            /// </summary>
-            /// <param name="mapInstance">The <see cref="MapInstance"/> our thread updates.</param>
-            /// <param name="onlyProjectiles">If true only map projectiles are updated and not the entire map.</param>
-            private void UpdateMap(MapInstance mapInstance, bool onlyProjectiles)
-            {
-                try
-                {
-                    if (onlyProjectiles)
-                    {   
-                        mapInstance.UpdateProjectiles(Timing.Global.Milliseconds);
-                        if (ActiveMapInstances.Keys.Contains(mapInstance.Id))
+                    var endTime = Timing.Global.Milliseconds;
+                    if (Timing.Global.Milliseconds > swCpsTimer)
+                    {
+                        Globals.Cps = swCps;
+                        swCps = 0;
+                        
+                        Console.Title = $"Intersect Server - CPS: {Globals.Cps}, Players: {players}, Active Maps: {ActiveMapInstances.Count}, Logic Threads: {LogicPool.ActiveThreads} ({LogicPool.InUseThreads} In Use), Pool Queue: {LogicPool.CurrentWorkItemsCount}, Idle: {LogicPool.IsIdle}";
+
+                        if (Options.Instance.Metrics.Enable)
                         {
-                            MapInstanceProjectileQueue.Enqueue(mapInstance);
+                            //Get Average CPU Usage for the last second
+                            var currentCpuTime = Process.GetCurrentProcess().TotalProcessorTime;
+                            var cpuUsedMs = (currentCpuTime - lastCpuTime).TotalMilliseconds;
+                            var totalMsPassed = Timing.Global.Milliseconds - (swCpsTimer - 1000);
+                            var cpuUsageTotal = (cpuUsedMs / (Environment.ProcessorCount * totalMsPassed)) * 100f;
+                            lastCpuTime = currentCpuTime;
+
+                            MetricsRoot.Instance.Application.Cpu.Record((int)cpuUsageTotal);
+                            MetricsRoot.Instance.Application.Memory.Record(Process.GetCurrentProcess().PrivateMemorySize64);
+
+                            MetricsRoot.Instance.Game.Cps.Record(Globals.Cps);
+
+
+                            //Also Update Networking Metrics
+                            MetricsRoot.Instance.Network.TotalBandwidth.Record(PacketHandler.ReceivedBytes + PacketSender.SentBytes);
+                            MetricsRoot.Instance.Network.SentBytes.Record(PacketSender.SentBytes);
+                            MetricsRoot.Instance.Network.SentPackets.Record(PacketSender.SentPackets);
+                            MetricsRoot.Instance.Network.ReceivedBytes.Record(PacketHandler.ReceivedBytes);
+                            MetricsRoot.Instance.Network.ReceivedPackets.Record(PacketHandler.ReceivedPackets);
+                            MetricsRoot.Instance.Network.AcceptedBytes.Record(PacketHandler.AcceptedBytes);
+                            MetricsRoot.Instance.Network.AcceptedPackets.Record(PacketHandler.AcceptedPackets);
+                            MetricsRoot.Instance.Network.DroppedBytes.Record(PacketHandler.DroppedBytes);
+                            MetricsRoot.Instance.Network.DroppedPackets.Record(PacketHandler.DroppedPackets);
+
+                            PacketSender.ResetMetrics();
+                            PacketHandler.ResetMetrics();
                         }
+
+                        //Should we send out guild updates?
+                        foreach (var guild in Guild.Guilds)
+                        {
+                            if (guild.Value.LastUpdateTime + Options.Instance.Guild.GuildUpdateInterval < Timing.Global.Milliseconds)
+                            {
+                                LogicPool.QueueWorkItem(guild.Value.Update);
+                            }
+                        }
+
+                        swCpsTimer = Timing.Global.Milliseconds + 1000;
+                    }
+
+                    if (Options.Instance.Metrics.Enable)
+                    {
+                        //Record how our Thread Pools are Operating
+                        MetricsRoot.Instance.Threading.LogicPoolActiveThreads.Record(LogicPool.ActiveThreads);
+                        MetricsRoot.Instance.Threading.LogicPoolInUseThreads.Record(LogicPool.InUseThreads);
+                        MetricsRoot.Instance.Threading.LogicPoolWorkItemsCount.Record(LogicPool.CurrentWorkItemsCount);
+                        MetricsRoot.Instance.Threading.NetworkPoolActiveThreads.Record(NetworkPoolDataProvider.ActiveThreads);
+                        MetricsRoot.Instance.Threading.NetworkPoolInUseThreads.Record(NetworkPoolDataProvider.InUseThreads);
+                        MetricsRoot.Instance.Threading.NetworkPoolWorkItemsCount.Record(NetworkPoolDataProvider.CurrentWorkItemsCount);
+                        MetricsRoot.Instance.Threading.DatabasePoolActiveThreads.Record(DbInterface.Pool.ActiveThreads);
+                        MetricsRoot.Instance.Threading.DatabasePoolInUseThreads.Record(DbInterface.Pool.InUseThreads);
+                        MetricsRoot.Instance.Threading.DatabasePoolWorkItemsCount.Record(DbInterface.Pool.CurrentWorkItemsCount);
+
+                        ThreadPool.GetMaxThreads(out int maxWorkerThreads, out int maxIOThreads);
+                        ThreadPool.GetAvailableThreads(out int availableWorkerThreads, out int availableIOThreads);
+                        MetricsRoot.Instance.Threading.SystemPoolInUseWorkerThreads.Record(maxWorkerThreads - availableWorkerThreads);
+                        MetricsRoot.Instance.Threading.SystemPoolInUseIOThreads.Record(maxIOThreads - availableIOThreads);
+
+                        if (Timing.Global.Milliseconds > metricsTimer)
+                        {
+                            MetricsRoot.Instance.Capture();
+
+                            foreach (var key in PacketSender.SentPacketTypes.Keys)
+                            {
+                                PacketSender.SentPacketTypes[key] = 0;
+                            }
+
+                            foreach (var key in PacketHandler.AcceptedPacketTypes.Keys)
+                            {
+                                PacketHandler.AcceptedPacketTypes[key] = 0;
+                            }
+
+                            metricsTimer = Timing.Global.Milliseconds + 5000;
+                        }
+                    }
+
+                    if (saveServerVariablesTimer < endTime)
+                    {
+                        DbInterface.Pool.QueueWorkItem(DbInterface.SaveUpdatedServerVariables);
+                        saveServerVariablesTimer = Timing.Global.Milliseconds + Options.Instance.Processing.DatabaseSaveServerVariablesInterval;
+                    }
+
+                    if (Options.Instance.Processing.CpsLock)
+                    {
+                        Thread.Sleep(1);
+                    }
+        
+                }
+                LogicPool.Shutdown();
+            }
+            catch (Exception exception)
+            {
+                ServerContext.DispatchUnhandledException(exception);
+            }
+            finally
+            {
+                ServerContext.Instance.RequestShutdown();
+            }
+        }
+
+        /// <summary>
+        /// Adds a map instance to the map update queues for our logic loop to start processing.
+        /// </summary>
+        /// <param name="mapInstance">The map instance in which to process in our queues.</param>
+        private void AddToQueue(MapInstance mapInstance)
+        {
+            if (Options.Instance.Processing.MapUpdateInterval != Options.Instance.Processing.ProjectileUpdateInterval)
+            {
+                MapInstanceProjectileQueue.Enqueue(mapInstance);
+            }
+            MapInstanceUpdateQueue.Enqueue(mapInstance);
+            ActiveMapInstances.Add(mapInstance.Id, mapInstance);
+            mapInstance.LastRequestedUpdateTime = Timing.Global.Milliseconds - Options.Instance.Processing.MapUpdateInterval;
+        }
+
+        /// <summary>
+        /// This function actually runs our map update function on the logic thread pool, and then re-queues our map for future updates if the map is still considered active.
+        /// </summary>
+        /// <param name="mapInstance">The <see cref="MapInstance"/> our thread updates.</param>
+        /// <param name="onlyProjectiles">If true only map projectiles are updated and not the entire map.</param>
+        private void UpdateMap(MapInstance mapInstance, bool onlyProjectiles)
+        {
+            try
+            {
+                if (onlyProjectiles)
+                {   
+                    mapInstance.UpdateProjectiles(Timing.Global.Milliseconds);
+                    if (ActiveMapInstances.Keys.Contains(mapInstance.Id))
+                    {
+                        MapInstanceProjectileQueue.Enqueue(mapInstance);
+                    }
+                }
+                else
+                {
+                    if (Options.Instance.Metrics.Enable)
+                    {
+                        var timeBeforeUpdate = Timing.Global.Milliseconds;
+                        var desiredMapUpdateTime = mapInstance.LastRequestedUpdateTime + Options.Instance.Processing.MapUpdateInterval;
+                        MetricsRoot.Instance.Game.MapUpdateQueuedTime.Record(timeBeforeUpdate - mapInstance.UpdateQueueStart);
+
+                        mapInstance.Update(Timing.Global.Milliseconds);
+
+                        var timeAfterUpdate = Timing.Global.Milliseconds;
+                        MetricsRoot.Instance.Game.MapUpdateProcessingTime.Record(timeAfterUpdate - timeBeforeUpdate);
+                        MetricsRoot.Instance.Game.MapTotalUpdateTime.Record(timeAfterUpdate - desiredMapUpdateTime);
                     }
                     else
                     {
-                        if (Options.Instance.Metrics.Enable)
-                        {
-                            var timeBeforeUpdate = Timing.Global.Milliseconds;
-                            var desiredMapUpdateTime = mapInstance.LastRequestedUpdateTime + Options.Instance.Processing.MapUpdateInterval;
-                            MetricsRoot.Instance.Game.MapUpdateQueuedTime.Record(timeBeforeUpdate - mapInstance.UpdateQueueStart);
+                        mapInstance.Update(Timing.Global.Milliseconds);
+                    }
 
-                            mapInstance.Update(Timing.Global.Milliseconds);
-
-                            var timeAfterUpdate = Timing.Global.Milliseconds;
-                            MetricsRoot.Instance.Game.MapUpdateProcessingTime.Record(timeAfterUpdate - timeBeforeUpdate);
-                            MetricsRoot.Instance.Game.MapTotalUpdateTime.Record(timeAfterUpdate - desiredMapUpdateTime);
-                        }
-                        else
-                        {
-                            mapInstance.Update(Timing.Global.Milliseconds);
-                        }
-
-                        if (ActiveMapInstances.Keys.Contains(mapInstance.Id))
-                        {
-                            MapInstanceUpdateQueue.Enqueue(mapInstance);
-                        }
+                    if (ActiveMapInstances.Keys.Contains(mapInstance.Id))
+                    {
+                        MapInstanceUpdateQueue.Enqueue(mapInstance);
                     }
                 }
-                catch (ThreadAbortException)
-                {
-                    //Ignore if this pool is being shut down
-                }
-                catch (Exception exception)
-                {
-                    ServerContext.DispatchUnhandledException(exception);
-                }
             }
-
+            catch (ThreadAbortException)
+            {
+                //Ignore if this pool is being shut down
+            }
+            catch (Exception exception)
+            {
+                ServerContext.DispatchUnhandledException(exception);
+            }
         }
+
     }
 }

--- a/Intersect.Server.Core/Core/LogicService.cs
+++ b/Intersect.Server.Core/Core/LogicService.cs
@@ -2,38 +2,35 @@
 using Intersect.Core;
 using Intersect.Server.Core.Services;
 
-using System.Threading;
+namespace Intersect.Server.Core;
 
-namespace Intersect.Server.Core
+internal sealed partial class LogicService : ApplicationService<IServerContext, ILogicService, LogicService>, ILogicService
 {
-    internal sealed partial class LogicService : ApplicationService<IServerContext, ILogicService, LogicService>, ILogicService
+
+    private readonly LogicThread mLogicThread;
+
+    public LogicService()
     {
-
-        private readonly LogicThread mLogicThread;
-
-        public LogicService()
-        {
-            mLogicThread = new LogicThread();
-        }
-
-        public Thread Thread { get; private set; }
-
-        public object LogicLock => mLogicThread.LogicLock;
-
-        public SmartThreadPool LogicPool => mLogicThread.LogicPool;
-
-        /// <inheritdoc />
-        public override bool IsEnabled => true;
-
-        /// <inheritdoc />
-        protected override void TaskStart(IServerContext applicationContext) =>
-            Thread = mLogicThread.Start(applicationContext);
-
-        /// <inheritdoc />
-        protected override void TaskStop(IServerContext applicationContext)
-        {
-            // Nothing to do, the thread already has a stopping condition
-        }
-
+        mLogicThread = new LogicThread();
     }
+
+    public Thread Thread { get; private set; }
+
+    public object LogicLock => mLogicThread.LogicLock;
+
+    public SmartThreadPool LogicPool => mLogicThread.LogicPool;
+
+    /// <inheritdoc />
+    public override bool IsEnabled => true;
+
+    /// <inheritdoc />
+    protected override void TaskStart(IServerContext applicationContext) =>
+        Thread = mLogicThread.Start(applicationContext);
+
+    /// <inheritdoc />
+    protected override void TaskStop(IServerContext applicationContext)
+    {
+        // Nothing to do, the thread already has a stopping condition
+    }
+
 }

--- a/Intersect.Server.Core/Core/ServerContext.cs
+++ b/Intersect.Server.Core/Core/ServerContext.cs
@@ -6,8 +6,6 @@ using Intersect.Server.Database;
 using Intersect.Server.Localization;
 using Intersect.Server.Networking;
 using System.Diagnostics;
-using System.Resources;
-using System.Security.Cryptography;
 using Intersect.Factories;
 using Intersect.Plugins;
 using Intersect.Server.Plugins;
@@ -17,264 +15,263 @@ using Intersect.Rsa;
 using Intersect.Server.Database.PlayerData.Players;
 
 
-namespace Intersect.Server.Core
+namespace Intersect.Server.Core;
+
+/// <summary>
+/// Implements <see cref="IServerContext"/>.
+/// </summary>
+internal partial class ServerContext : ApplicationContext<ServerContext, ServerCommandLineOptions>, IServerContext
 {
-    /// <summary>
-    /// Implements <see cref="IServerContext"/>.
-    /// </summary>
-    internal partial class ServerContext : ApplicationContext<ServerContext, ServerCommandLineOptions>, IServerContext
+    private const string DefaultResourceDirectory = "resources";
+
+    internal static string ResourceDirectory { get; set; } = DefaultResourceDirectory;
+
+    internal static bool IsDefaultResourceDirectory => string.Equals(
+        ResourceDirectory,
+        DefaultResourceDirectory,
+        StringComparison.Ordinal
+    );
+
+    public static ServerContextFactory ServerContextFactory { get; set; } = (options, logger, packetHelper) =>
+        new ServerContext(options, logger, packetHelper);
+
+    protected ServerContext(
+        ServerCommandLineOptions startupOptions,
+        Logger logger,
+        IPacketHelper packetHelper
+    ) : base(
+        startupOptions, logger, packetHelper
+    )
     {
-        private const string DefaultResourceDirectory = "resources";
+        // Register the factory for creating service plugin contexts
+        FactoryRegistry<IPluginContext>.RegisterFactory(new ServerPluginContext.Factory());
 
-        internal static string ResourceDirectory { get; set; } = DefaultResourceDirectory;
-
-        internal static bool IsDefaultResourceDirectory => string.Equals(
-            ResourceDirectory,
-            DefaultResourceDirectory,
-            StringComparison.Ordinal
-        );
-
-        public static ServerContextFactory ServerContextFactory { get; set; } = (options, logger, packetHelper) =>
-            new ServerContext(options, logger, packetHelper);
-
-        protected ServerContext(
-            ServerCommandLineOptions startupOptions,
-            Logger logger,
-            IPacketHelper packetHelper
-        ) : base(
-            startupOptions, logger, packetHelper
-        )
+        if (startupOptions.Port > 0)
         {
-            // Register the factory for creating service plugin contexts
-            FactoryRegistry<IPluginContext>.RegisterFactory(new ServerPluginContext.Factory());
-
-            if (startupOptions.Port > 0)
-            {
-                Options.ServerPort = startupOptions.Port;
-            }
-
-            Network = CreateNetwork();
+            Options.ServerPort = startupOptions.Port;
         }
 
-        public ILogicService LogicService => GetExpectedService<ILogicService>();
+        Network = CreateNetwork();
+    }
 
-        public INetwork Network { get; }
+    public ILogicService LogicService => GetExpectedService<ILogicService>();
 
-        #region Startup
+    public INetwork Network { get; }
 
-        protected override void InternalStart()
+    #region Startup
+
+    protected override void InternalStart()
+    {
+        try
         {
-            try
-            {
-                InternalStartNetworking();
-            }
-            catch (Exception exception)
-            {
-                Log.Error(exception);
-                Dispose();
-
-                throw;
-            }
+            InternalStartNetworking();
         }
-
-        #endregion
-
-        #region Dispose
-
-        internal int ExitCode { get; set; }
-
-        internal bool DisposeWithoutExiting { get; set; }
-
-        protected virtual void JoinOrKillConsoleThread(Stopwatch stopwatch) { }
-
-        protected virtual void OnDisposing(Stopwatch stopwatch) { }
-
-        protected override void Dispose(bool disposing)
+        catch (Exception exception)
         {
-            var stopwatch = new Stopwatch();
-            stopwatch.Start();
+            Log.Error(exception);
+            Dispose();
 
-            if (disposing)
+            throw;
+        }
+    }
+
+    #endregion
+
+    #region Dispose
+
+    internal int ExitCode { get; set; }
+
+    internal bool DisposeWithoutExiting { get; set; }
+
+    protected virtual void JoinOrKillConsoleThread(Stopwatch stopwatch) { }
+
+    protected virtual void OnDisposing(Stopwatch stopwatch) { }
+
+    protected override void Dispose(bool disposing)
+    {
+        var stopwatch = new Stopwatch();
+        stopwatch.Start();
+
+        if (disposing)
+        {
+            #region CLEAN THIS UP
+
+            // TODO: This may actually be fine here? Might want to move it into Bootstrapper though as "PrintShutdown()"
+            Console.WriteLine();
+            Console.WriteLine(Strings.Commands.exiting);
+            Console.WriteLine();
+
+            OnDisposing(stopwatch);
+
+            // Except this line, this line is fine.
+            Log.Info("Disposing network..." + $" ({stopwatch.ElapsedMilliseconds}ms)");
+            Network.Dispose();
+
+            Log.Info("Saving updated server variable values");
+            DbInterface.SaveUpdatedServerVariables();
+
+            // TODO: This probably also needs to not be a global, but will require more work to clean up.
+            Log.Info("Saving online users/players..." + $" ({stopwatch.ElapsedMilliseconds}ms)");
+
+            var savingTasks = new List<Task>();
+            foreach (var user in Database.PlayerData.User.OnlineList.ToArray())
             {
-                #region CLEAN THIS UP
-
-                // TODO: This may actually be fine here? Might want to move it into Bootstrapper though as "PrintShutdown()"
-                Console.WriteLine();
-                Console.WriteLine(Strings.Commands.exiting);
-                Console.WriteLine();
-
-                OnDisposing(stopwatch);
-
-                // Except this line, this line is fine.
-                Log.Info("Disposing network..." + $" ({stopwatch.ElapsedMilliseconds}ms)");
-                Network.Dispose();
-
-                Log.Info("Saving updated server variable values");
-                DbInterface.SaveUpdatedServerVariables();
-
-                // TODO: This probably also needs to not be a global, but will require more work to clean up.
-                Log.Info("Saving online users/players..." + $" ({stopwatch.ElapsedMilliseconds}ms)");
-
-                var savingTasks = new List<Task>();
-                foreach (var user in Database.PlayerData.User.OnlineList.ToArray())
-                {
-                    savingTasks.Add(Task.Run(() => user.SaveWithDebounce()));
-                }
-
-                Task.WaitAll(savingTasks.ToArray());
-
-
-                Log.Info("Saving loaded guilds....");
-
-                savingTasks.Clear();
-                //Should we send out guild updates?
-                foreach (var guild in Guild.Guilds)
-                {
-                    savingTasks.Add(Task.Run(() => guild.Value.Save()));
-                }
-
-                Task.WaitAll(savingTasks.ToArray());
-
-                // TODO: This probably also needs to not be a global, but will require more work to clean up.
-                Log.Info("Online users/players saved." + $" ({stopwatch.ElapsedMilliseconds}ms)");
-
-
-                //Disconnect All Clients
-                //Will kill their packet handling threads so we have a clean shutdown
-                lock (Globals.ClientLock)
-                {
-                    var clients = Globals.Clients.ToArray();
-                    foreach (var client in clients)
-                    {
-                        client.Disconnect("Server Shutdown", true);
-                    }
-                }
-
-                #endregion
-
-                if (!DisposeWithoutExiting)
-                {
-                    JoinOrKillConsoleThread(stopwatch);
-                }
-
-                if (ThreadLogic?.IsAlive ?? false)
-                {
-                    Log.Info("Shutting down the logic thread..." + $" ({stopwatch.ElapsedMilliseconds}ms)");
-                    if (!ThreadLogic.Join(10000))
-                    {
-                        try
-                        {
-                            ThreadLogic.Interrupt();
-                        }
-                        catch (ThreadAbortException threadAbortException)
-                        {
-                            Log.Error(threadAbortException, $"{nameof(ThreadLogic)} aborted.");
-                        }
-                    }
-                }
-
-                PacketHelper.HandlerRegistry.Dispose();
+                savingTasks.Add(Task.Run(() => user.SaveWithDebounce()));
             }
 
-            Log.Info("Base dispose." + $" ({stopwatch.ElapsedMilliseconds}ms)");
-            base.Dispose(disposing);
-            Log.Info("Finished disposing server context." + $" ({stopwatch.ElapsedMilliseconds}ms)");
+            Task.WaitAll(savingTasks.ToArray());
 
-            if (DisposeWithoutExiting)
+
+            Log.Info("Saving loaded guilds....");
+
+            savingTasks.Clear();
+            //Should we send out guild updates?
+            foreach (var guild in Guild.Guilds)
             {
-                return;
+                savingTasks.Add(Task.Run(() => guild.Value.Save()));
             }
 
-            Console.WriteLine(Strings.Commands.exited);
-            Exit();
-        }
+            Task.WaitAll(savingTasks.ToArray());
 
-        internal void Exit(int? exitCode = null)
-        {
-            Exit(exitCode ?? ExitCode);
-        }
-
-        internal static void Exit(int exitCode)
-        {
-            Environment.Exit(exitCode);
-        }
-
-        #endregion
-
-        #region Threads
-
-        public virtual void WaitForConsole() { }
-
-        private Thread ThreadLogic => LogicService.Thread;
-
-        #endregion
-
-        #region Network
+            // TODO: This probably also needs to not be a global, but will require more work to clean up.
+            Log.Info("Online users/players saved." + $" ({stopwatch.ElapsedMilliseconds}ms)");
 
 
-        internal static NetworkFactory? NetworkFactory { get; set; }
-
-        protected virtual RsaKey AsymmetricKey => new(default);
-
-        private INetwork CreateNetwork()
-        {
-            #region Apply CLI Options
-
-            //Options.ServerPort = StartupOptions.ValidPort(Options.ServerPort);
+            //Disconnect All Clients
+            //Will kill their packet handling threads so we have a clean shutdown
+            lock (Globals.ClientLock)
+            {
+                var clients = Globals.Clients.ToArray();
+                foreach (var client in clients)
+                {
+                    client.Disconnect("Server Shutdown", true);
+                }
+            }
 
             #endregion
 
-            var packetHandler = new PacketHandler(this, PacketHelper.HandlerRegistry);
-
-            var networkFactory = NetworkFactory;
-            if (networkFactory == default)
+            if (!DisposeWithoutExiting)
             {
-                throw new InvalidOperationException($"{nameof(NetworkFactory)} was not set.");
+                JoinOrKillConsoleThread(stopwatch);
             }
 
-            var network = networkFactory.Invoke(
-                this,
-                AsymmetricKey.Parameters,
-                packetHandler.HandlePacket,
-                packetHandler.PreProcessPacket
-            );
+            if (ThreadLogic?.IsAlive ?? false)
+            {
+                Log.Info("Shutting down the logic thread..." + $" ({stopwatch.ElapsedMilliseconds}ms)");
+                if (!ThreadLogic.Join(10000))
+                {
+                    try
+                    {
+                        ThreadLogic.Interrupt();
+                    }
+                    catch (ThreadAbortException threadAbortException)
+                    {
+                        Log.Error(threadAbortException, $"{nameof(ThreadLogic)} aborted.");
+                    }
+                }
+            }
 
-            return network;
+            PacketHelper.HandlerRegistry.Dispose();
         }
 
-        #region Listen
+        Log.Info("Base dispose." + $" ({stopwatch.ElapsedMilliseconds}ms)");
+        base.Dispose(disposing);
+        Log.Info("Finished disposing server context." + $" ({stopwatch.ElapsedMilliseconds}ms)");
 
-        protected virtual void InternalStartNetworking()
+        if (DisposeWithoutExiting)
         {
-            Console.WriteLine();
-
-            if (!Network.Listen())
-            {
-                Log.Error("An error occurred while attempting to connect.");
-            }
-            else
-            {
-                Console.WriteLine(Strings.Intro.started.ToString(Options.ServerPort));
-            }
+            return;
         }
 
-        #endregion
-
-        #endregion
-
-        #region Exception Handling
-
-        protected override void NotifyNonTerminatingExceptionOccurred() =>
-            Console.WriteLine(Strings.Errors.errorlogged);
-
-        internal static void DispatchUnhandledException(Exception exception, bool isTerminating = true)
-        {
-            var sender = Thread.CurrentThread;
-            Task.Factory.StartNew(
-                () => HandleUnhandledException(sender, new UnhandledExceptionEventArgs(exception, isTerminating))
-            );
-        }
-
-        #endregion Exception Handling
+        Console.WriteLine(Strings.Commands.exited);
+        Exit();
     }
+
+    internal void Exit(int? exitCode = null)
+    {
+        Exit(exitCode ?? ExitCode);
+    }
+
+    internal static void Exit(int exitCode)
+    {
+        Environment.Exit(exitCode);
+    }
+
+    #endregion
+
+    #region Threads
+
+    public virtual void WaitForConsole() { }
+
+    private Thread ThreadLogic => LogicService.Thread;
+
+    #endregion
+
+    #region Network
+
+
+    internal static NetworkFactory? NetworkFactory { get; set; }
+
+    protected virtual RsaKey AsymmetricKey => new(default);
+
+    private INetwork CreateNetwork()
+    {
+        #region Apply CLI Options
+
+        //Options.ServerPort = StartupOptions.ValidPort(Options.ServerPort);
+
+        #endregion
+
+        var packetHandler = new PacketHandler(this, PacketHelper.HandlerRegistry);
+
+        var networkFactory = NetworkFactory;
+        if (networkFactory == default)
+        {
+            throw new InvalidOperationException($"{nameof(NetworkFactory)} was not set.");
+        }
+
+        var network = networkFactory.Invoke(
+            this,
+            AsymmetricKey.Parameters,
+            packetHandler.HandlePacket,
+            packetHandler.PreProcessPacket
+        );
+
+        return network;
+    }
+
+    #region Listen
+
+    protected virtual void InternalStartNetworking()
+    {
+        Console.WriteLine();
+
+        if (!Network.Listen())
+        {
+            Log.Error("An error occurred while attempting to connect.");
+        }
+        else
+        {
+            Console.WriteLine(Strings.Intro.started.ToString(Options.ServerPort));
+        }
+    }
+
+    #endregion
+
+    #endregion
+
+    #region Exception Handling
+
+    protected override void NotifyNonTerminatingExceptionOccurred() =>
+        Console.WriteLine(Strings.Errors.errorlogged);
+
+    internal static void DispatchUnhandledException(Exception exception, bool isTerminating = true)
+    {
+        var sender = Thread.CurrentThread;
+        Task.Factory.StartNew(
+            () => HandleUnhandledException(sender, new UnhandledExceptionEventArgs(exception, isTerminating))
+        );
+    }
+
+    #endregion Exception Handling
 }

--- a/Intersect.Server.Core/Core/Services/ILogicService.cs
+++ b/Intersect.Server.Core/Core/Services/ILogicService.cs
@@ -1,12 +1,11 @@
 ﻿using Amib.Threading;
 using Intersect.Core;
 
-namespace Intersect.Server.Core.Services
-{
-    internal interface ILogicService : IThreadableApplicationService
-    {
-        object LogicLock { get; }
+namespace Intersect.Server.Core.Services;
 
-        SmartThreadPool LogicPool { get; }
-    }
+internal interface ILogicService : IThreadableApplicationService
+{
+    object LogicLock { get; }
+
+    SmartThreadPool LogicPool { get; }
 }

--- a/Intersect.Server.Core/Database/ContextInterface.cs
+++ b/Intersect.Server.Core/Database/ContextInterface.cs
@@ -1,59 +1,58 @@
 ﻿using Microsoft.EntityFrameworkCore.Infrastructure;
 
-namespace Intersect.Server.Database
+namespace Intersect.Server.Database;
+
+public abstract partial class ContextInterface<TContext> : IDisposable where TContext : IDbContext
 {
-    public abstract partial class ContextInterface<TContext> : IDisposable where TContext : IDbContext
+    private static readonly object Lock = new object();
+
+    protected ContextInterface(TContext context)
     {
-        private static readonly object Lock = new object();
-
-        protected ContextInterface(TContext context)
-        {
-            Context = context;
-            Monitor.Enter(Lock);
-        }
-
-        public TContext Context { get; }
-
-        #region Implementation of IDbContext
-
-        /// <inheritdoc />
-        public DatabaseFacade Database => Context.Database;
-
-        /// <inheritdoc />
-        public int SaveChanges() => Context.SaveChanges();
-
-        /// <inheritdoc />
-        public int SaveChanges(bool acceptAllChangesOnSuccess) => Context.SaveChanges(acceptAllChangesOnSuccess);
-
-        /// <inheritdoc />
-        public Task<int>
-            SaveChangesAsync(bool acceptAllChangesOnSuccess, CancellationToken cancellationToken = default) =>
-            Context.SaveChangesAsync(acceptAllChangesOnSuccess, cancellationToken);
-
-        /// <inheritdoc />
-        public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default) =>
-            Context.SaveChangesAsync(cancellationToken);
-
-        #endregion
-
-        #region IDisposable
-
-        protected void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                Context.SaveChanges();
-                Monitor.Exit(Lock);
-            }
-        }
-
-        /// <inheritdoc />
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        #endregion IDisposable
+        Context = context;
+        Monitor.Enter(Lock);
     }
+
+    public TContext Context { get; }
+
+    #region Implementation of IDbContext
+
+    /// <inheritdoc />
+    public DatabaseFacade Database => Context.Database;
+
+    /// <inheritdoc />
+    public int SaveChanges() => Context.SaveChanges();
+
+    /// <inheritdoc />
+    public int SaveChanges(bool acceptAllChangesOnSuccess) => Context.SaveChanges(acceptAllChangesOnSuccess);
+
+    /// <inheritdoc />
+    public Task<int>
+        SaveChangesAsync(bool acceptAllChangesOnSuccess, CancellationToken cancellationToken = default) =>
+        Context.SaveChangesAsync(acceptAllChangesOnSuccess, cancellationToken);
+
+    /// <inheritdoc />
+    public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default) =>
+        Context.SaveChangesAsync(cancellationToken);
+
+    #endregion
+
+    #region IDisposable
+
+    protected void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            Context.SaveChanges();
+            Monitor.Exit(Lock);
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    #endregion IDisposable
 }

--- a/Intersect.Server.Core/Database/ContextProvider.Locking.cs
+++ b/Intersect.Server.Core/Database/ContextProvider.Locking.cs
@@ -1,10 +1,9 @@
-﻿namespace Intersect.Server.Database
+﻿namespace Intersect.Server.Database;
+
+public sealed partial class ContextProvider
 {
-    public sealed partial class ContextProvider
+    private partial class LockProvider<TContext, UContext> where TContext : IntersectDbContext<TContext>, UContext
     {
-        private partial class LockProvider<TContext, UContext> where TContext : IntersectDbContext<TContext>, UContext
-        {
-            public static readonly object Lock = new object();
-        }
+        public static readonly object Lock = new object();
     }
 }

--- a/Intersect.Server.Core/Database/ContextProvider.cs
+++ b/Intersect.Server.Core/Database/ContextProvider.cs
@@ -1,37 +1,36 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace Intersect.Server.Database
+namespace Intersect.Server.Database;
+
+public sealed partial class ContextProvider
 {
-    public sealed partial class ContextProvider
+    private Dictionary<Type, DbContext> Contexts { get; } = new();
+    private Dictionary<Type, Type> ContextInterfaceTypes { get; } = new();
+
+    public void Add<TContext>(TContext context) where TContext : IntersectDbContext<TContext>
     {
-        private Dictionary<Type, DbContext> Contexts { get; } = new();
-        private Dictionary<Type, Type> ContextInterfaceTypes { get; } = new();
-
-        public void Add<TContext>(TContext context) where TContext : IntersectDbContext<TContext>
+        var contextType = typeof(TContext);
+        var contextInterfaceType = contextType.GetInterfaces()
+            .FirstOrDefault(type => typeof(IDbContext) != type && typeof(IDbContext).IsAssignableFrom(type));
+        if (Contexts.ContainsKey(contextInterfaceType))
         {
-            var contextType = typeof(TContext);
-            var contextInterfaceType = contextType.GetInterfaces()
-                .FirstOrDefault(type => typeof(IDbContext) != type && typeof(IDbContext).IsAssignableFrom(type));
-            if (Contexts.ContainsKey(contextInterfaceType))
-            {
-                throw new Exception($"Context for {contextInterfaceType.Name} already exists.");
-            }
-
-            Contexts[contextInterfaceType] = context;
+            throw new Exception($"Context for {contextInterfaceType.Name} already exists.");
         }
 
-        #region Implementation of IContextProvider
-
-        public TContext Access<TContext, TContextInterface>() where TContext : class, IDbContext
-        {
-            if (!Contexts.TryGetValue(typeof(TContext), out var context))
-            {
-                throw new Exception($"No context of type {typeof(TContext).Name} exists.");
-            }
-
-            return Activator.CreateInstance(typeof(TContextInterface), new object[] { context }) as TContext;
-        }
-
-        #endregion
+        Contexts[contextInterfaceType] = context;
     }
+
+    #region Implementation of IContextProvider
+
+    public TContext Access<TContext, TContextInterface>() where TContext : class, IDbContext
+    {
+        if (!Contexts.TryGetValue(typeof(TContext), out var context))
+        {
+            throw new Exception($"No context of type {typeof(TContext).Name} exists.");
+        }
+
+        return Activator.CreateInstance(typeof(TContextInterface), new object[] { context }) as TContext;
+    }
+
+    #endregion
 }

--- a/Intersect.Server.Core/Database/DatabaseTypeMigrationService.cs
+++ b/Intersect.Server.Core/Database/DatabaseTypeMigrationService.cs
@@ -1,10 +1,7 @@
-﻿using System.Collections.ObjectModel;
-using System.Reflection;
-using Intersect.Collections;
+﻿using System.Reflection;
 using Intersect.Extensions;
 using Intersect.Logging;
 using Intersect.Reflection;
-using Intersect.Server.Extensions;
 using Microsoft.EntityFrameworkCore;
 using Intersect.Server.Localization;
 using Microsoft.EntityFrameworkCore.Metadata;

--- a/Intersect.Server.Core/Database/DbInterface.cs
+++ b/Intersect.Server.Core/Database/DbInterface.cs
@@ -37,2153 +37,2152 @@ using Microsoft.EntityFrameworkCore;
 using MySqlConnector;
 using LogLevel = Intersect.Logging.LogLevel;
 
-namespace Intersect.Server.Database
+namespace Intersect.Server.Database;
+
+
+public static partial class DbInterface
 {
 
-    public static partial class DbInterface
-    {
+    /// <summary>
+    /// This is our thread pool for handling game-loop database interactions.
+    /// Min/Max Number of Threads & Idle Timeouts are set via server config.
+    /// </summary>
+    public static SmartThreadPool Pool = new(
+            new STPStartInfo()
+            {
+                ThreadPoolName = "DatabasePool",
+                IdleTimeout = Options.Instance.Processing.DatabaseThreadIdleTimeout,
+                MinWorkerThreads = Options.Instance.Processing.MinDatabaseThreads,
+                MaxWorkerThreads = Options.Instance.Processing.MaxDatabaseThreads
+            }
+        );
 
-        /// <summary>
-        /// This is our thread pool for handling game-loop database interactions.
-        /// Min/Max Number of Threads & Idle Timeouts are set via server config.
-        /// </summary>
-        public static SmartThreadPool Pool = new(
-                new STPStartInfo()
+    private static string GameDbFilename => Path.Combine(ServerContext.ResourceDirectory, "gamedata.db");
+
+    private static string LoggingDbFilename => Path.Combine(ServerContext.ResourceDirectory, "logging.db");
+
+    private static string PlayersDbFilename => Path.Combine(ServerContext.ResourceDirectory, "playerdata.db");
+
+    private static Logger _gameDatabaseLogger { get; set; }
+
+    private static Logger _playerDatabaseLogger { get; set; }
+
+    public static Dictionary<string, ServerVariableBase> ServerVariableEventTextLookup = new();
+
+    public static Dictionary<string, PlayerVariableBase> PlayerVariableEventTextLookup = new();
+
+    public static Dictionary<string, GuildVariableBase> GuildVariableEventTextLookup = new();
+
+    public static Dictionary<string, UserVariableBase> UserVariableEventTextLookup = new();
+
+    public static ConcurrentDictionary<Guid, ServerVariableBase> UpdatedServerVariables = new();
+
+    private static List<MapGrid> mapGrids = new();
+
+    public static GameContext CreateGameContext(
+        bool readOnly = true,
+        bool explicitLoad = false,
+        bool lazyLoading = false,
+        bool autoDetectChanges = false,
+        QueryTrackingBehavior? queryTrackingBehavior = default
+    ) => GameContext.Create(new DatabaseContextOptions
+    {
+        AutoDetectChanges = autoDetectChanges,
+        ConnectionStringBuilder = Options.Instance.GameDatabase.Type.CreateConnectionStringBuilder(
+            Options.Instance.GameDatabase,
+            GameDbFilename
+        ),
+        DatabaseType = Options.Instance.GameDatabase.Type,
+        ExplicitLoad = explicitLoad,
+        KillServerOnConcurrencyException = Options.Instance.GameDatabase.KillServerOnConcurrencyException,
+        LazyLoading = lazyLoading,
+#if DEBUG
+        LoggerFactory = new IntersectLoggerFactory(nameof(GameContext)),
+#endif
+        QueryTrackingBehavior = queryTrackingBehavior,
+        ReadOnly = readOnly,
+    });
+
+    internal static LoggingContext CreateLoggingContext(
+        bool readOnly = true,
+        bool explicitLoad = false,
+        bool lazyLoading = false,
+        bool autoDetectChanges = false,
+        QueryTrackingBehavior? queryTrackingBehavior = default
+    ) => LoggingContext.Create(new DatabaseContextOptions
+    {
+        AutoDetectChanges = autoDetectChanges,
+        ConnectionStringBuilder = Options.Instance.LoggingDatabase.Type.CreateConnectionStringBuilder(
+            Options.Instance.LoggingDatabase,
+            LoggingDbFilename
+        ),
+        DatabaseType = Options.Instance.LoggingDatabase.Type,
+        ExplicitLoad = explicitLoad,
+        KillServerOnConcurrencyException = Options.Instance.LoggingDatabase.KillServerOnConcurrencyException,
+        LazyLoading = lazyLoading,
+#if DEBUG
+        LoggerFactory = new IntersectLoggerFactory(nameof(LoggingContext)),
+#endif
+        QueryTrackingBehavior = queryTrackingBehavior,
+        ReadOnly = readOnly,
+    });
+
+    /// <summary>
+    /// Creates a game context to query. Best practice is to scope this within a using statement.
+    /// </summary>
+    /// <param name="readOnly">Defines whether or not the context should initialize with change tracking. If readonly is true then SaveChanges will not work.</param>
+    /// <returns></returns>
+    public static PlayerContext CreatePlayerContext(
+        bool readOnly = true,
+        bool explicitLoad = false,
+        bool lazyLoading = false,
+        bool autoDetectChanges = false,
+        QueryTrackingBehavior? queryTrackingBehavior = default
+    ) => PlayerContext.Create(new DatabaseContextOptions
+    {
+        AutoDetectChanges = autoDetectChanges,
+        ConnectionStringBuilder = Options.Instance.PlayerDatabase.Type.CreateConnectionStringBuilder(
+            Options.Instance.PlayerDatabase,
+            PlayersDbFilename
+        ),
+        DatabaseType = Options.Instance.PlayerDatabase.Type,
+        ExplicitLoad = explicitLoad,
+        KillServerOnConcurrencyException = Options.Instance.PlayerDatabase.KillServerOnConcurrencyException,
+        LazyLoading = lazyLoading,
+#if DEBUG
+        LoggerFactory = new IntersectLoggerFactory(nameof(PlayerContext)),
+#endif
+        QueryTrackingBehavior = queryTrackingBehavior,
+        ReadOnly = readOnly,
+    });
+
+    public static void InitializeDbLoggers()
+    {
+        if (Options.Instance.GameDatabase.LogLevel > LogLevel.None)
+        {
+            _gameDatabaseLogger = new Logger(
+                new LogConfiguration
                 {
-                    ThreadPoolName = "DatabasePool",
-                    IdleTimeout = Options.Instance.Processing.DatabaseThreadIdleTimeout,
-                    MinWorkerThreads = Options.Instance.Processing.MinDatabaseThreads,
-                    MaxWorkerThreads = Options.Instance.Processing.MaxDatabaseThreads
+                    Tag = "GAMEDB",
+                    LogLevel = Options.Instance.GameDatabase.LogLevel,
+                    Outputs = ImmutableList.Create<ILogOutput>(
+                        new FileOutput(Log.SuggestFilename(null, "gamedb"), LogLevel.Debug)
+                    )
                 }
             );
+        }
 
-        private static string GameDbFilename => Path.Combine(ServerContext.ResourceDirectory, "gamedata.db");
-
-        private static string LoggingDbFilename => Path.Combine(ServerContext.ResourceDirectory, "logging.db");
-
-        private static string PlayersDbFilename => Path.Combine(ServerContext.ResourceDirectory, "playerdata.db");
-
-        private static Logger _gameDatabaseLogger { get; set; }
-
-        private static Logger _playerDatabaseLogger { get; set; }
-
-        public static Dictionary<string, ServerVariableBase> ServerVariableEventTextLookup = new();
-
-        public static Dictionary<string, PlayerVariableBase> PlayerVariableEventTextLookup = new();
-
-        public static Dictionary<string, GuildVariableBase> GuildVariableEventTextLookup = new();
-
-        public static Dictionary<string, UserVariableBase> UserVariableEventTextLookup = new();
-
-        public static ConcurrentDictionary<Guid, ServerVariableBase> UpdatedServerVariables = new();
-
-        private static List<MapGrid> mapGrids = new();
-
-        public static GameContext CreateGameContext(
-            bool readOnly = true,
-            bool explicitLoad = false,
-            bool lazyLoading = false,
-            bool autoDetectChanges = false,
-            QueryTrackingBehavior? queryTrackingBehavior = default
-        ) => GameContext.Create(new DatabaseContextOptions
+        if (Options.Instance.PlayerDatabase.LogLevel > LogLevel.None)
         {
-            AutoDetectChanges = autoDetectChanges,
+            _playerDatabaseLogger = new Logger(
+                new LogConfiguration
+                {
+                    Tag = "PLAYERDB",
+                    LogLevel = Options.Instance.PlayerDatabase.LogLevel,
+                    Outputs = ImmutableList.Create<ILogOutput>(
+                        new FileOutput(Log.SuggestFilename(null, "playerdb"), LogLevel.Debug)
+                    )
+                }
+            );
+        }
+    }
+
+    //Check Directories
+    public static void CheckDirectories()
+    {
+        if (Directory.Exists(ServerContext.ResourceDirectory))
+        {
+            return;
+        }
+
+        if (ServerContext.IsDefaultResourceDirectory)
+        {
+            Directory.CreateDirectory(ServerContext.ResourceDirectory);
+        }
+        else
+        {
+            throw new DirectoryNotFoundException(
+                Path.Combine(Environment.CurrentDirectory, ServerContext.ResourceDirectory)
+            );
+        }
+    }
+
+    //As of now Database writes only occur on player saving & when editors make game changes
+    //Database writes are actually pretty rare. And even player saves are offloaded as tasks so
+    //if delayed it won't matter much.
+    //TODO: Options for saving frequency and number of backups to keep.
+    public static void BackupDatabase()
+    {
+    }
+
+    public static DbConnectionStringBuilder CreateConnectionStringBuilder(
+        DatabaseOptions databaseOptions,
+        string filename
+    )
+    {
+        switch (databaseOptions.Type)
+        {
+            case DatabaseType.SQLite:
+                return new SqliteConnectionStringBuilder($"Data Source={filename}");
+
+            case DatabaseType.MySQL:
+                return new MySqlConnectionStringBuilder
+                {
+                    Server = databaseOptions.Server,
+                    Port = databaseOptions.Port,
+                    Database = databaseOptions.Database,
+                    UserID = databaseOptions.Username,
+                    Password = databaseOptions.Password
+                };
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(databaseOptions.Type));
+        }
+    }
+
+    private static readonly MethodInfo _methodInfoProcessMigrations =
+        typeof(DbInterface)
+            .GetMethod(nameof(ProcessMigrations), BindingFlags.NonPublic | BindingFlags.Static);
+
+    private static void ProcessMigrations<TContext>(TContext context)
+        where TContext : IntersectDbContext<TContext>
+    {
+        if (!context.HasPendingMigrations)
+        {
+            Log.Verbose("No pending migrations, skipping...");
+            return;
+        }
+
+        Log.Verbose($"Pending schema migrations for {typeof(TContext).Name}:\n\t{string.Join("\n\t", context.PendingSchemaMigrations)}");
+        Log.Verbose($"Pending data migrations for {typeof(TContext).Name}:\n\t{string.Join("\n\t", context.PendingDataMigrationNames)}");
+
+        var migrationScheduler = new MigrationScheduler<TContext>(context);
+        Log.Verbose("Scheduling pending migrations...");
+        migrationScheduler.SchedulePendingMigrations();
+
+        Log.Verbose("Applying scheduled migrations...");
+        migrationScheduler.ApplyScheduledMigrations();
+
+        var remainingPendingSchemaMigrations = context.PendingSchemaMigrations.ToList();
+        var processedSchemaMigrations =
+            context.PendingSchemaMigrations.Where(migration => !remainingPendingSchemaMigrations.Contains(migration));
+
+        context.OnSchemaMigrationsProcessed(processedSchemaMigrations.ToArray());
+    }
+
+    private static bool EnsureUpdated(IServerContext serverContext)
+    {
+        Log.Verbose("Creating game context...");
+        using var gameContext = GameContext.Create(new DatabaseContextOptions
+        {
             ConnectionStringBuilder = Options.Instance.GameDatabase.Type.CreateConnectionStringBuilder(
                 Options.Instance.GameDatabase,
                 GameDbFilename
             ),
             DatabaseType = Options.Instance.GameDatabase.Type,
-            ExplicitLoad = explicitLoad,
-            KillServerOnConcurrencyException = Options.Instance.GameDatabase.KillServerOnConcurrencyException,
-            LazyLoading = lazyLoading,
-#if DEBUG
+            EnableDetailedErrors = true,
+            EnableSensitiveDataLogging = true,
             LoggerFactory = new IntersectLoggerFactory(nameof(GameContext)),
-#endif
-            QueryTrackingBehavior = queryTrackingBehavior,
-            ReadOnly = readOnly,
         });
 
-        internal static LoggingContext CreateLoggingContext(
-            bool readOnly = true,
-            bool explicitLoad = false,
-            bool lazyLoading = false,
-            bool autoDetectChanges = false,
-            QueryTrackingBehavior? queryTrackingBehavior = default
-        ) => LoggingContext.Create(new DatabaseContextOptions
+        Log.Verbose("Creating player context...");
+        using var playerContext = PlayerContext.Create(new DatabaseContextOptions
         {
-            AutoDetectChanges = autoDetectChanges,
-            ConnectionStringBuilder = Options.Instance.LoggingDatabase.Type.CreateConnectionStringBuilder(
-                Options.Instance.LoggingDatabase,
-                LoggingDbFilename
-            ),
-            DatabaseType = Options.Instance.LoggingDatabase.Type,
-            ExplicitLoad = explicitLoad,
-            KillServerOnConcurrencyException = Options.Instance.LoggingDatabase.KillServerOnConcurrencyException,
-            LazyLoading = lazyLoading,
-#if DEBUG
-            LoggerFactory = new IntersectLoggerFactory(nameof(LoggingContext)),
-#endif
-            QueryTrackingBehavior = queryTrackingBehavior,
-            ReadOnly = readOnly,
-        });
-
-        /// <summary>
-        /// Creates a game context to query. Best practice is to scope this within a using statement.
-        /// </summary>
-        /// <param name="readOnly">Defines whether or not the context should initialize with change tracking. If readonly is true then SaveChanges will not work.</param>
-        /// <returns></returns>
-        public static PlayerContext CreatePlayerContext(
-            bool readOnly = true,
-            bool explicitLoad = false,
-            bool lazyLoading = false,
-            bool autoDetectChanges = false,
-            QueryTrackingBehavior? queryTrackingBehavior = default
-        ) => PlayerContext.Create(new DatabaseContextOptions
-        {
-            AutoDetectChanges = autoDetectChanges,
             ConnectionStringBuilder = Options.Instance.PlayerDatabase.Type.CreateConnectionStringBuilder(
                 Options.Instance.PlayerDatabase,
                 PlayersDbFilename
             ),
             DatabaseType = Options.Instance.PlayerDatabase.Type,
-            ExplicitLoad = explicitLoad,
-            KillServerOnConcurrencyException = Options.Instance.PlayerDatabase.KillServerOnConcurrencyException,
-            LazyLoading = lazyLoading,
-#if DEBUG
+            EnableDetailedErrors = true,
+            EnableSensitiveDataLogging = true,
             LoggerFactory = new IntersectLoggerFactory(nameof(PlayerContext)),
-#endif
-            QueryTrackingBehavior = queryTrackingBehavior,
-            ReadOnly = readOnly,
         });
 
-        public static void InitializeDbLoggers()
+        Log.Verbose("Creating logging context...");
+        using var loggingContext = LoggingContext.Create(new DatabaseContextOptions
         {
-            if (Options.Instance.GameDatabase.LogLevel > LogLevel.None)
+            ConnectionStringBuilder = Options.Instance.LoggingDatabase.Type.CreateConnectionStringBuilder(
+                Options.Instance.LoggingDatabase,
+                LoggingDbFilename
+            ),
+            DatabaseType = Options.Instance.LoggingDatabase.Type,
+            EnableDetailedErrors = true,
+            EnableSensitiveDataLogging = true,
+            LoggerFactory = new IntersectLoggerFactory(nameof(LoggingContext)),
+        });
+
+        // We don't want anyone running the old migration tool accidentally
+        try
+        {
+            if (File.Exists("Intersect Migration Tool.exe"))
             {
-                _gameDatabaseLogger = new Logger(
-                    new LogConfiguration
-                    {
-                        Tag = "GAMEDB",
-                        LogLevel = Options.Instance.GameDatabase.LogLevel,
-                        Outputs = ImmutableList.Create<ILogOutput>(
-                            new FileOutput(Log.SuggestFilename(null, "gamedb"), LogLevel.Debug)
-                        )
-                    }
-                );
+                File.Delete("Intersect Migration Tool.exe");
             }
 
-            if (Options.Instance.PlayerDatabase.LogLevel > LogLevel.None)
+            if (File.Exists("Intersect Migration Tool.pdb"))
             {
-                _playerDatabaseLogger = new Logger(
-                    new LogConfiguration
-                    {
-                        Tag = "PLAYERDB",
-                        LogLevel = Options.Instance.PlayerDatabase.LogLevel,
-                        Outputs = ImmutableList.Create<ILogOutput>(
-                            new FileOutput(Log.SuggestFilename(null, "playerdb"), LogLevel.Debug)
-                        )
-                    }
-                );
+                File.Delete("Intersect Migration Tool.pdb");
+            }
+
+            if (File.Exists("Intersect Migration Tool.mdb"))
+            {
+                File.Delete("Intersect Migration Tool.mdb");
             }
         }
-
-        //Check Directories
-        public static void CheckDirectories()
+        catch
         {
-            if (Directory.Exists(ServerContext.ResourceDirectory))
-            {
-                return;
-            }
+            // ignored
+        }
 
-            if (ServerContext.IsDefaultResourceDirectory)
+        var gameContextPendingMigrations = gameContext.PendingSchemaMigrations;
+        var playerContextPendingMigrations = playerContext.PendingSchemaMigrations;
+        var loggingContextPendingMigrations = loggingContext.PendingSchemaMigrations;
+
+        var showMigrationWarning = (
+            gameContextPendingMigrations.Any() && !gameContextPendingMigrations.Contains("20180905042857_Initial")
+        ) || (
+            playerContextPendingMigrations.Any() &&
+            !playerContextPendingMigrations.Contains("20180927161502_InitialPlayerDb")
+        ) || (
+            loggingContextPendingMigrations.Any() &&
+            !loggingContextPendingMigrations.Contains("20191118024649_RequestLogs")
+        );
+
+        if (showMigrationWarning)
+        {
+            if (serverContext.StartupOptions.MigrateAutomatically)
             {
-                Directory.CreateDirectory(ServerContext.ResourceDirectory);
+                Console.WriteLine(Strings.Database.MigratingAutomatically);
+                Log.Default.Write("Skipping user prompt for database migration...");
             }
             else
             {
-                throw new DirectoryNotFoundException(
-                    Path.Combine(Environment.CurrentDirectory, ServerContext.ResourceDirectory)
+                Console.WriteLine();
+                Console.WriteLine(Strings.Database.upgraderequired);
+                Console.WriteLine(
+                    Strings.Database.upgradebackup.ToString(Strings.Database.upgradeready, Strings.Database.upgradeexit)
                 );
-            }
-        }
-
-        //As of now Database writes only occur on player saving & when editors make game changes
-        //Database writes are actually pretty rare. And even player saves are offloaded as tasks so
-        //if delayed it won't matter much.
-        //TODO: Options for saving frequency and number of backups to keep.
-        public static void BackupDatabase()
-        {
-        }
-
-        public static DbConnectionStringBuilder CreateConnectionStringBuilder(
-            DatabaseOptions databaseOptions,
-            string filename
-        )
-        {
-            switch (databaseOptions.Type)
-            {
-                case DatabaseType.SQLite:
-                    return new SqliteConnectionStringBuilder($"Data Source={filename}");
-
-                case DatabaseType.MySQL:
-                    return new MySqlConnectionStringBuilder
-                    {
-                        Server = databaseOptions.Server,
-                        Port = databaseOptions.Port,
-                        Database = databaseOptions.Database,
-                        UserID = databaseOptions.Username,
-                        Password = databaseOptions.Password
-                    };
-
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(databaseOptions.Type));
-            }
-        }
-
-        private static readonly MethodInfo _methodInfoProcessMigrations =
-            typeof(DbInterface)
-                .GetMethod(nameof(ProcessMigrations), BindingFlags.NonPublic | BindingFlags.Static);
-
-        private static void ProcessMigrations<TContext>(TContext context)
-            where TContext : IntersectDbContext<TContext>
-        {
-            if (!context.HasPendingMigrations)
-            {
-                Log.Verbose("No pending migrations, skipping...");
-                return;
-            }
-
-            Log.Verbose($"Pending schema migrations for {typeof(TContext).Name}:\n\t{string.Join("\n\t", context.PendingSchemaMigrations)}");
-            Log.Verbose($"Pending data migrations for {typeof(TContext).Name}:\n\t{string.Join("\n\t", context.PendingDataMigrationNames)}");
-
-            var migrationScheduler = new MigrationScheduler<TContext>(context);
-            Log.Verbose("Scheduling pending migrations...");
-            migrationScheduler.SchedulePendingMigrations();
-
-            Log.Verbose("Applying scheduled migrations...");
-            migrationScheduler.ApplyScheduledMigrations();
-
-            var remainingPendingSchemaMigrations = context.PendingSchemaMigrations.ToList();
-            var processedSchemaMigrations =
-                context.PendingSchemaMigrations.Where(migration => !remainingPendingSchemaMigrations.Contains(migration));
-
-            context.OnSchemaMigrationsProcessed(processedSchemaMigrations.ToArray());
-        }
-
-        private static bool EnsureUpdated(IServerContext serverContext)
-        {
-            Log.Verbose("Creating game context...");
-            using var gameContext = GameContext.Create(new DatabaseContextOptions
-            {
-                ConnectionStringBuilder = Options.Instance.GameDatabase.Type.CreateConnectionStringBuilder(
-                    Options.Instance.GameDatabase,
-                    GameDbFilename
-                ),
-                DatabaseType = Options.Instance.GameDatabase.Type,
-                EnableDetailedErrors = true,
-                EnableSensitiveDataLogging = true,
-                LoggerFactory = new IntersectLoggerFactory(nameof(GameContext)),
-            });
-
-            Log.Verbose("Creating player context...");
-            using var playerContext = PlayerContext.Create(new DatabaseContextOptions
-            {
-                ConnectionStringBuilder = Options.Instance.PlayerDatabase.Type.CreateConnectionStringBuilder(
-                    Options.Instance.PlayerDatabase,
-                    PlayersDbFilename
-                ),
-                DatabaseType = Options.Instance.PlayerDatabase.Type,
-                EnableDetailedErrors = true,
-                EnableSensitiveDataLogging = true,
-                LoggerFactory = new IntersectLoggerFactory(nameof(PlayerContext)),
-            });
-
-            Log.Verbose("Creating logging context...");
-            using var loggingContext = LoggingContext.Create(new DatabaseContextOptions
-            {
-                ConnectionStringBuilder = Options.Instance.LoggingDatabase.Type.CreateConnectionStringBuilder(
-                    Options.Instance.LoggingDatabase,
-                    LoggingDbFilename
-                ),
-                DatabaseType = Options.Instance.LoggingDatabase.Type,
-                EnableDetailedErrors = true,
-                EnableSensitiveDataLogging = true,
-                LoggerFactory = new IntersectLoggerFactory(nameof(LoggingContext)),
-            });
-
-            // We don't want anyone running the old migration tool accidentally
-            try
-            {
-                if (File.Exists("Intersect Migration Tool.exe"))
-                {
-                    File.Delete("Intersect Migration Tool.exe");
-                }
-
-                if (File.Exists("Intersect Migration Tool.pdb"))
-                {
-                    File.Delete("Intersect Migration Tool.pdb");
-                }
-
-                if (File.Exists("Intersect Migration Tool.mdb"))
-                {
-                    File.Delete("Intersect Migration Tool.mdb");
-                }
-            }
-            catch
-            {
-                // ignored
-            }
-
-            var gameContextPendingMigrations = gameContext.PendingSchemaMigrations;
-            var playerContextPendingMigrations = playerContext.PendingSchemaMigrations;
-            var loggingContextPendingMigrations = loggingContext.PendingSchemaMigrations;
-
-            var showMigrationWarning = (
-                gameContextPendingMigrations.Any() && !gameContextPendingMigrations.Contains("20180905042857_Initial")
-            ) || (
-                playerContextPendingMigrations.Any() &&
-                !playerContextPendingMigrations.Contains("20180927161502_InitialPlayerDb")
-            ) || (
-                loggingContextPendingMigrations.Any() &&
-                !loggingContextPendingMigrations.Contains("20191118024649_RequestLogs")
-            );
-
-            if (showMigrationWarning)
-            {
-                if (serverContext.StartupOptions.MigrateAutomatically)
-                {
-                    Console.WriteLine(Strings.Database.MigratingAutomatically);
-                    Log.Default.Write("Skipping user prompt for database migration...");
-                }
-                else
-                {
-                    Console.WriteLine();
-                    Console.WriteLine(Strings.Database.upgraderequired);
-                    Console.WriteLine(
-                        Strings.Database.upgradebackup.ToString(Strings.Database.upgradeready, Strings.Database.upgradeexit)
-                    );
-
-                    Console.WriteLine();
-                    while (true)
-                    {
-                        Console.Write("> ");
-                        var input = Console.ReadLine().Trim();
-                        if (input == Strings.Database.upgradeready.ToString().Trim())
-                        {
-                            break;
-                        }
-
-                        if (
-                            !string.Equals(
-                                input,
-                                Strings.Database.upgradeexit.ToString().Trim(),
-                                StringComparison.CurrentCultureIgnoreCase
-                            )
-                        )
-                        {
-                            continue;
-                        }
-
-                        Environment.Exit(1);
-
-                        return false;
-                    }
-                }
 
                 Console.WriteLine();
-                Console.WriteLine(
-                    "Please wait! Migrations can take several minutes, and even longer if you are using MySQL databases!"
-                );
-            }
-            else
-            {
-                Console.WriteLine("No migrations pending, skipping...");
-            }
-
-            var contexts = new List<DbContext> { gameContext, playerContext, loggingContext };
-            foreach (var context in contexts)
-            {
-                var contextType = context.GetType().FindGenericTypeParameters(typeof(IntersectDbContext<>)).First();
-                _methodInfoProcessMigrations.MakeGenericMethod(contextType).Invoke(null, new object[] { context });
-            }
-
-            return true;
-        }
-
-        // Database setup, version checking
-        internal static bool InitDatabase(IServerContext serverContext)
-        {
-            Console.WriteLine("Initializing database...");
-
-            if (!EnsureUpdated(serverContext))
-            {
-                Console.Error.WriteLine("Database not updated.");
-                return false;
-            }
-
-            Console.WriteLine("Loading game data...");
-
-            LoadAllGameObjects();
-            LoadTime();
-            OnClassesLoaded();
-            OnMapsLoaded();
-            CacheServerVariableEventTextLookups();
-            CachePlayerVariableEventTextLookups();
-            CacheGuildVariableEventTextLookups();
-            CacheUserVariableEventTextLookups();
-
-            return true;
-        }
-
-        public static Client GetPlayerClient(string username)
-        {
-            //Try to fetch a player entity by username, online or offline.
-            //Check Online First
-            lock (Globals.ClientLock)
-            {
-                foreach (var client in Globals.Clients)
+                while (true)
                 {
-                    if (client.Entity != null && client.Name.ToLower() == username.ToLower())
+                    Console.Write("> ");
+                    var input = Console.ReadLine().Trim();
+                    if (input == Strings.Database.upgradeready.ToString().Trim())
                     {
-                        return client;
+                        break;
                     }
+
+                    if (
+                        !string.Equals(
+                            input,
+                            Strings.Database.upgradeexit.ToString().Trim(),
+                            StringComparison.CurrentCultureIgnoreCase
+                        )
+                    )
+                    {
+                        continue;
+                    }
+
+                    Environment.Exit(1);
+
+                    return false;
                 }
             }
 
-            return null;
+            Console.WriteLine();
+            Console.WriteLine(
+                "Please wait! Migrations can take several minutes, and even longer if you are using MySQL databases!"
+            );
+        }
+        else
+        {
+            Console.WriteLine("No migrations pending, skipping...");
         }
 
-        public static void SetPlayerPower(string username, UserRights power)
+        var contexts = new List<DbContext> { gameContext, playerContext, loggingContext };
+        foreach (var context in contexts)
         {
-            var user = User.Find(username);
-            if (user != null)
-            {
-                user.Power = power;
-                user.Save();
-            }
-            else
-            {
-                Console.WriteLine(Strings.Account.doesnotexist);
-            }
+            var contextType = context.GetType().FindGenericTypeParameters(typeof(IntersectDbContext<>)).First();
+            _methodInfoProcessMigrations.MakeGenericMethod(contextType).Invoke(null, new object[] { context });
         }
 
-        public static bool SetPlayerPower(User user, UserRights power)
+        return true;
+    }
+
+    // Database setup, version checking
+    internal static bool InitDatabase(IServerContext serverContext)
+    {
+        Console.WriteLine("Initializing database...");
+
+        if (!EnsureUpdated(serverContext))
         {
-            if (user != null)
-            {
-                user.Power = power;
-                user.Save();
-
-                return true;
-            }
-            else
-            {
-                Console.WriteLine(Strings.Account.doesnotexist);
-
-                return false;
-            }
+            Console.Error.WriteLine("Database not updated.");
+            return false;
         }
 
-        //User Info
-        public static bool AccountExists(string accountname)
-        {
-            return User.Find(accountname) != null;
-        }
+        Console.WriteLine("Loading game data...");
 
-        public static string UsernameFromEmail(string email)
-        {
-            var user = User.FindByEmail(email);
-            if (user != null)
-            {
-                return user.Name;
-            }
-            return null;
-        }
+        LoadAllGameObjects();
+        LoadTime();
+        OnClassesLoaded();
+        OnMapsLoaded();
+        CacheServerVariableEventTextLookups();
+        CachePlayerVariableEventTextLookups();
+        CacheGuildVariableEventTextLookups();
+        CacheUserVariableEventTextLookups();
 
-        public static Player GetUserCharacter(User user, Guid playerId, bool explicitLoad = false)
-        {
-            if (user == default)
-            {
-                return default;
-            }
+        return true;
+    }
 
-            foreach (var player in user.Players)
+    public static Client GetPlayerClient(string username)
+    {
+        //Try to fetch a player entity by username, online or offline.
+        //Check Online First
+        lock (Globals.ClientLock)
+        {
+            foreach (var client in Globals.Clients)
             {
-                if (player.Id != playerId)
+                if (client.Entity != null && client.Name.ToLower() == username.ToLower())
                 {
-                    continue;
+                    return client;
                 }
+            }
+        }
 
-                if (!explicitLoad)
-                {
-                    return player;
-                }
+        return null;
+    }
 
-                try
-                {
-                    using var playerContext = CreatePlayerContext(readOnly: true, explicitLoad: false);
-                    player.LoadRelationships(playerContext);
-                    _ = Player.Validate(player);
-                }
-                catch (Exception exception)
-                {
-                    Debugger.Break();
-                    Log.Error(exception);
-                    throw new Exception($"Error during explicit load of player {BitConverter.ToString(playerId.ToByteArray()).Replace("-", string.Empty)}", exception);
-                }
+    public static void SetPlayerPower(string username, UserRights power)
+    {
+        var user = User.Find(username);
+        if (user != null)
+        {
+            user.Power = power;
+            user.Save();
+        }
+        else
+        {
+            Console.WriteLine(Strings.Account.doesnotexist);
+        }
+    }
 
+    public static bool SetPlayerPower(User user, UserRights power)
+    {
+        if (user != null)
+        {
+            user.Power = power;
+            user.Save();
+
+            return true;
+        }
+        else
+        {
+            Console.WriteLine(Strings.Account.doesnotexist);
+
+            return false;
+        }
+    }
+
+    //User Info
+    public static bool AccountExists(string accountname)
+    {
+        return User.Find(accountname) != null;
+    }
+
+    public static string UsernameFromEmail(string email)
+    {
+        var user = User.FindByEmail(email);
+        if (user != null)
+        {
+            return user.Name;
+        }
+        return null;
+    }
+
+    public static Player GetUserCharacter(User user, Guid playerId, bool explicitLoad = false)
+    {
+        if (user == default)
+        {
+            return default;
+        }
+
+        foreach (var player in user.Players)
+        {
+            if (player.Id != playerId)
+            {
+                continue;
+            }
+
+            if (!explicitLoad)
+            {
                 return player;
             }
 
-            return null;
-        }
-
-        public static bool TryRegister(
-            string username,
-            string email,
-            string password,
-            [NotNullWhen(true)] out User? user
-        )
-        {
             try
             {
-                var rawSaltData = RandomNumberGenerator.GetBytes(20);
-                var rawSalt = Convert.ToBase64String(rawSaltData);
-                var encodedSaltData = Encoding.UTF8.GetBytes(rawSalt);
-                var saltData = SHA256.HashData(encodedSaltData);
-                var salt = BitConverter.ToString(saltData).Replace("-", string.Empty);
-
-                user = new User
-                {
-                    Name = username,
-                    Email = email,
-                    Salt = salt,
-                    Password = User.SaltPasswordHash(password, salt),
-                    Power = UserRights.None,
-                };
-
-                if (User.Count() == 0)
-                {
-                    user.Power = UserRights.Admin;
-                }
-
-                user.Save(create: true);
-                return true;
+                using var playerContext = CreatePlayerContext(readOnly: true, explicitLoad: false);
+                player.LoadRelationships(playerContext);
+                _ = Player.Validate(player);
             }
             catch (Exception exception)
             {
+                Debugger.Break();
                 Log.Error(exception);
-                user = default;
-                return false;
+                throw new Exception($"Error during explicit load of player {BitConverter.ToString(playerId.ToByteArray()).Replace("-", string.Empty)}", exception);
             }
+
+            return player;
         }
 
-        public static void CreateAccount(
-            Client? client,
-            string username,
-            string password,
-            string email,
-            bool grantFirstUserAdmin = true
-        )
-        {
-            var salt = User.GenerateSalt();
-            var saltedPasswordHash = User.SaltPasswordHash(password, salt);
+        return null;
+    }
 
-            var user = new User
+    public static bool TryRegister(
+        string username,
+        string email,
+        string password,
+        [NotNullWhen(true)] out User? user
+    )
+    {
+        try
+        {
+            var rawSaltData = RandomNumberGenerator.GetBytes(20);
+            var rawSalt = Convert.ToBase64String(rawSaltData);
+            var encodedSaltData = Encoding.UTF8.GetBytes(rawSalt);
+            var saltData = SHA256.HashData(encodedSaltData);
+            var salt = BitConverter.ToString(saltData).Replace("-", string.Empty);
+
+            user = new User
             {
                 Name = username,
                 Email = email,
                 Salt = salt,
-                Password = saltedPasswordHash,
+                Password = User.SaltPasswordHash(password, salt),
                 Power = UserRights.None,
             };
 
-            if (grantFirstUserAdmin && User.Count() == 0)
+            if (User.Count() == 0)
             {
                 user.Power = UserRights.Admin;
             }
 
             user.Save(create: true);
+            return true;
+        }
+        catch (Exception exception)
+        {
+            Log.Error(exception);
+            user = default;
+            return false;
+        }
+    }
 
-            client?.SetUser(user);
+    public static void CreateAccount(
+        Client? client,
+        string username,
+        string password,
+        string email,
+        bool grantFirstUserAdmin = true
+    )
+    {
+        var salt = User.GenerateSalt();
+        var saltedPasswordHash = User.SaltPasswordHash(password, salt);
+
+        var user = new User
+        {
+            Name = username,
+            Email = email,
+            Salt = salt,
+            Password = saltedPasswordHash,
+            Power = UserRights.None,
+        };
+
+        if (grantFirstUserAdmin && User.Count() == 0)
+        {
+            user.Power = UserRights.Admin;
         }
 
-        public static void ResetPass(User user, string password)
+        user.Save(create: true);
+
+        client?.SetUser(user);
+    }
+
+    public static void ResetPass(User user, string password)
+    {
+        var sha = new SHA256Managed();
+
+        //Generate a Salt
+        var rng = new RNGCryptoServiceProvider();
+        var buff = new byte[20];
+        rng.GetBytes(buff);
+        var salt = BitConverter.ToString(sha.ComputeHash(Encoding.UTF8.GetBytes(Convert.ToBase64String(buff))))
+            .Replace("-", "");
+
+        user.Salt = salt;
+        user.Password = User.SaltPasswordHash(password, salt);
+        user.Save();
+    }
+
+    public static bool BagEmpty(Bag bag)
+    {
+        for (var i = 0; i < bag.Slots.Count; i++)
         {
-            var sha = new SHA256Managed();
-
-            //Generate a Salt
-            var rng = new RNGCryptoServiceProvider();
-            var buff = new byte[20];
-            rng.GetBytes(buff);
-            var salt = BitConverter.ToString(sha.ComputeHash(Encoding.UTF8.GetBytes(Convert.ToBase64String(buff))))
-                .Replace("-", "");
-
-            user.Salt = salt;
-            user.Password = User.SaltPasswordHash(password, salt);
-            user.Save();
-        }
-
-        public static bool BagEmpty(Bag bag)
-        {
-            for (var i = 0; i < bag.Slots.Count; i++)
+            if (bag.Slots[i] != null)
             {
-                if (bag.Slots[i] != null)
+                var item = ItemBase.Get(bag.Slots[i].ItemId);
+                if (item != null)
                 {
-                    var item = ItemBase.Get(bag.Slots[i].ItemId);
-                    if (item != null)
-                    {
-                        return false;
-                    }
+                    return false;
                 }
             }
+        }
 
+        return true;
+    }
+
+    //Game Object Saving/Loading
+    private static void LoadAllGameObjects()
+    {
+        foreach (var value in Enum.GetValues(typeof(GameObjectType)))
+        {
+            Debug.Assert(value != null, "value != null");
+            var type = (GameObjectType)value;
+            if (type == GameObjectType.Time)
+            {
+                continue;
+            }
+
+            LoadGameObjects(type);
+        }
+    }
+
+    private static void ClearGameObjects(GameObjectType type)
+    {
+        switch (type)
+        {
+            case GameObjectType.Animation:
+                AnimationBase.Lookup.Clear();
+
+                break;
+            case GameObjectType.Class:
+                ClassBase.Lookup.Clear();
+
+                break;
+            case GameObjectType.Item:
+                ItemBase.Lookup.Clear();
+
+                break;
+            case GameObjectType.Npc:
+                NpcBase.Lookup.Clear();
+
+                break;
+            case GameObjectType.Projectile:
+                ProjectileBase.Lookup.Clear();
+
+                break;
+            case GameObjectType.Quest:
+                QuestBase.Lookup.Clear();
+
+                break;
+            case GameObjectType.Resource:
+                ResourceBase.Lookup.Clear();
+
+                break;
+            case GameObjectType.Shop:
+                ShopBase.Lookup.Clear();
+
+                break;
+            case GameObjectType.Spell:
+                SpellBase.Lookup.Clear();
+
+                break;
+            case GameObjectType.CraftTables:
+                CraftingTableBase.Lookup.Clear();
+
+                break;
+            case GameObjectType.Crafts:
+                CraftBase.Lookup.Clear();
+
+                break;
+            case GameObjectType.Map:
+                MapBase.Lookup.Clear();
+
+                break;
+            case GameObjectType.Event:
+                EventBase.Lookup.Clear();
+
+                break;
+            case GameObjectType.PlayerVariable:
+                PlayerVariableBase.Lookup.Clear();
+
+                break;
+            case GameObjectType.ServerVariable:
+                ServerVariableBase.Lookup.Clear();
+
+                break;
+            case GameObjectType.Tileset:
+                TilesetBase.Lookup.Clear();
+
+                break;
+            case GameObjectType.Time:
+                break;
+            case GameObjectType.GuildVariable:
+                GuildVariableBase.Lookup.Clear();
+
+                break;
+            case GameObjectType.UserVariable:
+                UserVariableBase.Lookup.Clear();
+
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(type), type, null);
+        }
+    }
+
+    private static void LoadGameObjects(GameObjectType gameObjectType)
+    {
+        ClearGameObjects(gameObjectType);
+        try
+        {
+            using (var context = CreateGameContext(readOnly: true))
+            {
+                switch (gameObjectType)
+                {
+                    case GameObjectType.Animation:
+                        foreach (var anim in context.Animations) // TODO: fix "The data is NULL at ordinal 2"
+                        {
+                            AnimationBase.Lookup.Set(anim.Id, anim);
+                        }
+
+                        break;
+                    case GameObjectType.Class:
+                        foreach (var cls in context.Classes)
+                        {
+                            ClassBase.Lookup.Set(cls.Id, cls);
+                        }
+
+                        break;
+                    case GameObjectType.Item:
+
+                        var loadedItems = context.Items
+                            .Include(i => i.EquipmentProperties);
+
+                        foreach (var itm in loadedItems)
+                        {
+                            ItemBase.Lookup.Set(itm.Id, itm);
+                        }
+
+                        break;
+                    case GameObjectType.Npc:
+                        foreach (var npc in context.Npcs)
+                        {
+                            NpcBase.Lookup.Set(npc.Id, npc);
+                        }
+
+                        break;
+                    case GameObjectType.Projectile:
+                        foreach (var proj in context.Projectiles)
+                        {
+                            ProjectileBase.Lookup.Set(proj.Id, proj);
+                        }
+
+                        break;
+                    case GameObjectType.Quest:
+                        foreach (var qst in context.Quests)
+                        {
+                            QuestBase.Lookup.Set(qst.Id, qst);
+                        }
+
+                        break;
+                    case GameObjectType.Resource:
+                        foreach (var res in context.Resources)
+                        {
+                            ResourceBase.Lookup.Set(res.Id, res);
+                        }
+
+                        break;
+                    case GameObjectType.Shop:
+                        foreach (var shp in context.Shops)
+                        {
+                            ShopBase.Lookup.Set(shp.Id, shp);
+                        }
+
+                        break;
+                    case GameObjectType.Spell:
+                        foreach (var spl in context.Spells)
+                        {
+                            SpellBase.Lookup.Set(spl.Id, spl);
+                        }
+
+                        break;
+                    case GameObjectType.CraftTables:
+                        foreach (var craft in context.CraftingTables)
+                        {
+                            CraftingTableBase.Lookup.Set(craft.Id, craft);
+                        }
+
+                        break;
+                    case GameObjectType.Crafts:
+                        foreach (var craft in context.Crafts)
+                        {
+                            CraftBase.Lookup.Set(craft.Id, craft);
+                        }
+
+                        break;
+                    case GameObjectType.Map:
+                        foreach (var map in context.Maps)
+                        {
+                            MapController.Lookup.Set(map.Id, map);
+                            if (Options.Instance.MapOpts.Layers.DestroyOrphanedLayers)
+                            {
+                                map.DestroyOrphanedLayers();
+                            }
+                        }
+
+                        break;
+                    case GameObjectType.Event:
+                        foreach (var evt in context.Events)
+                        {
+                            EventBase.Lookup.Set(evt.Id, evt);
+                        }
+
+                        break;
+                    case GameObjectType.PlayerVariable:
+                        foreach (var psw in context.PlayerVariables)
+                        {
+                            PlayerVariableBase.Lookup.Set(psw.Id, psw);
+                        }
+
+                        break;
+                    case GameObjectType.ServerVariable:
+                        foreach (var psw in context.ServerVariables)
+                        {
+                            ServerVariableBase.Lookup.Set(psw.Id, psw);
+                        }
+
+                        break;
+                    case GameObjectType.Tileset:
+                        foreach (var psw in context.Tilesets)
+                        {
+                            TilesetBase.Lookup.Set(psw.Id, psw);
+                        }
+
+                        break;
+                    case GameObjectType.Time:
+                        break;
+                    case GameObjectType.GuildVariable:
+                        foreach (var psw in context.GuildVariables)
+                        {
+                            GuildVariableBase.Lookup.Set(psw.Id, psw);
+                        }
+
+                        break;
+                    case GameObjectType.UserVariable:
+                        foreach (var psw in context.UserVariables)
+                        {
+                            UserVariableBase.Lookup.Set(psw.Id, psw);
+                        }
+
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(gameObjectType), gameObjectType, null);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex);
+            throw;
+        }
+    }
+
+    public static IDatabaseObject AddGameObject(GameObjectType gameObjectType)
+    {
+        return AddGameObject(gameObjectType, Guid.Empty);
+    }
+
+    public static IDatabaseObject AddGameObject(GameObjectType gameObjectType, Guid predefinedid)
+    {
+        if (predefinedid == Guid.Empty)
+        {
+            predefinedid = Guid.NewGuid();
+        }
+
+        IDatabaseObject dbObj = null;
+        switch (gameObjectType)
+        {
+            case GameObjectType.Animation:
+                dbObj = new AnimationBase(predefinedid);
+
+                break;
+            case GameObjectType.Class:
+                dbObj = new ClassBase(predefinedid);
+
+                break;
+            case GameObjectType.Item:
+                dbObj = new ItemBase(predefinedid);
+
+                break;
+            case GameObjectType.Npc:
+                dbObj = new NpcBase(predefinedid);
+
+                break;
+            case GameObjectType.Projectile:
+                dbObj = new ProjectileBase(predefinedid);
+
+                break;
+            case GameObjectType.Resource:
+                dbObj = new ResourceBase(predefinedid);
+
+                break;
+            case GameObjectType.Shop:
+                dbObj = new ShopBase(predefinedid);
+
+                break;
+            case GameObjectType.Spell:
+                dbObj = new SpellBase(predefinedid);
+
+                break;
+            case GameObjectType.CraftTables:
+                dbObj = new CraftingTableBase(predefinedid);
+
+                break;
+            case GameObjectType.Crafts:
+                dbObj = new CraftBase(predefinedid);
+
+                break;
+            case GameObjectType.Map:
+                dbObj = new MapController(predefinedid);
+
+                break;
+            case GameObjectType.Event:
+                dbObj = new EventBase(predefinedid);
+
+                break;
+            case GameObjectType.PlayerVariable:
+                dbObj = new PlayerVariableBase(predefinedid);
+
+                break;
+            case GameObjectType.ServerVariable:
+                dbObj = new ServerVariableBase(predefinedid);
+
+                break;
+            case GameObjectType.Tileset:
+                dbObj = new TilesetBase(predefinedid);
+
+                break;
+            case GameObjectType.Time:
+                break;
+
+            case GameObjectType.Quest:
+                dbObj = new QuestBase(predefinedid);
+                ((QuestBase)dbObj).StartEvent = (EventBase)AddGameObject(GameObjectType.Event);
+                ((QuestBase)dbObj).EndEvent = (EventBase)AddGameObject(GameObjectType.Event);
+                ((QuestBase)dbObj).StartEvent.CommonEvent = false;
+                ((QuestBase)dbObj).EndEvent.CommonEvent = false;
+
+                break;
+
+            case GameObjectType.GuildVariable:
+                dbObj = new GuildVariableBase(predefinedid);
+
+                break;
+
+            case GameObjectType.UserVariable:
+                dbObj = new UserVariableBase(predefinedid);
+
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(gameObjectType), gameObjectType, null);
+        }
+
+        return dbObj == null ? null : AddGameObject(gameObjectType, dbObj);
+    }
+
+    public static IDatabaseObject AddGameObject(GameObjectType gameObjectType, IDatabaseObject dbObj)
+    {
+        try
+        {
+            using (var context = CreateGameContext(readOnly: false))
+            {
+
+                switch (gameObjectType)
+                {
+                    case GameObjectType.Animation:
+                        context.Animations.Add((AnimationBase)dbObj);
+                        AnimationBase.Lookup.Set(dbObj.Id, dbObj);
+
+                        break;
+
+                    case GameObjectType.Class:
+                        context.Classes.Add((ClassBase)dbObj);
+                        ClassBase.Lookup.Set(dbObj.Id, dbObj);
+
+                        break;
+
+                    case GameObjectType.Item:
+                        context.Items.Add((ItemBase)dbObj);
+                        ItemBase.Lookup.Set(dbObj.Id, dbObj);
+
+                        break;
+                    case GameObjectType.Npc:
+                        context.Npcs.Add((NpcBase)dbObj);
+                        NpcBase.Lookup.Set(dbObj.Id, dbObj);
+
+                        break;
+
+                    case GameObjectType.Projectile:
+                        context.Projectiles.Add((ProjectileBase)dbObj);
+                        ProjectileBase.Lookup.Set(dbObj.Id, dbObj);
+
+                        break;
+
+                    case GameObjectType.Quest:
+                        context.Quests.Add((QuestBase)dbObj);
+                        QuestBase.Lookup.Set(dbObj.Id, dbObj);
+
+                        break;
+
+                    case GameObjectType.Resource:
+                        context.Resources.Add((ResourceBase)dbObj);
+                        ResourceBase.Lookup.Set(dbObj.Id, dbObj);
+
+                        break;
+
+                    case GameObjectType.Shop:
+                        context.Shops.Add((ShopBase)dbObj);
+                        ShopBase.Lookup.Set(dbObj.Id, dbObj);
+
+                        break;
+
+                    case GameObjectType.Spell:
+                        context.Spells.Add((SpellBase)dbObj);
+                        SpellBase.Lookup.Set(dbObj.Id, dbObj);
+
+                        break;
+
+                    case GameObjectType.CraftTables:
+                        context.CraftingTables.Add((CraftingTableBase)dbObj);
+                        CraftingTableBase.Lookup.Set(dbObj.Id, dbObj);
+
+                        break;
+
+                    case GameObjectType.Crafts:
+                        context.Crafts.Add((CraftBase)dbObj);
+                        CraftBase.Lookup.Set(dbObj.Id, dbObj);
+
+                        break;
+
+                    case GameObjectType.Map:
+                        context.Maps.Add((MapController)dbObj);
+                        MapController.Lookup.Set(dbObj.Id, dbObj);
+
+                        break;
+
+                    case GameObjectType.Event:
+                        context.Events.Add((EventBase)dbObj);
+                        EventBase.Lookup.Set(dbObj.Id, dbObj);
+
+                        break;
+
+                    case GameObjectType.PlayerVariable:
+                        context.PlayerVariables.Add((PlayerVariableBase)dbObj);
+                        PlayerVariableBase.Lookup.Set(dbObj.Id, dbObj);
+
+                        break;
+
+                    case GameObjectType.ServerVariable:
+                        context.ServerVariables.Add((ServerVariableBase)dbObj);
+                        ServerVariableBase.Lookup.Set(dbObj.Id, dbObj);
+
+                        break;
+
+                    case GameObjectType.Tileset:
+                        context.Tilesets.Add((TilesetBase)dbObj);
+                        TilesetBase.Lookup.Set(dbObj.Id, dbObj);
+
+                        break;
+
+                    case GameObjectType.Time:
+                        break;
+
+                    case GameObjectType.GuildVariable:
+                        context.GuildVariables.Add((GuildVariableBase)dbObj);
+                        GuildVariableBase.Lookup.Set(dbObj.Id, dbObj);
+
+                        break;
+
+                    case GameObjectType.UserVariable:
+                        context.UserVariables.Add((UserVariableBase)dbObj);
+                        UserVariableBase.Lookup.Set(dbObj.Id, dbObj);
+
+                        break;
+
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(gameObjectType), gameObjectType, null);
+                }
+
+                context.ChangeTracker.DetectChanges();
+                context.Entry(dbObj).State = EntityState.Added;
+                context.SaveChanges();
+            }
+
+            return dbObj;
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex);
+            throw;
+        }
+    }
+
+    public static void DeleteGameObject(IDatabaseObject gameObject)
+    {
+        try
+        {
+            using (var context = CreateGameContext(readOnly: false))
+            {
+                switch (gameObject.Type)
+                {
+                    case GameObjectType.Animation:
+                        context.Animations.Remove((AnimationBase)gameObject);
+
+                        break;
+                    case GameObjectType.Class:
+                        context.Classes.Remove((ClassBase)gameObject);
+
+                        break;
+                    case GameObjectType.Item:
+                        context.Items.Remove((ItemBase)gameObject);
+
+                        break;
+                    case GameObjectType.Npc:
+                        context.Npcs.Remove((NpcBase)gameObject);
+
+                        break;
+                    case GameObjectType.Projectile:
+                        context.Projectiles.Remove((ProjectileBase)gameObject);
+
+                        break;
+                    case GameObjectType.Quest:
+
+                        if (((QuestBase)gameObject).StartEvent != null)
+                        {
+                            context.Events.Remove(((QuestBase)gameObject).StartEvent);
+                            context.Entry(((QuestBase)gameObject).StartEvent).State = EntityState.Deleted;
+                            EventBase.Lookup.Delete(((QuestBase)gameObject).StartEvent);
+                        }
+
+                        if (((QuestBase)gameObject).EndEvent != null)
+                        {
+                            context.Events.Remove(((QuestBase)gameObject).EndEvent);
+                            context.Entry(((QuestBase)gameObject).EndEvent).State = EntityState.Deleted;
+                            EventBase.Lookup.Delete(((QuestBase)gameObject).EndEvent);
+                        }
+
+                        foreach (var tsk in ((QuestBase)gameObject).Tasks)
+                        {
+                            if (tsk.CompletionEvent != null)
+                            {
+                                context.Events.Remove(tsk.CompletionEvent);
+                                context.Entry(tsk.CompletionEvent).State = EntityState.Deleted;
+                                EventBase.Lookup.Delete(tsk.CompletionEvent);
+                            }
+                        }
+
+                        context.Quests.Remove((QuestBase)gameObject);
+
+                        break;
+                    case GameObjectType.Resource:
+                        context.Resources.Remove((ResourceBase)gameObject);
+
+                        break;
+                    case GameObjectType.Shop:
+                        context.Shops.Remove((ShopBase)gameObject);
+
+                        break;
+                    case GameObjectType.Spell:
+                        context.Spells.Remove((SpellBase)gameObject);
+
+                        break;
+                    case GameObjectType.CraftTables:
+                        context.CraftingTables.Remove((CraftingTableBase)gameObject);
+
+                        break;
+                    case GameObjectType.Crafts:
+                        context.Crafts.Remove((CraftBase)gameObject);
+
+                        break;
+                    case GameObjectType.Map:
+                        //Delete all map events first
+                        foreach (var evtId in ((MapController)gameObject).EventIds)
+                        {
+                            var evt = EventBase.Get(evtId);
+                            if (evt != null)
+                            {
+                                DeleteGameObject(evt);
+                            }
+                        }
+                        context.Maps.Remove((MapController)gameObject);
+                        MapController.Lookup.Delete(gameObject);
+
+                        break;
+                    case GameObjectType.Event:
+                        context.Events.Remove((EventBase)gameObject);
+
+                        break;
+                    case GameObjectType.PlayerVariable:
+                        context.PlayerVariables.Remove((PlayerVariableBase)gameObject);
+
+                        break;
+                    case GameObjectType.ServerVariable:
+                        context.ServerVariables.Remove((ServerVariableBase)gameObject);
+
+                        break;
+                    case GameObjectType.Tileset:
+                        context.Tilesets.Remove((TilesetBase)gameObject);
+
+                        break;
+                    case GameObjectType.Time:
+                        break;
+                    case GameObjectType.GuildVariable:
+                        context.GuildVariables.Remove((GuildVariableBase)gameObject);
+
+                        break;
+                    case GameObjectType.UserVariable:
+                        context.UserVariables.Remove((UserVariableBase)gameObject);
+
+                        break;
+                }
+
+                if (gameObject.Type.GetLookup().Values.Contains(gameObject))
+                {
+                    if (!gameObject.Type.GetLookup().Delete(gameObject))
+                    {
+                        throw new Exception();
+                    }
+                }
+
+                context.ChangeTracker.DetectChanges();
+                context.Entry(gameObject).State = EntityState.Deleted;
+                context.SaveChanges();
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex);
+            throw;
+        }
+    }
+
+    public static void SaveGameObject(IDatabaseObject gameObject)
+    {
+        try
+        {
+            using (var context = CreateGameContext(readOnly: false))
+            {
+
+                switch (gameObject.Type)
+                {
+                    case GameObjectType.Animation:
+                        context.Animations.Update((AnimationBase)gameObject);
+
+                        break;
+                    case GameObjectType.Class:
+                        context.Classes.Update((ClassBase)gameObject);
+
+                        break;
+                    case GameObjectType.Item:
+                    {
+                        if (gameObject is not ItemBase itemDescriptor)
+                        {
+                            throw new InvalidOperationException();
+                        }
+
+                        itemDescriptor.ValidateStatRanges();
+
+                        if (itemDescriptor.EquipmentProperties?.DescriptorId == Guid.Empty)
+                        {
+                            context.Items_EquipmentProperties.Add(itemDescriptor.EquipmentProperties);
+                        }
+                        else
+                        {
+                            EquipmentProperties? deletedEquipmentProperties =
+                                context.Items_EquipmentProperties.FirstOrDefault(
+                                    ep => ep.DescriptorId == itemDescriptor.Id
+                                );
+                            if (deletedEquipmentProperties != default)
+                            {
+                                context.Items_EquipmentProperties.Remove(deletedEquipmentProperties);
+                            }
+                        }
+
+                        context.Items.Update(itemDescriptor);
+
+                        break;
+                    }
+                    case GameObjectType.Npc:
+                        context.Npcs.Update((NpcBase)gameObject);
+
+                        break;
+                    case GameObjectType.Projectile:
+                        context.Projectiles.Update((ProjectileBase)gameObject);
+
+                        break;
+                    case GameObjectType.Quest:
+
+                        if (((QuestBase)gameObject).StartEvent != null)
+                        {
+                            context.Events.Update(((QuestBase)gameObject).StartEvent);
+                        }
+
+                        if (((QuestBase)gameObject).EndEvent != null)
+                        {
+                            context.Events.Update(((QuestBase)gameObject).EndEvent);
+                        }
+
+                        foreach (var tsk in ((QuestBase)gameObject).Tasks)
+                        {
+                            if (tsk.CompletionEvent != null)
+                            {
+                                context.Events.Update(tsk.CompletionEvent);
+                            }
+                        }
+
+                        context.Quests.Update((QuestBase)gameObject);
+
+                        break;
+                    case GameObjectType.Resource:
+                        context.Resources.Update((ResourceBase)gameObject);
+
+                        break;
+                    case GameObjectType.Shop:
+                        context.Shops.Update((ShopBase)gameObject);
+
+                        break;
+                    case GameObjectType.Spell:
+                        context.Spells.Update((SpellBase)gameObject);
+
+                        break;
+                    case GameObjectType.CraftTables:
+                        context.CraftingTables.Update((CraftingTableBase)gameObject);
+
+                        break;
+                    case GameObjectType.Crafts:
+                        context.Crafts.Update((CraftBase)gameObject);
+
+                        break;
+                    case GameObjectType.Map:
+                        context.Maps.Update((MapController)gameObject);
+
+                        break;
+                    case GameObjectType.Event:
+                        context.Events.Update((EventBase)gameObject);
+
+                        break;
+                    case GameObjectType.PlayerVariable:
+                        context.PlayerVariables.Update((PlayerVariableBase)gameObject);
+
+                        break;
+                    case GameObjectType.ServerVariable:
+                        context.ServerVariables.Update((ServerVariableBase)gameObject);
+
+                        break;
+                    case GameObjectType.Tileset:
+                        context.Tilesets.Update((TilesetBase)gameObject);
+
+                        break;
+                    case GameObjectType.Time:
+                        break;
+                    case GameObjectType.GuildVariable:
+                        context.GuildVariables.Update((GuildVariableBase)gameObject);
+
+                        break;
+                    case GameObjectType.UserVariable:
+                        context.UserVariables.Update((UserVariableBase)gameObject);
+
+                        break;
+                }
+
+                context.ChangeTracker.DetectChanges();
+                context.SaveChanges();
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex);
+            throw;
+        }
+    }
+
+    //Post Loading Functions
+    private static void OnMapsLoaded()
+    {
+        if (MapBase.Lookup.Count == 0)
+        {
+            Console.WriteLine(Strings.Database.nomaps);
+            AddGameObject(GameObjectType.Map);
+        }
+
+        GenerateMapGrids();
+        LoadMapFolders();
+        CheckAllMapConnections();
+
+        foreach (var map in MapController.Lookup)
+        {
+            ((MapController)map.Value).Initialize();
+        }
+    }
+
+    private static void OnClassesLoaded()
+    {
+        if (ClassBase.Lookup.Count == 0)
+        {
+            Console.WriteLine(Strings.Database.noclasses);
+            var cls = (ClassBase)AddGameObject(GameObjectType.Class);
+            cls.Name = Strings.Database.Default;
+            var defaultMale = new ClassSprite()
+            {
+                Sprite = "Base_Male.png",
+                Gender = Gender.Male
+            };
+
+            var defaultFemale = new ClassSprite()
+            {
+                Sprite = "Base_Female.png",
+                Gender = Gender.Female
+            };
+
+            cls.Sprites.Add(defaultMale);
+            cls.Sprites.Add(defaultFemale);
+            for (var i = 0; i < Enum.GetValues<Vital>().Length; i++)
+            {
+                cls.BaseVital[i] = 20;
+            }
+
+            for (var i = 0; i < Enum.GetValues<Stat>().Length; i++)
+            {
+                cls.BaseStat[i] = 20;
+            }
+            SaveGameObject(cls);
+        }
+    }
+
+    public static void CachePlayerVariableEventTextLookups()
+    {
+        var lookup = new Dictionary<string, PlayerVariableBase>();
+        var addedIds = new HashSet<string>();
+        foreach (PlayerVariableBase variable in PlayerVariableBase.Lookup.Values)
+        {
+            if (!string.IsNullOrWhiteSpace(variable.TextId) && !addedIds.Contains(variable.TextId))
+            {
+                lookup.Add(Strings.Events.playervar + "{" + variable.TextId + "}", variable);
+                lookup.Add(Strings.Events.playerswitch + "{" + variable.TextId + "}", variable);
+                addedIds.Add(variable.TextId);
+            }
+        }
+        PlayerVariableEventTextLookup = lookup;
+    }
+
+    public static void CacheServerVariableEventTextLookups()
+    {
+        var lookup = new Dictionary<string, ServerVariableBase>();
+        var addedIds = new HashSet<string>();
+        foreach (ServerVariableBase variable in ServerVariableBase.Lookup.Values)
+        {
+            if (!string.IsNullOrWhiteSpace(variable.TextId) && !addedIds.Contains(variable.TextId))
+            {
+                lookup.Add(Strings.Events.globalvar + "{" + variable.TextId + "}", variable);
+                lookup.Add(Strings.Events.globalswitch + "{" + variable.TextId + "}", variable);
+                addedIds.Add(variable.TextId);
+            }
+        }
+        ServerVariableEventTextLookup = lookup;
+    }
+
+    public static void CacheGuildVariableEventTextLookups()
+    {
+        var lookup = new Dictionary<string, GuildVariableBase>();
+        var addedIds = new HashSet<string>();
+        foreach (GuildVariableBase variable in GuildVariableBase.Lookup.Values)
+        {
+            if (!string.IsNullOrWhiteSpace(variable.TextId) && !addedIds.Contains(variable.TextId))
+            {
+                lookup.Add(Strings.Events.guildvar + "{" + variable.TextId + "}", variable);
+                addedIds.Add(variable.TextId);
+            }
+        }
+        GuildVariableEventTextLookup = lookup;
+    }
+
+    public static void CacheUserVariableEventTextLookups()
+    {
+        var lookup = new Dictionary<string, UserVariableBase>();
+        var addedIds = new HashSet<string>();
+        foreach (UserVariableBase variable in UserVariableBase.Lookup.Values)
+        {
+            if (!string.IsNullOrWhiteSpace(variable.TextId) && !addedIds.Contains(variable.TextId))
+            {
+                lookup.Add(Strings.Events.UserVariable + "{" + variable.TextId + "}", variable);
+                addedIds.Add(variable.TextId);
+            }
+        }
+        UserVariableEventTextLookup = lookup;
+    }
+
+    //Extra Map Helper Functions
+    public static void CheckAllMapConnections()
+    {
+        var changed = false;
+        foreach (MapController map in MapController.Lookup.Values)
+        {
+            CheckMapConnections(map, MapController.Lookup);
+        }
+    }
+
+    public static bool CheckMapConnections(MapController map, DatabaseObjectLookup maps)
+    {
+        var updated = false;
+        if (!maps.Keys.Contains(map.Up) && map.Up != Guid.Empty)
+        {
+            map.Up = Guid.Empty;
+            updated = true;
+        }
+
+        if (!maps.Keys.Contains(map.Down) && map.Down != Guid.Empty)
+        {
+            map.Down = Guid.Empty;
+            updated = true;
+        }
+
+        if (!maps.Keys.Contains(map.Left) && map.Left != Guid.Empty)
+        {
+            map.Left = Guid.Empty;
+            updated = true;
+        }
+
+        if (!maps.Keys.Contains(map.Right) && map.Right != Guid.Empty)
+        {
+            map.Right = Guid.Empty;
+            updated = true;
+        }
+
+        if (updated)
+        {
+            SaveGameObject(map);
+            PacketSender.SendMapToEditors(map.Id);
             return true;
         }
 
-        //Game Object Saving/Loading
-        private static void LoadAllGameObjects()
+        return false;
+    }
+
+    public static void GenerateMapGrids()
+    {
+        lock (mapGrids)
         {
-            foreach (var value in Enum.GetValues(typeof(GameObjectType)))
+            mapGrids.Clear();
+            foreach (var map in MapController.Lookup.Values)
             {
-                Debug.Assert(value != null, "value != null");
-                var type = (GameObjectType)value;
-                if (type == GameObjectType.Time)
+                if (mapGrids.Count < 1)
                 {
+                    mapGrids.Add(new MapGrid(map.Id, 0));
                     continue;
                 }
 
-                LoadGameObjects(type);
-            }
-        }
-
-        private static void ClearGameObjects(GameObjectType type)
-        {
-            switch (type)
-            {
-                case GameObjectType.Animation:
-                    AnimationBase.Lookup.Clear();
-
-                    break;
-                case GameObjectType.Class:
-                    ClassBase.Lookup.Clear();
-
-                    break;
-                case GameObjectType.Item:
-                    ItemBase.Lookup.Clear();
-
-                    break;
-                case GameObjectType.Npc:
-                    NpcBase.Lookup.Clear();
-
-                    break;
-                case GameObjectType.Projectile:
-                    ProjectileBase.Lookup.Clear();
-
-                    break;
-                case GameObjectType.Quest:
-                    QuestBase.Lookup.Clear();
-
-                    break;
-                case GameObjectType.Resource:
-                    ResourceBase.Lookup.Clear();
-
-                    break;
-                case GameObjectType.Shop:
-                    ShopBase.Lookup.Clear();
-
-                    break;
-                case GameObjectType.Spell:
-                    SpellBase.Lookup.Clear();
-
-                    break;
-                case GameObjectType.CraftTables:
-                    CraftingTableBase.Lookup.Clear();
-
-                    break;
-                case GameObjectType.Crafts:
-                    CraftBase.Lookup.Clear();
-
-                    break;
-                case GameObjectType.Map:
-                    MapBase.Lookup.Clear();
-
-                    break;
-                case GameObjectType.Event:
-                    EventBase.Lookup.Clear();
-
-                    break;
-                case GameObjectType.PlayerVariable:
-                    PlayerVariableBase.Lookup.Clear();
-
-                    break;
-                case GameObjectType.ServerVariable:
-                    ServerVariableBase.Lookup.Clear();
-
-                    break;
-                case GameObjectType.Tileset:
-                    TilesetBase.Lookup.Clear();
-
-                    break;
-                case GameObjectType.Time:
-                    break;
-                case GameObjectType.GuildVariable:
-                    GuildVariableBase.Lookup.Clear();
-
-                    break;
-                case GameObjectType.UserVariable:
-                    UserVariableBase.Lookup.Clear();
-
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(type), type, null);
-            }
-        }
-
-        private static void LoadGameObjects(GameObjectType gameObjectType)
-        {
-            ClearGameObjects(gameObjectType);
-            try
-            {
-                using (var context = CreateGameContext(readOnly: true))
+                for (var y = 0; y < mapGrids.Count; y++)
                 {
-                    switch (gameObjectType)
+                    if (!mapGrids[y].Contains(map.Id))
                     {
-                        case GameObjectType.Animation:
-                            foreach (var anim in context.Animations) // TODO: fix "The data is NULL at ordinal 2"
-                            {
-                                AnimationBase.Lookup.Set(anim.Id, anim);
-                            }
-
-                            break;
-                        case GameObjectType.Class:
-                            foreach (var cls in context.Classes)
-                            {
-                                ClassBase.Lookup.Set(cls.Id, cls);
-                            }
-
-                            break;
-                        case GameObjectType.Item:
-
-                            var loadedItems = context.Items
-                                .Include(i => i.EquipmentProperties);
-
-                            foreach (var itm in loadedItems)
-                            {
-                                ItemBase.Lookup.Set(itm.Id, itm);
-                            }
-
-                            break;
-                        case GameObjectType.Npc:
-                            foreach (var npc in context.Npcs)
-                            {
-                                NpcBase.Lookup.Set(npc.Id, npc);
-                            }
-
-                            break;
-                        case GameObjectType.Projectile:
-                            foreach (var proj in context.Projectiles)
-                            {
-                                ProjectileBase.Lookup.Set(proj.Id, proj);
-                            }
-
-                            break;
-                        case GameObjectType.Quest:
-                            foreach (var qst in context.Quests)
-                            {
-                                QuestBase.Lookup.Set(qst.Id, qst);
-                            }
-
-                            break;
-                        case GameObjectType.Resource:
-                            foreach (var res in context.Resources)
-                            {
-                                ResourceBase.Lookup.Set(res.Id, res);
-                            }
-
-                            break;
-                        case GameObjectType.Shop:
-                            foreach (var shp in context.Shops)
-                            {
-                                ShopBase.Lookup.Set(shp.Id, shp);
-                            }
-
-                            break;
-                        case GameObjectType.Spell:
-                            foreach (var spl in context.Spells)
-                            {
-                                SpellBase.Lookup.Set(spl.Id, spl);
-                            }
-
-                            break;
-                        case GameObjectType.CraftTables:
-                            foreach (var craft in context.CraftingTables)
-                            {
-                                CraftingTableBase.Lookup.Set(craft.Id, craft);
-                            }
-
-                            break;
-                        case GameObjectType.Crafts:
-                            foreach (var craft in context.Crafts)
-                            {
-                                CraftBase.Lookup.Set(craft.Id, craft);
-                            }
-
-                            break;
-                        case GameObjectType.Map:
-                            foreach (var map in context.Maps)
-                            {
-                                MapController.Lookup.Set(map.Id, map);
-                                if (Options.Instance.MapOpts.Layers.DestroyOrphanedLayers)
-                                {
-                                    map.DestroyOrphanedLayers();
-                                }
-                            }
-
-                            break;
-                        case GameObjectType.Event:
-                            foreach (var evt in context.Events)
-                            {
-                                EventBase.Lookup.Set(evt.Id, evt);
-                            }
-
-                            break;
-                        case GameObjectType.PlayerVariable:
-                            foreach (var psw in context.PlayerVariables)
-                            {
-                                PlayerVariableBase.Lookup.Set(psw.Id, psw);
-                            }
-
-                            break;
-                        case GameObjectType.ServerVariable:
-                            foreach (var psw in context.ServerVariables)
-                            {
-                                ServerVariableBase.Lookup.Set(psw.Id, psw);
-                            }
-
-                            break;
-                        case GameObjectType.Tileset:
-                            foreach (var psw in context.Tilesets)
-                            {
-                                TilesetBase.Lookup.Set(psw.Id, psw);
-                            }
-
-                            break;
-                        case GameObjectType.Time:
-                            break;
-                        case GameObjectType.GuildVariable:
-                            foreach (var psw in context.GuildVariables)
-                            {
-                                GuildVariableBase.Lookup.Set(psw.Id, psw);
-                            }
-
-                            break;
-                        case GameObjectType.UserVariable:
-                            foreach (var psw in context.UserVariables)
-                            {
-                                UserVariableBase.Lookup.Set(psw.Id, psw);
-                            }
-
-                            break;
-                        default:
-                            throw new ArgumentOutOfRangeException(nameof(gameObjectType), gameObjectType, null);
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex);
-                throw;
-            }
-        }
-
-        public static IDatabaseObject AddGameObject(GameObjectType gameObjectType)
-        {
-            return AddGameObject(gameObjectType, Guid.Empty);
-        }
-
-        public static IDatabaseObject AddGameObject(GameObjectType gameObjectType, Guid predefinedid)
-        {
-            if (predefinedid == Guid.Empty)
-            {
-                predefinedid = Guid.NewGuid();
-            }
-
-            IDatabaseObject dbObj = null;
-            switch (gameObjectType)
-            {
-                case GameObjectType.Animation:
-                    dbObj = new AnimationBase(predefinedid);
-
-                    break;
-                case GameObjectType.Class:
-                    dbObj = new ClassBase(predefinedid);
-
-                    break;
-                case GameObjectType.Item:
-                    dbObj = new ItemBase(predefinedid);
-
-                    break;
-                case GameObjectType.Npc:
-                    dbObj = new NpcBase(predefinedid);
-
-                    break;
-                case GameObjectType.Projectile:
-                    dbObj = new ProjectileBase(predefinedid);
-
-                    break;
-                case GameObjectType.Resource:
-                    dbObj = new ResourceBase(predefinedid);
-
-                    break;
-                case GameObjectType.Shop:
-                    dbObj = new ShopBase(predefinedid);
-
-                    break;
-                case GameObjectType.Spell:
-                    dbObj = new SpellBase(predefinedid);
-
-                    break;
-                case GameObjectType.CraftTables:
-                    dbObj = new CraftingTableBase(predefinedid);
-
-                    break;
-                case GameObjectType.Crafts:
-                    dbObj = new CraftBase(predefinedid);
-
-                    break;
-                case GameObjectType.Map:
-                    dbObj = new MapController(predefinedid);
-
-                    break;
-                case GameObjectType.Event:
-                    dbObj = new EventBase(predefinedid);
-
-                    break;
-                case GameObjectType.PlayerVariable:
-                    dbObj = new PlayerVariableBase(predefinedid);
-
-                    break;
-                case GameObjectType.ServerVariable:
-                    dbObj = new ServerVariableBase(predefinedid);
-
-                    break;
-                case GameObjectType.Tileset:
-                    dbObj = new TilesetBase(predefinedid);
-
-                    break;
-                case GameObjectType.Time:
-                    break;
-
-                case GameObjectType.Quest:
-                    dbObj = new QuestBase(predefinedid);
-                    ((QuestBase)dbObj).StartEvent = (EventBase)AddGameObject(GameObjectType.Event);
-                    ((QuestBase)dbObj).EndEvent = (EventBase)AddGameObject(GameObjectType.Event);
-                    ((QuestBase)dbObj).StartEvent.CommonEvent = false;
-                    ((QuestBase)dbObj).EndEvent.CommonEvent = false;
-
-                    break;
-
-                case GameObjectType.GuildVariable:
-                    dbObj = new GuildVariableBase(predefinedid);
-
-                    break;
-
-                case GameObjectType.UserVariable:
-                    dbObj = new UserVariableBase(predefinedid);
-
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(gameObjectType), gameObjectType, null);
-            }
-
-            return dbObj == null ? null : AddGameObject(gameObjectType, dbObj);
-        }
-
-        public static IDatabaseObject AddGameObject(GameObjectType gameObjectType, IDatabaseObject dbObj)
-        {
-            try
-            {
-                using (var context = CreateGameContext(readOnly: false))
-                {
-
-                    switch (gameObjectType)
-                    {
-                        case GameObjectType.Animation:
-                            context.Animations.Add((AnimationBase)dbObj);
-                            AnimationBase.Lookup.Set(dbObj.Id, dbObj);
-
-                            break;
-
-                        case GameObjectType.Class:
-                            context.Classes.Add((ClassBase)dbObj);
-                            ClassBase.Lookup.Set(dbObj.Id, dbObj);
-
-                            break;
-
-                        case GameObjectType.Item:
-                            context.Items.Add((ItemBase)dbObj);
-                            ItemBase.Lookup.Set(dbObj.Id, dbObj);
-
-                            break;
-                        case GameObjectType.Npc:
-                            context.Npcs.Add((NpcBase)dbObj);
-                            NpcBase.Lookup.Set(dbObj.Id, dbObj);
-
-                            break;
-
-                        case GameObjectType.Projectile:
-                            context.Projectiles.Add((ProjectileBase)dbObj);
-                            ProjectileBase.Lookup.Set(dbObj.Id, dbObj);
-
-                            break;
-
-                        case GameObjectType.Quest:
-                            context.Quests.Add((QuestBase)dbObj);
-                            QuestBase.Lookup.Set(dbObj.Id, dbObj);
-
-                            break;
-
-                        case GameObjectType.Resource:
-                            context.Resources.Add((ResourceBase)dbObj);
-                            ResourceBase.Lookup.Set(dbObj.Id, dbObj);
-
-                            break;
-
-                        case GameObjectType.Shop:
-                            context.Shops.Add((ShopBase)dbObj);
-                            ShopBase.Lookup.Set(dbObj.Id, dbObj);
-
-                            break;
-
-                        case GameObjectType.Spell:
-                            context.Spells.Add((SpellBase)dbObj);
-                            SpellBase.Lookup.Set(dbObj.Id, dbObj);
-
-                            break;
-
-                        case GameObjectType.CraftTables:
-                            context.CraftingTables.Add((CraftingTableBase)dbObj);
-                            CraftingTableBase.Lookup.Set(dbObj.Id, dbObj);
-
-                            break;
-
-                        case GameObjectType.Crafts:
-                            context.Crafts.Add((CraftBase)dbObj);
-                            CraftBase.Lookup.Set(dbObj.Id, dbObj);
-
-                            break;
-
-                        case GameObjectType.Map:
-                            context.Maps.Add((MapController)dbObj);
-                            MapController.Lookup.Set(dbObj.Id, dbObj);
-
-                            break;
-
-                        case GameObjectType.Event:
-                            context.Events.Add((EventBase)dbObj);
-                            EventBase.Lookup.Set(dbObj.Id, dbObj);
-
-                            break;
-
-                        case GameObjectType.PlayerVariable:
-                            context.PlayerVariables.Add((PlayerVariableBase)dbObj);
-                            PlayerVariableBase.Lookup.Set(dbObj.Id, dbObj);
-
-                            break;
-
-                        case GameObjectType.ServerVariable:
-                            context.ServerVariables.Add((ServerVariableBase)dbObj);
-                            ServerVariableBase.Lookup.Set(dbObj.Id, dbObj);
-
-                            break;
-
-                        case GameObjectType.Tileset:
-                            context.Tilesets.Add((TilesetBase)dbObj);
-                            TilesetBase.Lookup.Set(dbObj.Id, dbObj);
-
-                            break;
-
-                        case GameObjectType.Time:
-                            break;
-
-                        case GameObjectType.GuildVariable:
-                            context.GuildVariables.Add((GuildVariableBase)dbObj);
-                            GuildVariableBase.Lookup.Set(dbObj.Id, dbObj);
-
-                            break;
-
-                        case GameObjectType.UserVariable:
-                            context.UserVariables.Add((UserVariableBase)dbObj);
-                            UserVariableBase.Lookup.Set(dbObj.Id, dbObj);
-
-                            break;
-
-                        default:
-                            throw new ArgumentOutOfRangeException(nameof(gameObjectType), gameObjectType, null);
-                    }
-
-                    context.ChangeTracker.DetectChanges();
-                    context.Entry(dbObj).State = EntityState.Added;
-                    context.SaveChanges();
-                }
-
-                return dbObj;
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex);
-                throw;
-            }
-        }
-
-        public static void DeleteGameObject(IDatabaseObject gameObject)
-        {
-            try
-            {
-                using (var context = CreateGameContext(readOnly: false))
-                {
-                    switch (gameObject.Type)
-                    {
-                        case GameObjectType.Animation:
-                            context.Animations.Remove((AnimationBase)gameObject);
-
-                            break;
-                        case GameObjectType.Class:
-                            context.Classes.Remove((ClassBase)gameObject);
-
-                            break;
-                        case GameObjectType.Item:
-                            context.Items.Remove((ItemBase)gameObject);
-
-                            break;
-                        case GameObjectType.Npc:
-                            context.Npcs.Remove((NpcBase)gameObject);
-
-                            break;
-                        case GameObjectType.Projectile:
-                            context.Projectiles.Remove((ProjectileBase)gameObject);
-
-                            break;
-                        case GameObjectType.Quest:
-
-                            if (((QuestBase)gameObject).StartEvent != null)
-                            {
-                                context.Events.Remove(((QuestBase)gameObject).StartEvent);
-                                context.Entry(((QuestBase)gameObject).StartEvent).State = EntityState.Deleted;
-                                EventBase.Lookup.Delete(((QuestBase)gameObject).StartEvent);
-                            }
-
-                            if (((QuestBase)gameObject).EndEvent != null)
-                            {
-                                context.Events.Remove(((QuestBase)gameObject).EndEvent);
-                                context.Entry(((QuestBase)gameObject).EndEvent).State = EntityState.Deleted;
-                                EventBase.Lookup.Delete(((QuestBase)gameObject).EndEvent);
-                            }
-
-                            foreach (var tsk in ((QuestBase)gameObject).Tasks)
-                            {
-                                if (tsk.CompletionEvent != null)
-                                {
-                                    context.Events.Remove(tsk.CompletionEvent);
-                                    context.Entry(tsk.CompletionEvent).State = EntityState.Deleted;
-                                    EventBase.Lookup.Delete(tsk.CompletionEvent);
-                                }
-                            }
-
-                            context.Quests.Remove((QuestBase)gameObject);
-
-                            break;
-                        case GameObjectType.Resource:
-                            context.Resources.Remove((ResourceBase)gameObject);
-
-                            break;
-                        case GameObjectType.Shop:
-                            context.Shops.Remove((ShopBase)gameObject);
-
-                            break;
-                        case GameObjectType.Spell:
-                            context.Spells.Remove((SpellBase)gameObject);
-
-                            break;
-                        case GameObjectType.CraftTables:
-                            context.CraftingTables.Remove((CraftingTableBase)gameObject);
-
-                            break;
-                        case GameObjectType.Crafts:
-                            context.Crafts.Remove((CraftBase)gameObject);
-
-                            break;
-                        case GameObjectType.Map:
-                            //Delete all map events first
-                            foreach (var evtId in ((MapController)gameObject).EventIds)
-                            {
-                                var evt = EventBase.Get(evtId);
-                                if (evt != null)
-                                {
-                                    DeleteGameObject(evt);
-                                }
-                            }
-                            context.Maps.Remove((MapController)gameObject);
-                            MapController.Lookup.Delete(gameObject);
-
-                            break;
-                        case GameObjectType.Event:
-                            context.Events.Remove((EventBase)gameObject);
-
-                            break;
-                        case GameObjectType.PlayerVariable:
-                            context.PlayerVariables.Remove((PlayerVariableBase)gameObject);
-
-                            break;
-                        case GameObjectType.ServerVariable:
-                            context.ServerVariables.Remove((ServerVariableBase)gameObject);
-
-                            break;
-                        case GameObjectType.Tileset:
-                            context.Tilesets.Remove((TilesetBase)gameObject);
-
-                            break;
-                        case GameObjectType.Time:
-                            break;
-                        case GameObjectType.GuildVariable:
-                            context.GuildVariables.Remove((GuildVariableBase)gameObject);
-
-                            break;
-                        case GameObjectType.UserVariable:
-                            context.UserVariables.Remove((UserVariableBase)gameObject);
-
-                            break;
-                    }
-
-                    if (gameObject.Type.GetLookup().Values.Contains(gameObject))
-                    {
-                        if (!gameObject.Type.GetLookup().Delete(gameObject))
+                        if (y != mapGrids.Count - 1)
                         {
-                            throw new Exception();
+                            continue;
                         }
+
+                        mapGrids.Add(new MapGrid(map.Id, mapGrids.Count));
                     }
 
-                    context.ChangeTracker.DetectChanges();
-                    context.Entry(gameObject).State = EntityState.Deleted;
-                    context.SaveChanges();
+                    break;
                 }
             }
-            catch (Exception ex)
-            {
-                Log.Error(ex);
-                throw;
-            }
-        }
 
-        public static void SaveGameObject(IDatabaseObject gameObject)
-        {
-            try
-            {
-                using (var context = CreateGameContext(readOnly: false))
-                {
-
-                    switch (gameObject.Type)
-                    {
-                        case GameObjectType.Animation:
-                            context.Animations.Update((AnimationBase)gameObject);
-
-                            break;
-                        case GameObjectType.Class:
-                            context.Classes.Update((ClassBase)gameObject);
-
-                            break;
-                        case GameObjectType.Item:
-                        {
-                            if (gameObject is not ItemBase itemDescriptor)
-                            {
-                                throw new InvalidOperationException();
-                            }
-
-                            itemDescriptor.ValidateStatRanges();
-
-                            if (itemDescriptor.EquipmentProperties?.DescriptorId == Guid.Empty)
-                            {
-                                context.Items_EquipmentProperties.Add(itemDescriptor.EquipmentProperties);
-                            }
-                            else
-                            {
-                                EquipmentProperties? deletedEquipmentProperties =
-                                    context.Items_EquipmentProperties.FirstOrDefault(
-                                        ep => ep.DescriptorId == itemDescriptor.Id
-                                    );
-                                if (deletedEquipmentProperties != default)
-                                {
-                                    context.Items_EquipmentProperties.Remove(deletedEquipmentProperties);
-                                }
-                            }
-
-                            context.Items.Update(itemDescriptor);
-
-                            break;
-                        }
-                        case GameObjectType.Npc:
-                            context.Npcs.Update((NpcBase)gameObject);
-
-                            break;
-                        case GameObjectType.Projectile:
-                            context.Projectiles.Update((ProjectileBase)gameObject);
-
-                            break;
-                        case GameObjectType.Quest:
-
-                            if (((QuestBase)gameObject).StartEvent != null)
-                            {
-                                context.Events.Update(((QuestBase)gameObject).StartEvent);
-                            }
-
-                            if (((QuestBase)gameObject).EndEvent != null)
-                            {
-                                context.Events.Update(((QuestBase)gameObject).EndEvent);
-                            }
-
-                            foreach (var tsk in ((QuestBase)gameObject).Tasks)
-                            {
-                                if (tsk.CompletionEvent != null)
-                                {
-                                    context.Events.Update(tsk.CompletionEvent);
-                                }
-                            }
-
-                            context.Quests.Update((QuestBase)gameObject);
-
-                            break;
-                        case GameObjectType.Resource:
-                            context.Resources.Update((ResourceBase)gameObject);
-
-                            break;
-                        case GameObjectType.Shop:
-                            context.Shops.Update((ShopBase)gameObject);
-
-                            break;
-                        case GameObjectType.Spell:
-                            context.Spells.Update((SpellBase)gameObject);
-
-                            break;
-                        case GameObjectType.CraftTables:
-                            context.CraftingTables.Update((CraftingTableBase)gameObject);
-
-                            break;
-                        case GameObjectType.Crafts:
-                            context.Crafts.Update((CraftBase)gameObject);
-
-                            break;
-                        case GameObjectType.Map:
-                            context.Maps.Update((MapController)gameObject);
-
-                            break;
-                        case GameObjectType.Event:
-                            context.Events.Update((EventBase)gameObject);
-
-                            break;
-                        case GameObjectType.PlayerVariable:
-                            context.PlayerVariables.Update((PlayerVariableBase)gameObject);
-
-                            break;
-                        case GameObjectType.ServerVariable:
-                            context.ServerVariables.Update((ServerVariableBase)gameObject);
-
-                            break;
-                        case GameObjectType.Tileset:
-                            context.Tilesets.Update((TilesetBase)gameObject);
-
-                            break;
-                        case GameObjectType.Time:
-                            break;
-                        case GameObjectType.GuildVariable:
-                            context.GuildVariables.Update((GuildVariableBase)gameObject);
-
-                            break;
-                        case GameObjectType.UserVariable:
-                            context.UserVariables.Update((UserVariableBase)gameObject);
-
-                            break;
-                    }
-
-                    context.ChangeTracker.DetectChanges();
-                    context.SaveChanges();
-                }
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex);
-                throw;
-            }
-        }
-
-        //Post Loading Functions
-        private static void OnMapsLoaded()
-        {
-            if (MapBase.Lookup.Count == 0)
-            {
-                Console.WriteLine(Strings.Database.nomaps);
-                AddGameObject(GameObjectType.Map);
-            }
-
-            GenerateMapGrids();
-            LoadMapFolders();
-            CheckAllMapConnections();
-
-            foreach (var map in MapController.Lookup)
-            {
-                ((MapController)map.Value).Initialize();
-            }
-        }
-
-        private static void OnClassesLoaded()
-        {
-            if (ClassBase.Lookup.Count == 0)
-            {
-                Console.WriteLine(Strings.Database.noclasses);
-                var cls = (ClassBase)AddGameObject(GameObjectType.Class);
-                cls.Name = Strings.Database.Default;
-                var defaultMale = new ClassSprite()
-                {
-                    Sprite = "Base_Male.png",
-                    Gender = Gender.Male
-                };
-
-                var defaultFemale = new ClassSprite()
-                {
-                    Sprite = "Base_Female.png",
-                    Gender = Gender.Female
-                };
-
-                cls.Sprites.Add(defaultMale);
-                cls.Sprites.Add(defaultFemale);
-                for (var i = 0; i < Enum.GetValues<Vital>().Length; i++)
-                {
-                    cls.BaseVital[i] = 20;
-                }
-
-                for (var i = 0; i < Enum.GetValues<Stat>().Length; i++)
-                {
-                    cls.BaseStat[i] = 20;
-                }
-                SaveGameObject(cls);
-            }
-        }
-
-        public static void CachePlayerVariableEventTextLookups()
-        {
-            var lookup = new Dictionary<string, PlayerVariableBase>();
-            var addedIds = new HashSet<string>();
-            foreach (PlayerVariableBase variable in PlayerVariableBase.Lookup.Values)
-            {
-                if (!string.IsNullOrWhiteSpace(variable.TextId) && !addedIds.Contains(variable.TextId))
-                {
-                    lookup.Add(Strings.Events.playervar + "{" + variable.TextId + "}", variable);
-                    lookup.Add(Strings.Events.playerswitch + "{" + variable.TextId + "}", variable);
-                    addedIds.Add(variable.TextId);
-                }
-            }
-            PlayerVariableEventTextLookup = lookup;
-        }
-
-        public static void CacheServerVariableEventTextLookups()
-        {
-            var lookup = new Dictionary<string, ServerVariableBase>();
-            var addedIds = new HashSet<string>();
-            foreach (ServerVariableBase variable in ServerVariableBase.Lookup.Values)
-            {
-                if (!string.IsNullOrWhiteSpace(variable.TextId) && !addedIds.Contains(variable.TextId))
-                {
-                    lookup.Add(Strings.Events.globalvar + "{" + variable.TextId + "}", variable);
-                    lookup.Add(Strings.Events.globalswitch + "{" + variable.TextId + "}", variable);
-                    addedIds.Add(variable.TextId);
-                }
-            }
-            ServerVariableEventTextLookup = lookup;
-        }
-
-        public static void CacheGuildVariableEventTextLookups()
-        {
-            var lookup = new Dictionary<string, GuildVariableBase>();
-            var addedIds = new HashSet<string>();
-            foreach (GuildVariableBase variable in GuildVariableBase.Lookup.Values)
-            {
-                if (!string.IsNullOrWhiteSpace(variable.TextId) && !addedIds.Contains(variable.TextId))
-                {
-                    lookup.Add(Strings.Events.guildvar + "{" + variable.TextId + "}", variable);
-                    addedIds.Add(variable.TextId);
-                }
-            }
-            GuildVariableEventTextLookup = lookup;
-        }
-
-        public static void CacheUserVariableEventTextLookups()
-        {
-            var lookup = new Dictionary<string, UserVariableBase>();
-            var addedIds = new HashSet<string>();
-            foreach (UserVariableBase variable in UserVariableBase.Lookup.Values)
-            {
-                if (!string.IsNullOrWhiteSpace(variable.TextId) && !addedIds.Contains(variable.TextId))
-                {
-                    lookup.Add(Strings.Events.UserVariable + "{" + variable.TextId + "}", variable);
-                    addedIds.Add(variable.TextId);
-                }
-            }
-            UserVariableEventTextLookup = lookup;
-        }
-
-        //Extra Map Helper Functions
-        public static void CheckAllMapConnections()
-        {
-            var changed = false;
             foreach (MapController map in MapController.Lookup.Values)
             {
-                CheckMapConnections(map, MapController.Lookup);
-            }
-        }
-
-        public static bool CheckMapConnections(MapController map, DatabaseObjectLookup maps)
-        {
-            var updated = false;
-            if (!maps.Keys.Contains(map.Up) && map.Up != Guid.Empty)
-            {
-                map.Up = Guid.Empty;
-                updated = true;
-            }
-
-            if (!maps.Keys.Contains(map.Down) && map.Down != Guid.Empty)
-            {
-                map.Down = Guid.Empty;
-                updated = true;
-            }
-
-            if (!maps.Keys.Contains(map.Left) && map.Left != Guid.Empty)
-            {
-                map.Left = Guid.Empty;
-                updated = true;
-            }
-
-            if (!maps.Keys.Contains(map.Right) && map.Right != Guid.Empty)
-            {
-                map.Right = Guid.Empty;
-                updated = true;
-            }
-
-            if (updated)
-            {
-                SaveGameObject(map);
-                PacketSender.SendMapToEditors(map.Id);
-                return true;
-            }
-
-            return false;
-        }
-
-        public static void GenerateMapGrids()
-        {
-            lock (mapGrids)
-            {
-                mapGrids.Clear();
-                foreach (var map in MapController.Lookup.Values)
+                lock (map.GetMapLock())
                 {
-                    if (mapGrids.Count < 1)
+                    var gridIndex = map.MapGrid;
+                    var grid = mapGrids[gridIndex];
+                    var surroundingMapIds = new List<Guid>();
+                    var surroundingMaps = new List<MapController>();
+                    for (var x = map.MapGridX - 1; x <= map.MapGridX + 1; x++)
                     {
-                        mapGrids.Add(new MapGrid(map.Id, 0));
-                        continue;
-                    }
-
-                    for (var y = 0; y < mapGrids.Count; y++)
-                    {
-                        if (!mapGrids[y].Contains(map.Id))
+                        for (var y = map.MapGridY - 1; y <= map.MapGridY + 1; y++)
                         {
-                            if (y != mapGrids.Count - 1)
+                            if (x == map.MapGridX && y == map.MapGridY)
                             {
                                 continue;
                             }
 
-                            mapGrids.Add(new MapGrid(map.Id, mapGrids.Count));
-                        }
-
-                        break;
-                    }
-                }
-
-                foreach (MapController map in MapController.Lookup.Values)
-                {
-                    lock (map.GetMapLock())
-                    {
-                        var gridIndex = map.MapGrid;
-                        var grid = mapGrids[gridIndex];
-                        var surroundingMapIds = new List<Guid>();
-                        var surroundingMaps = new List<MapController>();
-                        for (var x = map.MapGridX - 1; x <= map.MapGridX + 1; x++)
-                        {
-                            for (var y = map.MapGridY - 1; y <= map.MapGridY + 1; y++)
+                            if (x < grid.XMin || x >= grid.XMax || y < grid.YMin || y >= grid.YMax)
                             {
-                                if (x == map.MapGridX && y == map.MapGridY)
-                                {
-                                    continue;
-                                }
+                                continue;
+                            }
 
-                                if (x < grid.XMin || x >= grid.XMax || y < grid.YMin || y >= grid.YMax)
-                                {
-                                    continue;
-                                }
+                            if (grid.MapIdGrid[x, y] == Guid.Empty)
+                            {
+                                continue;
+                            }
 
-                                if (grid.MapIdGrid[x, y] == Guid.Empty)
-                                {
-                                    continue;
-                                }
-
-                                var idFromGrid = grid.MapIdGrid[x, y];
-                                surroundingMapIds.Add(idFromGrid);
-                                if (MapController.TryGet(idFromGrid, out var mapOnGrid))
-                                {
-                                    surroundingMaps.Add(mapOnGrid);
-                                }
+                            var idFromGrid = grid.MapIdGrid[x, y];
+                            surroundingMapIds.Add(idFromGrid);
+                            if (MapController.TryGet(idFromGrid, out var mapOnGrid))
+                            {
+                                surroundingMaps.Add(mapOnGrid);
                             }
                         }
-                        map.SurroundingMapIds = surroundingMapIds.ToArray();
-                        map.SurroundingMaps = surroundingMaps.ToArray();
                     }
-                }
-
-                for (var gridIndex = 0; gridIndex < mapGrids.Count; gridIndex++)
-                {
-                    PacketSender.SendMapGridToAll(gridIndex);
-                }
-            }
-        }
-
-        public static MapGrid GetGrid(int index)
-        {
-            lock (mapGrids)
-            {
-                return mapGrids[index];
-            }
-        }
-
-        public static bool GridsContain(Guid id)
-        {
-            lock (mapGrids)
-            {
-                return mapGrids.Any(mapGrid => mapGrid.Contains(id));
-            }
-        }
-
-        //Map Folders
-        private static void LoadMapFolders()
-        {
-            try
-            {
-                using (var context = CreateGameContext(readOnly: false))
-                {
-                    var mapFolders = context.MapFolders.OrderBy(f => f.Id).FirstOrDefault();
-                    if (mapFolders == null)
-                    {
-                        context.MapFolders.Add(MapList.List);
-                        context.ChangeTracker.DetectChanges();
-                        context.SaveChanges();
-                    }
-                    else
-                    {
-                        MapList.List = mapFolders;
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex);
-                throw;
-            }
-
-            foreach (var map in MapBase.Lookup)
-            {
-                if (MapList.List.FindMap(map.Value.Id) == null)
-                {
-                    MapList.List.AddMap(map.Value.Id, map.Value.TimeCreated, MapBase.Lookup);
+                    map.SurroundingMapIds = surroundingMapIds.ToArray();
+                    map.SurroundingMaps = surroundingMaps.ToArray();
                 }
             }
 
-            MapList.List.PostLoad(MapBase.Lookup, true, true);
-            PacketSender.SendMapListToAll();
-        }
-
-        public static void SaveMapList()
-        {
-            try
+            for (var gridIndex = 0; gridIndex < mapGrids.Count; gridIndex++)
             {
-                using (var context = CreateGameContext(readOnly: false))
+                PacketSender.SendMapGridToAll(gridIndex);
+            }
+        }
+    }
+
+    public static MapGrid GetGrid(int index)
+    {
+        lock (mapGrids)
+        {
+            return mapGrids[index];
+        }
+    }
+
+    public static bool GridsContain(Guid id)
+    {
+        lock (mapGrids)
+        {
+            return mapGrids.Any(mapGrid => mapGrid.Contains(id));
+        }
+    }
+
+    //Map Folders
+    private static void LoadMapFolders()
+    {
+        try
+        {
+            using (var context = CreateGameContext(readOnly: false))
+            {
+                var mapFolders = context.MapFolders.OrderBy(f => f.Id).FirstOrDefault();
+                if (mapFolders == null)
                 {
-                    context.MapFolders.Update(MapList.List);
+                    context.MapFolders.Add(MapList.List);
                     context.ChangeTracker.DetectChanges();
                     context.SaveChanges();
-                }
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex);
-                throw;
-            }
-        }
-
-        //Time
-        private static void LoadTime()
-        {
-            try
-            {
-                using (var context = CreateGameContext(readOnly: false))
-                {
-                    var time = context.Time.OrderBy(t => t.Id).FirstOrDefault();
-                    if (time == null)
-                    {
-                        context.Time.Add(TimeBase.GetTimeBase());
-                        context.ChangeTracker.DetectChanges();
-                        context.SaveChanges();
-                    }
-                    else
-                    {
-                        TimeBase.SetStaticTime(time);
-                    }
-                }
-                Time.Init();
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex);
-                throw;
-            }
-        }
-
-        public static void SaveTime()
-        {
-            try
-            {
-                using (var context = CreateGameContext(readOnly: false))
-                {
-                    context.Time.Update(TimeBase.GetTimeBase());
-                    context.ChangeTracker.DetectChanges();
-                    context.SaveChanges();
-                }
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex);
-                throw;
-            }
-        }
-
-        public static void SaveUpdatedServerVariables()
-        {
-            if (UpdatedServerVariables.Count > 0)
-            {
-                using (var context = CreateGameContext(readOnly: false))
-                {
-                    foreach (var variable in UpdatedServerVariables)
-                    {
-                        var serverVar = variable.Value;
-                        if (serverVar != null)
-                        {
-                            context.ServerVariables.Update(variable.Value);
-                        }
-                        UpdatedServerVariables.TryRemove(variable.Key, out ServerVariableBase obj);
-                    }
-                    context.SaveChanges();
-                }
-            }
-        }
-
-        public static void HandleMigrationCommand()
-        {
-            var databases = new List<(Type, DatabaseOptions, string)>
-            {
-                (typeof(GameContext), Options.Instance.GameDatabase, Strings.Migration.GameDatabaseName),
-                (typeof(PlayerContext), Options.Instance.PlayerDatabase, Strings.Migration.PlayerDatabaseName),
-                (typeof(LoggingContext), Options.Instance.LoggingDatabase, Strings.Migration.LoggingDatabaseName)
-            };
-
-            Console.WriteLine();
-            Console.WriteLine(Strings.Migration.SelectContext);
-            Console.WriteLine();
-
-            for (var databaseIndex = 0; databaseIndex < databases.Count; databaseIndex++)
-            {
-                var (contextType, options, databaseName) = databases[databaseIndex];
-                var selectionNumber = databaseIndex + 1;
-                var databaseTypeName = options.Type.GetName();
-                Console.WriteLine(Strings.Migration.SelectDatabase.ToString(
-                    selectionNumber,
-                    databaseName,
-                    databaseTypeName,
-                    contextType == typeof(GameContext) ? Strings.Migration.SqliteRecommended : string.Empty
-                ));
-            }
-
-            Console.WriteLine();
-            Console.WriteLine(Strings.Migration.Cancel);
-
-            // TODO: Remove > when moving to ReadKeyWait when console magic is ready
-            Console.Write("> ");
-            var input = Console.ReadLine();
-            Console.WriteLine();
-
-            if (!int.TryParse(input, out var selectedDatabaseIndex))
-            {
-                Console.WriteLine(Strings.Migration.MigrationCanceled);
-                return;
-            }
-
-            if (selectedDatabaseIndex < 1 || selectedDatabaseIndex > databases.Count)
-            {
-                Console.WriteLine(Strings.Migration.MigrationCanceled);
-                return;
-            }
-
-            var (selectedContextType, selectedOptions, selectedDatabaseName) = databases[selectedDatabaseIndex - 1];
-
-            var databaseTypes = new List<DatabaseType> { DatabaseType.Sqlite, DatabaseType.MySql };
-
-            Console.WriteLine();
-            Console.WriteLine(Strings.Migration.SelectProvider.ToString(selectedDatabaseName));
-            var databaseTypeIndex = 1;
-            foreach (var databaseType in databaseTypes)
-            {
-                Console.WriteLine(
-                    Strings.Migration.SelectDatabaseType.ToString(databaseTypeIndex, databaseType.GetName()));
-                ++databaseTypeIndex;
-            }
-
-            Console.WriteLine();
-            Console.WriteLine(Strings.Migration.Cancel);
-
-            // TODO: Remove > when moving to ReadKeyWait when console magic is ready
-            Console.Write("> ");
-            input = Console.ReadLine();
-            Console.WriteLine();
-
-            if (!int.TryParse(input, out var selectedDatabaseTypeIndex))
-            {
-                Console.WriteLine(Strings.Migration.MigrationCanceled);
-                return;
-            }
-
-            if (selectedDatabaseTypeIndex < 1 || selectedDatabaseTypeIndex > databaseTypes.Count)
-            {
-                Console.WriteLine(Strings.Migration.MigrationCanceled);
-                return;
-            }
-
-            var selectedDatabaseType = databaseTypes[selectedDatabaseTypeIndex - 1];
-            if (selectedDatabaseType == selectedOptions.Type)
-            {
-                Console.WriteLine();
-                Console.WriteLine(
-                    Strings.Migration.AlreadyUsingProvider.ToString(selectedDatabaseName,
-                        selectedDatabaseType.GetName()));
-                Console.WriteLine(Strings.Migration.MigrationCanceled);
-                return;
-            }
-
-            try
-            {
-                Task task;
-                if (selectedContextType == typeof(GameContext))
-                {
-                    task = Migrate<GameContext>(selectedOptions, selectedDatabaseType);
-                }
-                else if (selectedContextType == typeof(PlayerContext))
-                {
-                    task = Migrate<PlayerContext>(selectedOptions, selectedDatabaseType);
-                }
-                else if (selectedContextType == typeof(LoggingContext))
-                {
-                    task = Migrate<LoggingContext>(selectedOptions, selectedDatabaseType);
                 }
                 else
                 {
-                    throw new InvalidOperationException();
+                    MapList.List = mapFolders;
                 }
-
-                task.Wait();
             }
-            catch (Exception exception)
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex);
+            throw;
+        }
+
+        foreach (var map in MapBase.Lookup)
+        {
+            if (MapList.List.FindMap(map.Value.Id) == null)
             {
-                Log.Error(exception);
-                throw;
+                MapList.List.AddMap(map.Value.Id, map.Value.TimeCreated, MapBase.Lookup);
             }
         }
 
-        public static async Task Migrate<TContext>(DatabaseOptions fromDatabaseOptions, DatabaseType toDatabaseType)
-            where TContext : IntersectDbContext<TContext>
+        MapList.List.PostLoad(MapBase.Lookup, true, true);
+        PacketSender.SendMapListToAll();
+    }
+
+    public static void SaveMapList()
+    {
+        try
         {
-            string sqliteFileName;
-            if (typeof(TContext) == typeof(GameContext))
+            using (var context = CreateGameContext(readOnly: false))
             {
-                sqliteFileName = GameDbFilename;
+                context.MapFolders.Update(MapList.List);
+                context.ChangeTracker.DetectChanges();
+                context.SaveChanges();
             }
-            else if (typeof(TContext) == typeof(LoggingContext))
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex);
+            throw;
+        }
+    }
+
+    //Time
+    private static void LoadTime()
+    {
+        try
+        {
+            using (var context = CreateGameContext(readOnly: false))
             {
-                sqliteFileName = LoggingDbFilename;
+                var time = context.Time.OrderBy(t => t.Id).FirstOrDefault();
+                if (time == null)
+                {
+                    context.Time.Add(TimeBase.GetTimeBase());
+                    context.ChangeTracker.DetectChanges();
+                    context.SaveChanges();
+                }
+                else
+                {
+                    TimeBase.SetStaticTime(time);
+                }
             }
-            else if (typeof(TContext) == typeof(PlayerContext))
+            Time.Init();
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex);
+            throw;
+        }
+    }
+
+    public static void SaveTime()
+    {
+        try
+        {
+            using (var context = CreateGameContext(readOnly: false))
             {
-                sqliteFileName = PlayersDbFilename;
+                context.Time.Update(TimeBase.GetTimeBase());
+                context.ChangeTracker.DetectChanges();
+                context.SaveChanges();
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex);
+            throw;
+        }
+    }
+
+    public static void SaveUpdatedServerVariables()
+    {
+        if (UpdatedServerVariables.Count > 0)
+        {
+            using (var context = CreateGameContext(readOnly: false))
+            {
+                foreach (var variable in UpdatedServerVariables)
+                {
+                    var serverVar = variable.Value;
+                    if (serverVar != null)
+                    {
+                        context.ServerVariables.Update(variable.Value);
+                    }
+                    UpdatedServerVariables.TryRemove(variable.Key, out ServerVariableBase obj);
+                }
+                context.SaveChanges();
+            }
+        }
+    }
+
+    public static void HandleMigrationCommand()
+    {
+        var databases = new List<(Type, DatabaseOptions, string)>
+        {
+            (typeof(GameContext), Options.Instance.GameDatabase, Strings.Migration.GameDatabaseName),
+            (typeof(PlayerContext), Options.Instance.PlayerDatabase, Strings.Migration.PlayerDatabaseName),
+            (typeof(LoggingContext), Options.Instance.LoggingDatabase, Strings.Migration.LoggingDatabaseName)
+        };
+
+        Console.WriteLine();
+        Console.WriteLine(Strings.Migration.SelectContext);
+        Console.WriteLine();
+
+        for (var databaseIndex = 0; databaseIndex < databases.Count; databaseIndex++)
+        {
+            var (contextType, options, databaseName) = databases[databaseIndex];
+            var selectionNumber = databaseIndex + 1;
+            var databaseTypeName = options.Type.GetName();
+            Console.WriteLine(Strings.Migration.SelectDatabase.ToString(
+                selectionNumber,
+                databaseName,
+                databaseTypeName,
+                contextType == typeof(GameContext) ? Strings.Migration.SqliteRecommended : string.Empty
+            ));
+        }
+
+        Console.WriteLine();
+        Console.WriteLine(Strings.Migration.Cancel);
+
+        // TODO: Remove > when moving to ReadKeyWait when console magic is ready
+        Console.Write("> ");
+        var input = Console.ReadLine();
+        Console.WriteLine();
+
+        if (!int.TryParse(input, out var selectedDatabaseIndex))
+        {
+            Console.WriteLine(Strings.Migration.MigrationCanceled);
+            return;
+        }
+
+        if (selectedDatabaseIndex < 1 || selectedDatabaseIndex > databases.Count)
+        {
+            Console.WriteLine(Strings.Migration.MigrationCanceled);
+            return;
+        }
+
+        var (selectedContextType, selectedOptions, selectedDatabaseName) = databases[selectedDatabaseIndex - 1];
+
+        var databaseTypes = new List<DatabaseType> { DatabaseType.Sqlite, DatabaseType.MySql };
+
+        Console.WriteLine();
+        Console.WriteLine(Strings.Migration.SelectProvider.ToString(selectedDatabaseName));
+        var databaseTypeIndex = 1;
+        foreach (var databaseType in databaseTypes)
+        {
+            Console.WriteLine(
+                Strings.Migration.SelectDatabaseType.ToString(databaseTypeIndex, databaseType.GetName()));
+            ++databaseTypeIndex;
+        }
+
+        Console.WriteLine();
+        Console.WriteLine(Strings.Migration.Cancel);
+
+        // TODO: Remove > when moving to ReadKeyWait when console magic is ready
+        Console.Write("> ");
+        input = Console.ReadLine();
+        Console.WriteLine();
+
+        if (!int.TryParse(input, out var selectedDatabaseTypeIndex))
+        {
+            Console.WriteLine(Strings.Migration.MigrationCanceled);
+            return;
+        }
+
+        if (selectedDatabaseTypeIndex < 1 || selectedDatabaseTypeIndex > databaseTypes.Count)
+        {
+            Console.WriteLine(Strings.Migration.MigrationCanceled);
+            return;
+        }
+
+        var selectedDatabaseType = databaseTypes[selectedDatabaseTypeIndex - 1];
+        if (selectedDatabaseType == selectedOptions.Type)
+        {
+            Console.WriteLine();
+            Console.WriteLine(
+                Strings.Migration.AlreadyUsingProvider.ToString(selectedDatabaseName,
+                    selectedDatabaseType.GetName()));
+            Console.WriteLine(Strings.Migration.MigrationCanceled);
+            return;
+        }
+
+        try
+        {
+            Task task;
+            if (selectedContextType == typeof(GameContext))
+            {
+                task = Migrate<GameContext>(selectedOptions, selectedDatabaseType);
+            }
+            else if (selectedContextType == typeof(PlayerContext))
+            {
+                task = Migrate<PlayerContext>(selectedOptions, selectedDatabaseType);
+            }
+            else if (selectedContextType == typeof(LoggingContext))
+            {
+                task = Migrate<LoggingContext>(selectedOptions, selectedDatabaseType);
             }
             else
             {
                 throw new InvalidOperationException();
             }
 
-            var fromContextOptions = new DatabaseContextOptions
-            {
-                AutoDetectChanges = false,
-                ConnectionStringBuilder =
-                    fromDatabaseOptions.Type.CreateConnectionStringBuilder(fromDatabaseOptions, sqliteFileName),
-                DatabaseType = fromDatabaseOptions.Type,
-                ExplicitLoad = false,
-                LazyLoading = false,
-                LoggerFactory = default,
-                QueryTrackingBehavior = default,
-                ReadOnly = false
-            };
+            task.Wait();
+        }
+        catch (Exception exception)
+        {
+            Log.Error(exception);
+            throw;
+        }
+    }
 
-            DatabaseOptions toDatabaseOptions;
-            DatabaseContextOptions toContextOptions;
-            switch (toDatabaseType)
-            {
-                case DatabaseType.MySql:
+    public static async Task Migrate<TContext>(DatabaseOptions fromDatabaseOptions, DatabaseType toDatabaseType)
+        where TContext : IntersectDbContext<TContext>
+    {
+        string sqliteFileName;
+        if (typeof(TContext) == typeof(GameContext))
+        {
+            sqliteFileName = GameDbFilename;
+        }
+        else if (typeof(TContext) == typeof(LoggingContext))
+        {
+            sqliteFileName = LoggingDbFilename;
+        }
+        else if (typeof(TContext) == typeof(PlayerContext))
+        {
+            sqliteFileName = PlayersDbFilename;
+        }
+        else
+        {
+            throw new InvalidOperationException();
+        }
+
+        var fromContextOptions = new DatabaseContextOptions
+        {
+            AutoDetectChanges = false,
+            ConnectionStringBuilder =
+                fromDatabaseOptions.Type.CreateConnectionStringBuilder(fromDatabaseOptions, sqliteFileName),
+            DatabaseType = fromDatabaseOptions.Type,
+            ExplicitLoad = false,
+            LazyLoading = false,
+            LoggerFactory = default,
+            QueryTrackingBehavior = default,
+            ReadOnly = false
+        };
+
+        DatabaseOptions toDatabaseOptions;
+        DatabaseContextOptions toContextOptions;
+        switch (toDatabaseType)
+        {
+            case DatabaseType.MySql:
+                {
+                    while (true)
                     {
-                        while (true)
+                        Console.WriteLine(Strings.Migration.EnterConnectionStringParameters);
+
+                        Console.Write(Strings.Migration.PromptHost.ToString(Strings.Migration.DefaultHost));
+                        var host = Console.ReadLine()?.Trim();
+                        if (string.IsNullOrWhiteSpace(host))
                         {
-                            Console.WriteLine(Strings.Migration.EnterConnectionStringParameters);
-
-                            Console.Write(Strings.Migration.PromptHost.ToString(Strings.Migration.DefaultHost));
-                            var host = Console.ReadLine()?.Trim();
-                            if (string.IsNullOrWhiteSpace(host))
-                            {
-                                host = Strings.Migration.DefaultHost;
-                            }
-
-                            Console.Write(Strings.Migration.PromptPort.ToString(Strings.Migration.DefaultPortMySql));
-                            var portString = Console.ReadLine()?.Trim();
-                            if (string.IsNullOrWhiteSpace(portString))
-                            {
-                                portString = Strings.Migration.DefaultPortMySql;
-                            }
-                            var port = ushort.Parse(portString);
-
-                            var contextName = typeof(TContext).Name.Replace("Context", "").ToLowerInvariant();
-                            var version = typeof(DbInterface).Assembly.GetVersionName();
-                            var defaultDatabase = Strings.Migration.DefaultDatabase.ToString(version, contextName);
-                            Console.Write(Strings.Migration.PromptDatabase.ToString(defaultDatabase));
-                            var database = Console.ReadLine()?.Trim();
-                            if (string.IsNullOrWhiteSpace(database))
-                            {
-                                database = defaultDatabase;
-                            }
-
-                            Console.Write(Strings.Migration.PromptUsername.ToString(Strings.Migration.DefaultUsername));
-                            var username = Console.ReadLine().Trim();
-                            if (string.IsNullOrWhiteSpace(username))
-                            {
-                                username = Strings.Migration.DefaultUsername;
-                            }
-
-                            Console.Write(Strings.Migration.PromptPassword);
-                            var password = GetPassword();
-
-                            Console.WriteLine();
-                            Console.WriteLine(Strings.Migration.MySqlConnecting);
-
-                            toDatabaseOptions = new()
-                            {
-                                Type = toDatabaseType,
-                                Server = host,
-                                Port = port,
-                                Database = database,
-                                Username = username,
-                                Password = password
-                            };
-                            toContextOptions = new()
-                            {
-                                ConnectionStringBuilder = toDatabaseType.CreateConnectionStringBuilder(
-                                    toDatabaseOptions,
-                                    default
-                                ),
-                                DatabaseType = toDatabaseType
-                            };
-
-                            try
-                            {
-                                await using var testContext = IntersectDbContext<TContext>.Create(toContextOptions);
-                                break;
-                            }
-                            catch (Exception exception)
-                            {
-                                Log.Error(Strings.Migration.MySqlConnectionError.ToString(exception));
-                                Console.WriteLine();
-                                Console.WriteLine(Strings.Migration.MySqlTryAgain);
-                                var input = Console.ReadLine();
-                                var key = input.Length > 0 ? input[0] : ' ';
-                                Console.WriteLine();
-
-                                var shouldTryAgain = string.Equals(
-                                    Strings.Migration.TryAgainCharacter,
-                                    key.ToString(),
-                                    StringComparison.Ordinal
-                                );
-
-                                if (shouldTryAgain)
-                                {
-                                    continue;
-                                }
-
-                                Log.Info(Strings.Migration.MigrationCanceled);
-                                return;
-                            }
+                            host = Strings.Migration.DefaultHost;
                         }
 
-                        break;
-                    }
+                        Console.Write(Strings.Migration.PromptPort.ToString(Strings.Migration.DefaultPortMySql));
+                        var portString = Console.ReadLine()?.Trim();
+                        if (string.IsNullOrWhiteSpace(portString))
+                        {
+                            portString = Strings.Migration.DefaultPortMySql;
+                        }
+                        var port = ushort.Parse(portString);
 
-                case DatabaseType.Sqlite:
-                    {
-                        string dbFileName;
-                        if (typeof(TContext).Extends<GameContext>())
+                        var contextName = typeof(TContext).Name.Replace("Context", "").ToLowerInvariant();
+                        var version = typeof(DbInterface).Assembly.GetVersionName();
+                        var defaultDatabase = Strings.Migration.DefaultDatabase.ToString(version, contextName);
+                        Console.Write(Strings.Migration.PromptDatabase.ToString(defaultDatabase));
+                        var database = Console.ReadLine()?.Trim();
+                        if (string.IsNullOrWhiteSpace(database))
                         {
-                            dbFileName = GameDbFilename;
-                        }
-                        else if (typeof(TContext).Extends<PlayerContext>())
-                        {
-                            dbFileName = PlayersDbFilename;
-                        }
-                        else if (typeof(TContext).Extends<LoggingContext>())
-                        {
-                            dbFileName = LoggingDbFilename;
-                        }
-                        else
-                        {
-                            throw new InvalidOperationException($"Unsupported context type: {typeof(TContext).FullName}");
+                            database = defaultDatabase;
                         }
 
-                        // Check if target SQLite file exists
-                        if (File.Exists(dbFileName))
+                        Console.Write(Strings.Migration.PromptUsername.ToString(Strings.Migration.DefaultUsername));
+                        var username = Console.ReadLine().Trim();
+                        if (string.IsNullOrWhiteSpace(username))
                         {
-                            // If it does, check if it is OK to overwrite
-                            Console.WriteLine();
-                            Log.Error(Strings.Migration.DatabaseFileAlreadyExists.ToString(dbFileName));
-                            var input = Console.ReadLine();
-                            var key = input.Length > 0 ? input[0] : ' ';
-                            Console.WriteLine();
-                            if (key.ToString() != Strings.Migration.ConfirmCharacter)
-                            {
-                                Log.Info(Strings.Migration.MigrationCanceled);
-                                return;
-                            }
-
-                            File.Delete(dbFileName);
+                            username = Strings.Migration.DefaultUsername;
                         }
 
-                        toDatabaseOptions = new() { Type = toDatabaseType };
+                        Console.Write(Strings.Migration.PromptPassword);
+                        var password = GetPassword();
+
+                        Console.WriteLine();
+                        Console.WriteLine(Strings.Migration.MySqlConnecting);
+
+                        toDatabaseOptions = new()
+                        {
+                            Type = toDatabaseType,
+                            Server = host,
+                            Port = port,
+                            Database = database,
+                            Username = username,
+                            Password = password
+                        };
                         toContextOptions = new()
                         {
                             ConnectionStringBuilder = toDatabaseType.CreateConnectionStringBuilder(
                                 toDatabaseOptions,
-                                dbFileName
+                                default
                             ),
                             DatabaseType = toDatabaseType
                         };
 
-                        break;
+                        try
+                        {
+                            await using var testContext = IntersectDbContext<TContext>.Create(toContextOptions);
+                            break;
+                        }
+                        catch (Exception exception)
+                        {
+                            Log.Error(Strings.Migration.MySqlConnectionError.ToString(exception));
+                            Console.WriteLine();
+                            Console.WriteLine(Strings.Migration.MySqlTryAgain);
+                            var input = Console.ReadLine();
+                            var key = input.Length > 0 ? input[0] : ' ';
+                            Console.WriteLine();
+
+                            var shouldTryAgain = string.Equals(
+                                Strings.Migration.TryAgainCharacter,
+                                key.ToString(),
+                                StringComparison.Ordinal
+                            );
+
+                            if (shouldTryAgain)
+                            {
+                                continue;
+                            }
+
+                            Log.Info(Strings.Migration.MigrationCanceled);
+                            return;
+                        }
                     }
 
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(toDatabaseType), toDatabaseType, null);
-            }
+                    break;
+                }
 
-            // Shut down server, start migration.
-            Log.Info(Strings.Migration.StoppingServer);
+            case DatabaseType.Sqlite:
+                {
+                    string dbFileName;
+                    if (typeof(TContext).Extends<GameContext>())
+                    {
+                        dbFileName = GameDbFilename;
+                    }
+                    else if (typeof(TContext).Extends<PlayerContext>())
+                    {
+                        dbFileName = PlayersDbFilename;
+                    }
+                    else if (typeof(TContext).Extends<LoggingContext>())
+                    {
+                        dbFileName = LoggingDbFilename;
+                    }
+                    else
+                    {
+                        throw new InvalidOperationException($"Unsupported context type: {typeof(TContext).FullName}");
+                    }
 
-            //This variable will end the server loop and save any pending changes
-            ServerContext.Instance.DisposeWithoutExiting = true;
-            ServerContext.Instance.RequestShutdown();
+                    // Check if target SQLite file exists
+                    if (File.Exists(dbFileName))
+                    {
+                        // If it does, check if it is OK to overwrite
+                        Console.WriteLine();
+                        Log.Error(Strings.Migration.DatabaseFileAlreadyExists.ToString(dbFileName));
+                        var input = Console.ReadLine();
+                        var key = input.Length > 0 ? input[0] : ' ';
+                        Console.WriteLine();
+                        if (key.ToString() != Strings.Migration.ConfirmCharacter)
+                        {
+                            Log.Info(Strings.Migration.MigrationCanceled);
+                            return;
+                        }
 
-            while (ServerContext.Instance.IsRunning)
+                        File.Delete(dbFileName);
+                    }
+
+                    toDatabaseOptions = new() { Type = toDatabaseType };
+                    toContextOptions = new()
+                    {
+                        ConnectionStringBuilder = toDatabaseType.CreateConnectionStringBuilder(
+                            toDatabaseOptions,
+                            dbFileName
+                        ),
+                        DatabaseType = toDatabaseType
+                    };
+
+                    break;
+                }
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(toDatabaseType), toDatabaseType, null);
+        }
+
+        // Shut down server, start migration.
+        Log.Info(Strings.Migration.StoppingServer);
+
+        //This variable will end the server loop and save any pending changes
+        ServerContext.Instance.DisposeWithoutExiting = true;
+        ServerContext.Instance.RequestShutdown();
+
+        while (ServerContext.Instance.IsRunning)
+        {
+            Thread.Sleep(100);
+        }
+
+        Log.Info(Strings.Migration.StartingMigration);
+        var migrationService = new DatabaseTypeMigrationService();
+        if (await migrationService.TryMigrate<TContext>(fromContextOptions, toContextOptions))
+        {
+            if (typeof(TContext).Extends<GameContext>())
             {
-                Thread.Sleep(100);
+                Options.Instance.GameDatabase = toDatabaseOptions;
             }
-
-            Log.Info(Strings.Migration.StartingMigration);
-            var migrationService = new DatabaseTypeMigrationService();
-            if (await migrationService.TryMigrate<TContext>(fromContextOptions, toContextOptions))
+            else if (typeof(TContext).Extends<PlayerContext>())
             {
-                if (typeof(TContext).Extends<GameContext>())
-                {
-                    Options.Instance.GameDatabase = toDatabaseOptions;
-                }
-                else if (typeof(TContext).Extends<PlayerContext>())
-                {
-                    Options.Instance.PlayerDatabase = toDatabaseOptions;
-                }
-                else if (typeof(TContext).Extends<LoggingContext>())
-                {
-                    Options.Instance.LoggingDatabase = toDatabaseOptions;
-                }
-                else
-                {
-                    throw new InvalidOperationException($"Unsupported context type: {typeof(TContext).FullName}");
-                }
-
-                Options.SaveToDisk();
-
-                Log.Info(Strings.Migration.MigrationComplete);
-                Bootstrapper.Context.WaitForConsole();
-                ServerContext.Exit(0);
+                Options.Instance.PlayerDatabase = toDatabaseOptions;
+            }
+            else if (typeof(TContext).Extends<LoggingContext>())
+            {
+                Options.Instance.LoggingDatabase = toDatabaseOptions;
             }
             else
             {
-                Log.Error($"Error migrating context type: {typeof(TContext).FullName}");
-                ServerContext.Exit(1);
+                throw new InvalidOperationException($"Unsupported context type: {typeof(TContext).FullName}");
             }
-        }
 
-        private static void MigrateDbSet<T>(DbSet<T> oldDbSet, DbSet<T> newDbSet) where T : class
+            Options.SaveToDisk();
+
+            Log.Info(Strings.Migration.MigrationComplete);
+            Bootstrapper.Context.WaitForConsole();
+            ServerContext.Exit(0);
+        }
+        else
         {
-            foreach (var itm in oldDbSet)
-            {
-                newDbSet.Add(itm);
-            }
+            Log.Error($"Error migrating context type: {typeof(TContext).FullName}");
+            ServerContext.Exit(1);
         }
+    }
 
-        //Code taken from Stackoverflow on 9/20/2018
-        //Answer by Dai and Damian Leszczyński - Vash
-        //https://stackoverflow.com/questions/3404421/password-masking-console-application
-        public static string GetPassword()
+    private static void MigrateDbSet<T>(DbSet<T> oldDbSet, DbSet<T> newDbSet) where T : class
+    {
+        foreach (var itm in oldDbSet)
         {
-            var pwd = "";
-            while (true)
+            newDbSet.Add(itm);
+        }
+    }
+
+    //Code taken from Stackoverflow on 9/20/2018
+    //Answer by Dai and Damian Leszczyński - Vash
+    //https://stackoverflow.com/questions/3404421/password-masking-console-application
+    public static string GetPassword()
+    {
+        var pwd = "";
+        while (true)
+        {
+            var i = Console.ReadKey(true);
+            if (i.Key == ConsoleKey.Enter)
             {
-                var i = Console.ReadKey(true);
-                if (i.Key == ConsoleKey.Enter)
+                break;
+            }
+            else if (i.Key == ConsoleKey.Backspace)
+            {
+                if (pwd.Length > 1)
                 {
-                    break;
-                }
-                else if (i.Key == ConsoleKey.Backspace)
-                {
-                    if (pwd.Length > 1)
-                    {
-                        pwd = pwd.Remove(pwd.Length - 2, 1);
-                        Console.Write("\b \b");
-                    }
-                }
-                else if (i.KeyChar != '\u0000'
-                ) // KeyChar == '\u0000' if the key pressed does not correspond to a printable character, e.g. F1, Pause-Break, etc
-                {
-                    pwd = pwd + i.KeyChar;
-                    Console.Write("*");
+                    pwd = pwd.Remove(pwd.Length - 2, 1);
+                    Console.Write("\b \b");
                 }
             }
-
-            return pwd;
+            else if (i.KeyChar != '\u0000'
+            ) // KeyChar == '\u0000' if the key pressed does not correspond to a printable character, e.g. F1, Pause-Break, etc
+            {
+                pwd = pwd + i.KeyChar;
+                Console.Write("*");
+            }
         }
+
+        return pwd;
     }
 }

--- a/Intersect.Server.Core/Database/DbUpdateConcurrencyExceptionExtensions.cs
+++ b/Intersect.Server.Core/Database/DbUpdateConcurrencyExceptionExtensions.cs
@@ -4,34 +4,33 @@ using Intersect.Logging;
 
 using Microsoft.EntityFrameworkCore;
 
-namespace Intersect.Server.Database
+namespace Intersect.Server.Database;
+
+internal static class DbUpdateConcurrencyExceptionExtensions
 {
-    internal static class DbUpdateConcurrencyExceptionExtensions
+    public static void LogError(this DbUpdateConcurrencyException concurrencyException)
     {
-        public static void LogError(this DbUpdateConcurrencyException concurrencyException)
+        var concurrencyErrors = new StringBuilder();
+        _ = concurrencyErrors.AppendLine($"Entry count: {concurrencyException.Entries.Count}");
+        foreach (var entry in concurrencyException.Entries)
         {
-            var concurrencyErrors = new StringBuilder();
-            _ = concurrencyErrors.AppendLine($"Entry count: {concurrencyException.Entries.Count}");
-            foreach (var entry in concurrencyException.Entries)
+            var type = entry.GetType().FullName.ToString();
+            _ = concurrencyErrors
+                .AppendLine($"Entry Type [{type}] State: {entry.State}")
+                .AppendLine("--------------------");
+
+            var proposedValues = entry.CurrentValues;
+            var databaseValues = entry.GetDatabaseValues();
+
+            foreach (var property in proposedValues.Properties)
             {
-                var type = entry.GetType().FullName.ToString();
-                _ = concurrencyErrors
-                    .AppendLine($"Entry Type [{type}] State: {entry.State}")
-                    .AppendLine("--------------------");
-
-                var proposedValues = entry.CurrentValues;
-                var databaseValues = entry.GetDatabaseValues();
-
-                foreach (var property in proposedValues.Properties)
-                {
-                    _ = concurrencyErrors.AppendLine($"{property.Name} (Token: {property.IsConcurrencyToken}): Proposed: {proposedValues[property]}  Original Value: {entry.OriginalValues[property]}  Database Value: {(databaseValues != null ? databaseValues[property] : "null")}");
-                }
-
-                _ = concurrencyErrors
-                    .AppendLine()
-                    .AppendLine();
+                _ = concurrencyErrors.AppendLine($"{property.Name} (Token: {property.IsConcurrencyToken}): Proposed: {proposedValues[property]}  Original Value: {entry.OriginalValues[property]}  Database Value: {(databaseValues != null ? databaseValues[property] : "null")}");
             }
-            Log.Error(concurrencyErrors.ToString());
+
+            _ = concurrencyErrors
+                .AppendLine()
+                .AppendLine();
         }
+        Log.Error(concurrencyErrors.ToString());
     }
 }

--- a/Intersect.Server.Core/Database/GameData/GameContext.cs
+++ b/Intersect.Server.Core/Database/GameData/GameContext.cs
@@ -7,116 +7,115 @@ using Intersect.Server.Database.GameData.Migrations;
 using Intersect.Server.Maps;
 using Microsoft.EntityFrameworkCore;
 
-namespace Intersect.Server.Database.GameData
+namespace Intersect.Server.Database.GameData;
+
+/// <summary>
+/// <see cref="DbContext"/> implementation that contains static game content descriptors.
+/// </summary>
+public abstract partial class GameContext : IntersectDbContext<GameContext>, IGameContext
 {
-    /// <summary>
-    /// <see cref="DbContext"/> implementation that contains static game content descriptors.
-    /// </summary>
-    public abstract partial class GameContext : IntersectDbContext<GameContext>, IGameContext
+    /// <inheritdoc />
+    protected GameContext(DatabaseContextOptions databaseContextOptions) : base(databaseContextOptions) { }
+
+    //Animations
+    public DbSet<AnimationBase> Animations { get; set; }
+
+    //Crafting
+    public DbSet<CraftBase> Crafts { get; set; }
+
+    public DbSet<CraftingTableBase> CraftingTables { get; set; }
+
+    //Classes
+    public DbSet<ClassBase> Classes { get; set; }
+
+    //Events
+    public DbSet<EventBase> Events { get; set; }
+
+    //Items
+    public DbSet<ItemBase> Items { get; set; }
+
+    //Equipment Properties of Items
+    public DbSet<EquipmentProperties> Items_EquipmentProperties { get; set; }
+
+    //Maps
+    public DbSet<MapController> Maps { get; set; }
+
+    public DbSet<MapList> MapFolders { get; set; }
+
+    //NPCs
+    public DbSet<NpcBase> Npcs { get; set; }
+
+    //Projectiles
+    public DbSet<ProjectileBase> Projectiles { get; set; }
+
+    //Quests
+    public DbSet<QuestBase> Quests { get; set; }
+
+    //Resources
+    public DbSet<ResourceBase> Resources { get; set; }
+
+    //Shops
+    public DbSet<ShopBase> Shops { get; set; }
+
+    //Spells
+    public DbSet<SpellBase> Spells { get; set; }
+
+    //Variables
+    public DbSet<PlayerVariableBase> PlayerVariables { get; set; }
+
+    public DbSet<ServerVariableBase> ServerVariables { get; set; }
+
+    public DbSet<GuildVariableBase> GuildVariables { get; set; }
+
+    public DbSet<UserVariableBase> UserVariables { get; set; }
+
+    //Tilesets
+    public DbSet<TilesetBase> Tilesets { get; set; }
+
+    //Time
+    public DbSet<TimeBase> Time { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        /// <inheritdoc />
-        protected GameContext(DatabaseContextOptions databaseContextOptions) : base(databaseContextOptions) { }
+        modelBuilder.Entity<EquipmentProperties>()
+            .HasOne(property => property.Descriptor)
+            .WithOne(item => item.EquipmentProperties)
+            .HasForeignKey<EquipmentProperties>(property => property.DescriptorId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
 
-        //Animations
-        public DbSet<AnimationBase> Animations { get; set; }
-
-        //Crafting
-        public DbSet<CraftBase> Crafts { get; set; }
-
-        public DbSet<CraftingTableBase> CraftingTables { get; set; }
-
-        //Classes
-        public DbSet<ClassBase> Classes { get; set; }
-
-        //Events
-        public DbSet<EventBase> Events { get; set; }
-
-        //Items
-        public DbSet<ItemBase> Items { get; set; }
-
-        //Equipment Properties of Items
-        public DbSet<EquipmentProperties> Items_EquipmentProperties { get; set; }
-
-        //Maps
-        public DbSet<MapController> Maps { get; set; }
-
-        public DbSet<MapList> MapFolders { get; set; }
-
-        //NPCs
-        public DbSet<NpcBase> Npcs { get; set; }
-
-        //Projectiles
-        public DbSet<ProjectileBase> Projectiles { get; set; }
-
-        //Quests
-        public DbSet<QuestBase> Quests { get; set; }
-
-        //Resources
-        public DbSet<ResourceBase> Resources { get; set; }
-
-        //Shops
-        public DbSet<ShopBase> Shops { get; set; }
-
-        //Spells
-        public DbSet<SpellBase> Spells { get; set; }
-
-        //Variables
-        public DbSet<PlayerVariableBase> PlayerVariables { get; set; }
-
-        public DbSet<ServerVariableBase> ServerVariables { get; set; }
-
-        public DbSet<GuildVariableBase> GuildVariables { get; set; }
-
-        public DbSet<UserVariableBase> UserVariables { get; set; }
-
-        //Tilesets
-        public DbSet<TilesetBase> Tilesets { get; set; }
-
-        //Time
-        public DbSet<TimeBase> Time { get; set; }
-
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
+    public override void OnSchemaMigrationsProcessed(string[] migrations)
+    {
+        if (migrations.IndexOf("20190611170819_CombiningSwitchesVariables") > -1)
         {
-            modelBuilder.Entity<EquipmentProperties>()
-                .HasOne(property => property.Descriptor)
-                .WithOne(item => item.EquipmentProperties)
-                .HasForeignKey<EquipmentProperties>(property => property.DescriptorId)
-                .OnDelete(DeleteBehavior.Cascade);
+            Beta6Migration.Run(this);
         }
 
-        public override void OnSchemaMigrationsProcessed(string[] migrations)
+        if (migrations.IndexOf("20201004032158_EnablingCerasVersionTolerance") > -1)
         {
-            if (migrations.IndexOf("20190611170819_CombiningSwitchesVariables") > -1)
-            {
-                Beta6Migration.Run(this);
-            }
-
-            if (migrations.IndexOf("20201004032158_EnablingCerasVersionTolerance") > -1)
-            {
-                CerasVersionToleranceMigration.Run(this);
-            }
-
-            if (migrations.IndexOf("20210512071349_BoundItemExtension") > -1)
-            {
-                BoundItemExtensionMigration.Run(this);
-            }
-
-            if (migrations.IndexOf("20211031200145_FixQuestTaskCompletionEvents") > -1)
-            {
-                FixQuestTaskCompletionEventsMigration.Run(this);
-            }
+            CerasVersionToleranceMigration.Run(this);
         }
 
-        internal static partial class Queries
+        if (migrations.IndexOf("20210512071349_BoundItemExtension") > -1)
         {
-            internal static readonly Func<Guid, ServerVariableBase> ServerVariableById =
-                (Guid id) => (ServerVariableBase)ServerVariableBase.Lookup.FirstOrDefault(variable => variable.Key == id).Value;
-
-            internal static readonly Func<string, ServerVariableBase> ServerVariableByName =
-                (string name) => (ServerVariableBase)ServerVariableBase.Lookup.FirstOrDefault(variable => string.Equals(variable.Value.Name, name, StringComparison.OrdinalIgnoreCase)).Value;
-
-            internal static readonly Func<int, int, IEnumerable<ServerVariableBase>> ServerVariables =
-                (int page, int count) => ServerVariableBase.Lookup.Select(v => (ServerVariableBase)v.Value).OrderBy(v => v.Id.ToString()).Skip(page * count).Take(count);
+            BoundItemExtensionMigration.Run(this);
         }
+
+        if (migrations.IndexOf("20211031200145_FixQuestTaskCompletionEvents") > -1)
+        {
+            FixQuestTaskCompletionEventsMigration.Run(this);
+        }
+    }
+
+    internal static partial class Queries
+    {
+        internal static readonly Func<Guid, ServerVariableBase> ServerVariableById =
+            (Guid id) => (ServerVariableBase)ServerVariableBase.Lookup.FirstOrDefault(variable => variable.Key == id).Value;
+
+        internal static readonly Func<string, ServerVariableBase> ServerVariableByName =
+            (string name) => (ServerVariableBase)ServerVariableBase.Lookup.FirstOrDefault(variable => string.Equals(variable.Value.Name, name, StringComparison.OrdinalIgnoreCase)).Value;
+
+        internal static readonly Func<int, int, IEnumerable<ServerVariableBase>> ServerVariables =
+            (int page, int count) => ServerVariableBase.Lookup.Select(v => (ServerVariableBase)v.Value).OrderBy(v => v.Id.ToString()).Skip(page * count).Take(count);
     }
 }

--- a/Intersect.Server.Core/Database/GameData/IGameContext.cs
+++ b/Intersect.Server.Core/Database/GameData/IGameContext.cs
@@ -6,44 +6,43 @@ using Intersect.Server.Maps;
 
 using Microsoft.EntityFrameworkCore;
 
-namespace Intersect.Server.Database.GameData
+namespace Intersect.Server.Database.GameData;
+
+public interface IGameContext : IDbContext
 {
-    public interface IGameContext : IDbContext
-    {
-        DbSet<AnimationBase> Animations { get; set; }
+    DbSet<AnimationBase> Animations { get; set; }
 
-        DbSet<CraftBase> Crafts { get; set; }
+    DbSet<CraftBase> Crafts { get; set; }
 
-        DbSet<CraftingTableBase> CraftingTables { get; set; }
+    DbSet<CraftingTableBase> CraftingTables { get; set; }
 
-        DbSet<ClassBase> Classes { get; set; }
+    DbSet<ClassBase> Classes { get; set; }
 
-        DbSet<EventBase> Events { get; set; }
+    DbSet<EventBase> Events { get; set; }
 
-        DbSet<ItemBase> Items { get; set; }
+    DbSet<ItemBase> Items { get; set; }
 
-        DbSet<EquipmentProperties> Items_EquipmentProperties { get; set; }
+    DbSet<EquipmentProperties> Items_EquipmentProperties { get; set; }
 
-        DbSet<MapController> Maps { get; set; }
+    DbSet<MapController> Maps { get; set; }
 
-        DbSet<MapList> MapFolders { get; set; }
+    DbSet<MapList> MapFolders { get; set; }
 
-        DbSet<NpcBase> Npcs { get; set; }
+    DbSet<NpcBase> Npcs { get; set; }
 
-        DbSet<ProjectileBase> Projectiles { get; set; }
+    DbSet<ProjectileBase> Projectiles { get; set; }
 
-        DbSet<QuestBase> Quests { get; set; }
+    DbSet<QuestBase> Quests { get; set; }
 
-        DbSet<ResourceBase> Resources { get; set; }
+    DbSet<ResourceBase> Resources { get; set; }
 
-        DbSet<ShopBase> Shops { get; set; }
+    DbSet<ShopBase> Shops { get; set; }
 
-        DbSet<SpellBase> Spells { get; set; }
+    DbSet<SpellBase> Spells { get; set; }
 
-        DbSet<ServerVariableBase> ServerVariables { get; set; }
+    DbSet<ServerVariableBase> ServerVariables { get; set; }
 
-        DbSet<TilesetBase> Tilesets { get; set; }
+    DbSet<TilesetBase> Tilesets { get; set; }
 
-        DbSet<TimeBase> Time { get; set; }
-    }
+    DbSet<TimeBase> Time { get; set; }
 }

--- a/Intersect.Server.Core/Database/GameData/Migrations/Beta6Migration.cs
+++ b/Intersect.Server.Core/Database/GameData/Migrations/Beta6Migration.cs
@@ -13,735 +13,733 @@ using Newtonsoft.Json.Linq;
 using MapAttribute = Intersect.GameObjects.Maps.MapAttribute;
 using VariableMod = Intersect.Enums.VariableMod;
 
-namespace Intersect.Server.Database.GameData.Migrations
+namespace Intersect.Server.Database.GameData.Migrations;
+
+
+public static partial class Beta6Migration
 {
 
-    public static partial class Beta6Migration
+    private static Intersect.Network.Ceras mCeras;
+
+    public static void Run(GameContext context)
     {
+        var nameTypeDict = new Dictionary<string, Type>();
+        nameTypeDict.Add("Intersect.GameObjects.Maps.TileArray[]", typeof(LegacyTileArray[]));
+        mCeras = new Intersect.Network.Ceras(nameTypeDict);
 
-        private static Intersect.Network.Ceras mCeras;
+        RemoveByteBufferUsageFromMaps(context);
 
-        public static void Run(GameContext context)
+        //Fix SetSwitch/SetVariable Event Commands
+        FixVariableCommandsAndConditions(context, "Events", "Pages");
+
+        //Convert Conditions (Events/EventCommands/Items/Quests/etc/etc/etc)
+        FixVariableCommandsAndConditions(context, "Npcs", "AttackOnSightConditions");
+        FixVariableCommandsAndConditions(context, "Npcs", "PlayerCanAttackConditions");
+        FixVariableCommandsAndConditions(context, "Npcs", "PlayerFriendConditions");
+        FixVariableCommandsAndConditions(context, "Spells", "CastRequirements");
+        FixVariableCommandsAndConditions(context, "Resources", "HarvestingRequirements");
+        FixVariableCommandsAndConditions(context, "Quests", "Requirements");
+        FixVariableCommandsAndConditions(context, "Items", "UsageRequirements");
+    }
+
+    private static void FixVariableCommandsAndConditions(GameContext context, string table, string column)
+    {
+        var connection = context.Database.GetDbConnection();
+        connection.Open();
+        var updates = new List<KeyValuePair<object, string>>();
+        using (var cmd = connection.CreateCommand())
         {
-            var nameTypeDict = new Dictionary<string, Type>();
-            nameTypeDict.Add("Intersect.GameObjects.Maps.TileArray[]", typeof(LegacyTileArray[]));
-            mCeras = new Intersect.Network.Ceras(nameTypeDict);
+            cmd.CommandText = "Select Id, " + column + " FROM " + table + ";";
+            var reader = cmd.ExecuteReader();
+            while (reader.Read())
+            {
+                var id = reader["Id"];
 
-            RemoveByteBufferUsageFromMaps(context);
+                var json = reader[column].ToString();
 
-            //Fix SetSwitch/SetVariable Event Commands
-            FixVariableCommandsAndConditions(context, "Events", "Pages");
+                var fixedJson = FixJson(json);
 
-            //Convert Conditions (Events/EventCommands/Items/Quests/etc/etc/etc)
-            FixVariableCommandsAndConditions(context, "Npcs", "AttackOnSightConditions");
-            FixVariableCommandsAndConditions(context, "Npcs", "PlayerCanAttackConditions");
-            FixVariableCommandsAndConditions(context, "Npcs", "PlayerFriendConditions");
-            FixVariableCommandsAndConditions(context, "Spells", "CastRequirements");
-            FixVariableCommandsAndConditions(context, "Resources", "HarvestingRequirements");
-            FixVariableCommandsAndConditions(context, "Quests", "Requirements");
-            FixVariableCommandsAndConditions(context, "Items", "UsageRequirements");
+                updates.Add(new KeyValuePair<object, string>(id, fixedJson));
+            }
         }
 
-        private static void FixVariableCommandsAndConditions(GameContext context, string table, string column)
+        connection.Close();
+        connection.Open();
+
+        if (updates.Count > 0)
         {
-            var connection = context.Database.GetDbConnection();
-            connection.Open();
-            var updates = new List<KeyValuePair<object, string>>();
-            using (var cmd = connection.CreateCommand())
+            var trans = connection.BeginTransaction();
+
+            using (var updateCmd = connection.CreateCommand())
             {
-                cmd.CommandText = "Select Id, " + column + " FROM " + table + ";";
-                var reader = cmd.ExecuteReader();
-                while (reader.Read())
+                var i = 0;
+                var currentCount = 0;
+                updateCmd.CommandText = "";
+                updateCmd.Transaction = trans;
+                foreach (var update in updates)
                 {
-                    var id = reader["Id"];
+                    updateCmd.CommandText +=
+                        "UPDATE " + table + " SET " + column + " = @json" + i + " WHERE Id = @Id" + i + ";";
 
-                    var json = reader[column].ToString();
-
-                    var fixedJson = FixJson(json);
-
-                    updates.Add(new KeyValuePair<object, string>(id, fixedJson));
-                }
-            }
-
-            connection.Close();
-            connection.Open();
-
-            if (updates.Count > 0)
-            {
-                var trans = connection.BeginTransaction();
-
-                using (var updateCmd = connection.CreateCommand())
-                {
-                    var i = 0;
-                    var currentCount = 0;
-                    updateCmd.CommandText = "";
-                    updateCmd.Transaction = trans;
-                    foreach (var update in updates)
+                    if (context.Database.ProviderName.Contains("Sqlite"))
                     {
-                        updateCmd.CommandText +=
-                            "UPDATE " + table + " SET " + column + " = @json" + i + " WHERE Id = @Id" + i + ";";
-
-                        if (context.Database.ProviderName.Contains("Sqlite"))
-                        {
-                            updateCmd.Parameters.Add(new SqliteParameter("@Id" + i, update.Key));
-                            updateCmd.Parameters.Add(new SqliteParameter("@json" + i, update.Value));
-                        }
-                        else
-                        {
-                            updateCmd.Parameters.Add(new MySqlParameter("@Id" + i, update.Key));
-                            updateCmd.Parameters.Add(new MySqlParameter("@json" + i, update.Value));
-                        }
-
-                        i++;
-                        currentCount++;
-
-                        if (currentCount > 256)
-                        {
-                            updateCmd.ExecuteNonQuery();
-                            updateCmd.CommandText = "";
-                            updateCmd.Parameters.Clear();
-                            currentCount = 0;
-                        }
+                        updateCmd.Parameters.Add(new SqliteParameter("@Id" + i, update.Key));
+                        updateCmd.Parameters.Add(new SqliteParameter("@json" + i, update.Value));
+                    }
+                    else
+                    {
+                        updateCmd.Parameters.Add(new MySqlParameter("@Id" + i, update.Key));
+                        updateCmd.Parameters.Add(new MySqlParameter("@json" + i, update.Value));
                     }
 
-                    updateCmd.ExecuteNonQuery();
-                    updateCmd.Parameters.Clear();
-                }
+                    i++;
+                    currentCount++;
 
-                trans.Commit();
-            }
-
-            connection.Close();
-        }
-
-        private static string FixJson(string json)
-        {
-            var obj = JArray.Parse(json);
-            ParseJson(obj);
-            var newJson = obj.ToString(Formatting.None);
-
-            return newJson;
-        }
-
-        private static void ParseJson(JToken obj)
-        {
-            foreach (var child in obj)
-            {
-                if (child.Type == JTokenType.Object)
-                {
-                    //Stuff
-                    var childObj = (JObject) child;
-
-                    var type = child["$type"];
-                    if (type != null)
+                    if (currentCount > 256)
                     {
-                        switch (type.ToString())
-                        {
-                            case "Intersect.GameObjects.Events.Commands.SetSwitchCommand, Intersect Core":
-                                var newNode = ConvertSetSwitchCommand(childObj);
-                                childObj.RemoveAll();
-                                foreach (var node in newNode)
-                                {
-                                    childObj.Add(node.Key, node.Value);
-                                }
-
-                                break;
-
-                            case "Intersect.GameObjects.Events.Commands.SetVariableCommand, Intersect Core":
-                                var newNode1 = ConvertSetVariableCommand(childObj);
-                                childObj.RemoveAll();
-                                foreach (var node in newNode1)
-                                {
-                                    childObj.Add(node.Key, node.Value);
-                                }
-
-                                break;
-                            case "Intersect.GameObjects.Events.PlayerVariableCondition, Intersect Core":
-                                var newNode2 = ConvertPlayerVariableCondition(childObj);
-                                childObj.RemoveAll();
-                                foreach (var node in newNode2)
-                                {
-                                    childObj.Add(node.Key, node.Value);
-                                }
-
-                                break;
-                            case "Intersect.GameObjects.Events.PlayerSwitchCondition, Intersect Core":
-                                var newNode3 = ConvertPlayerSwitchCondition(childObj);
-                                childObj.RemoveAll();
-                                foreach (var node in newNode3)
-                                {
-                                    childObj.Add(node.Key, node.Value);
-                                }
-
-                                break;
-                            case "Intersect.GameObjects.Events.ServerVariableCondition, Intersect Core":
-                                var newNode4 = ConvertGlobalVariableCondition(childObj);
-                                childObj.RemoveAll();
-                                foreach (var node in newNode4)
-                                {
-                                    childObj.Add(node.Key, node.Value);
-                                }
-
-                                break;
-                            case "Intersect.GameObjects.Events.ServerSwitchCondition, Intersect Core":
-                                var newNode5 = ConvertGlobalSwitchCondition(childObj);
-                                childObj.RemoveAll();
-                                foreach (var node in newNode5)
-                                {
-                                    childObj.Add(node.Key, node.Value);
-                                }
-
-                                break;
-                            default:
-                                break;
-                        }
-                    }
-                }
-                else if (child.Type == JTokenType.String)
-                {
-                    var property = child.Parent as JProperty;
-                    if (property != null && property.Name == "Lists")
-                    {
-                        try
-                        {
-                            var newJson = FixJson(property.Value?.ToString());
-                            property.Value = newJson;
-                        }
-                        catch
-                        {
-                            // Not important to abort or log
-                        }
+                        updateCmd.ExecuteNonQuery();
+                        updateCmd.CommandText = "";
+                        updateCmd.Parameters.Clear();
+                        currentCount = 0;
                     }
                 }
 
-                ParseJson(child);
+                updateCmd.ExecuteNonQuery();
+                updateCmd.Parameters.Clear();
             }
+
+            trans.Commit();
         }
 
-        //OLD
-        //public class SetSwitchCommand : EventCommand
-        //{
-        //    public override EventCommandType Type { get; } = EventCommandType.SetSwitch;
-        //    public SwitchTypes SwitchType { get; set; } = SwitchTypes.PlayerSwitch;
-        //    public Guid SwitchId { get; set; }
-        //    public bool Value { get; set; }
-        //    public bool SyncParty { get; set; }
-        //}
+        connection.Close();
+    }
 
-        private static JObject ConvertSetSwitchCommand(JObject obj)
+    private static string FixJson(string json)
+    {
+        var obj = JArray.Parse(json);
+        ParseJson(obj);
+        var newJson = obj.ToString(Formatting.None);
+
+        return newJson;
+    }
+
+    private static void ParseJson(JToken obj)
+    {
+        foreach (var child in obj)
         {
-            var cmd = new SetVariableCommand();
+            if (child.Type == JTokenType.Object)
+            {
+                //Stuff
+                var childObj = (JObject) child;
 
-            if (obj.ContainsKey("SwitchId"))
-            {
-                cmd.VariableId = Guid.Parse(obj["SwitchId"].ToString());
-            }
-
-            if (obj.ContainsKey("SwitchType") && int.Parse(obj["SwitchType"].ToString()) == 1)
-            {
-                cmd.VariableType = VariableType.ServerVariable;
-            }
-            else
-            {
-                cmd.VariableType = VariableType.PlayerVariable;
-            }
-
-            if (obj.ContainsKey("SyncParty") && bool.Parse(obj["SyncParty"].ToString()))
-            {
-                cmd.SyncParty = true;
-            }
-            else
-            {
-                cmd.SyncParty = false;
-            }
-
-            var mod = new BooleanVariableMod();
-            cmd.Modification = mod;
-
-            if (obj.ContainsKey("Value") && bool.Parse(obj["Value"].ToString()))
-            {
-                mod.Value = true;
-            }
-            else
-            {
-                mod.Value = false;
-            }
-
-            var newJson = JsonConvert.SerializeObject(
-                cmd, typeof(EventCommand),
-                new JsonSerializerSettings()
+                var type = child["$type"];
+                if (type != null)
                 {
-                    Formatting = Formatting.None, TypeNameHandling = TypeNameHandling.Auto,
-                    DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate,
-                    ObjectCreationHandling = ObjectCreationHandling.Replace
-                }
-            );
-
-            return JObject.Parse(newJson);
-        }
-
-        //OLD
-        //public class SetVariableCommand : EventCommand
-        //{
-        //    public VariableMods ModType { get; set; } = VariableMods.Set;
-        //    public int Value { get; set; }
-        //    public int HighValue { get; set; }
-        //    public Guid DuplicateVariableId { get; set; }
-        //}
-
-        private static JObject ConvertSetVariableCommand(JObject obj)
-        {
-            var cmd = new SetVariableCommand();
-
-            if (obj.ContainsKey("VariableId"))
-            {
-                cmd.VariableId = Guid.Parse(obj["VariableId"].ToString());
-            }
-
-            if (obj.ContainsKey("VariableType") && int.Parse(obj["VariableType"].ToString()) == 1)
-            {
-                cmd.VariableType = VariableType.ServerVariable;
-            }
-            else
-            {
-                cmd.VariableType = VariableType.PlayerVariable;
-            }
-
-            if (obj.ContainsKey("SyncParty") && bool.Parse(obj["SyncParty"].ToString()))
-            {
-                cmd.SyncParty = true;
-            }
-            else
-            {
-                cmd.SyncParty = false;
-            }
-
-            var mod = new IntegerVariableMod();
-            cmd.Modification = mod;
-
-            if (obj.ContainsKey("Value"))
-            {
-                mod.Value = long.Parse(obj["Value"].ToString());
-            }
-
-            if (obj.ContainsKey("DupVariableId"))
-            {
-                mod.DuplicateVariableId = Guid.Parse(obj["DupVariableId"].ToString());
-            }
-
-            if (obj.ContainsKey("HighValue"))
-            {
-                mod.HighValue = long.Parse(obj["HighValue"].ToString());
-            }
-
-            if (obj.ContainsKey("ModType"))
-            {
-                mod.ModType = (VariableMod) int.Parse(obj["ModType"].ToString());
-            }
-
-            var newJson = JsonConvert.SerializeObject(
-                cmd, typeof(EventCommand),
-                new JsonSerializerSettings()
-                {
-                    Formatting = Formatting.None, TypeNameHandling = TypeNameHandling.Auto,
-                    DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate,
-                    ObjectCreationHandling = ObjectCreationHandling.Replace
-                }
-            );
-
-            return JObject.Parse(newJson);
-        }
-
-        //OLD
-        //public class PlayerSwitchCondition : Condition
-        //{
-        //    public override ConditionTypes Type { get; } = ConditionTypes.PlayerSwitch;
-        //    public Guid SwitchId { get; set; }
-        //    public bool Value { get; set; }
-        //}
-
-        private static JObject ConvertPlayerSwitchCondition(JObject obj)
-        {
-            var cmd = new VariableIsCondition();
-
-            if (obj.ContainsKey("SwitchId"))
-            {
-                cmd.VariableId = Guid.Parse(obj["SwitchId"].ToString());
-            }
-
-            cmd.VariableType = VariableType.PlayerVariable;
-
-            var comp = new BooleanVariableComparison();
-            cmd.Comparison = comp;
-
-            comp.ComparingEqual = true;
-
-            if (obj.ContainsKey("Value"))
-            {
-                comp.Value = bool.Parse(obj["Value"].ToString());
-            }
-
-            var newJson = JsonConvert.SerializeObject(
-                cmd, typeof(Condition),
-                new JsonSerializerSettings()
-                {
-                    Formatting = Formatting.None, TypeNameHandling = TypeNameHandling.Auto,
-                    DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate,
-                    ObjectCreationHandling = ObjectCreationHandling.Replace
-                }
-            );
-
-            return JObject.Parse(newJson);
-        }
-
-        //OLD
-        //public class ServerSwitchCondition : Condition
-        //{
-        //    public override ConditionTypes Type { get; } = ConditionTypes.ServerSwitch;
-        //    public Guid SwitchId { get; set; }
-        //    public bool Value { get; set; }
-        //}
-
-        private static JObject ConvertGlobalSwitchCondition(JObject obj)
-        {
-            var cmd = new VariableIsCondition();
-
-            if (obj.ContainsKey("SwitchId"))
-            {
-                cmd.VariableId = Guid.Parse(obj["SwitchId"].ToString());
-            }
-
-            cmd.VariableType = VariableType.ServerVariable;
-
-            var comp = new BooleanVariableComparison();
-            cmd.Comparison = comp;
-
-            comp.ComparingEqual = true;
-
-            if (obj.ContainsKey("Value"))
-            {
-                comp.Value = bool.Parse(obj["Value"].ToString());
-            }
-
-            var newJson = JsonConvert.SerializeObject(
-                cmd, typeof(Condition),
-                new JsonSerializerSettings()
-                {
-                    Formatting = Formatting.None, TypeNameHandling = TypeNameHandling.Auto,
-                    DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate,
-                    ObjectCreationHandling = ObjectCreationHandling.Replace
-                }
-            );
-
-            return JObject.Parse(newJson);
-        }
-
-        //OLD
-        //public class PlayerVariableCondition : Condition
-        //{
-        //    public override ConditionTypes Type { get; } = ConditionTypes.PlayerVariable;
-        //    public Guid VariableId { get; set; }
-        //    public VariableComparators Comparator { get; set; } = VariableComparators.Equal;
-        //    public VariableCompareTypes CompareType { get; set; } = VariableCompareTypes.StaticValue;
-        //    public long Value { get; set; }
-        //    public Guid CompareVariableId { get; set; }
-        //}
-
-        private static JObject ConvertPlayerVariableCondition(JObject obj)
-        {
-            var cmd = new VariableIsCondition();
-
-            if (obj.ContainsKey("VariableId"))
-            {
-                cmd.VariableId = Guid.Parse(obj["VariableId"].ToString());
-            }
-
-            cmd.VariableType = VariableType.PlayerVariable;
-
-            var comp = new IntegerVariableComparison();
-            cmd.Comparison = comp;
-
-            if (obj.ContainsKey("Value"))
-            {
-                comp.Value = long.Parse(obj["Value"].ToString());
-            }
-
-            if (obj.ContainsKey("CompareVariableId"))
-            {
-                comp.CompareVariableId = Guid.Parse(obj["CompareVariableId"].ToString());
-            }
-
-            if (obj.ContainsKey("Comparator"))
-            {
-                comp.Comparator = (VariableComparator) int.Parse(obj["Comparator"].ToString());
-            }
-
-            if (!obj.ContainsKey("CompareType"))
-            {
-                comp.CompareVariableId = Guid.Empty;
-            }
-            else
-            {
-                if (int.Parse(obj["CompareType"].ToString()) == 1)
-                {
-                    comp.CompareVariableType = VariableType.PlayerVariable;
-                }
-                else
-                {
-                    comp.CompareVariableType = VariableType.ServerVariable;
-                }
-            }
-
-            var newJson = JsonConvert.SerializeObject(
-                cmd, typeof(Condition),
-                new JsonSerializerSettings()
-                {
-                    Formatting = Formatting.None, TypeNameHandling = TypeNameHandling.Auto,
-                    DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate,
-                    ObjectCreationHandling = ObjectCreationHandling.Replace
-                }
-            );
-
-            return JObject.Parse(newJson);
-        }
-
-        //OLD
-        //public class ServerVariableCondition : Condition
-        //{
-        //    public override ConditionTypes Type { get; } = ConditionTypes.ServerVariable;
-        //    public Guid VariableId { get; set; }
-        //    public VariableComparators Comparator { get; set; } = VariableComparators.Equal;
-        //    public VariableCompareTypes CompareType { get; set; } = VariableCompareTypes.StaticValue;
-        //    public long Value { get; set; }
-        //    public Guid CompareVariableId { get; set; }
-        //}
-
-        private static JObject ConvertGlobalVariableCondition(JObject obj)
-        {
-            var cmd = new VariableIsCondition();
-
-            if (obj.ContainsKey("VariableId"))
-            {
-                cmd.VariableId = Guid.Parse(obj["VariableId"].ToString());
-            }
-
-            cmd.VariableType = VariableType.ServerVariable;
-
-            var comp = new IntegerVariableComparison();
-            cmd.Comparison = comp;
-
-            if (obj.ContainsKey("Value"))
-            {
-                comp.Value = long.Parse(obj["Value"].ToString());
-            }
-
-            if (obj.ContainsKey("CompareVariableId"))
-            {
-                comp.CompareVariableId = Guid.Parse(obj["CompareVariableId"].ToString());
-            }
-
-            if (obj.ContainsKey("Comparator"))
-            {
-                comp.Comparator = (VariableComparator) int.Parse(obj["Comparator"].ToString());
-            }
-
-            if (!obj.ContainsKey("CompareType"))
-            {
-                comp.CompareVariableId = Guid.Empty;
-            }
-            else
-            {
-                if (int.Parse(obj["CompareType"].ToString()) == 1)
-                {
-                    comp.CompareVariableType = VariableType.PlayerVariable;
-                }
-                else
-                {
-                    comp.CompareVariableType = VariableType.ServerVariable;
-                }
-            }
-
-            var newJson = JsonConvert.SerializeObject(
-                cmd, typeof(Condition),
-                new JsonSerializerSettings()
-                {
-                    Formatting = Formatting.None, TypeNameHandling = TypeNameHandling.Auto,
-                    DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate,
-                    ObjectCreationHandling = ObjectCreationHandling.Replace
-                }
-            );
-
-            return JObject.Parse(newJson);
-        }
-
-        private static void RemoveByteBufferUsageFromMaps(GameContext context)
-        {
-            var connection = context.Database.GetDbConnection();
-            connection.Open();
-            var updates = new List<Tuple<object, byte[], byte[]>>();
-            using (var cmd = connection.CreateCommand())
-            {
-                cmd.CommandText = "Select Id, Attributes, TileData from Maps;";
-                var reader = cmd.ExecuteReader();
-                while (reader.Read())
-                {
-                    var id = reader["Id"];
-
-                    var tileData = (byte[]) reader["TileData"];
-                    var newTileData = ReencodeTileData(tileData);
-
-                    var attributeData = (byte[]) reader["Attributes"];
-                    var newAttributeData = mCeras.Compress(
-                        JsonConvert.DeserializeObject<MapAttribute[,]>(
-                            System.Text.Encoding.UTF8.GetString(Decompress(attributeData)),
-                            new JsonSerializerSettings()
+                    switch (type.ToString())
+                    {
+                        case "Intersect.GameObjects.Events.Commands.SetSwitchCommand, Intersect Core":
+                            var newNode = ConvertSetSwitchCommand(childObj);
+                            childObj.RemoveAll();
+                            foreach (var node in newNode)
                             {
-                                TypeNameHandling = TypeNameHandling.Auto,
-                                DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate,
-                                ObjectCreationHandling = ObjectCreationHandling.Replace
+                                childObj.Add(node.Key, node.Value);
                             }
-                        )
+
+                            break;
+
+                        case "Intersect.GameObjects.Events.Commands.SetVariableCommand, Intersect Core":
+                            var newNode1 = ConvertSetVariableCommand(childObj);
+                            childObj.RemoveAll();
+                            foreach (var node in newNode1)
+                            {
+                                childObj.Add(node.Key, node.Value);
+                            }
+
+                            break;
+                        case "Intersect.GameObjects.Events.PlayerVariableCondition, Intersect Core":
+                            var newNode2 = ConvertPlayerVariableCondition(childObj);
+                            childObj.RemoveAll();
+                            foreach (var node in newNode2)
+                            {
+                                childObj.Add(node.Key, node.Value);
+                            }
+
+                            break;
+                        case "Intersect.GameObjects.Events.PlayerSwitchCondition, Intersect Core":
+                            var newNode3 = ConvertPlayerSwitchCondition(childObj);
+                            childObj.RemoveAll();
+                            foreach (var node in newNode3)
+                            {
+                                childObj.Add(node.Key, node.Value);
+                            }
+
+                            break;
+                        case "Intersect.GameObjects.Events.ServerVariableCondition, Intersect Core":
+                            var newNode4 = ConvertGlobalVariableCondition(childObj);
+                            childObj.RemoveAll();
+                            foreach (var node in newNode4)
+                            {
+                                childObj.Add(node.Key, node.Value);
+                            }
+
+                            break;
+                        case "Intersect.GameObjects.Events.ServerSwitchCondition, Intersect Core":
+                            var newNode5 = ConvertGlobalSwitchCondition(childObj);
+                            childObj.RemoveAll();
+                            foreach (var node in newNode5)
+                            {
+                                childObj.Add(node.Key, node.Value);
+                            }
+
+                            break;
+                        default:
+                            break;
+                    }
+                }
+            }
+            else if (child.Type == JTokenType.String)
+            {
+                var property = child.Parent as JProperty;
+                if (property != null && property.Name == "Lists")
+                {
+                    try
+                    {
+                        var newJson = FixJson(property.Value?.ToString());
+                        property.Value = newJson;
+                    }
+                    catch
+                    {
+                        // Not important to abort or log
+                    }
+                }
+            }
+
+            ParseJson(child);
+        }
+    }
+
+    //OLD
+    //public class SetSwitchCommand : EventCommand
+    //{
+    //    public override EventCommandType Type { get; } = EventCommandType.SetSwitch;
+    //    public SwitchTypes SwitchType { get; set; } = SwitchTypes.PlayerSwitch;
+    //    public Guid SwitchId { get; set; }
+    //    public bool Value { get; set; }
+    //    public bool SyncParty { get; set; }
+    //}
+
+    private static JObject ConvertSetSwitchCommand(JObject obj)
+    {
+        var cmd = new SetVariableCommand();
+
+        if (obj.ContainsKey("SwitchId"))
+        {
+            cmd.VariableId = Guid.Parse(obj["SwitchId"].ToString());
+        }
+
+        if (obj.ContainsKey("SwitchType") && int.Parse(obj["SwitchType"].ToString()) == 1)
+        {
+            cmd.VariableType = VariableType.ServerVariable;
+        }
+        else
+        {
+            cmd.VariableType = VariableType.PlayerVariable;
+        }
+
+        if (obj.ContainsKey("SyncParty") && bool.Parse(obj["SyncParty"].ToString()))
+        {
+            cmd.SyncParty = true;
+        }
+        else
+        {
+            cmd.SyncParty = false;
+        }
+
+        var mod = new BooleanVariableMod();
+        cmd.Modification = mod;
+
+        if (obj.ContainsKey("Value") && bool.Parse(obj["Value"].ToString()))
+        {
+            mod.Value = true;
+        }
+        else
+        {
+            mod.Value = false;
+        }
+
+        var newJson = JsonConvert.SerializeObject(
+            cmd, typeof(EventCommand),
+            new JsonSerializerSettings()
+            {
+                Formatting = Formatting.None, TypeNameHandling = TypeNameHandling.Auto,
+                DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate,
+                ObjectCreationHandling = ObjectCreationHandling.Replace
+            }
+        );
+
+        return JObject.Parse(newJson);
+    }
+
+    //OLD
+    //public class SetVariableCommand : EventCommand
+    //{
+    //    public VariableMods ModType { get; set; } = VariableMods.Set;
+    //    public int Value { get; set; }
+    //    public int HighValue { get; set; }
+    //    public Guid DuplicateVariableId { get; set; }
+    //}
+
+    private static JObject ConvertSetVariableCommand(JObject obj)
+    {
+        var cmd = new SetVariableCommand();
+
+        if (obj.ContainsKey("VariableId"))
+        {
+            cmd.VariableId = Guid.Parse(obj["VariableId"].ToString());
+        }
+
+        if (obj.ContainsKey("VariableType") && int.Parse(obj["VariableType"].ToString()) == 1)
+        {
+            cmd.VariableType = VariableType.ServerVariable;
+        }
+        else
+        {
+            cmd.VariableType = VariableType.PlayerVariable;
+        }
+
+        if (obj.ContainsKey("SyncParty") && bool.Parse(obj["SyncParty"].ToString()))
+        {
+            cmd.SyncParty = true;
+        }
+        else
+        {
+            cmd.SyncParty = false;
+        }
+
+        var mod = new IntegerVariableMod();
+        cmd.Modification = mod;
+
+        if (obj.ContainsKey("Value"))
+        {
+            mod.Value = long.Parse(obj["Value"].ToString());
+        }
+
+        if (obj.ContainsKey("DupVariableId"))
+        {
+            mod.DuplicateVariableId = Guid.Parse(obj["DupVariableId"].ToString());
+        }
+
+        if (obj.ContainsKey("HighValue"))
+        {
+            mod.HighValue = long.Parse(obj["HighValue"].ToString());
+        }
+
+        if (obj.ContainsKey("ModType"))
+        {
+            mod.ModType = (VariableMod) int.Parse(obj["ModType"].ToString());
+        }
+
+        var newJson = JsonConvert.SerializeObject(
+            cmd, typeof(EventCommand),
+            new JsonSerializerSettings()
+            {
+                Formatting = Formatting.None, TypeNameHandling = TypeNameHandling.Auto,
+                DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate,
+                ObjectCreationHandling = ObjectCreationHandling.Replace
+            }
+        );
+
+        return JObject.Parse(newJson);
+    }
+
+    //OLD
+    //public class PlayerSwitchCondition : Condition
+    //{
+    //    public override ConditionTypes Type { get; } = ConditionTypes.PlayerSwitch;
+    //    public Guid SwitchId { get; set; }
+    //    public bool Value { get; set; }
+    //}
+
+    private static JObject ConvertPlayerSwitchCondition(JObject obj)
+    {
+        var cmd = new VariableIsCondition();
+
+        if (obj.ContainsKey("SwitchId"))
+        {
+            cmd.VariableId = Guid.Parse(obj["SwitchId"].ToString());
+        }
+
+        cmd.VariableType = VariableType.PlayerVariable;
+
+        var comp = new BooleanVariableComparison();
+        cmd.Comparison = comp;
+
+        comp.ComparingEqual = true;
+
+        if (obj.ContainsKey("Value"))
+        {
+            comp.Value = bool.Parse(obj["Value"].ToString());
+        }
+
+        var newJson = JsonConvert.SerializeObject(
+            cmd, typeof(Condition),
+            new JsonSerializerSettings()
+            {
+                Formatting = Formatting.None, TypeNameHandling = TypeNameHandling.Auto,
+                DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate,
+                ObjectCreationHandling = ObjectCreationHandling.Replace
+            }
+        );
+
+        return JObject.Parse(newJson);
+    }
+
+    //OLD
+    //public class ServerSwitchCondition : Condition
+    //{
+    //    public override ConditionTypes Type { get; } = ConditionTypes.ServerSwitch;
+    //    public Guid SwitchId { get; set; }
+    //    public bool Value { get; set; }
+    //}
+
+    private static JObject ConvertGlobalSwitchCondition(JObject obj)
+    {
+        var cmd = new VariableIsCondition();
+
+        if (obj.ContainsKey("SwitchId"))
+        {
+            cmd.VariableId = Guid.Parse(obj["SwitchId"].ToString());
+        }
+
+        cmd.VariableType = VariableType.ServerVariable;
+
+        var comp = new BooleanVariableComparison();
+        cmd.Comparison = comp;
+
+        comp.ComparingEqual = true;
+
+        if (obj.ContainsKey("Value"))
+        {
+            comp.Value = bool.Parse(obj["Value"].ToString());
+        }
+
+        var newJson = JsonConvert.SerializeObject(
+            cmd, typeof(Condition),
+            new JsonSerializerSettings()
+            {
+                Formatting = Formatting.None, TypeNameHandling = TypeNameHandling.Auto,
+                DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate,
+                ObjectCreationHandling = ObjectCreationHandling.Replace
+            }
+        );
+
+        return JObject.Parse(newJson);
+    }
+
+    //OLD
+    //public class PlayerVariableCondition : Condition
+    //{
+    //    public override ConditionTypes Type { get; } = ConditionTypes.PlayerVariable;
+    //    public Guid VariableId { get; set; }
+    //    public VariableComparators Comparator { get; set; } = VariableComparators.Equal;
+    //    public VariableCompareTypes CompareType { get; set; } = VariableCompareTypes.StaticValue;
+    //    public long Value { get; set; }
+    //    public Guid CompareVariableId { get; set; }
+    //}
+
+    private static JObject ConvertPlayerVariableCondition(JObject obj)
+    {
+        var cmd = new VariableIsCondition();
+
+        if (obj.ContainsKey("VariableId"))
+        {
+            cmd.VariableId = Guid.Parse(obj["VariableId"].ToString());
+        }
+
+        cmd.VariableType = VariableType.PlayerVariable;
+
+        var comp = new IntegerVariableComparison();
+        cmd.Comparison = comp;
+
+        if (obj.ContainsKey("Value"))
+        {
+            comp.Value = long.Parse(obj["Value"].ToString());
+        }
+
+        if (obj.ContainsKey("CompareVariableId"))
+        {
+            comp.CompareVariableId = Guid.Parse(obj["CompareVariableId"].ToString());
+        }
+
+        if (obj.ContainsKey("Comparator"))
+        {
+            comp.Comparator = (VariableComparator) int.Parse(obj["Comparator"].ToString());
+        }
+
+        if (!obj.ContainsKey("CompareType"))
+        {
+            comp.CompareVariableId = Guid.Empty;
+        }
+        else
+        {
+            if (int.Parse(obj["CompareType"].ToString()) == 1)
+            {
+                comp.CompareVariableType = VariableType.PlayerVariable;
+            }
+            else
+            {
+                comp.CompareVariableType = VariableType.ServerVariable;
+            }
+        }
+
+        var newJson = JsonConvert.SerializeObject(
+            cmd, typeof(Condition),
+            new JsonSerializerSettings()
+            {
+                Formatting = Formatting.None, TypeNameHandling = TypeNameHandling.Auto,
+                DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate,
+                ObjectCreationHandling = ObjectCreationHandling.Replace
+            }
+        );
+
+        return JObject.Parse(newJson);
+    }
+
+    //OLD
+    //public class ServerVariableCondition : Condition
+    //{
+    //    public override ConditionTypes Type { get; } = ConditionTypes.ServerVariable;
+    //    public Guid VariableId { get; set; }
+    //    public VariableComparators Comparator { get; set; } = VariableComparators.Equal;
+    //    public VariableCompareTypes CompareType { get; set; } = VariableCompareTypes.StaticValue;
+    //    public long Value { get; set; }
+    //    public Guid CompareVariableId { get; set; }
+    //}
+
+    private static JObject ConvertGlobalVariableCondition(JObject obj)
+    {
+        var cmd = new VariableIsCondition();
+
+        if (obj.ContainsKey("VariableId"))
+        {
+            cmd.VariableId = Guid.Parse(obj["VariableId"].ToString());
+        }
+
+        cmd.VariableType = VariableType.ServerVariable;
+
+        var comp = new IntegerVariableComparison();
+        cmd.Comparison = comp;
+
+        if (obj.ContainsKey("Value"))
+        {
+            comp.Value = long.Parse(obj["Value"].ToString());
+        }
+
+        if (obj.ContainsKey("CompareVariableId"))
+        {
+            comp.CompareVariableId = Guid.Parse(obj["CompareVariableId"].ToString());
+        }
+
+        if (obj.ContainsKey("Comparator"))
+        {
+            comp.Comparator = (VariableComparator) int.Parse(obj["Comparator"].ToString());
+        }
+
+        if (!obj.ContainsKey("CompareType"))
+        {
+            comp.CompareVariableId = Guid.Empty;
+        }
+        else
+        {
+            if (int.Parse(obj["CompareType"].ToString()) == 1)
+            {
+                comp.CompareVariableType = VariableType.PlayerVariable;
+            }
+            else
+            {
+                comp.CompareVariableType = VariableType.ServerVariable;
+            }
+        }
+
+        var newJson = JsonConvert.SerializeObject(
+            cmd, typeof(Condition),
+            new JsonSerializerSettings()
+            {
+                Formatting = Formatting.None, TypeNameHandling = TypeNameHandling.Auto,
+                DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate,
+                ObjectCreationHandling = ObjectCreationHandling.Replace
+            }
+        );
+
+        return JObject.Parse(newJson);
+    }
+
+    private static void RemoveByteBufferUsageFromMaps(GameContext context)
+    {
+        var connection = context.Database.GetDbConnection();
+        connection.Open();
+        var updates = new List<Tuple<object, byte[], byte[]>>();
+        using (var cmd = connection.CreateCommand())
+        {
+            cmd.CommandText = "Select Id, Attributes, TileData from Maps;";
+            var reader = cmd.ExecuteReader();
+            while (reader.Read())
+            {
+                var id = reader["Id"];
+
+                var tileData = (byte[]) reader["TileData"];
+                var newTileData = ReencodeTileData(tileData);
+
+                var attributeData = (byte[]) reader["Attributes"];
+                var newAttributeData = mCeras.Compress(
+                    JsonConvert.DeserializeObject<MapAttribute[,]>(
+                        System.Text.Encoding.UTF8.GetString(Decompress(attributeData)),
+                        new JsonSerializerSettings()
+                        {
+                            TypeNameHandling = TypeNameHandling.Auto,
+                            DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate,
+                            ObjectCreationHandling = ObjectCreationHandling.Replace
+                        }
+                    )
+                );
+
+                updates.Add(new Tuple<object, byte[], byte[]>(id, newAttributeData, newTileData));
+            }
+        }
+
+        connection.Close();
+        connection.Open();
+        if (updates.Count > 0)
+        {
+            var trans = connection.BeginTransaction();
+
+            using (var updateCmd = connection.CreateCommand())
+            {
+                updateCmd.CommandText = "";
+                updateCmd.Transaction = trans;
+                var i = 0;
+                var currentCount = 0;
+                foreach (var update in updates)
+                {
+                    updateCmd.CommandText += "UPDATE Maps SET Attributes = @Attributes" +
+                                             i +
+                                             ", TileData = @TileData" +
+                                             i +
+                                             " WHERE Id = @Id" +
+                                             i +
+                                             ";";
+
+                    if (context.Database.ProviderName.Contains("Sqlite"))
+                    {
+                        updateCmd.Parameters.Add(new SqliteParameter("@Id" + i, (object) update.Item1));
+                        updateCmd.Parameters.Add(new SqliteParameter("@Attributes" + i, (byte[]) update.Item2));
+                        updateCmd.Parameters.Add(new SqliteParameter("@TileData" + i, (byte[]) update.Item3));
+                    }
+                    else
+                    {
+                        updateCmd.Parameters.Add(new MySqlParameter("@Id" + i, (object) update.Item1));
+                        updateCmd.Parameters.Add(new MySqlParameter("@Attributes" + i, (byte[]) update.Item2));
+                        updateCmd.Parameters.Add(new MySqlParameter("@TileData" + i, (byte[]) update.Item3));
+                    }
+
+                    i++;
+                    currentCount++;
+
+                    if (currentCount > 256)
+                    {
+                        updateCmd.ExecuteNonQuery();
+                        updateCmd.CommandText = "";
+                        updateCmd.Parameters.Clear();
+                        currentCount = 0;
+                    }
+                }
+
+                updateCmd.ExecuteNonQuery();
+                updateCmd.Parameters.Clear();
+            }
+
+            trans.Commit();
+        }
+
+        connection.Close();
+    }
+
+    private static byte[] ReencodeTileData(byte[] tileData)
+    {
+        var data = Decompress(tileData);
+        var readPos = 0;
+        var Layers = new LegacyTileArray[5];
+        for (var i = 0; i < 5; i++)
+        {
+            Layers[i].Tiles = new LegacyTile[Options.MapWidth, Options.MapHeight];
+            for (var x = 0; x < Options.MapWidth; x++)
+            {
+                for (var y = 0; y < Options.MapHeight; y++)
+                {
+                    Layers[i].Tiles[x, y].TilesetId = new Guid(
+                        new Byte[16]
+                        {
+                            data[readPos++], data[readPos++], data[readPos++], data[readPos++], data[readPos++],
+                            data[readPos++], data[readPos++], data[readPos++], data[readPos++], data[readPos++],
+                            data[readPos++], data[readPos++], data[readPos++], data[readPos++], data[readPos++],
+                            data[readPos++]
+                        }
                     );
 
-                    updates.Add(new Tuple<object, byte[], byte[]>(id, newAttributeData, newTileData));
+                    Layers[i].Tiles[x, y].X = BitConverter.ToInt32(data, readPos);
+                    readPos += 4;
+                    Layers[i].Tiles[x, y].Y = BitConverter.ToInt32(data, readPos);
+                    readPos += 4;
+                    Layers[i].Tiles[x, y].Autotile = data[readPos++];
                 }
             }
+        }
 
-            connection.Close();
-            connection.Open();
-            if (updates.Count > 0)
+        return mCeras.Compress(Layers);
+    }
+
+    private static byte[] Decompress(byte[] data)
+    {
+        var len = BitConverter.ToInt32(data, 0);
+        var compressedData = new byte[data.Length - 4];
+        for (var i = 4; i < data.Length; i++)
+        {
+            compressedData[i - 4] = data[i];
+        }
+
+        var decompessed = new byte[len];
+        using (var ms = new MemoryStream(compressedData))
+        {
+            using (var decompressionStream = new DeflateStream(ms, CompressionMode.Decompress))
             {
-                var trans = connection.BeginTransaction();
-
-                using (var updateCmd = connection.CreateCommand())
-                {
-                    updateCmd.CommandText = "";
-                    updateCmd.Transaction = trans;
-                    var i = 0;
-                    var currentCount = 0;
-                    foreach (var update in updates)
-                    {
-                        updateCmd.CommandText += "UPDATE Maps SET Attributes = @Attributes" +
-                                                 i +
-                                                 ", TileData = @TileData" +
-                                                 i +
-                                                 " WHERE Id = @Id" +
-                                                 i +
-                                                 ";";
-
-                        if (context.Database.ProviderName.Contains("Sqlite"))
-                        {
-                            updateCmd.Parameters.Add(new SqliteParameter("@Id" + i, (object) update.Item1));
-                            updateCmd.Parameters.Add(new SqliteParameter("@Attributes" + i, (byte[]) update.Item2));
-                            updateCmd.Parameters.Add(new SqliteParameter("@TileData" + i, (byte[]) update.Item3));
-                        }
-                        else
-                        {
-                            updateCmd.Parameters.Add(new MySqlParameter("@Id" + i, (object) update.Item1));
-                            updateCmd.Parameters.Add(new MySqlParameter("@Attributes" + i, (byte[]) update.Item2));
-                            updateCmd.Parameters.Add(new MySqlParameter("@TileData" + i, (byte[]) update.Item3));
-                        }
-
-                        i++;
-                        currentCount++;
-
-                        if (currentCount > 256)
-                        {
-                            updateCmd.ExecuteNonQuery();
-                            updateCmd.CommandText = "";
-                            updateCmd.Parameters.Clear();
-                            currentCount = 0;
-                        }
-                    }
-
-                    updateCmd.ExecuteNonQuery();
-                    updateCmd.Parameters.Clear();
-                }
-
-                trans.Commit();
+                decompressionStream.Read(decompessed, 0, decompessed.Length);
             }
 
-            connection.Close();
+            return decompessed;
         }
 
-        private static byte[] ReencodeTileData(byte[] tileData)
-        {
-            var data = Decompress(tileData);
-            var readPos = 0;
-            var Layers = new LegacyTileArray[5];
-            for (var i = 0; i < 5; i++)
-            {
-                Layers[i].Tiles = new LegacyTile[Options.MapWidth, Options.MapHeight];
-                for (var x = 0; x < Options.MapWidth; x++)
-                {
-                    for (var y = 0; y < Options.MapHeight; y++)
-                    {
-                        Layers[i].Tiles[x, y].TilesetId = new Guid(
-                            new Byte[16]
-                            {
-                                data[readPos++], data[readPos++], data[readPos++], data[readPos++], data[readPos++],
-                                data[readPos++], data[readPos++], data[readPos++], data[readPos++], data[readPos++],
-                                data[readPos++], data[readPos++], data[readPos++], data[readPos++], data[readPos++],
-                                data[readPos++]
-                            }
-                        );
+        return null;
+    }
 
-                        Layers[i].Tiles[x, y].X = BitConverter.ToInt32(data, readPos);
-                        readPos += 4;
-                        Layers[i].Tiles[x, y].Y = BitConverter.ToInt32(data, readPos);
-                        readPos += 4;
-                        Layers[i].Tiles[x, y].Autotile = data[readPos++];
-                    }
-                }
-            }
+    private partial struct LegacyTileArray
+    {
 
-            return mCeras.Compress(Layers);
-        }
+        public LegacyTile[,] Tiles;
 
-        private static byte[] Decompress(byte[] data)
-        {
-            var len = BitConverter.ToInt32(data, 0);
-            var compressedData = new byte[data.Length - 4];
-            for (var i = 4; i < data.Length; i++)
-            {
-                compressedData[i - 4] = data[i];
-            }
+    }
 
-            var decompessed = new byte[len];
-            using (var ms = new MemoryStream(compressedData))
-            {
-                using (var decompressionStream = new DeflateStream(ms, CompressionMode.Decompress))
-                {
-                    decompressionStream.Read(decompessed, 0, decompessed.Length);
-                }
+    private partial struct LegacyTile
+    {
 
-                return decompessed;
-            }
+        public Guid TilesetId;
 
-            return null;
-        }
+        public int X;
 
-        private partial struct LegacyTileArray
-        {
+        public int Y;
 
-            public LegacyTile[,] Tiles;
+        public byte Autotile;
 
-        }
-
-        private partial struct LegacyTile
-        {
-
-            public Guid TilesetId;
-
-            public int X;
-
-            public int Y;
-
-            public byte Autotile;
-
-            [JsonIgnore] public object TilesetTex;
-
-        }
+        [JsonIgnore] public object TilesetTex;
 
     }
 

--- a/Intersect.Server.Core/Database/GameData/Migrations/BoundItemExtensionMigration.cs
+++ b/Intersect.Server.Core/Database/GameData/Migrations/BoundItemExtensionMigration.cs
@@ -1,50 +1,49 @@
-﻿namespace Intersect.Server.Database.GameData.Migrations
+﻿namespace Intersect.Server.Database.GameData.Migrations;
+
+public partial class BoundItemExtensionMigration
 {
-    public partial class BoundItemExtensionMigration
+
+    public static void Run(GameContext context)
     {
-
-        public static void Run(GameContext context)
-        {
-            MigrateBoundItems(context);
-        }
-
-        public static void MigrateBoundItems(GameContext context)
-        {
-            // Go through all of our items to reconfigure the new item binding properties.
-            foreach(var item in context.Items)
-            {
-
-                // Determine whether or not the Bound property(now CanDrop) was true, if so set all the binding options to not allow item drops.
-                if (item.CanDrop == true)
-                {
-                    item.CanDrop = false;
-                    item.CanTrade = false;
-                    item.CanSell = false;
-                    item.CanBank = false;
-                    item.CanBag = false;
-                    item.CanGuildBank = false;
-
-                    item.DropChanceOnDeath = 0;
-                }
-                // If it wasn't bound before, unbind all the new options!
-                else
-                {
-                    item.CanDrop = true;
-                    item.CanTrade = true;
-                    item.CanSell = true;
-                    item.CanBank = true;
-                    item.CanBag = true;
-                    item.CanGuildBank = true;
-
-                    // Set item drop chance to the default configuration option.
-                    item.DropChanceOnDeath = Options.ItemDropChance;
-                }
-            }
-
-            // Track our changes and save them or the work we've just done is lost.
-            context.ChangeTracker.DetectChanges();
-            context.SaveChanges();
-        }
-
+        MigrateBoundItems(context);
     }
+
+    public static void MigrateBoundItems(GameContext context)
+    {
+        // Go through all of our items to reconfigure the new item binding properties.
+        foreach(var item in context.Items)
+        {
+
+            // Determine whether or not the Bound property(now CanDrop) was true, if so set all the binding options to not allow item drops.
+            if (item.CanDrop == true)
+            {
+                item.CanDrop = false;
+                item.CanTrade = false;
+                item.CanSell = false;
+                item.CanBank = false;
+                item.CanBag = false;
+                item.CanGuildBank = false;
+
+                item.DropChanceOnDeath = 0;
+            }
+            // If it wasn't bound before, unbind all the new options!
+            else
+            {
+                item.CanDrop = true;
+                item.CanTrade = true;
+                item.CanSell = true;
+                item.CanBank = true;
+                item.CanBag = true;
+                item.CanGuildBank = true;
+
+                // Set item drop chance to the default configuration option.
+                item.DropChanceOnDeath = Options.ItemDropChance;
+            }
+        }
+
+        // Track our changes and save them or the work we've just done is lost.
+        context.ChangeTracker.DetectChanges();
+        context.SaveChanges();
+    }
+
 }

--- a/Intersect.Server.Core/Database/GameData/Migrations/CerasVersionToleranceMigration.cs
+++ b/Intersect.Server.Core/Database/GameData/Migrations/CerasVersionToleranceMigration.cs
@@ -8,320 +8,319 @@ using MySqlConnector;
 using Newtonsoft.Json;
 using MapAttribute = Intersect.Enums.MapAttribute;
 
-namespace Intersect.Server.Database.GameData.Migrations
+namespace Intersect.Server.Database.GameData.Migrations;
+
+public partial class CerasVersionToleranceMigration
 {
-    public partial class CerasVersionToleranceMigration
+    private static JsonSerializerSettings mJsonSerializerSettings = new JsonSerializerSettings()
     {
-        private static JsonSerializerSettings mJsonSerializerSettings = new JsonSerializerSettings()
+        TypeNameHandling = TypeNameHandling.Auto,
+        DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate,
+        ObjectCreationHandling = ObjectCreationHandling.Replace
+    };
+
+    private static Intersect.Network.Ceras mOldCeras;
+
+    public static void Run(GameContext context)
+    {
+        var nameTypeDict = new Dictionary<string, Type>();
+
+        nameTypeDict.Add("Intersect.GameObjects.Maps.TileArray[]", typeof(LegacyTileArray[]));
+
+        nameTypeDict.Add("Intersect.GameObjects.Maps.MapAttribute[,]", typeof(LegacyMapAttribute[,]));
+        nameTypeDict.Add("Intersect.GameObjects.Maps.MapAttribute", typeof(LegacyMapAttribute));
+        nameTypeDict.Add("Intersect.GameObjects.Maps.MapBlockedAttribute", typeof(LegacyMapBlockedAttribute));
+        nameTypeDict.Add("Intersect.GameObjects.Maps.MapItemAttribute", typeof(LegacyMapItemAttribute));
+        nameTypeDict.Add("Intersect.GameObjects.Maps.MapZDimensionAttribute", typeof(LegacyMapZDimensionAttribute));
+        nameTypeDict.Add("Intersect.GameObjects.Maps.MapNpcAvoidAttribute", typeof(LegacyMapNpcAvoidAttribute));
+        nameTypeDict.Add("Intersect.GameObjects.Maps.MapWarpAttribute", typeof(LegacyMapWarpAttribute));
+        nameTypeDict.Add("Intersect.GameObjects.Maps.MapSoundAttribute", typeof(LegacyMapSoundAttribute));
+        nameTypeDict.Add("Intersect.GameObjects.Maps.MapResourceAttribute", typeof(LegacyMapResourceAttribute));
+        nameTypeDict.Add("Intersect.GameObjects.Maps.MapAnimationAttribute", typeof(LegacyMapAnimationAttribute));
+        nameTypeDict.Add("Intersect.GameObjects.Maps.MapGrappleStoneAttribute", typeof(LegacyMapGrappleStoneAttribute));
+        nameTypeDict.Add("Intersect.GameObjects.Maps.MapSlideAttribute", typeof(LegacyMapSlideAttribute));
+
+        mOldCeras = new LegacyCeras(nameTypeDict);
+
+        UpdateMapTilesAttributesWithCerasVersionTolerance(context);
+    }
+
+    private static void UpdateMapTilesAttributesWithCerasVersionTolerance(GameContext context)
+    {
+        var connection = context.Database.GetDbConnection();
+        connection.Open();
+        var updates = new List<Tuple<object, byte[], byte[]>>();
+        using (var cmd = connection.CreateCommand())
         {
-            TypeNameHandling = TypeNameHandling.Auto,
-            DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate,
-            ObjectCreationHandling = ObjectCreationHandling.Replace
-        };
-
-        private static Intersect.Network.Ceras mOldCeras;
-
-        public static void Run(GameContext context)
-        {
-            var nameTypeDict = new Dictionary<string, Type>();
-
-            nameTypeDict.Add("Intersect.GameObjects.Maps.TileArray[]", typeof(LegacyTileArray[]));
-
-            nameTypeDict.Add("Intersect.GameObjects.Maps.MapAttribute[,]", typeof(LegacyMapAttribute[,]));
-            nameTypeDict.Add("Intersect.GameObjects.Maps.MapAttribute", typeof(LegacyMapAttribute));
-            nameTypeDict.Add("Intersect.GameObjects.Maps.MapBlockedAttribute", typeof(LegacyMapBlockedAttribute));
-            nameTypeDict.Add("Intersect.GameObjects.Maps.MapItemAttribute", typeof(LegacyMapItemAttribute));
-            nameTypeDict.Add("Intersect.GameObjects.Maps.MapZDimensionAttribute", typeof(LegacyMapZDimensionAttribute));
-            nameTypeDict.Add("Intersect.GameObjects.Maps.MapNpcAvoidAttribute", typeof(LegacyMapNpcAvoidAttribute));
-            nameTypeDict.Add("Intersect.GameObjects.Maps.MapWarpAttribute", typeof(LegacyMapWarpAttribute));
-            nameTypeDict.Add("Intersect.GameObjects.Maps.MapSoundAttribute", typeof(LegacyMapSoundAttribute));
-            nameTypeDict.Add("Intersect.GameObjects.Maps.MapResourceAttribute", typeof(LegacyMapResourceAttribute));
-            nameTypeDict.Add("Intersect.GameObjects.Maps.MapAnimationAttribute", typeof(LegacyMapAnimationAttribute));
-            nameTypeDict.Add("Intersect.GameObjects.Maps.MapGrappleStoneAttribute", typeof(LegacyMapGrappleStoneAttribute));
-            nameTypeDict.Add("Intersect.GameObjects.Maps.MapSlideAttribute", typeof(LegacyMapSlideAttribute));
-
-            mOldCeras = new LegacyCeras(nameTypeDict);
-
-            UpdateMapTilesAttributesWithCerasVersionTolerance(context);
-        }
-
-        private static void UpdateMapTilesAttributesWithCerasVersionTolerance(GameContext context)
-        {
-            var connection = context.Database.GetDbConnection();
-            connection.Open();
-            var updates = new List<Tuple<object, byte[], byte[]>>();
-            using (var cmd = connection.CreateCommand())
+            cmd.CommandText = "Select Id, Attributes, TileData from Maps;";
+            var reader = cmd.ExecuteReader();
+            while (reader.Read())
             {
-                cmd.CommandText = "Select Id, Attributes, TileData from Maps;";
-                var reader = cmd.ExecuteReader();
-                while (reader.Read())
+                var id = reader["Id"];
+
+                #region "Convert tileData to Dictionary<string, Tile[,]> where the key is the layer name"
+                var tileData = (byte[])reader["TileData"];
+                var tileLayers = (LegacyTileArray[])mOldCeras.Decompress(tileData);
+
+                var newTileLayers = new Dictionary<string, Tile[,]>();
+                for (int i = 0; i < tileLayers.Length; i++)
                 {
-                    var id = reader["Id"];
-
-                    #region "Convert tileData to Dictionary<string, Tile[,]> where the key is the layer name"
-                    var tileData = (byte[])reader["TileData"];
-                    var tileLayers = (LegacyTileArray[])mOldCeras.Decompress(tileData);
-
-                    var newTileLayers = new Dictionary<string, Tile[,]>();
-                    for (int i = 0; i < tileLayers.Length; i++)
+                    var knownLayers = new string[] { "Ground", "Mask 1", "Mask 2", "Fringe 1", "Fringe 2" };
+                    var name = i < knownLayers.Length ? knownLayers[i] : "Layer " + i;
+                    var tiles = new Tile[tileLayers[i].Tiles.GetLength(0), tileLayers[i].Tiles.GetLength(1)];
+                    for (int x = 0; x < tileLayers[i].Tiles.GetLength(0); x++)
                     {
-                        var knownLayers = new string[] { "Ground", "Mask 1", "Mask 2", "Fringe 1", "Fringe 2" };
-                        var name = i < knownLayers.Length ? knownLayers[i] : "Layer " + i;
-                        var tiles = new Tile[tileLayers[i].Tiles.GetLength(0), tileLayers[i].Tiles.GetLength(1)];
-                        for (int x = 0; x < tileLayers[i].Tiles.GetLength(0); x++)
+                        for (int y = 0; y < tileLayers[i].Tiles.GetLength(1); y++)
                         {
-                            for (int y = 0; y < tileLayers[i].Tiles.GetLength(1); y++)
+                            tiles[x, y] = new Tile()
                             {
-                                tiles[x, y] = new Tile()
-                                {
-                                    X = tileLayers[i].Tiles[x, y].X,
-                                    Y = tileLayers[i].Tiles[x, y].Y,
-                                    Autotile = tileLayers[i].Tiles[x, y].Autotile,
-                                    TilesetId = tileLayers[i].Tiles[x, y].TilesetId,
-                                    TilesetTex = tileLayers[i].Tiles[x, y].TilesetTex
-                                };
-                            }
+                                X = tileLayers[i].Tiles[x, y].X,
+                                Y = tileLayers[i].Tiles[x, y].Y,
+                                Autotile = tileLayers[i].Tiles[x, y].Autotile,
+                                TilesetId = tileLayers[i].Tiles[x, y].TilesetId,
+                                TilesetTex = tileLayers[i].Tiles[x, y].TilesetTex
+                            };
                         }
-                        newTileLayers.Add(name, tiles);
                     }
-
-                    //Ceras is too buggy for this at rest storage. Switching to compressed json for now.
-                    //Using ceras to compress and then decompress newTileLayers would result (for some reason) in it losing all tileset ids
-                    var newTileData = LZ4.PickleString(JsonConvert.SerializeObject(newTileLayers, Formatting.None, mJsonSerializerSettings));
-                    #endregion
-
-                    #region "Convert Attributes back into the same data type, but with version tolerance"
-                    var attributeData = (byte[])reader["Attributes"];
-
-                    //Only works on Ceras 4.0.40 -- I don't know why..
-                    //Later versions of ceras are unable to decompress map attributes (on SOME maps)
-                    //Feel free to ask JC for the demo game db if you want to debug
-                    var attributes = mOldCeras.Decompress<LegacyMapAttribute[,]>(attributeData);
-
-                    //Trying to use Ceras to re-serialize as the proper classes loses guid values for some reason, so lets do some fun json to get this converted.
-                    var legacyAttributes = JsonConvert.SerializeObject(attributes, Formatting.None, mJsonSerializerSettings);
-
-                    //Fix type names?
-                    var attributesJson = legacyAttributes.Replace("Intersect.Server.Database.GameData.Migrations.CerasVersionToleranceMigration+Legacy", "Intersect.GameObjects.Maps.").Replace(", Intersect Server", ", Intersect Core");
-
-                    var newAttributeDataJson = LZ4.PickleString(attributesJson);
-                    #endregion
-
-                    updates.Add(new Tuple<object, byte[], byte[]>(id, newAttributeDataJson, newTileData));
+                    newTileLayers.Add(name, tiles);
                 }
+
+                //Ceras is too buggy for this at rest storage. Switching to compressed json for now.
+                //Using ceras to compress and then decompress newTileLayers would result (for some reason) in it losing all tileset ids
+                var newTileData = LZ4.PickleString(JsonConvert.SerializeObject(newTileLayers, Formatting.None, mJsonSerializerSettings));
+                #endregion
+
+                #region "Convert Attributes back into the same data type, but with version tolerance"
+                var attributeData = (byte[])reader["Attributes"];
+
+                //Only works on Ceras 4.0.40 -- I don't know why..
+                //Later versions of ceras are unable to decompress map attributes (on SOME maps)
+                //Feel free to ask JC for the demo game db if you want to debug
+                var attributes = mOldCeras.Decompress<LegacyMapAttribute[,]>(attributeData);
+
+                //Trying to use Ceras to re-serialize as the proper classes loses guid values for some reason, so lets do some fun json to get this converted.
+                var legacyAttributes = JsonConvert.SerializeObject(attributes, Formatting.None, mJsonSerializerSettings);
+
+                //Fix type names?
+                var attributesJson = legacyAttributes.Replace("Intersect.Server.Database.GameData.Migrations.CerasVersionToleranceMigration+Legacy", "Intersect.GameObjects.Maps.").Replace(", Intersect Server", ", Intersect Core");
+
+                var newAttributeDataJson = LZ4.PickleString(attributesJson);
+                #endregion
+
+                updates.Add(new Tuple<object, byte[], byte[]>(id, newAttributeDataJson, newTileData));
             }
+        }
 
-            connection.Close();
-            connection.Open();
-            if (updates.Count > 0)
+        connection.Close();
+        connection.Open();
+        if (updates.Count > 0)
+        {
+            var trans = connection.BeginTransaction();
+
+            using (var updateCmd = connection.CreateCommand())
             {
-                var trans = connection.BeginTransaction();
-
-                using (var updateCmd = connection.CreateCommand())
+                updateCmd.CommandText = string.Empty;
+                updateCmd.Transaction = trans;
+                var i = 0;
+                var currentCount = 0;
+                foreach (var update in updates)
                 {
-                    updateCmd.CommandText = string.Empty;
-                    updateCmd.Transaction = trans;
-                    var i = 0;
-                    var currentCount = 0;
-                    foreach (var update in updates)
+                    updateCmd.CommandText += "UPDATE Maps SET Attributes = @Attributes" +
+                                             i +
+                                             ", TileData = @TileData" +
+                                             i +
+                                             " WHERE Id = @Id" +
+                                             i +
+                                             ";";
+
+                    if (context.Database.ProviderName.Contains("Sqlite"))
                     {
-                        updateCmd.CommandText += "UPDATE Maps SET Attributes = @Attributes" +
-                                                 i +
-                                                 ", TileData = @TileData" +
-                                                 i +
-                                                 " WHERE Id = @Id" +
-                                                 i +
-                                                 ";";
-
-                        if (context.Database.ProviderName.Contains("Sqlite"))
-                        {
-                            updateCmd.Parameters.Add(new SqliteParameter("@Id" + i, (object)update.Item1));
-                            updateCmd.Parameters.Add(new SqliteParameter("@Attributes" + i, (byte[])update.Item2));
-                            updateCmd.Parameters.Add(new SqliteParameter("@TileData" + i, (byte[])update.Item3));
-                        }
-                        else
-                        {
-                            updateCmd.Parameters.Add(new MySqlParameter("@Id" + i, (object)update.Item1));
-                            updateCmd.Parameters.Add(new MySqlParameter("@Attributes" + i, (byte[])update.Item2));
-                            updateCmd.Parameters.Add(new MySqlParameter("@TileData" + i, (byte[])update.Item3));
-                        }
-
-                        i++;
-                        currentCount++;
-
-                        if (currentCount > 256)
-                        {
-                            updateCmd.ExecuteNonQuery();
-                            updateCmd.CommandText = "";
-                            updateCmd.Parameters.Clear();
-                            currentCount = 0;
-                        }
+                        updateCmd.Parameters.Add(new SqliteParameter("@Id" + i, (object)update.Item1));
+                        updateCmd.Parameters.Add(new SqliteParameter("@Attributes" + i, (byte[])update.Item2));
+                        updateCmd.Parameters.Add(new SqliteParameter("@TileData" + i, (byte[])update.Item3));
+                    }
+                    else
+                    {
+                        updateCmd.Parameters.Add(new MySqlParameter("@Id" + i, (object)update.Item1));
+                        updateCmd.Parameters.Add(new MySqlParameter("@Attributes" + i, (byte[])update.Item2));
+                        updateCmd.Parameters.Add(new MySqlParameter("@TileData" + i, (byte[])update.Item3));
                     }
 
-                    updateCmd.ExecuteNonQuery();
-                    updateCmd.Parameters.Clear();
+                    i++;
+                    currentCount++;
+
+                    if (currentCount > 256)
+                    {
+                        updateCmd.ExecuteNonQuery();
+                        updateCmd.CommandText = "";
+                        updateCmd.Parameters.Clear();
+                        currentCount = 0;
+                    }
                 }
 
-                trans.Commit();
+                updateCmd.ExecuteNonQuery();
+                updateCmd.Parameters.Clear();
             }
 
-            connection.Close();
+            trans.Commit();
         }
 
-        private partial struct LegacyTileArray
+        connection.Close();
+    }
+
+    private partial struct LegacyTileArray
+    {
+
+        public LegacyTile[,] Tiles;
+
+    }
+
+    private partial struct LegacyTile
+    {
+
+        public Guid TilesetId;
+
+        public int X;
+
+        public int Y;
+
+        public byte Autotile;
+
+        [JsonIgnore] public object TilesetTex;
+
+    }
+
+    private abstract partial class LegacyMapAttribute
+    {
+        public abstract MapAttribute Type { get; }
+
+        public static LegacyMapAttribute CreateAttribute(MapAttribute type)
         {
-
-            public LegacyTile[,] Tiles;
-
-        }
-
-        private partial struct LegacyTile
-        {
-
-            public Guid TilesetId;
-
-            public int X;
-
-            public int Y;
-
-            public byte Autotile;
-
-            [JsonIgnore] public object TilesetTex;
-
-        }
-
-        private abstract partial class LegacyMapAttribute
-        {
-            public abstract MapAttribute Type { get; }
-
-            public static LegacyMapAttribute CreateAttribute(MapAttribute type)
+            switch (type)
             {
-                switch (type)
-                {
-                    case MapAttribute.Walkable:
-                        return null;
-                    case MapAttribute.Blocked:
-                        return new LegacyMapBlockedAttribute();
-                    case MapAttribute.Item:
-                        return new LegacyMapItemAttribute();
-                    case MapAttribute.ZDimension:
-                        return new LegacyMapZDimensionAttribute();
-                    case MapAttribute.NpcAvoid:
-                        return new LegacyMapNpcAvoidAttribute();
-                    case MapAttribute.Warp:
-                        return new LegacyMapWarpAttribute();
-                    case MapAttribute.Sound:
-                        return new LegacyMapSoundAttribute();
-                    case MapAttribute.Resource:
-                        return new LegacyMapResourceAttribute();
-                    case MapAttribute.Animation:
-                        return new LegacyMapAnimationAttribute();
-                    case MapAttribute.GrappleStone:
-                        return new LegacyMapGrappleStoneAttribute();
-                    case MapAttribute.Slide:
-                        return new LegacyMapSlideAttribute();
-                }
-
-                return null;
+                case MapAttribute.Walkable:
+                    return null;
+                case MapAttribute.Blocked:
+                    return new LegacyMapBlockedAttribute();
+                case MapAttribute.Item:
+                    return new LegacyMapItemAttribute();
+                case MapAttribute.ZDimension:
+                    return new LegacyMapZDimensionAttribute();
+                case MapAttribute.NpcAvoid:
+                    return new LegacyMapNpcAvoidAttribute();
+                case MapAttribute.Warp:
+                    return new LegacyMapWarpAttribute();
+                case MapAttribute.Sound:
+                    return new LegacyMapSoundAttribute();
+                case MapAttribute.Resource:
+                    return new LegacyMapResourceAttribute();
+                case MapAttribute.Animation:
+                    return new LegacyMapAnimationAttribute();
+                case MapAttribute.GrappleStone:
+                    return new LegacyMapGrappleStoneAttribute();
+                case MapAttribute.Slide:
+                    return new LegacyMapSlideAttribute();
             }
+
+            return null;
         }
+    }
 
-        private partial class LegacyMapBlockedAttribute : LegacyMapAttribute
-        {
+    private partial class LegacyMapBlockedAttribute : LegacyMapAttribute
+    {
 
-            public override MapAttribute Type { get; } = MapAttribute.Blocked;
+        public override MapAttribute Type { get; } = MapAttribute.Blocked;
 
-        }
+    }
 
-        private partial class LegacyMapItemAttribute : LegacyMapAttribute
-        {
+    private partial class LegacyMapItemAttribute : LegacyMapAttribute
+    {
 
-            public override MapAttribute Type { get; } = MapAttribute.Item;
+        public override MapAttribute Type { get; } = MapAttribute.Item;
 
-            public Guid ItemId { get; set; }
+        public Guid ItemId { get; set; }
 
-            public int Quantity { get; set; }
+        public int Quantity { get; set; }
 
-        }
+    }
 
-        private partial class LegacyMapZDimensionAttribute : LegacyMapAttribute
-        {
+    private partial class LegacyMapZDimensionAttribute : LegacyMapAttribute
+    {
 
-            public override MapAttribute Type { get; } = MapAttribute.ZDimension;
+        public override MapAttribute Type { get; } = MapAttribute.ZDimension;
 
-            public byte GatewayTo { get; set; }
+        public byte GatewayTo { get; set; }
 
-            public byte BlockedLevel { get; set; }
+        public byte BlockedLevel { get; set; }
 
-        }
+    }
 
-        private partial class LegacyMapNpcAvoidAttribute : LegacyMapAttribute
-        {
+    private partial class LegacyMapNpcAvoidAttribute : LegacyMapAttribute
+    {
 
-            public override MapAttribute Type { get; } = MapAttribute.NpcAvoid;
+        public override MapAttribute Type { get; } = MapAttribute.NpcAvoid;
 
-        }
+    }
 
-        private partial class LegacyMapWarpAttribute : LegacyMapAttribute
-        {
+    private partial class LegacyMapWarpAttribute : LegacyMapAttribute
+    {
 
-            public override MapAttribute Type { get; } = MapAttribute.Warp;
+        public override MapAttribute Type { get; } = MapAttribute.Warp;
 
-            public Guid MapId { get; set; }
+        public Guid MapId { get; set; }
 
-            public byte X { get; set; }
+        public byte X { get; set; }
 
-            public byte Y { get; set; }
+        public byte Y { get; set; }
 
-            public WarpDirection Direction { get; set; } = WarpDirection.Retain;
+        public WarpDirection Direction { get; set; } = WarpDirection.Retain;
 
-        }
+    }
 
-        private partial class LegacyMapSoundAttribute : LegacyMapAttribute
-        {
+    private partial class LegacyMapSoundAttribute : LegacyMapAttribute
+    {
 
-            public override MapAttribute Type { get; } = MapAttribute.Sound;
+        public override MapAttribute Type { get; } = MapAttribute.Sound;
 
-            public string File { get; set; }
+        public string File { get; set; }
 
-            public byte Distance { get; set; }
+        public byte Distance { get; set; }
 
-        }
+    }
 
-        private partial class LegacyMapResourceAttribute : LegacyMapAttribute
-        {
+    private partial class LegacyMapResourceAttribute : LegacyMapAttribute
+    {
 
-            public override MapAttribute Type { get; } = MapAttribute.Resource;
+        public override MapAttribute Type { get; } = MapAttribute.Resource;
 
-            public Guid ResourceId { get; set; }
+        public Guid ResourceId { get; set; }
 
-            public byte SpawnLevel { get; set; }
+        public byte SpawnLevel { get; set; }
 
-        }
+    }
 
-        private partial class LegacyMapAnimationAttribute : LegacyMapAttribute
-        {
+    private partial class LegacyMapAnimationAttribute : LegacyMapAttribute
+    {
 
-            public override MapAttribute Type { get; } = MapAttribute.Animation;
+        public override MapAttribute Type { get; } = MapAttribute.Animation;
 
-            public Guid AnimationId { get; set; }
+        public Guid AnimationId { get; set; }
 
-        }
+    }
 
-        private partial class LegacyMapGrappleStoneAttribute : LegacyMapAttribute
-        {
+    private partial class LegacyMapGrappleStoneAttribute : LegacyMapAttribute
+    {
 
-            public override MapAttribute Type { get; } = MapAttribute.GrappleStone;
+        public override MapAttribute Type { get; } = MapAttribute.GrappleStone;
 
-        }
+    }
 
-        private partial class LegacyMapSlideAttribute : LegacyMapAttribute
-        {
+    private partial class LegacyMapSlideAttribute : LegacyMapAttribute
+    {
 
-            public override MapAttribute Type { get; } = MapAttribute.Slide;
+        public override MapAttribute Type { get; } = MapAttribute.Slide;
 
-            public byte Direction { get; set; }
+        public byte Direction { get; set; }
 
-        }
     }
 }

--- a/Intersect.Server.Core/Database/GameData/Migrations/FixQuestTaskCompletionEventsMigration.cs
+++ b/Intersect.Server.Core/Database/GameData/Migrations/FixQuestTaskCompletionEventsMigration.cs
@@ -1,55 +1,54 @@
 ﻿using Intersect.Logging;
 using Intersect.GameObjects.Events;
 
-namespace Intersect.Server.Database.GameData.Migrations
+namespace Intersect.Server.Database.GameData.Migrations;
+
+public partial class FixQuestTaskCompletionEventsMigration
 {
-    public partial class FixQuestTaskCompletionEventsMigration
+
+    public static void Run(GameContext context)
     {
+        FixQuestTaskCompletionEvents(context);
+    }
 
-        public static void Run(GameContext context)
+    public static void FixQuestTaskCompletionEvents(GameContext context)
+    {
+        Log.Info("Checking for broken Quest Task Completion Events, this process might take several minutes depending on your quest count!");
+
+        // Go through each and every quest to check if all the tasks have valid events.
+        foreach (var quest in context.Quests)
         {
-            FixQuestTaskCompletionEvents(context);
-        }
-
-        public static void FixQuestTaskCompletionEvents(GameContext context)
-        {
-            Log.Info("Checking for broken Quest Task Completion Events, this process might take several minutes depending on your quest count!");
-
-            // Go through each and every quest to check if all the tasks have valid events.
-            foreach (var quest in context.Quests)
+            foreach(var task in quest.Tasks)
             {
-                foreach(var task in quest.Tasks)
+                // Determine whether the event Id is incorrect and if we can find an event with the task Id as intended.
+                var incorrectEventId = task.CompletionEventId == null || task.CompletionEventId == Guid.Empty || context.Events.Where(e => e.Id == task.CompletionEventId).FirstOrDefault() == null;
+                var foundEvent = context.Events.Where(e => e.Id == task.Id).FirstOrDefault();
+
+                // If the event Id is incorrect and we can't find the event.. recreate it!
+                if (incorrectEventId && foundEvent == null)
                 {
-                    // Determine whether the event Id is incorrect and if we can find an event with the task Id as intended.
-                    var incorrectEventId = task.CompletionEventId == null || task.CompletionEventId == Guid.Empty || context.Events.Where(e => e.Id == task.CompletionEventId).FirstOrDefault() == null;
-                    var foundEvent = context.Events.Where(e => e.Id == task.Id).FirstOrDefault();
+                    var ev = new EventBase(task.Id, Guid.Empty, 0, 0, false);
+                    ev.CommonEvent = false;
+                    ev.Name = $"Quest: {quest.Name} - Task Completion Event";
+                    context.Events.Add(ev);
+                    EventBase.Lookup.Set(ev.Id, ev);
+                    task.CompletionEventId = task.Id;
 
-                    // If the event Id is incorrect and we can't find the event.. recreate it!
-                    if (incorrectEventId && foundEvent == null)
-                    {
-                        var ev = new EventBase(task.Id, Guid.Empty, 0, 0, false);
-                        ev.CommonEvent = false;
-                        ev.Name = $"Quest: {quest.Name} - Task Completion Event";
-                        context.Events.Add(ev);
-                        EventBase.Lookup.Set(ev.Id, ev);
-                        task.CompletionEventId = task.Id;
+                    Log.Info($"Fixed quest {quest.Name} ({quest.Id}) task {task.Id}, created new event {task.Id}.");
+                }
+                // if the Event ID is incorrect but we CAN find the event, link it!
+                else if (incorrectEventId && foundEvent != null)
+                {
+                    task.CompletionEventId = foundEvent.Id;
 
-                        Log.Info($"Fixed quest {quest.Name} ({quest.Id}) task {task.Id}, created new event {task.Id}.");
-                    }
-                    // if the Event ID is incorrect but we CAN find the event, link it!
-                    else if (incorrectEventId && foundEvent != null)
-                    {
-                        task.CompletionEventId = foundEvent.Id;
-
-                        Log.Info($"Fixed quest {quest.Name} ({quest.Id}) task {task.Id}, linked up old event {foundEvent.Id}.");
-                    }
+                    Log.Info($"Fixed quest {quest.Name} ({quest.Id}) task {task.Id}, linked up old event {foundEvent.Id}.");
                 }
             }
-
-            // Track our changes and save them or the work we've just done is lost.
-            context.ChangeTracker.DetectChanges();
-            context.SaveChanges();
         }
 
+        // Track our changes and save them or the work we've just done is lost.
+        context.ChangeTracker.DetectChanges();
+        context.SaveChanges();
     }
+
 }

--- a/Intersect.Server.Core/Database/IDbContext.cs
+++ b/Intersect.Server.Core/Database/IDbContext.cs
@@ -1,20 +1,19 @@
 ﻿using Intersect.Config;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
-namespace Intersect.Server.Database
+namespace Intersect.Server.Database;
+
+public interface IDbContext
 {
-    public interface IDbContext
-    {
-        DatabaseFacade Database { get; }
+    DatabaseFacade Database { get; }
 
-        DatabaseType DatabaseType { get; }
+    DatabaseType DatabaseType { get; }
 
-        int SaveChanges();
+    int SaveChanges();
 
-        int SaveChanges(bool acceptAllChangesOnSuccess);
+    int SaveChanges(bool acceptAllChangesOnSuccess);
 
-        Task<int> SaveChangesAsync(bool acceptAllChangesOnSuccess, CancellationToken cancellationToken = default);
+    Task<int> SaveChangesAsync(bool acceptAllChangesOnSuccess, CancellationToken cancellationToken = default);
 
-        Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
-    }
+    Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
 }

--- a/Intersect.Server.Core/Database/ISeedableContext.cs
+++ b/Intersect.Server.Core/Database/ISeedableContext.cs
@@ -1,13 +1,11 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace Intersect.Server.Database
+namespace Intersect.Server.Database;
+
+
+public interface ISeedableContext
 {
 
-    public interface ISeedableContext
-    {
-
-        DbSet<TType> GetDbSet<TType>() where TType : class;
-
-    }
+    DbSet<TType> GetDbSet<TType>() where TType : class;
 
 }

--- a/Intersect.Server.Core/Database/IntersectDbContext.DataMigrations.cs
+++ b/Intersect.Server.Core/Database/IntersectDbContext.DataMigrations.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 using Intersect.Reflection;
 
 namespace Intersect.Server.Database;

--- a/Intersect.Server.Core/Database/IntersectDbContext.Instantiation.cs
+++ b/Intersect.Server.Core/Database/IntersectDbContext.Instantiation.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.Linq.Expressions;
 using System.Reflection;
 using Intersect.Config;

--- a/Intersect.Server.Core/Database/IntersectDbContext.cs
+++ b/Intersect.Server.Core/Database/IntersectDbContext.cs
@@ -12,7 +12,6 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.Extensions.Primitives;
 
 namespace Intersect.Server.Database;
 

--- a/Intersect.Server.Core/Database/IntersectLoggerFactory.cs
+++ b/Intersect.Server.Core/Database/IntersectLoggerFactory.cs
@@ -1,6 +1,5 @@
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Reflection;
 using Intersect.Logging;
 using Intersect.Logging.Formatting;
 using Intersect.Logging.Output;

--- a/Intersect.Server.Core/Database/Item.cs
+++ b/Intersect.Server.Core/Database/Item.cs
@@ -5,7 +5,6 @@ using Intersect.Enums;
 using Intersect.GameObjects;
 using Intersect.Network.Packets.Server;
 using Intersect.Server.Database.PlayerData.Players;
-using Intersect.Utilities;
 using Newtonsoft.Json;
 
 namespace Intersect.Server.Database;

--- a/Intersect.Server.Core/Database/Logging/Entities/ChatHistory.cs
+++ b/Intersect.Server.Core/Database/Logging/Entities/ChatHistory.cs
@@ -3,76 +3,75 @@ using Intersect.Server.Entities;
 using Newtonsoft.Json;
 using System.ComponentModel.DataAnnotations.Schema;
 
-namespace Intersect.Server.Database.Logging.Entities
+namespace Intersect.Server.Database.Logging.Entities;
+
+public partial class ChatHistory
 {
-    public partial class ChatHistory
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
+    public Guid Id { get; private set; } = Guid.NewGuid();
+
+    public Guid UserId { get; set; }
+
+    public Guid PlayerId { get; set; }
+
+    public string Ip { get; set; }
+
+    public DateTime TimeStamp { get; set; }
+
+    [JsonIgnore]
+    public ChatMessageType MessageType { get; set; }
+
+    [JsonProperty("MessageType")]
+    public string MessageTypeName => Enum.GetName(typeof(ChatMessageType), MessageType);
+
+    public string MessageText { get; set; }
+
+    public Guid TargetId { get; set; }
+
+    [NotMapped]
+    public string Username { get; set; }
+
+    [NotMapped]
+    public string PlayerName { get; set; }
+
+    [NotMapped]
+    public string TargetName { get; set; }
+
+    public ChatHistory()
     {
-        [DatabaseGenerated(DatabaseGeneratedOption.None)]
-        public Guid Id { get; private set; } = Guid.NewGuid();
+        TimeStamp = DateTime.UtcNow;
+    }
 
-        public Guid UserId { get; set; }
-
-        public Guid PlayerId { get; set; }
-
-        public string Ip { get; set; }
-
-        public DateTime TimeStamp { get; set; }
-
-        [JsonIgnore]
-        public ChatMessageType MessageType { get; set; }
-
-        [JsonProperty("MessageType")]
-        public string MessageTypeName => Enum.GetName(typeof(ChatMessageType), MessageType);
-
-        public string MessageText { get; set; }
-
-        public Guid TargetId { get; set; }
-
-        [NotMapped]
-        public string Username { get; set; }
-
-        [NotMapped]
-        public string PlayerName { get; set; }
-
-        [NotMapped]
-        public string TargetName { get; set; }
-
-        public ChatHistory()
+    /// <summary>
+    /// Logs a chat message if chat message logging is enabled
+    /// </summary>
+    /// <param name="player">The player to which to send a message.</param>
+    /// <param name="message">The message to send.</param>
+    /// <param name="type">The type of message we are sending.</param>
+    /// <param name="target">The target id of this message, can be a player or guild id.</param>
+    public static void LogMessage(Player player, string message, ChatMessageType type, Guid targetId)
+    {
+        if (Options.Instance.Logging.Chat)
         {
-            TimeStamp = DateTime.UtcNow;
-        }
-
-        /// <summary>
-        /// Logs a chat message if chat message logging is enabled
-        /// </summary>
-        /// <param name="player">The player to which to send a message.</param>
-        /// <param name="message">The message to send.</param>
-        /// <param name="type">The type of message we are sending.</param>
-        /// <param name="target">The target id of this message, can be a player or guild id.</param>
-        public static void LogMessage(Player player, string message, ChatMessageType type, Guid targetId)
-        {
-            if (Options.Instance.Logging.Chat)
+            DbInterface.Pool.QueueWorkItem(new Action<ChatHistory>(Log), new ChatHistory
             {
-                DbInterface.Pool.QueueWorkItem(new Action<ChatHistory>(Log), new ChatHistory
-                {
-                    TimeStamp = DateTime.UtcNow,
-                    UserId = player?.Client?.User?.Id ?? Guid.Empty,
-                    PlayerId = player?.Id ?? Guid.Empty,
-                    Ip = player?.Client?.Ip,
-                    MessageType = type,
-                    MessageText = message,
-                    TargetId = targetId
-                });
-            }
+                TimeStamp = DateTime.UtcNow,
+                UserId = player?.Client?.User?.Id ?? Guid.Empty,
+                PlayerId = player?.Id ?? Guid.Empty,
+                Ip = player?.Client?.Ip,
+                MessageType = type,
+                MessageText = message,
+                TargetId = targetId
+            });
         }
+    }
 
-        private static void Log(ChatHistory chatHistory)
+    private static void Log(ChatHistory chatHistory)
+    {
+        using (var loggingContext = DbInterface.CreateLoggingContext(readOnly: false))
         {
-            using (var loggingContext = DbInterface.CreateLoggingContext(readOnly: false))
-            {
-                loggingContext.ChatHistory.Add(chatHistory);
-                loggingContext.SaveChanges();
-            }
+            loggingContext.ChatHistory.Add(chatHistory);
+            loggingContext.SaveChanges();
         }
     }
 }

--- a/Intersect.Server.Core/Database/Logging/Entities/GuildHistory.cs
+++ b/Intersect.Server.Core/Database/Logging/Entities/GuildHistory.cs
@@ -2,113 +2,112 @@
 using Newtonsoft.Json;
 using System.ComponentModel.DataAnnotations.Schema;
 
-namespace Intersect.Server.Database.Logging.Entities
+namespace Intersect.Server.Database.Logging.Entities;
+
+public partial class GuildHistory
 {
-    public partial class GuildHistory
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
+    public Guid Id { get; private set; } = Guid.NewGuid();
+
+    public Guid GuildId { get; private set; }
+
+    public Guid UserId { get; set; }
+
+    public Guid PlayerId { get; set; }
+
+    public string Ip { get; set; }
+
+    public DateTime TimeStamp { get; set; }
+
+    [JsonIgnore]
+    public GuildActivityType Type { get; set; }
+
+    [JsonProperty("ActivityType")]
+    public string ActivityTypeName => Enum.GetName(typeof(GuildActivityType), Type);
+
+    public string Meta { get; set; }
+
+    public Guid InitiatorId { get; set; }
+
+    [NotMapped]
+    public string Username { get; set; }
+
+    [NotMapped]
+    public string PlayerName { get; set; }
+
+    [NotMapped]
+    public string InitiatorName { get; set; }
+
+    public GuildHistory()
     {
-        [DatabaseGenerated(DatabaseGeneratedOption.None)]
-        public Guid Id { get; private set; } = Guid.NewGuid();
+        TimeStamp = DateTime.UtcNow;
+    }
 
-        public Guid GuildId { get; private set; }
+    /// <summary>
+    /// Defines all different types of logged guild actions.
+    /// </summary>
+    public enum GuildActivityType
+    {
+        Created,
+        Disbanded,
+        Joined,
+        Left,
+        Kicked,
+        Promoted,
+        Demoted,
+        Transfer,
+        Rename
+    }
 
-        public Guid UserId { get; set; }
+    /// <summary>
+    /// Logs guild activity
+    /// </summary>
+    /// <param name="guildId">The player to which to send a message.</param>
+    /// <param name="player">The player which this activity impacts.</param>
+    /// <param name="initiator">The id of the player who caused this activity (or null if caused by the api or something else).</param>
+    /// <param name="type">The type of message we are sending.</param>
+    /// <param name="meta">Any other info regarding this activity</param>
+    public static void LogActivity(
+        Guid guildId,
+        Player player,
+        Player initiator,
+        GuildActivityType type,
+        string meta = ""
+    ) =>
+        LogActivity(
+            guildId,
+            player?.UserId ?? default,
+            player?.Id ?? default,
+            player?.Client?.Ip ?? string.Empty,
+            initiator,
+            type,
+            meta
+        );
 
-        public Guid PlayerId { get; set; }
-
-        public string Ip { get; set; }
-
-        public DateTime TimeStamp { get; set; }
-
-        [JsonIgnore]
-        public GuildActivityType Type { get; set; }
-
-        [JsonProperty("ActivityType")]
-        public string ActivityTypeName => Enum.GetName(typeof(GuildActivityType), Type);
-
-        public string Meta { get; set; }
-
-        public Guid InitiatorId { get; set; }
-
-        [NotMapped]
-        public string Username { get; set; }
-
-        [NotMapped]
-        public string PlayerName { get; set; }
-
-        [NotMapped]
-        public string InitiatorName { get; set; }
-
-        public GuildHistory()
+    public static void LogActivity(Guid guildId, Guid userId, Guid playerId, string playerIp, Player initiator, GuildActivityType type, string meta = "")
+    {
+        if (Options.Instance.Logging.GuildActivity)
         {
-            TimeStamp = DateTime.UtcNow;
-        }
-
-        /// <summary>
-        /// Defines all different types of logged guild actions.
-        /// </summary>
-        public enum GuildActivityType
-        {
-            Created,
-            Disbanded,
-            Joined,
-            Left,
-            Kicked,
-            Promoted,
-            Demoted,
-            Transfer,
-            Rename
-        }
-
-        /// <summary>
-        /// Logs guild activity
-        /// </summary>
-        /// <param name="guildId">The player to which to send a message.</param>
-        /// <param name="player">The player which this activity impacts.</param>
-        /// <param name="initiator">The id of the player who caused this activity (or null if caused by the api or something else).</param>
-        /// <param name="type">The type of message we are sending.</param>
-        /// <param name="meta">Any other info regarding this activity</param>
-        public static void LogActivity(
-            Guid guildId,
-            Player player,
-            Player initiator,
-            GuildActivityType type,
-            string meta = ""
-        ) =>
-            LogActivity(
-                guildId,
-                player?.UserId ?? default,
-                player?.Id ?? default,
-                player?.Client?.Ip ?? string.Empty,
-                initiator,
-                type,
-                meta
-            );
-
-        public static void LogActivity(Guid guildId, Guid userId, Guid playerId, string playerIp, Player initiator, GuildActivityType type, string meta = "")
-        {
-            if (Options.Instance.Logging.GuildActivity)
+            DbInterface.Pool.QueueWorkItem(new Action<GuildHistory>(Log), new GuildHistory
             {
-                DbInterface.Pool.QueueWorkItem(new Action<GuildHistory>(Log), new GuildHistory
-                {
-                    GuildId = guildId,
-                    TimeStamp = DateTime.UtcNow,
-                    UserId = userId,
-                    PlayerId = playerId,
-                    Ip = playerIp,
-                    InitiatorId = initiator?.Id ?? Guid.Empty,
-                    Type = type,
-                    Meta = meta,
-                });
-            }
+                GuildId = guildId,
+                TimeStamp = DateTime.UtcNow,
+                UserId = userId,
+                PlayerId = playerId,
+                Ip = playerIp,
+                InitiatorId = initiator?.Id ?? Guid.Empty,
+                Type = type,
+                Meta = meta,
+            });
         }
+    }
 
-        private static void Log(GuildHistory guildHistory)
+    private static void Log(GuildHistory guildHistory)
+    {
+        using (var loggingContext = DbInterface.CreateLoggingContext(readOnly: false))
         {
-            using (var loggingContext = DbInterface.CreateLoggingContext(readOnly: false))
-            {
-                loggingContext.GuildHistory.Add(guildHistory);
-                loggingContext.SaveChanges();
-            }
+            loggingContext.GuildHistory.Add(guildHistory);
+            loggingContext.SaveChanges();
         }
     }
 }

--- a/Intersect.Server.Core/Database/Logging/Entities/TradeHistory.cs
+++ b/Intersect.Server.Core/Database/Logging/Entities/TradeHistory.cs
@@ -2,108 +2,107 @@
 using Newtonsoft.Json;
 using System.ComponentModel.DataAnnotations.Schema;
 
-namespace Intersect.Server.Database.Logging.Entities
+namespace Intersect.Server.Database.Logging.Entities;
+
+public partial class TradeHistory
 {
-    public partial class TradeHistory
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
+    public Guid Id { get; private set; } = Guid.NewGuid();
+
+    public Guid TradeId { get; set; }
+
+    public Guid UserId { get; set; }
+
+    public Guid PlayerId { get; set; }
+
+    public string Ip { get; set; }
+
+    public DateTime TimeStamp { get; set; }
+
+    public Guid TargetId { get; set; }
+
+    [Column("Items")]
+    [JsonIgnore]
+    public string ItemsJson
     {
-        [DatabaseGenerated(DatabaseGeneratedOption.None)]
-        public Guid Id { get; private set; } = Guid.NewGuid();
-
-        public Guid TradeId { get; set; }
-
-        public Guid UserId { get; set; }
-
-        public Guid PlayerId { get; set; }
-
-        public string Ip { get; set; }
-
-        public DateTime TimeStamp { get; set; }
-
-        public Guid TargetId { get; set; }
-
-        [Column("Items")]
-        [JsonIgnore]
-        public string ItemsJson
+        get
         {
-            get
-            {
-                return JsonConvert.SerializeObject(Items);
-            }
-
-            set
-            {
-                Items = JsonConvert.DeserializeObject<Item[]>(value);
-            }
+            return JsonConvert.SerializeObject(Items);
         }
 
-        [NotMapped]
-        public Item[] Items { get; set; } = new Item[0];
-
-        [Column("TargetItems")]
-        [JsonIgnore]
-        public string TargetItemsJson
+        set
         {
-            get
-            {
-                return JsonConvert.SerializeObject(TargetItems);
-            }
+            Items = JsonConvert.DeserializeObject<Item[]>(value);
+        }
+    }
 
-            set
-            {
-                TargetItems = JsonConvert.DeserializeObject<Item[]>(value);
-            }
+    [NotMapped]
+    public Item[] Items { get; set; } = new Item[0];
+
+    [Column("TargetItems")]
+    [JsonIgnore]
+    public string TargetItemsJson
+    {
+        get
+        {
+            return JsonConvert.SerializeObject(TargetItems);
         }
 
-        [NotMapped]
-        public Item[] TargetItems { get; set; } = new Item[0];
-
-        [NotMapped]
-        public string Username { get; set; }
-
-        [NotMapped]
-        public string PlayerName { get; set; }
-
-        [NotMapped]
-        public string TargetName { get; set; }
-
-        public TradeHistory()
+        set
         {
-            TimeStamp = DateTime.UtcNow;
+            TargetItems = JsonConvert.DeserializeObject<Item[]>(value);
         }
+    }
 
-        /// <summary>
-        /// Log a trade if trade logging is enabled
-        /// </summary>
-        /// <param name="tradeId">Unique id for this trade</param>
-        /// <param name="player">First trader</param>
-        /// <param name="target">Second trader</param>
-        /// <param name="ourItems">The items the first trader offered</param>
-        /// <param name="theirItems">The items the second trader offered</param>
-        public static void LogTrade(Guid tradeId, Player player, Player target, Item[] ourItems, Item[] theirItems)
+    [NotMapped]
+    public Item[] TargetItems { get; set; } = new Item[0];
+
+    [NotMapped]
+    public string Username { get; set; }
+
+    [NotMapped]
+    public string PlayerName { get; set; }
+
+    [NotMapped]
+    public string TargetName { get; set; }
+
+    public TradeHistory()
+    {
+        TimeStamp = DateTime.UtcNow;
+    }
+
+    /// <summary>
+    /// Log a trade if trade logging is enabled
+    /// </summary>
+    /// <param name="tradeId">Unique id for this trade</param>
+    /// <param name="player">First trader</param>
+    /// <param name="target">Second trader</param>
+    /// <param name="ourItems">The items the first trader offered</param>
+    /// <param name="theirItems">The items the second trader offered</param>
+    public static void LogTrade(Guid tradeId, Player player, Player target, Item[] ourItems, Item[] theirItems)
+    {
+        if (Options.Instance.Logging.Trade)
         {
-            if (Options.Instance.Logging.Trade)
+            DbInterface.Pool.QueueWorkItem(new Action<TradeHistory>(Log), new TradeHistory
             {
-                DbInterface.Pool.QueueWorkItem(new Action<TradeHistory>(Log), new TradeHistory
-                {
-                    TradeId = tradeId,
-                    TimeStamp = DateTime.UtcNow,
-                    UserId = player?.Client?.User?.Id ?? Guid.Empty,
-                    PlayerId = player?.Id ?? Guid.Empty,
-                    Ip = player?.Client?.Ip,
-                    TargetId = target?.Id ?? Guid.Empty,
-                    Items = ourItems,
-                    TargetItems = theirItems
-                });
-            }
+                TradeId = tradeId,
+                TimeStamp = DateTime.UtcNow,
+                UserId = player?.Client?.User?.Id ?? Guid.Empty,
+                PlayerId = player?.Id ?? Guid.Empty,
+                Ip = player?.Client?.Ip,
+                TargetId = target?.Id ?? Guid.Empty,
+                Items = ourItems,
+                TargetItems = theirItems
+            });
         }
+    }
 
-        private static void Log(TradeHistory tradeHistory)
+    private static void Log(TradeHistory tradeHistory)
+    {
+        using (var loggingContext = DbInterface.CreateLoggingContext(readOnly: false))
         {
-            using (var loggingContext = DbInterface.CreateLoggingContext(readOnly: false))
-            {
-                loggingContext.TradeHistory.Add(tradeHistory);
-                loggingContext.SaveChanges();
-            }
+            loggingContext.TradeHistory.Add(tradeHistory);
+            loggingContext.SaveChanges();
         }
     }
 }

--- a/Intersect.Server.Core/Database/Logging/Entities/UserActivityHistory.cs
+++ b/Intersect.Server.Core/Database/Logging/Entities/UserActivityHistory.cs
@@ -1,172 +1,171 @@
 ﻿using Newtonsoft.Json;
 using System.ComponentModel.DataAnnotations.Schema;
 
-namespace Intersect.Server.Database.Logging.Entities
+namespace Intersect.Server.Database.Logging.Entities;
+
+public partial class UserActivityHistory
 {
-    public partial class UserActivityHistory
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
+    public Guid Id { get; private set; } = Guid.NewGuid();
+
+    public DateTime TimeStamp { get; set; }
+
+    public Guid UserId { get; set; }
+
+    public Guid? PlayerId { get; set; }
+
+    [JsonIgnore]
+    public UserAction Action { get; set; }
+
+    [JsonProperty("Action")]
+    public string ActionString => Enum.GetName(typeof(UserAction), Action);
+
+    [JsonIgnore]
+    public PeerType Peer { get; set; }
+
+    [JsonProperty("Peer")]
+    public string PeerString => Enum.GetName(typeof(PeerType), Peer);
+
+    public string Ip { get; set; }
+
+    public string Meta { get; set; }
+
+    public UserActivityHistory()
     {
-        [DatabaseGenerated(DatabaseGeneratedOption.None)]
-        public Guid Id { get; private set; } = Guid.NewGuid();
+        TimeStamp = DateTime.UtcNow;
+    }
 
-        public DateTime TimeStamp { get; set; }
+    public enum PeerType
+    {
+        Client,
 
-        public Guid UserId { get; set; }
+        Editor
+    }
 
-        public Guid? PlayerId { get; set; }
+    public enum UserAction
+    {
+        Create,
 
-        [JsonIgnore]
-        public UserAction Action { get; set; }
+        Delete,
 
-        [JsonProperty("Action")]
-        public string ActionString => Enum.GetName(typeof(UserAction), Action);
+        PasswordRecoveryAttempt,
 
-        [JsonIgnore]
-        public PeerType Peer { get; set; }
+        PasswordRecoveryDispatched,
 
-        [JsonProperty("Peer")]
-        public string PeerString => Enum.GetName(typeof(PeerType), Peer);
+        PasswordChanged,
 
-        public string Ip { get; set; }
+        TwoFactorAdd,
 
-        public string Meta { get; set; }
+        TwoFactorRemove,
 
-        public UserActivityHistory()
+        TwoFactorSuccess,
+
+        TwoFactorFailure,
+
+        TwoFactorTimeout,
+
+        Login,
+
+        FailedLogin,
+
+        Logout,
+
+        DisconnectLogout,
+
+        DisconnectTimeout,
+
+        DisconnectBan,
+        
+        DisconnectBanFail,
+
+        DisconnectKick,
+        
+        DisconnectKickFail,
+        
+        Kill,
+        
+        KillFail,
+        
+        Mute,
+        
+        MuteFail,
+
+        CreatePlayer,
+
+        DeletePlayer,
+
+        SelectPlayer,
+
+        SwitchPlayer,
+
+        NameChange,
+
+        DisconnectDatabaseFailure,
+    }
+
+    /// <summary>
+    /// Spawns a task in our database pool to write an activity into the user activity history table
+    /// </summary>
+    /// <param name="userId">Id of the user corresponding to this event</param>
+    /// <param name="playerId">Id of the player corresponding to this event</param>
+    /// <param name="ip">Ip of the client corresponding to this event</param>
+    /// <param name="peer">Peer type that raised this event, client or editor</param>
+    /// <param name="action">User action taken to be logged</param>
+    /// <param name="meta">Any extra metadata/notes for this event</param>
+    public static void LogActivity(Guid userId, Guid playerId, string ip, PeerType peer, UserAction action, string meta)
+    {
+        if (!Options.Instance.Logging.UserActivity)
         {
-            TimeStamp = DateTime.UtcNow;
+            return;
         }
 
-        public enum PeerType
+        DbInterface.Pool.QueueWorkItem(Log, new UserActivityHistory
         {
-            Client,
+            TimeStamp = DateTime.UtcNow,
+            UserId = userId,
+            PlayerId = playerId,
+            Ip = ip ?? string.Empty,
+            Peer = peer,
+            Action = action,
+            Meta = meta,
+        });
+    }
 
-            Editor
+    public static async Task<UserActivityHistory?> LogActivityAsync(
+        Guid userId,
+        Guid playerId,
+        string ip,
+        PeerType peer,
+        UserAction action,
+        string meta
+    )
+    {
+
+        if (!Options.Instance.Logging.UserActivity)
+        {
+            return default;
         }
 
-        public enum UserAction
+        var history = new UserActivityHistory
         {
-            Create,
+            TimeStamp = DateTime.UtcNow,
+            UserId = userId,
+            PlayerId = playerId,
+            Ip = ip ?? string.Empty,
+            Peer = peer,
+            Action = action,
+            Meta = meta,
+        };
 
-            Delete,
+        var result = DbInterface.Pool.QueueWorkItem(Log, history);
+        result.GetWorkItemResult();
+        return history;
+    }
 
-            PasswordRecoveryAttempt,
-
-            PasswordRecoveryDispatched,
-
-            PasswordChanged,
-
-            TwoFactorAdd,
-
-            TwoFactorRemove,
-
-            TwoFactorSuccess,
-
-            TwoFactorFailure,
-
-            TwoFactorTimeout,
-
-            Login,
-
-            FailedLogin,
-
-            Logout,
-
-            DisconnectLogout,
-
-            DisconnectTimeout,
-
-            DisconnectBan,
-            
-            DisconnectBanFail,
-
-            DisconnectKick,
-            
-            DisconnectKickFail,
-            
-            Kill,
-            
-            KillFail,
-            
-            Mute,
-            
-            MuteFail,
-
-            CreatePlayer,
-
-            DeletePlayer,
-
-            SelectPlayer,
-
-            SwitchPlayer,
-
-            NameChange,
-
-            DisconnectDatabaseFailure,
-        }
-
-        /// <summary>
-        /// Spawns a task in our database pool to write an activity into the user activity history table
-        /// </summary>
-        /// <param name="userId">Id of the user corresponding to this event</param>
-        /// <param name="playerId">Id of the player corresponding to this event</param>
-        /// <param name="ip">Ip of the client corresponding to this event</param>
-        /// <param name="peer">Peer type that raised this event, client or editor</param>
-        /// <param name="action">User action taken to be logged</param>
-        /// <param name="meta">Any extra metadata/notes for this event</param>
-        public static void LogActivity(Guid userId, Guid playerId, string ip, PeerType peer, UserAction action, string meta)
-        {
-            if (!Options.Instance.Logging.UserActivity)
-            {
-                return;
-            }
-
-            DbInterface.Pool.QueueWorkItem(Log, new UserActivityHistory
-            {
-                TimeStamp = DateTime.UtcNow,
-                UserId = userId,
-                PlayerId = playerId,
-                Ip = ip ?? string.Empty,
-                Peer = peer,
-                Action = action,
-                Meta = meta,
-            });
-        }
-
-        public static async Task<UserActivityHistory?> LogActivityAsync(
-            Guid userId,
-            Guid playerId,
-            string ip,
-            PeerType peer,
-            UserAction action,
-            string meta
-        )
-        {
-
-            if (!Options.Instance.Logging.UserActivity)
-            {
-                return default;
-            }
-
-            var history = new UserActivityHistory
-            {
-                TimeStamp = DateTime.UtcNow,
-                UserId = userId,
-                PlayerId = playerId,
-                Ip = ip ?? string.Empty,
-                Peer = peer,
-                Action = action,
-                Meta = meta,
-            };
-
-            var result = DbInterface.Pool.QueueWorkItem(Log, history);
-            result.GetWorkItemResult();
-            return history;
-        }
-
-        private static void Log(UserActivityHistory userActivityHistory)
-        {
-            using var loggingContext = DbInterface.CreateLoggingContext(readOnly: false);
-            loggingContext.UserActivityHistory.Add(userActivityHistory);
-            loggingContext.SaveChanges();
-        }
+    private static void Log(UserActivityHistory userActivityHistory)
+    {
+        using var loggingContext = DbInterface.CreateLoggingContext(readOnly: false);
+        loggingContext.UserActivityHistory.Add(userActivityHistory);
+        loggingContext.SaveChanges();
     }
 }

--- a/Intersect.Server.Core/Database/Logging/ILoggingContext.cs
+++ b/Intersect.Server.Core/Database/Logging/ILoggingContext.cs
@@ -2,20 +2,19 @@
 
 using Microsoft.EntityFrameworkCore;
 
-namespace Intersect.Server.Database.Logging
+namespace Intersect.Server.Database.Logging;
+
+public interface ILoggingContext : IDbContext, IDisposable
 {
-    public interface ILoggingContext : IDbContext, IDisposable
-    {
-        DbSet<RequestLog> RequestLogs { get; }
+    DbSet<RequestLog> RequestLogs { get; }
 
-        DbSet<UserActivityHistory> UserActivityHistory { get; }
+    DbSet<UserActivityHistory> UserActivityHistory { get; }
 
-        DbSet<ChatHistory> ChatHistory { get; }
+    DbSet<ChatHistory> ChatHistory { get; }
 
-        DbSet<TradeHistory> TradeHistory { get; }
-        
-        DbSet<GuildHistory> GuildHistory { get; }
+    DbSet<TradeHistory> TradeHistory { get; }
+    
+    DbSet<GuildHistory> GuildHistory { get; }
 
-        void Seed();
-    }
+    void Seed();
 }

--- a/Intersect.Server.Core/Database/Logging/LoggingContext.cs
+++ b/Intersect.Server.Core/Database/Logging/LoggingContext.cs
@@ -6,40 +6,39 @@ using Microsoft.EntityFrameworkCore;
 
 using System.Data.Common;
 
-namespace Intersect.Server.Database.Logging
+namespace Intersect.Server.Database.Logging;
+
+public abstract partial class LoggingContext : IntersectDbContext<LoggingContext>, ILoggingContext
 {
-    public abstract partial class LoggingContext : IntersectDbContext<LoggingContext>, ILoggingContext
+    /// <inheritdoc />
+    protected LoggingContext(DatabaseContextOptions databaseContextOptions) : base(databaseContextOptions) { }
+
+    public static DbConnectionStringBuilder DefaultConnectionStringBuilder =>
+        new SqliteConnectionStringBuilder(@"Data Source=resources/logging.db");
+
+    public DbSet<RequestLog> RequestLogs { get; set; }
+
+    public DbSet<UserActivityHistory> UserActivityHistory { get; set; }
+
+    public DbSet<ChatHistory> ChatHistory { get; set; }
+
+    public DbSet<TradeHistory> TradeHistory { get; set; }
+
+    public DbSet<GuildHistory> GuildHistory { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        /// <inheritdoc />
-        protected LoggingContext(DatabaseContextOptions databaseContextOptions) : base(databaseContextOptions) { }
+        base.OnModelCreating(modelBuilder);
 
-        public static DbConnectionStringBuilder DefaultConnectionStringBuilder =>
-            new SqliteConnectionStringBuilder(@"Data Source=resources/logging.db");
+        modelBuilder.ApplyConfiguration(new RequestLog.Mapper());
+    }
 
-        public DbSet<RequestLog> RequestLogs { get; set; }
-
-        public DbSet<UserActivityHistory> UserActivityHistory { get; set; }
-
-        public DbSet<ChatHistory> ChatHistory { get; set; }
-
-        public DbSet<TradeHistory> TradeHistory { get; set; }
-
-        public DbSet<GuildHistory> GuildHistory { get; set; }
-
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            base.OnModelCreating(modelBuilder);
-
-            modelBuilder.ApplyConfiguration(new RequestLog.Mapper());
-        }
-
-        public void Seed()
-        {
+    public void Seed()
+    {
 #if DEBUG
-            new SeedTrades().SeedIfEmpty(this);
-            ChangeTracker.DetectChanges();
-            SaveChanges();
+        new SeedTrades().SeedIfEmpty(this);
+        ChangeTracker.DetectChanges();
+        SaveChanges();
 #endif
-        }
     }
 }

--- a/Intersect.Server.Core/Database/Logging/RequestLog.cs
+++ b/Intersect.Server.Core/Database/Logging/RequestLog.cs
@@ -9,69 +9,67 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using LogLevel = Intersect.Logging.LogLevel;
 
-namespace Intersect.Server.Database.Logging
+namespace Intersect.Server.Database.Logging;
+
+[Serializable]
+public partial class RequestLog
 {
-    [Serializable]
-    public partial class RequestLog
+    private string mMethod;
+
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
+    [Column(Order = 0)]
+    [Key]
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public DateTime Time { get; set; }
+
+    [JsonConverter(typeof(StringEnumConverter))]
+    public LogLevel Level { get; set; }
+
+    public string Method
     {
-        private string mMethod;
+        get => mMethod;
+        set => mMethod = value?.ToUpperInvariant();
+    }
 
-        [DatabaseGenerated(DatabaseGeneratedOption.None)]
-        [Column(Order = 0)]
-        [Key]
-        public Guid Id { get; set; } = Guid.NewGuid();
+    public int StatusCode { get; set; }
 
-        public DateTime Time { get; set; }
+    public string StatusMessage { get; set; }
 
-        [JsonConverter(typeof(StringEnumConverter))]
-        public LogLevel Level { get; set; }
+    public string Uri { get; set; }
 
-        public string Method
+    private string SerializedRequestHeaders
+    {
+        get => JsonConvert.SerializeObject(RequestHeaders);
+        set => RequestHeaders = JsonConvert.DeserializeObject<Dictionary<string, List<string>>>(value);
+    }
+
+    [NotMapped]
+    public IDictionary<string, List<string>> RequestHeaders { get; set; }
+
+    private string SerializedResponseHeaders
+    {
+        get => JsonConvert.SerializeObject(ResponseHeaders);
+        set => ResponseHeaders = JsonConvert.DeserializeObject<Dictionary<string, List<string>>>(value);
+    }
+
+    [NotMapped]
+    public IDictionary<string, List<string>> ResponseHeaders { get; set; }
+
+    public partial class Mapper : IEntityTypeConfiguration<RequestLog>
+    {
+
+        /// <inheritdoc />
+        public void Configure(EntityTypeBuilder<RequestLog> builder)
         {
-            get => mMethod;
-            set => mMethod = value?.ToUpperInvariant();
-        }
-
-        public int StatusCode { get; set; }
-
-        public string StatusMessage { get; set; }
-
-        public string Uri { get; set; }
-
-        private string SerializedRequestHeaders
-        {
-            get => JsonConvert.SerializeObject(RequestHeaders);
-            set => RequestHeaders = JsonConvert.DeserializeObject<Dictionary<string, List<string>>>(value);
-        }
-
-        [NotMapped]
-        public IDictionary<string, List<string>> RequestHeaders { get; set; }
-
-        private string SerializedResponseHeaders
-        {
-            get => JsonConvert.SerializeObject(ResponseHeaders);
-            set => ResponseHeaders = JsonConvert.DeserializeObject<Dictionary<string, List<string>>>(value);
-        }
-
-        [NotMapped]
-        public IDictionary<string, List<string>> ResponseHeaders { get; set; }
-
-        public partial class Mapper : IEntityTypeConfiguration<RequestLog>
-        {
-
-            /// <inheritdoc />
-            public void Configure(EntityTypeBuilder<RequestLog> builder)
+            if (builder == null)
             {
-                if (builder == null)
-                {
-                    throw new ArgumentNullException(nameof(builder));
-                }
-
-                builder.Property(rl => rl.SerializedRequestHeaders).IsNotNull().HasColumnName(nameof(RequestHeaders));
-
-                builder.Property(rl => rl.SerializedResponseHeaders).IsNotNull().HasColumnName(nameof(ResponseHeaders));
+                throw new ArgumentNullException(nameof(builder));
             }
 
+            builder.Property(rl => rl.SerializedRequestHeaders).IsNotNull().HasColumnName(nameof(RequestHeaders));
+
+            builder.Property(rl => rl.SerializedResponseHeaders).IsNotNull().HasColumnName(nameof(ResponseHeaders));
         }
 
     }

--- a/Intersect.Server.Core/Database/Logging/Seed/SeedTrades.cs
+++ b/Intersect.Server.Core/Database/Logging/Seed/SeedTrades.cs
@@ -2,75 +2,74 @@
 
 using Microsoft.EntityFrameworkCore;
 
-namespace Intersect.Server.Database.Logging.Seed
+namespace Intersect.Server.Database.Logging.Seed;
+
+internal partial class SeedTrades : SeedData<TradeHistory>
 {
-    internal partial class SeedTrades : SeedData<TradeHistory>
+    public override void Seed(DbSet<TradeHistory> dbSet)
     {
-        public override void Seed(DbSet<TradeHistory> dbSet)
+        var chunkSize = 1000;
+        for (short i = 0; i < 10; ++i)
         {
-            var chunkSize = 1000;
-            for (short i = 0; i < 10; ++i)
+            var tradeHistories = Enumerable.Range(0, chunkSize).SelectMany(j =>
             {
-                var tradeHistories = Enumerable.Range(0, chunkSize).SelectMany(j =>
+                var ij = i * chunkSize + j;
+                var octets = new byte[]
                 {
-                    var ij = i * chunkSize + j;
-                    var octets = new byte[]
-                    {
-                        (byte)((ij >> 24) & 0xff),
-                        (byte)((ij >> 16) & 0xff),
-                        (byte)((ij >>  8) & 0xff),
-                        (byte)((ij >>  0) & 0xff),
-                        default,
-                        default,
-                        default,
-                        default
-                    };
+                    (byte)((ij >> 24) & 0xff),
+                    (byte)((ij >> 16) & 0xff),
+                    (byte)((ij >>  8) & 0xff),
+                    (byte)((ij >>  0) & 0xff),
+                    default,
+                    default,
+                    default,
+                    default
+                };
 
-                    var sourceItems = new Item[]
+                var sourceItems = new Item[]
+                        {
+                            new Item
                             {
-                                new Item
-                                {
-                                    ItemId = Guid.NewGuid(),
-                                    Quantity = j
-                                }
-                            };
-                    var targetItems = new Item[]
+                                ItemId = Guid.NewGuid(),
+                                Quantity = j
+                            }
+                        };
+                var targetItems = new Item[]
+                        {
+                            new Item
                             {
-                                new Item
-                                {
-                                    ItemId = Guid.NewGuid(),
-                                    Quantity = i
-                                }
-                            };
+                                ItemId = Guid.NewGuid(),
+                                Quantity = i
+                            }
+                        };
 
-                    return new[]
+                return new[]
+                {
+                    new TradeHistory
                     {
-                        new TradeHistory
-                        {
-                            TradeId = new Guid(j, default, i, octets),
-                            UserId = new Guid(j, default, i, octets),
-                            PlayerId = new Guid(j, 0, i, octets),
-                            Ip = string.Join(".", octets.Take(4).Select(o => Convert.ToString(o, 10))),
-                            TimeStamp = DateTime.UtcNow.AddMilliseconds(ij),
-                            TargetId = new Guid(j, 1, i, octets),
-                            Items = sourceItems,
-                            TargetItems = targetItems
-                        },
-                        new TradeHistory
-                        {
-                            TradeId = new Guid(j, default, i, octets),
-                            UserId = new Guid(j, 1, i, octets),
-                            PlayerId = new Guid(j, 1, i, octets),
-                            Ip = string.Join(".", octets.Take(4).Select(o => Convert.ToString(o, 10))),
-                            TimeStamp = DateTime.UtcNow.AddMilliseconds(ij),
-                            TargetId = new Guid(j, 0, i, octets),
-                            Items = targetItems,
-                            TargetItems = sourceItems
-                        }
-                    };
-                });
-                dbSet.AddRange(tradeHistories);
-            }
+                        TradeId = new Guid(j, default, i, octets),
+                        UserId = new Guid(j, default, i, octets),
+                        PlayerId = new Guid(j, 0, i, octets),
+                        Ip = string.Join(".", octets.Take(4).Select(o => Convert.ToString(o, 10))),
+                        TimeStamp = DateTime.UtcNow.AddMilliseconds(ij),
+                        TargetId = new Guid(j, 1, i, octets),
+                        Items = sourceItems,
+                        TargetItems = targetItems
+                    },
+                    new TradeHistory
+                    {
+                        TradeId = new Guid(j, default, i, octets),
+                        UserId = new Guid(j, 1, i, octets),
+                        PlayerId = new Guid(j, 1, i, octets),
+                        Ip = string.Join(".", octets.Take(4).Select(o => Convert.ToString(o, 10))),
+                        TimeStamp = DateTime.UtcNow.AddMilliseconds(ij),
+                        TargetId = new Guid(j, 0, i, octets),
+                        Items = targetItems,
+                        TargetItems = sourceItems
+                    }
+                };
+            });
+            dbSet.AddRange(tradeHistories);
         }
     }
 }

--- a/Intersect.Server.Core/Database/MigrationBuilderExtensions.cs
+++ b/Intersect.Server.Core/Database/MigrationBuilderExtensions.cs
@@ -4,77 +4,75 @@ using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations.Builders;
 
-namespace Intersect.Server.Database
+namespace Intersect.Server.Database;
+
+
+public static partial class MigrationBuilderExtensions
 {
 
-    public static partial class MigrationBuilderExtensions
+    public static DatabaseType GetDatabaseType(this MigrationBuilder migrationBuilder)
     {
-
-        public static DatabaseType GetDatabaseType(this MigrationBuilder migrationBuilder)
+        switch (migrationBuilder.ActiveProvider)
         {
-            switch (migrationBuilder.ActiveProvider)
-            {
-                default:
-                    if (migrationBuilder.ActiveProvider?.ToLowerInvariant().Contains("sqlite") ?? false)
-                    {
-                        return DatabaseType.SQLite;
-                    }
-
-                    return DatabaseType.MySQL;
-            }
-        }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="migrationBuilder"></param>
-        /// <param name="conditionalQueries"></param>
-        /// <param name="suppressTransaction"></param>
-        /// <returns></returns>
-        /// <see cref="MigrationBuilder.Sql(string, bool)"/>
-        public static OperationBuilder<SqlOperation> Sql(
-            this MigrationBuilder migrationBuilder,
-            params (DatabaseType DatabaseType, string Sql)[] conditionalQueries
-        )
-        {
-            return migrationBuilder.Sql(
-                conditionalQueries
-                    .Select(conditionalQuery => (conditionalQuery.DatabaseType, conditionalQuery.Sql, false))
-                    .ToArray()
-            );
-        }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="migrationBuilder"></param>
-        /// <param name="conditionalQueries"></param>
-        /// <returns></returns>
-        /// <see cref="MigrationBuilder.Sql(string, bool)"/>
-        public static OperationBuilder<SqlOperation> Sql(
-            this MigrationBuilder migrationBuilder,
-            params (DatabaseType DatabaseType, string Sql, bool SuppressTransaction)[]
-                conditionalQueries
-        )
-        {
-            OperationBuilder<SqlOperation> operationBuilder = null;
-            var databaseType = migrationBuilder.GetDatabaseType();
-            foreach (var conditionalQuery in conditionalQueries)
-            {
-                if (databaseType == conditionalQuery.DatabaseType)
+            default:
+                if (migrationBuilder.ActiveProvider?.ToLowerInvariant().Contains("sqlite") ?? false)
                 {
-                    operationBuilder = migrationBuilder.Sql(conditionalQuery.Sql, conditionalQuery.SuppressTransaction);
+                    return DatabaseType.SQLite;
                 }
-            }
 
-            if (operationBuilder == null)
+                return DatabaseType.MySQL;
+        }
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="migrationBuilder"></param>
+    /// <param name="conditionalQueries"></param>
+    /// <param name="suppressTransaction"></param>
+    /// <returns></returns>
+    /// <see cref="MigrationBuilder.Sql(string, bool)"/>
+    public static OperationBuilder<SqlOperation> Sql(
+        this MigrationBuilder migrationBuilder,
+        params (DatabaseType DatabaseType, string Sql)[] conditionalQueries
+    )
+    {
+        return migrationBuilder.Sql(
+            conditionalQueries
+                .Select(conditionalQuery => (conditionalQuery.DatabaseType, conditionalQuery.Sql, false))
+                .ToArray()
+        );
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="migrationBuilder"></param>
+    /// <param name="conditionalQueries"></param>
+    /// <returns></returns>
+    /// <see cref="MigrationBuilder.Sql(string, bool)"/>
+    public static OperationBuilder<SqlOperation> Sql(
+        this MigrationBuilder migrationBuilder,
+        params (DatabaseType DatabaseType, string Sql, bool SuppressTransaction)[]
+            conditionalQueries
+    )
+    {
+        OperationBuilder<SqlOperation> operationBuilder = null;
+        var databaseType = migrationBuilder.GetDatabaseType();
+        foreach (var conditionalQuery in conditionalQueries)
+        {
+            if (databaseType == conditionalQuery.DatabaseType)
             {
-                throw new ArgumentException(@"No queries were executed.", nameof(conditionalQueries));
+                operationBuilder = migrationBuilder.Sql(conditionalQuery.Sql, conditionalQuery.SuppressTransaction);
             }
-
-            return operationBuilder;
         }
 
+        if (operationBuilder == null)
+        {
+            throw new ArgumentException(@"No queries were executed.", nameof(conditionalQueries));
+        }
+
+        return operationBuilder;
     }
 
 }

--- a/Intersect.Server.Core/Database/MigrationScheduler.cs
+++ b/Intersect.Server.Core/Database/MigrationScheduler.cs
@@ -1,6 +1,4 @@
 using Intersect.Logging;
-using Intersect.Reflection;
-using Intersect.Server.Database.DataMigrations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
 

--- a/Intersect.Server.Core/Database/PlayerData/Api/RefreshToken.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Api/RefreshToken.cs
@@ -7,320 +7,337 @@ using Microsoft.EntityFrameworkCore;
 
 using Newtonsoft.Json;
 
-namespace Intersect.Server.Database.PlayerData.Api
+namespace Intersect.Server.Database.PlayerData.Api;
+
+
+public partial class RefreshToken
 {
 
-    public partial class RefreshToken
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
+    [Column(Order = 0)]
+    [Key]
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    [Required, ForeignKey(nameof(User))]
+    public Guid UserId { get; set; }
+
+    [JsonIgnore]
+    public User User { get; set; }
+
+    public Guid ClientId { get; set; }
+
+    [Required]
+    public string Subject { get; set; }
+
+    public DateTime Issued { get; set; }
+
+    public DateTime Expires { get; set; }
+
+    [Required]
+    public Guid TicketId { get; set; }
+
+    [Required]
+    [ProtectedPersonalData]
+    public string Ticket { get; set; }
+
+    // To help avoid concurrency exceptions
+    private static readonly ConcurrentDictionary<Guid, EntityState> _pendingChanges = new ConcurrentDictionary<Guid, EntityState>();
+
+    public static async ValueTask<bool> TryAddAsync(
+        RefreshToken token,
+        bool checkForDuplicates = true,
+        CancellationToken cancellationToken = default
+    )
     {
+        var tokensToRemove = new List<RefreshToken>();
 
-        [DatabaseGenerated(DatabaseGeneratedOption.None)]
-        [Column(Order = 0)]
-        [Key]
-        public Guid Id { get; set; } = Guid.NewGuid();
-
-        [Required, ForeignKey(nameof(User))]
-        public Guid UserId { get; set; }
-
-        [JsonIgnore]
-        public User User { get; set; }
-
-        public Guid ClientId { get; set; }
-
-        [Required]
-        public string Subject { get; set; }
-
-        public DateTime Issued { get; set; }
-
-        public DateTime Expires { get; set; }
-
-        [Required]
-        public Guid TicketId { get; set; }
-
-        [Required]
-        [ProtectedPersonalData]
-        public string Ticket { get; set; }
-
-        // To help avoid concurrency exceptions
-        private static readonly ConcurrentDictionary<Guid, EntityState> _pendingChanges = new ConcurrentDictionary<Guid, EntityState>();
-
-        public static async ValueTask<bool> TryAddAsync(
-            RefreshToken token,
-            bool checkForDuplicates = true,
-            CancellationToken cancellationToken = default
-        )
-        {
-            var tokensToRemove = new List<RefreshToken>();
-
-            using (var context = DbInterface.CreatePlayerContext(readOnly: false))
-            {
-                try
-                {
-                    if (context.RefreshTokens == null)
-                    {
-                        return false;
-                    }
-
-                    if (checkForDuplicates)
-                    {
-                        if (TryFind(token.Id, out var duplicate))
-                        {
-                            tokensToRemove.Add(duplicate);
-                        }
-
-                        var forClient = FindExpiredForClient(token.ClientId)?.ToList();
-                        if (forClient != null)
-                        {
-                            tokensToRemove.AddRange(forClient);
-                        }
-
-                        var forUser = FindExpiredForUser(token.UserId)?.ToList();
-                        if (forUser != null)
-                        {
-                            tokensToRemove.AddRange(forUser);
-                        }
-                    }
-
-                    _ = context.RefreshTokens.Add(token);
-                    context.ChangeTracker.DetectChanges();
-
-                    if (tokensToRemove.Count > 0)
-                    {
-                        _ = RemoveAllAsync(tokensToRemove, cancellationToken);
-                    }
-
-                    _ = _pendingChanges.TryAdd(token.Id, context.Entry(token).State);
-                    _ = await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-                    _ = _pendingChanges.TryRemove(token.Id, out _);
-
-                    return true;
-                }
-                catch (DbUpdateConcurrencyException concurrencyException)
-                {
-                    concurrencyException.LogError();
-                    throw;
-                }
-            }
-        }
-
-        public static bool TryFind(Guid id, out RefreshToken refreshToken)
+        using (var context = DbInterface.CreatePlayerContext(readOnly: false))
         {
             try
             {
-                using var context = DbInterface.CreatePlayerContext();
-                refreshToken = context?.RefreshTokens?.Where(token => token.Id == id).Include(token => token.User).FirstOrDefault();
-                return refreshToken != default;
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex);
-                refreshToken = default;
-                return false;
-            }
-        }
-
-        public static RefreshToken FindForTicket(Guid ticketId)
-        {
-            if (ticketId == Guid.Empty)
-            {
-                return null;
-            }
-
-            try
-            {
-                using (var context = DbInterface.CreatePlayerContext())
-                {
-                    var refreshToken = context?.RefreshTokens.FirstOrDefault(queryToken => queryToken.TicketId == ticketId);
-
-                    if (refreshToken == null || DateTime.UtcNow < refreshToken.Expires)
-                    {
-                        return refreshToken;
-                    }
-
-                    _ = Remove(refreshToken);
-
-                    return null;
-                }
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex);
-                return null;
-            }
-        }
-
-        public static IEnumerable<RefreshToken> FindForClient(Guid clientId)
-        {
-            if (clientId == Guid.Empty)
-            {
-                return null;
-            }
-
-            try
-            {
-                using (var context = DbInterface.CreatePlayerContext())
-                {
-                    var tokenQuery = context?.RefreshTokens.Where(queryToken => queryToken.ClientId == clientId);
-
-                    return tokenQuery.AsEnumerable()?.ToList();
-                }
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex);
-                return null;
-            }
-        }
-
-        public static IEnumerable<RefreshToken> FindExpiredForClient(Guid clientId)
-        {
-            if (clientId == Guid.Empty)
-            {
-                return null;
-            }
-
-            try
-            {
-                using (var context = DbInterface.CreatePlayerContext())
-                {
-                    var tokenQuery = context?.RefreshTokens.Where(queryToken => queryToken.ClientId == clientId && queryToken.Expires < DateTime.UtcNow);
-
-                    return tokenQuery.AsEnumerable()?.ToList();
-                }
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex);
-                return null;
-            }
-        }
-
-        public static IEnumerable<RefreshToken> FindForUser(Guid userId)
-        {
-            if (userId == Guid.Empty)
-            {
-                return null;
-            }
-
-            try
-            {
-                using (var context = DbInterface.CreatePlayerContext())
-                {
-                    var tokenQuery = context?.RefreshTokens.Where(queryToken => queryToken.UserId == userId);
-
-                    return tokenQuery.AsEnumerable()?.ToList();
-                }
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex);
-                return null;
-            }
-        }
-
-        public static IEnumerable<RefreshToken> FindForUser(User user)
-        {
-            return FindForUser(user.Id);
-        }
-
-        public static IEnumerable<RefreshToken> FindExpiredForUser(Guid userId)
-        {
-            if (userId == Guid.Empty)
-            {
-                return null;
-            }
-
-            try
-            {
-                using (var context = DbInterface.CreatePlayerContext())
-                {
-                    var tokenQuery = context?.RefreshTokens.Where(queryToken => queryToken.UserId == userId && queryToken.Expires < DateTime.UtcNow);
-
-                    return tokenQuery.AsEnumerable()?.ToList();
-                }
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex);
-                return null;
-            }
-        }
-
-        public static IEnumerable<RefreshToken> FindExpiredForUser(User user)
-        {
-            return FindExpiredForUser(user.Id);
-        }
-
-        public static RefreshToken FindOneForUser(Guid userId)
-        {
-            try
-            {
-                using (var context = DbInterface.CreatePlayerContext())
-                {
-                    var token = context?.RefreshTokens.First(queryToken => queryToken.UserId == userId);
-
-                    return token;
-                }
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex);
-                return null;
-            }
-        }
-
-        public static RefreshToken FindOneForUser(User user)
-        {
-            return FindOneForUser(user.Id);
-        }
-
-        public static bool HasTokens(Guid userId)
-        {
-            try
-            {
-                using (var context = DbInterface.CreatePlayerContext())
-                {
-                    return context.RefreshTokens.Any(queryToken => queryToken.UserId == userId);
-                }
-            }
-            catch (Exception exception)
-            {
-                Log.Error(exception);
-                throw;
-            }
-        }
-
-        public static bool HasTokens(User user) => HasTokens(user.Id);
-
-        public static bool Remove(Guid id) => TryFind(id, out var token) && Remove(token);
-
-        public static bool Remove(RefreshToken token) => RemoveAll(new []{ token });
-
-        public static bool RemoveAll(IEnumerable<RefreshToken> tokens) => RemoveAllAsync(tokens.ToList(), default).Result;
-
-        public static async Task<bool> RemoveAllAsync(IList<RefreshToken> tokens, CancellationToken cancellationToken)
-        {
-            try
-            {
-                var unblockedTokens = tokens.Where(token => _pendingChanges.TryAdd(token.Id, EntityState.Deleted)).ToArray();
-
-                if (unblockedTokens.Length < 1)
+                if (context.RefreshTokens == null)
                 {
                     return false;
                 }
 
-                Log.Diagnostic($"Attempted to remove {tokens.Count} tokens but only {unblockedTokens.Length} were available to remove.");
-
-                using (var context = DbInterface.CreatePlayerContext(readOnly: false))
+                if (checkForDuplicates)
                 {
-                    context.RefreshTokens.RemoveRange(unblockedTokens);
-                    _ = await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+                    if (TryFind(token.Id, out var duplicate))
+                    {
+                        tokensToRemove.Add(duplicate);
+                    }
+
+                    var forClient = FindExpiredForClient(token.ClientId)?.ToList();
+                    if (forClient != null)
+                    {
+                        tokensToRemove.AddRange(forClient);
+                    }
+
+                    var forUser = FindExpiredForUser(token.UserId)?.ToList();
+                    if (forUser != null)
+                    {
+                        tokensToRemove.AddRange(forUser);
+                    }
                 }
 
-                foreach (var token in unblockedTokens)
+                _ = context.RefreshTokens.Add(token);
+                context.ChangeTracker.DetectChanges();
+
+                if (tokensToRemove.Count > 0)
                 {
-                    _ = _pendingChanges.TryRemove(token.Id, out _);
+                    _ = RemoveAllAsync(tokensToRemove, cancellationToken);
                 }
 
+                _ = _pendingChanges.TryAdd(token.Id, context.Entry(token).State);
+                _ = await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+                _ = _pendingChanges.TryRemove(token.Id, out _);
+
+                return true;
+            }
+            catch (DbUpdateConcurrencyException concurrencyException)
+            {
+                concurrencyException.LogError();
+                throw;
+            }
+        }
+    }
+
+    public static bool TryFind(Guid id, out RefreshToken refreshToken)
+    {
+        try
+        {
+            using var context = DbInterface.CreatePlayerContext();
+            refreshToken = context?.RefreshTokens?.Where(token => token.Id == id).Include(token => token.User).FirstOrDefault();
+            return refreshToken != default;
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex);
+            refreshToken = default;
+            return false;
+        }
+    }
+
+    public static RefreshToken FindForTicket(Guid ticketId)
+    {
+        if (ticketId == Guid.Empty)
+        {
+            return null;
+        }
+
+        try
+        {
+            using (var context = DbInterface.CreatePlayerContext())
+            {
+                var refreshToken = context?.RefreshTokens.FirstOrDefault(queryToken => queryToken.TicketId == ticketId);
+
+                if (refreshToken == null || DateTime.UtcNow < refreshToken.Expires)
+                {
+                    return refreshToken;
+                }
+
+                _ = Remove(refreshToken);
+
+                return null;
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex);
+            return null;
+        }
+    }
+
+    public static IEnumerable<RefreshToken> FindForClient(Guid clientId)
+    {
+        if (clientId == Guid.Empty)
+        {
+            return null;
+        }
+
+        try
+        {
+            using (var context = DbInterface.CreatePlayerContext())
+            {
+                var tokenQuery = context?.RefreshTokens.Where(queryToken => queryToken.ClientId == clientId);
+
+                return tokenQuery.AsEnumerable()?.ToList();
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex);
+            return null;
+        }
+    }
+
+    public static IEnumerable<RefreshToken> FindExpiredForClient(Guid clientId)
+    {
+        if (clientId == Guid.Empty)
+        {
+            return null;
+        }
+
+        try
+        {
+            using (var context = DbInterface.CreatePlayerContext())
+            {
+                var tokenQuery = context?.RefreshTokens.Where(queryToken => queryToken.ClientId == clientId && queryToken.Expires < DateTime.UtcNow);
+
+                return tokenQuery.AsEnumerable()?.ToList();
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex);
+            return null;
+        }
+    }
+
+    public static IEnumerable<RefreshToken> FindForUser(Guid userId)
+    {
+        if (userId == Guid.Empty)
+        {
+            return null;
+        }
+
+        try
+        {
+            using (var context = DbInterface.CreatePlayerContext())
+            {
+                var tokenQuery = context?.RefreshTokens.Where(queryToken => queryToken.UserId == userId);
+
+                return tokenQuery.AsEnumerable()?.ToList();
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex);
+            return null;
+        }
+    }
+
+    public static IEnumerable<RefreshToken> FindForUser(User user)
+    {
+        return FindForUser(user.Id);
+    }
+
+    public static IEnumerable<RefreshToken> FindExpiredForUser(Guid userId)
+    {
+        if (userId == Guid.Empty)
+        {
+            return null;
+        }
+
+        try
+        {
+            using (var context = DbInterface.CreatePlayerContext())
+            {
+                var tokenQuery = context?.RefreshTokens.Where(queryToken => queryToken.UserId == userId && queryToken.Expires < DateTime.UtcNow);
+
+                return tokenQuery.AsEnumerable()?.ToList();
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex);
+            return null;
+        }
+    }
+
+    public static IEnumerable<RefreshToken> FindExpiredForUser(User user)
+    {
+        return FindExpiredForUser(user.Id);
+    }
+
+    public static RefreshToken FindOneForUser(Guid userId)
+    {
+        try
+        {
+            using (var context = DbInterface.CreatePlayerContext())
+            {
+                var token = context?.RefreshTokens.First(queryToken => queryToken.UserId == userId);
+
+                return token;
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex);
+            return null;
+        }
+    }
+
+    public static RefreshToken FindOneForUser(User user)
+    {
+        return FindOneForUser(user.Id);
+    }
+
+    public static bool HasTokens(Guid userId)
+    {
+        try
+        {
+            using (var context = DbInterface.CreatePlayerContext())
+            {
+                return context.RefreshTokens.Any(queryToken => queryToken.UserId == userId);
+            }
+        }
+        catch (Exception exception)
+        {
+            Log.Error(exception);
+            throw;
+        }
+    }
+
+    public static bool HasTokens(User user) => HasTokens(user.Id);
+
+    public static bool Remove(Guid id) => TryFind(id, out var token) && Remove(token);
+
+    public static bool Remove(RefreshToken token) => RemoveAll(new []{ token });
+
+    public static bool RemoveAll(IEnumerable<RefreshToken> tokens) => RemoveAllAsync(tokens.ToList(), default).Result;
+
+    public static async Task<bool> RemoveAllAsync(IList<RefreshToken> tokens, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var unblockedTokens = tokens.Where(token => _pendingChanges.TryAdd(token.Id, EntityState.Deleted)).ToArray();
+
+            if (unblockedTokens.Length < 1)
+            {
+                return false;
+            }
+
+            Log.Diagnostic($"Attempted to remove {tokens.Count} tokens but only {unblockedTokens.Length} were available to remove.");
+
+            using (var context = DbInterface.CreatePlayerContext(readOnly: false))
+            {
+                context.RefreshTokens.RemoveRange(unblockedTokens);
+                _ = await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            foreach (var token in unblockedTokens)
+            {
+                _ = _pendingChanges.TryRemove(token.Id, out _);
+            }
+
+            return true;
+        }
+        catch (DbUpdateConcurrencyException concurrencyException)
+        {
+            concurrencyException.LogError();
+            return false;
+        }
+    }
+
+    public static async Task<bool> RemoveForUserAsync(Guid userId, CancellationToken cancellationToken)
+    {
+        using (var context = DbInterface.CreatePlayerContext(readOnly: false))
+        {
+            try
+            {
+                context.RefreshTokens.RemoveRange(context.RefreshTokens.Where(token => token.UserId == userId));
+                _ = await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
                 return true;
             }
             catch (DbUpdateConcurrencyException concurrencyException)
@@ -329,70 +346,52 @@ namespace Intersect.Server.Database.PlayerData.Api
                 return false;
             }
         }
+    }
 
-        public static async Task<bool> RemoveForUserAsync(Guid userId, CancellationToken cancellationToken)
+    public static async Task<int> RemoveExpiredAsync(int pruneCount, CancellationToken cancellationToken = default)
+    {
+        try
         {
             using (var context = DbInterface.CreatePlayerContext(readOnly: false))
             {
+                var remaining = 0;
                 try
                 {
-                    context.RefreshTokens.RemoveRange(context.RefreshTokens.Where(token => token.UserId == userId));
+                    var tokensToRemove = context.RefreshTokens
+                        .Where(queryToken => queryToken.Expires < DateTime.UtcNow)
+                        .OrderBy(qt => qt.Expires)
+                        .Take(pruneCount)
+                        .ToArray();
+                    var unblockedTokens = tokensToRemove
+                        .Where(token => _pendingChanges.TryAdd(token.Id, EntityState.Deleted))
+                        .ToArray();
+                    context.RefreshTokens.RemoveRange(unblockedTokens);
                     _ = await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-                    return true;
+                    foreach (var token in unblockedTokens)
+                    {
+                        _ = _pendingChanges.TryRemove(token.Id, out _);
+                    }
+
+                    remaining = tokensToRemove.Length - unblockedTokens.Length;
                 }
                 catch (DbUpdateConcurrencyException concurrencyException)
                 {
                     concurrencyException.LogError();
-                    return false;
                 }
+
+                if (remaining == 0)
+                {
+                    remaining = context.RefreshTokens.Any(queryToken => queryToken.Expires < DateTime.UtcNow)
+                        ? 1
+                        : 0;
+                }
+
+                return remaining;
             }
         }
-
-        public static async Task<int> RemoveExpiredAsync(int pruneCount, CancellationToken cancellationToken = default)
+        catch
         {
-            try
-            {
-                using (var context = DbInterface.CreatePlayerContext(readOnly: false))
-                {
-                    var remaining = 0;
-                    try
-                    {
-                        var tokensToRemove = context.RefreshTokens
-                            .Where(queryToken => queryToken.Expires < DateTime.UtcNow)
-                            .OrderBy(qt => qt.Expires)
-                            .Take(pruneCount)
-                            .ToArray();
-                        var unblockedTokens = tokensToRemove
-                            .Where(token => _pendingChanges.TryAdd(token.Id, EntityState.Deleted))
-                            .ToArray();
-                        context.RefreshTokens.RemoveRange(unblockedTokens);
-                        _ = await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-                        foreach (var token in unblockedTokens)
-                        {
-                            _ = _pendingChanges.TryRemove(token.Id, out _);
-                        }
-
-                        remaining = tokensToRemove.Length - unblockedTokens.Length;
-                    }
-                    catch (DbUpdateConcurrencyException concurrencyException)
-                    {
-                        concurrencyException.LogError();
-                    }
-
-                    if (remaining == 0)
-                    {
-                        remaining = context.RefreshTokens.Any(queryToken => queryToken.Expires < DateTime.UtcNow)
-                            ? 1
-                            : 0;
-                    }
-
-                    return remaining;
-                }
-            }
-            catch
-            {
-                throw;
-            }
+            throw;
         }
     }
 }

--- a/Intersect.Server.Core/Database/PlayerData/Ban.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Ban.cs
@@ -12,297 +12,296 @@ using Newtonsoft.Json;
 // ReSharper disable UnusedAutoPropertyAccessor.Local
 // ReSharper disable AutoPropertyCanBeMadeGetOnly.Local
 
-namespace Intersect.Server.Database.PlayerData
+namespace Intersect.Server.Database.PlayerData;
+
+public partial class Ban
 {
-    public partial class Ban
+    public Ban() { }
+
+    private Ban(string ip, string reason, int durationDays, string banner)
     {
-        public Ban() { }
+        Ip = ip;
+        StartTime = DateTime.UtcNow;
+        Reason = reason;
+        EndTime = StartTime.AddDays(durationDays);
+        Banner = banner;
+    }
 
-        private Ban(string ip, string reason, int durationDays, string banner)
+    public Ban(Guid userId, string ip, string reason, int durationDays, string banner) : this(
+        ip, reason, durationDays, banner
+    )
+    {
+        UserId = userId;
+    }
+
+    public Ban(User user, string ip, string reason, int durationDays, string banner) : this(
+        ip, reason, durationDays, banner
+    )
+    {
+        User = user;
+    }
+
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
+    public Guid Id { get; private set; } = Guid.NewGuid();
+
+    [ForeignKey("Player"), Column("PlayerId")] // SOURCE TODO: Migrate column
+    public Guid UserId { get; private set; }
+
+    [JsonIgnore, Column("Player")] // SOURCE TODO: Migrate column
+    public virtual User User { get; private set; }
+
+    public string Ip { get; private set; }
+
+    public DateTime StartTime { get; private set; }
+
+    public DateTime EndTime { get; set; }
+
+    public string Reason { get; private set; }
+
+    public string Banner { get; private set; }
+
+    [NotMapped]
+    public bool IsExpired => Expired(this);
+
+    public static bool Expired(Ban ban) => ban.EndTime <= DateTime.UtcNow;
+
+    public static bool Add(Ban ban)
+    {
+        if (ban == null || ban.User == null && ban.UserId == Guid.Empty)
         {
-            Ip = ip;
-            StartTime = DateTime.UtcNow;
-            Reason = reason;
-            EndTime = StartTime.AddDays(durationDays);
-            Banner = banner;
-        }
-
-        public Ban(Guid userId, string ip, string reason, int durationDays, string banner) : this(
-            ip, reason, durationDays, banner
-        )
-        {
-            UserId = userId;
-        }
-
-        public Ban(User user, string ip, string reason, int durationDays, string banner) : this(
-            ip, reason, durationDays, banner
-        )
-        {
-            User = user;
-        }
-
-        [DatabaseGenerated(DatabaseGeneratedOption.None)]
-        public Guid Id { get; private set; } = Guid.NewGuid();
-
-        [ForeignKey("Player"), Column("PlayerId")] // SOURCE TODO: Migrate column
-        public Guid UserId { get; private set; }
-
-        [JsonIgnore, Column("Player")] // SOURCE TODO: Migrate column
-        public virtual User User { get; private set; }
-
-        public string Ip { get; private set; }
-
-        public DateTime StartTime { get; private set; }
-
-        public DateTime EndTime { get; set; }
-
-        public string Reason { get; private set; }
-
-        public string Banner { get; private set; }
-
-        [NotMapped]
-        public bool IsExpired => Expired(this);
-
-        public static bool Expired(Ban ban) => ban.EndTime <= DateTime.UtcNow;
-
-        public static bool Add(Ban ban)
-        {
-            if (ban == null || ban.User == null && ban.UserId == Guid.Empty)
-            {
-                return false;
-            }
-
-            try
-            {
-                using (var context = DbInterface.CreatePlayerContext(readOnly: false))
-                {
-                    context.Entry(ban).State = EntityState.Added;
-                    context.SaveChanges();
-                }
-                return true;
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, "Failed to add ban for user " + ban.User?.Name);
-                //ServerContext.DispatchUnhandledException(new Exception("Failed to save user, shutting down to prevent rollbacks!"), true);
-            }
             return false;
         }
 
-        public static bool Add(
-            Guid userId,
-            int duration,
-            string reason,
-            string banner,
-            string ip
-        ) =>
-            Add(new Ban(userId, ip, reason, duration, banner));
-
-        public static bool Add(
-            User user,
-            int duration,
-            string reason,
-            string banner,
-            string ip
-        ) =>
-            Add(new Ban(user, ip, reason, duration, banner));
-
-        public static bool Add(
-            Client client,
-            int duration,
-            string reason,
-            string banner,
-            string ip
-        ) =>
-            client.User != null && Add(client.User, duration, reason, banner, ip);
-
-        public static bool Remove(Ban ban)
+        try
         {
-            if (ban == null || ban.User == null && ban.UserId == Guid.Empty)
+            using (var context = DbInterface.CreatePlayerContext(readOnly: false))
             {
-                return false;
+                context.Entry(ban).State = EntityState.Added;
+                context.SaveChanges();
             }
-
-            try
-            {
-                using (var context = DbInterface.CreatePlayerContext(readOnly: false))
-                {
-                    context.Entry(ban).State = EntityState.Deleted;
-                    context.SaveChanges();
-                }
-                return true;
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, "Failed to remove ban " + ban?.Id);
-                //ServerContext.DispatchUnhandledException(new Exception("Failed to save user, shutting down to prevent rollbacks!"), true);
-            }
-            return false;
-        }
-
-        public static bool Remove(string ip, bool expired = true)
-        {
-            try
-            {
-                using (var context = DbInterface.CreatePlayerContext(readOnly: false))
-                {
-                    var bans = context.Bans.Where(e => e.Ip == ip && (!expired || Expired(e))).ToList();
-
-                    if ((bans?.Count ?? 0) == 0)
-                    {
-                        return true;
-                    }
-
-                    foreach (var ban in bans)
-                    {
-                        context.Entry(ban).State = EntityState.Deleted;
-                    }
-                    context.SaveChanges();
-                }
-                return true;
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, "Failed to remove bans for ip " + ip);
-                //ServerContext.DispatchUnhandledException(new Exception("Failed to save user, shutting down to prevent rollbacks!"), true);
-            }
-            return false;
-        }
-
-        public static bool Remove(Guid userId, bool expired = true)
-        {
-            try
-            {
-                using (var context = DbInterface.CreatePlayerContext(readOnly: false))
-                {
-                    var bans = context.Bans.Where(e => e.UserId == userId && (!expired || Expired(e))).ToList();
-
-                    if ((bans?.Count ?? 0) == 0)
-                    {
-                        return true;
-                    }
-
-                    foreach (var ban in bans)
-                    {
-                        context.Entry(ban).State = EntityState.Deleted;
-                    }
-                    context.SaveChanges();
-                }
-                return true;
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, "Failed to remove bans for user with id " + userId);
-                //ServerContext.DispatchUnhandledException(new Exception("Failed to save user, shutting down to prevent rollbacks!"), true);
-            }
-            return false;
-        }
-
-        public static bool Remove(User user)
-        {
-            if (!Remove(user.Ban))
-            {
-                return false;
-            }
-
-            user.UserBan = null;
-
             return true;
         }
-
-        public static bool Remove(Client client) => client.User != null && Remove(client.User);
-
-        public static string CheckBan(User user, string ip)
+        catch (Exception ex)
         {
-            var ban = user?.Ban;
-
-            // ReSharper disable once InvertIf
-            if (ban == null)
-            {
-                ban = Find(ip);
-                if (user != null)
-                {
-                    user.IpBan = ban;
-                }
-            }
-
-            var expired = ban?.IsExpired ?? true;
-
-            if (expired && ban != null)
-            {
-                Remove(ban);
-                user.IpBan = null;
-                user.UserBan = null;
-            }
-
-            return expired
-                ? null
-                : Strings.Account.banstatus.ToString(ban.StartTime, ban.Banner, ban.EndTime, ban.Reason);
+            Log.Error(ex, "Failed to add ban for user " + ban.User?.Name);
+            //ServerContext.DispatchUnhandledException(new Exception("Failed to save user, shutting down to prevent rollbacks!"), true);
         }
-
-        public static bool IsBanned(IPAddress ipAddress, [NotNullWhen(true)] out string? message)
-        {
-            message = CheckBan(ipAddress.ToString());
-            return message != default;
-        }
-        
-        public static string CheckBan(string ip) => CheckBan(null, ip);
-
-        public static Ban Find(User user) => Find(user.Id);
-
-        public static Ban Find(Guid userId)
-        {
-            try
-            {
-                using (var context = DbInterface.CreatePlayerContext())
-                {
-                    return ByUser(context, userId)?.FirstOrDefault();
-                }
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex);
-                return null;
-            }
-        }
-
-        public static Ban Find(string ip)
-        {
-            if (string.IsNullOrWhiteSpace(ip))
-            {
-                return null;
-            }
-
-            try
-            {
-                using (var context = DbInterface.CreatePlayerContext())
-                {
-                    return ByIp(context, ip)?.FirstOrDefault();
-                }
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex);
-                return null;
-            }
-        }
-
-        #region Compiled Queries
-
-        private static readonly Func<PlayerContext, Guid, IEnumerable<Ban>> ByUser =
-            EF.CompileQuery<PlayerContext, Guid, Ban>(
-                (context, userId) => context.Bans.Where(ban => ban.UserId == userId && ban.EndTime > DateTime.UtcNow)
-            ) ??
-            throw new InvalidOperationException();
-
-        private static readonly Func<PlayerContext, string, IEnumerable<Ban>> ByIp =
-            EF.CompileQuery<PlayerContext, string, Ban>(
-                (context, ip) => context.Bans.Where(
-                    ban => ban.Ip == ip && ban.EndTime > DateTime.UtcNow
-                )
-            ) ??
-            throw new InvalidOperationException();
-
-        #endregion Compiled Queries
+        return false;
     }
+
+    public static bool Add(
+        Guid userId,
+        int duration,
+        string reason,
+        string banner,
+        string ip
+    ) =>
+        Add(new Ban(userId, ip, reason, duration, banner));
+
+    public static bool Add(
+        User user,
+        int duration,
+        string reason,
+        string banner,
+        string ip
+    ) =>
+        Add(new Ban(user, ip, reason, duration, banner));
+
+    public static bool Add(
+        Client client,
+        int duration,
+        string reason,
+        string banner,
+        string ip
+    ) =>
+        client.User != null && Add(client.User, duration, reason, banner, ip);
+
+    public static bool Remove(Ban ban)
+    {
+        if (ban == null || ban.User == null && ban.UserId == Guid.Empty)
+        {
+            return false;
+        }
+
+        try
+        {
+            using (var context = DbInterface.CreatePlayerContext(readOnly: false))
+            {
+                context.Entry(ban).State = EntityState.Deleted;
+                context.SaveChanges();
+            }
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Failed to remove ban " + ban?.Id);
+            //ServerContext.DispatchUnhandledException(new Exception("Failed to save user, shutting down to prevent rollbacks!"), true);
+        }
+        return false;
+    }
+
+    public static bool Remove(string ip, bool expired = true)
+    {
+        try
+        {
+            using (var context = DbInterface.CreatePlayerContext(readOnly: false))
+            {
+                var bans = context.Bans.Where(e => e.Ip == ip && (!expired || Expired(e))).ToList();
+
+                if ((bans?.Count ?? 0) == 0)
+                {
+                    return true;
+                }
+
+                foreach (var ban in bans)
+                {
+                    context.Entry(ban).State = EntityState.Deleted;
+                }
+                context.SaveChanges();
+            }
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Failed to remove bans for ip " + ip);
+            //ServerContext.DispatchUnhandledException(new Exception("Failed to save user, shutting down to prevent rollbacks!"), true);
+        }
+        return false;
+    }
+
+    public static bool Remove(Guid userId, bool expired = true)
+    {
+        try
+        {
+            using (var context = DbInterface.CreatePlayerContext(readOnly: false))
+            {
+                var bans = context.Bans.Where(e => e.UserId == userId && (!expired || Expired(e))).ToList();
+
+                if ((bans?.Count ?? 0) == 0)
+                {
+                    return true;
+                }
+
+                foreach (var ban in bans)
+                {
+                    context.Entry(ban).State = EntityState.Deleted;
+                }
+                context.SaveChanges();
+            }
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Failed to remove bans for user with id " + userId);
+            //ServerContext.DispatchUnhandledException(new Exception("Failed to save user, shutting down to prevent rollbacks!"), true);
+        }
+        return false;
+    }
+
+    public static bool Remove(User user)
+    {
+        if (!Remove(user.Ban))
+        {
+            return false;
+        }
+
+        user.UserBan = null;
+
+        return true;
+    }
+
+    public static bool Remove(Client client) => client.User != null && Remove(client.User);
+
+    public static string CheckBan(User user, string ip)
+    {
+        var ban = user?.Ban;
+
+        // ReSharper disable once InvertIf
+        if (ban == null)
+        {
+            ban = Find(ip);
+            if (user != null)
+            {
+                user.IpBan = ban;
+            }
+        }
+
+        var expired = ban?.IsExpired ?? true;
+
+        if (expired && ban != null)
+        {
+            Remove(ban);
+            user.IpBan = null;
+            user.UserBan = null;
+        }
+
+        return expired
+            ? null
+            : Strings.Account.banstatus.ToString(ban.StartTime, ban.Banner, ban.EndTime, ban.Reason);
+    }
+
+    public static bool IsBanned(IPAddress ipAddress, [NotNullWhen(true)] out string? message)
+    {
+        message = CheckBan(ipAddress.ToString());
+        return message != default;
+    }
+    
+    public static string CheckBan(string ip) => CheckBan(null, ip);
+
+    public static Ban Find(User user) => Find(user.Id);
+
+    public static Ban Find(Guid userId)
+    {
+        try
+        {
+            using (var context = DbInterface.CreatePlayerContext())
+            {
+                return ByUser(context, userId)?.FirstOrDefault();
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex);
+            return null;
+        }
+    }
+
+    public static Ban Find(string ip)
+    {
+        if (string.IsNullOrWhiteSpace(ip))
+        {
+            return null;
+        }
+
+        try
+        {
+            using (var context = DbInterface.CreatePlayerContext())
+            {
+                return ByIp(context, ip)?.FirstOrDefault();
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex);
+            return null;
+        }
+    }
+
+    #region Compiled Queries
+
+    private static readonly Func<PlayerContext, Guid, IEnumerable<Ban>> ByUser =
+        EF.CompileQuery<PlayerContext, Guid, Ban>(
+            (context, userId) => context.Bans.Where(ban => ban.UserId == userId && ban.EndTime > DateTime.UtcNow)
+        ) ??
+        throw new InvalidOperationException();
+
+    private static readonly Func<PlayerContext, string, IEnumerable<Ban>> ByIp =
+        EF.CompileQuery<PlayerContext, string, Ban>(
+            (context, ip) => context.Bans.Where(
+                ban => ban.Ip == ip && ban.EndTime > DateTime.UtcNow
+            )
+        ) ??
+        throw new InvalidOperationException();
+
+    #endregion Compiled Queries
 }

--- a/Intersect.Server.Core/Database/PlayerData/IPlayerContext.cs
+++ b/Intersect.Server.Core/Database/PlayerData/IPlayerContext.cs
@@ -4,40 +4,39 @@ using Intersect.Server.Entities;
 
 using Microsoft.EntityFrameworkCore;
 
-namespace Intersect.Server.Database.PlayerData
+namespace Intersect.Server.Database.PlayerData;
+
+public interface IPlayerContext : IDbContext
 {
-    public interface IPlayerContext : IDbContext
-    {
-        DbSet<User> Users { get; set; }
+    DbSet<User> Users { get; set; }
 
-        DbSet<Mute> Mutes { get; set; }
+    DbSet<Mute> Mutes { get; set; }
 
-        DbSet<Ban> Bans { get; set; }
+    DbSet<Ban> Bans { get; set; }
 
-        DbSet<RefreshToken> RefreshTokens { get; set; }
+    DbSet<RefreshToken> RefreshTokens { get; set; }
 
-        DbSet<Player> Players { get; set; }
+    DbSet<Player> Players { get; set; }
 
-        DbSet<BankSlot> Player_Bank { get; set; }
+    DbSet<BankSlot> Player_Bank { get; set; }
 
-        DbSet<Friend> Player_Friends { get; set; }
+    DbSet<Friend> Player_Friends { get; set; }
 
-        DbSet<HotbarSlot> Player_Hotbar { get; set; }
+    DbSet<HotbarSlot> Player_Hotbar { get; set; }
 
-        DbSet<InventorySlot> Player_Items { get; set; }
+    DbSet<InventorySlot> Player_Items { get; set; }
 
-        DbSet<Quest> Player_Quests { get; set; }
+    DbSet<Quest> Player_Quests { get; set; }
 
-        DbSet<SpellSlot> Player_Spells { get; set; }
+    DbSet<SpellSlot> Player_Spells { get; set; }
 
-        DbSet<PlayerVariable> Player_Variables { get; set; }
+    DbSet<PlayerVariable> Player_Variables { get; set; }
 
-        DbSet<Bag> Bags { get; set; }
+    DbSet<Bag> Bags { get; set; }
 
-        DbSet<BagSlot> Bag_Items { get; set; }
+    DbSet<BagSlot> Bag_Items { get; set; }
 
-        DbSet<Guild> Guilds { get; set; }
+    DbSet<Guild> Guilds { get; set; }
 
-        DbSet<GuildBankSlot> Guild_Bank { get; set; }
-    }
+    DbSet<GuildBankSlot> Guild_Bank { get; set; }
 }

--- a/Intersect.Server.Core/Database/PlayerData/Migrations/GuildBankMaxSlotMigration.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Migrations/GuildBankMaxSlotMigration.cs
@@ -1,31 +1,30 @@
 ﻿using Intersect.Logging;
 
-namespace Intersect.Server.Database.PlayerData.Migrations
+namespace Intersect.Server.Database.PlayerData.Migrations;
+
+public partial class GuildBankMaxSlotMigration
 {
-    public partial class GuildBankMaxSlotMigration
+    public static void Run(PlayerContext context)
     {
-        public static void Run(PlayerContext context)
-        {
-            CapGuildBankSize(context);
-        }
+        CapGuildBankSize(context);
+    }
 
-        public static void CapGuildBankSize(PlayerContext context)
-        {
-            Log.Info("Checking to see if there are any guilds exceeding the configured max bank size...");
+    public static void CapGuildBankSize(PlayerContext context)
+    {
+        Log.Info("Checking to see if there are any guilds exceeding the configured max bank size...");
 
-            // Go through each and every quest to check if all the tasks have valid events.
-            foreach (var guild in context.Guilds)
+        // Go through each and every quest to check if all the tasks have valid events.
+        foreach (var guild in context.Guilds)
+        {
+            if (guild.BankSlotsCount > Options.Instance.Bank.MaxSlots)
             {
-                if (guild.BankSlotsCount > Options.Instance.Bank.MaxSlots)
-                {
-                    Log.Info($"Too many bank slots ({guild.BankSlotsCount}) for guild {guild.Name}. Setting to {Options.Instance.Bank.MaxSlots}.");
-                    guild.BankSlotsCount = Options.Instance.Bank.MaxSlots;
-                }
+                Log.Info($"Too many bank slots ({guild.BankSlotsCount}) for guild {guild.Name}. Setting to {Options.Instance.Bank.MaxSlots}.");
+                guild.BankSlotsCount = Options.Instance.Bank.MaxSlots;
             }
-
-            // Track our changes and save them or the work we've just done is lost.
-            context.ChangeTracker.DetectChanges();
-            context.SaveChanges();
         }
+
+        // Track our changes and save them or the work we've just done is lost.
+        context.ChangeTracker.DetectChanges();
+        context.SaveChanges();
     }
 }

--- a/Intersect.Server.Core/Database/PlayerData/Mute.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Mute.cs
@@ -10,333 +10,331 @@ using Newtonsoft.Json;
 // ReSharper disable UnusedAutoPropertyAccessor.Local
 // ReSharper disable AutoPropertyCanBeMadeGetOnly.Local
 
-namespace Intersect.Server.Database.PlayerData
+namespace Intersect.Server.Database.PlayerData;
+
+
+public partial class Mute
 {
 
-    public partial class Mute
+    public Mute()
     {
+    }
 
-        public Mute()
+    private Mute(string ip, string reason, int durationDays, string muter)
+    {
+        Ip = ip;
+        StartTime = DateTime.UtcNow;
+        Reason = reason;
+        EndTime = StartTime.AddDays(durationDays);
+        Muter = muter;
+    }
+
+    public Mute(Guid userId, string ip, string reason, int durationDays, string muter) : this(
+        ip, reason, durationDays, muter
+    )
+    {
+        UserId = userId;
+    }
+
+    public Mute(User user, string ip, string reason, int durationDays, string muter) : this(
+        ip, reason, durationDays, muter
+    )
+    {
+        User = user;
+    }
+
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
+    public Guid Id { get; private set; } = Guid.NewGuid();
+
+    [ForeignKey("Player"), Column("PlayerId")] // SOURCE TODO: Migrate column
+    public Guid UserId { get; private set; }
+
+    [JsonIgnore, Column("Player")] // SOURCE TODO: Migrate column
+    public virtual User User { get; private set; }
+
+    [JsonIgnore, NotMapped]
+    public bool IsIp => Guid.Empty == UserId;
+
+    public string Ip { get; private set; }
+
+    public DateTime StartTime { get; private set; }
+
+    public DateTime EndTime { get; set; }
+
+    public string Reason { get; private set; }
+
+    public string Muter { get; private set; }
+
+    [NotMapped]
+    public bool IsExpired => Expired(this);
+
+    public static bool Expired(Mute mute) => mute.EndTime <= DateTime.UtcNow;
+
+    public static bool Add(Mute mute)
+    {
+        if (mute == null || mute.User == null && mute.UserId == Guid.Empty)
         {
+            return false;
         }
 
-        private Mute(string ip, string reason, int durationDays, string muter)
+        try
         {
-            Ip = ip;
-            StartTime = DateTime.UtcNow;
-            Reason = reason;
-            EndTime = StartTime.AddDays(durationDays);
-            Muter = muter;
+            using (var context = DbInterface.CreatePlayerContext(readOnly: false))
+            {
+                context.Entry(mute).State = EntityState.Added;
+                context.SaveChanges();
+            }
+            return true;
         }
-
-        public Mute(Guid userId, string ip, string reason, int durationDays, string muter) : this(
-            ip, reason, durationDays, muter
-        )
+        catch (Exception ex)
         {
-            UserId = userId;
+            Log.Error(ex, "Failed to add mute for user " + mute.User?.Name);
         }
+        return false;
+    }
 
-        public Mute(User user, string ip, string reason, int durationDays, string muter) : this(
-            ip, reason, durationDays, muter
-        )
+    public static bool Add(
+        Guid userId,
+        int duration,
+        string reason,
+        string muter,
+        string ip
+    ) =>
+        Add(new Mute(userId, ip, reason, duration, muter));
+
+    public static bool Add(
+        User user,
+        int duration,
+        string reason,
+        string muter,
+        string ip
+    )
+    {
+        user.UserMute = new Mute(user, ip, reason, duration, muter);
+
+        return Add(user.UserMute);
+    }
+
+    public static bool Add(
+        Client client,
+        int duration,
+        string reason,
+        string muter,
+        string ip
+    ) =>
+        client.User != null && Add(client.User, duration, reason, muter, ip);
+
+    public static bool Remove(Mute mute)
+    {
+        try
         {
-            User = user;
+            using (var context = DbInterface.CreatePlayerContext(readOnly: false))
+            {
+                context.Entry(mute).State = EntityState.Deleted;
+                context.SaveChanges();
+            }
+            return true;
         }
-
-        [DatabaseGenerated(DatabaseGeneratedOption.None)]
-        public Guid Id { get; private set; } = Guid.NewGuid();
-
-        [ForeignKey("Player"), Column("PlayerId")] // SOURCE TODO: Migrate column
-        public Guid UserId { get; private set; }
-
-        [JsonIgnore, Column("Player")] // SOURCE TODO: Migrate column
-        public virtual User User { get; private set; }
-
-        [JsonIgnore, NotMapped]
-        public bool IsIp => Guid.Empty == UserId;
-
-        public string Ip { get; private set; }
-
-        public DateTime StartTime { get; private set; }
-
-        public DateTime EndTime { get; set; }
-
-        public string Reason { get; private set; }
-
-        public string Muter { get; private set; }
-
-        [NotMapped]
-        public bool IsExpired => Expired(this);
-
-        public static bool Expired(Mute mute) => mute.EndTime <= DateTime.UtcNow;
-
-        public static bool Add(Mute mute)
+        catch (Exception ex)
         {
-            if (mute == null || mute.User == null && mute.UserId == Guid.Empty)
+            Log.Error(ex, "Failed to delete mute for user " + mute.User?.Name);
+        }
+        return false;
+    }
+
+    public static bool Remove(string ip, bool expired = true)
+    {
+        try
+        {
+            using (var context = DbInterface.CreatePlayerContext(readOnly: false))
+            {
+                var mutes = context.Mutes.Where(e => e.Ip == ip && (!expired || Expired(e))).ToList();
+                if ((mutes?.Count ?? 0) == 0)
+                {
+                    return true;
+                }
+                foreach (var mute in mutes)
+                {
+                    context.Entry(mute).State = EntityState.Deleted;
+                }
+                context.SaveChanges();
+            }
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Failed to remove mutes for ip " + ip);
+        }
+        return false;
+    }
+
+    public static bool Remove(Guid userId, bool expired = true)
+    {
+        try
+        {
+            using (var context = DbInterface.CreatePlayerContext(readOnly: false))
+            {
+                var mutes = context.Mutes.Where(e => e.UserId == userId && (!expired || Expired(e))).ToList();
+
+                if ((mutes?.Count ?? 0) == 0)
+                {
+                    return true;
+                }
+
+                foreach (var mute in mutes)
+                {
+                    context.Entry(mute).State = EntityState.Deleted;
+                }
+                context.SaveChanges();
+            }
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Failed to remove mutes user with id " + userId);
+        }
+        return false;
+    }
+
+    public static bool Remove(User user)
+    {
+        try
+        {
+            if (!Remove(user.UserMute))
             {
                 return false;
             }
 
-            try
-            {
-                using (var context = DbInterface.CreatePlayerContext(readOnly: false))
-                {
-                    context.Entry(mute).State = EntityState.Added;
-                    context.SaveChanges();
-                }
-                return true;
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, "Failed to add mute for user " + mute.User?.Name);
-            }
-            return false;
+            user.UserMute = null;
+            user.Save();
+            return true;
         }
-
-        public static bool Add(
-            Guid userId,
-            int duration,
-            string reason,
-            string muter,
-            string ip
-        ) =>
-            Add(new Mute(userId, ip, reason, duration, muter));
-
-        public static bool Add(
-            User user,
-            int duration,
-            string reason,
-            string muter,
-            string ip
-        )
+        catch (Exception ex)
         {
-            user.UserMute = new Mute(user, ip, reason, duration, muter);
-
-            return Add(user.UserMute);
+            Log.Error(ex, "Failed to remove mutes user " + user?.Id);
         }
-
-        public static bool Add(
-            Client client,
-            int duration,
-            string reason,
-            string muter,
-            string ip
-        ) =>
-            client.User != null && Add(client.User, duration, reason, muter, ip);
-
-        public static bool Remove(Mute mute)
-        {
-            try
-            {
-                using (var context = DbInterface.CreatePlayerContext(readOnly: false))
-                {
-                    context.Entry(mute).State = EntityState.Deleted;
-                    context.SaveChanges();
-                }
-                return true;
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, "Failed to delete mute for user " + mute.User?.Name);
-            }
-            return false;
-        }
-
-        public static bool Remove(string ip, bool expired = true)
-        {
-            try
-            {
-                using (var context = DbInterface.CreatePlayerContext(readOnly: false))
-                {
-                    var mutes = context.Mutes.Where(e => e.Ip == ip && (!expired || Expired(e))).ToList();
-                    if ((mutes?.Count ?? 0) == 0)
-                    {
-                        return true;
-                    }
-                    foreach (var mute in mutes)
-                    {
-                        context.Entry(mute).State = EntityState.Deleted;
-                    }
-                    context.SaveChanges();
-                }
-                return true;
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, "Failed to remove mutes for ip " + ip);
-            }
-            return false;
-        }
-
-        public static bool Remove(Guid userId, bool expired = true)
-        {
-            try
-            {
-                using (var context = DbInterface.CreatePlayerContext(readOnly: false))
-                {
-                    var mutes = context.Mutes.Where(e => e.UserId == userId && (!expired || Expired(e))).ToList();
-
-                    if ((mutes?.Count ?? 0) == 0)
-                    {
-                        return true;
-                    }
-
-                    foreach (var mute in mutes)
-                    {
-                        context.Entry(mute).State = EntityState.Deleted;
-                    }
-                    context.SaveChanges();
-                }
-                return true;
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, "Failed to remove mutes user with id " + userId);
-            }
-            return false;
-        }
-
-        public static bool Remove(User user)
-        {
-            try
-            {
-                if (!Remove(user.UserMute))
-                {
-                    return false;
-                }
-
-                user.UserMute = null;
-                user.Save();
-                return true;
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, "Failed to remove mutes user " + user?.Id);
-            }
-            return false;
-        }
-
-        public static bool Remove(Client client) => client.User != null && Remove(client.User);
-
-        public static string FindMuteReason(
-            Guid userId,
-            string ip
-        )
-        {
-            try
-            {
-                var mute = Find(userId) ?? Find(ip);
-
-                var expired = mute?.IsExpired ?? true;
-
-                if (expired && mute != null)
-                {
-                    Remove(mute);
-                }
-
-                return expired
-                    ? null
-                    : Strings.Account.mutestatus.ToString(mute.StartTime, mute.Muter, mute.EndTime, mute.Reason);
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex);
-                return null;
-            }
-        }
-
-        public static string FindMuteReason(
-            User user,
-            string ip
-        )
-        {
-            try
-            {
-                if (user.Mute == null)
-                {
-                    user.IpMute = Find(ip);
-                }
-
-                var mute = user.Mute;
-
-                var expired = mute?.IsExpired ?? true;
-
-                if (expired && mute != null)
-                {
-                    Remove(mute);
-                    user.IpMute = null;
-                    user.UserMute = null;
-                }
-
-                return expired
-                    ? null
-                    : Strings.Account.mutestatus.ToString(mute.StartTime, mute.Muter, mute.EndTime, mute.Reason);
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex);
-                return null;
-            }
-        }
-
-        public static Mute Find(User user) => Find(user.Id);
-
-        public static Mute Find(Guid userId)
-        {
-            try
-            {
-                using (var context = DbInterface.CreatePlayerContext())
-                {
-                    return ByUser(context, userId)?.FirstOrDefault();
-                }
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex);
-                return null;
-            }
-        }
-
-        public static Mute Find(string ip)
-        {
-            if (string.IsNullOrWhiteSpace(ip))
-            {
-                return null;
-            }
-
-            try
-            {
-                using (var context = DbInterface.CreatePlayerContext())
-                {
-                    return ByIp(context, ip)?.FirstOrDefault();
-                }
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex);
-                return null;
-            }
-        }
-
-        #region Compiled Queries
-
-        private static readonly Func<PlayerContext, Guid, IEnumerable<Mute>> ByUser =
-            EF.CompileQuery<PlayerContext, Guid, Mute>(
-                (context, userId) =>
-                    context.Mutes.Where(mute => mute.UserId == userId && mute.EndTime > DateTime.UtcNow)
-            ) ??
-            throw new InvalidOperationException();
-
-        private static readonly Func<PlayerContext, string, IEnumerable<Mute>> ByIp =
-            EF.CompileQuery<PlayerContext, string, Mute>(
-                (context, ip) => context.Mutes.Where(
-                    mute => mute.Ip == ip && mute.EndTime > DateTime.UtcNow
-                )
-            ) ??
-            throw new InvalidOperationException();
-
-        #endregion Compiled Queries
-
+        return false;
     }
+
+    public static bool Remove(Client client) => client.User != null && Remove(client.User);
+
+    public static string FindMuteReason(
+        Guid userId,
+        string ip
+    )
+    {
+        try
+        {
+            var mute = Find(userId) ?? Find(ip);
+
+            var expired = mute?.IsExpired ?? true;
+
+            if (expired && mute != null)
+            {
+                Remove(mute);
+            }
+
+            return expired
+                ? null
+                : Strings.Account.mutestatus.ToString(mute.StartTime, mute.Muter, mute.EndTime, mute.Reason);
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex);
+            return null;
+        }
+    }
+
+    public static string FindMuteReason(
+        User user,
+        string ip
+    )
+    {
+        try
+        {
+            if (user.Mute == null)
+            {
+                user.IpMute = Find(ip);
+            }
+
+            var mute = user.Mute;
+
+            var expired = mute?.IsExpired ?? true;
+
+            if (expired && mute != null)
+            {
+                Remove(mute);
+                user.IpMute = null;
+                user.UserMute = null;
+            }
+
+            return expired
+                ? null
+                : Strings.Account.mutestatus.ToString(mute.StartTime, mute.Muter, mute.EndTime, mute.Reason);
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex);
+            return null;
+        }
+    }
+
+    public static Mute Find(User user) => Find(user.Id);
+
+    public static Mute Find(Guid userId)
+    {
+        try
+        {
+            using (var context = DbInterface.CreatePlayerContext())
+            {
+                return ByUser(context, userId)?.FirstOrDefault();
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex);
+            return null;
+        }
+    }
+
+    public static Mute Find(string ip)
+    {
+        if (string.IsNullOrWhiteSpace(ip))
+        {
+            return null;
+        }
+
+        try
+        {
+            using (var context = DbInterface.CreatePlayerContext())
+            {
+                return ByIp(context, ip)?.FirstOrDefault();
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex);
+            return null;
+        }
+    }
+
+    #region Compiled Queries
+
+    private static readonly Func<PlayerContext, Guid, IEnumerable<Mute>> ByUser =
+        EF.CompileQuery<PlayerContext, Guid, Mute>(
+            (context, userId) =>
+                context.Mutes.Where(mute => mute.UserId == userId && mute.EndTime > DateTime.UtcNow)
+        ) ??
+        throw new InvalidOperationException();
+
+    private static readonly Func<PlayerContext, string, IEnumerable<Mute>> ByIp =
+        EF.CompileQuery<PlayerContext, string, Mute>(
+            (context, ip) => context.Mutes.Where(
+                mute => mute.Ip == ip && mute.EndTime > DateTime.UtcNow
+            )
+        ) ??
+        throw new InvalidOperationException();
+
+    #endregion Compiled Queries
 
 }

--- a/Intersect.Server.Core/Database/PlayerData/PlayerContext.cs
+++ b/Intersect.Server.Core/Database/PlayerData/PlayerContext.cs
@@ -6,187 +6,185 @@ using Intersect.Server.Database.PlayerData.SeedData;
 using Intersect.Server.Entities;
 using Microsoft.EntityFrameworkCore;
 
-namespace Intersect.Server.Database.PlayerData
+namespace Intersect.Server.Database.PlayerData;
+
+public abstract partial class PlayerContext : IntersectDbContext<PlayerContext>, IPlayerContext
 {
-    public abstract partial class PlayerContext : IntersectDbContext<PlayerContext>, IPlayerContext
+    /// <inheritdoc />
+    protected PlayerContext(DatabaseContextOptions databaseContextOptions) : base(databaseContextOptions) { }
+
+    public DbSet<User> Users { get; set; }
+
+    public DbSet<Mute> Mutes { get; set; }
+
+    public DbSet<Ban> Bans { get; set; }
+
+    public DbSet<RefreshToken> RefreshTokens { get; set; }
+
+    public DbSet<Player> Players { get; set; }
+
+    public DbSet<BankSlot> Player_Bank { get; set; }
+
+    public DbSet<Friend> Player_Friends { get; set; }
+
+    public DbSet<HotbarSlot> Player_Hotbar { get; set; }
+
+    public DbSet<InventorySlot> Player_Items { get; set; }
+
+    public DbSet<Quest> Player_Quests { get; set; }
+
+    public DbSet<SpellSlot> Player_Spells { get; set; }
+
+    public DbSet<PlayerVariable> Player_Variables { get; set; }
+
+    public DbSet<Bag> Bags { get; set; }
+
+    public DbSet<BagSlot> Bag_Items { get; set; }
+
+    public DbSet<Guild> Guilds { get; set; }
+
+    public DbSet<GuildBankSlot> Guild_Bank { get; set; }
+
+    public DbSet<GuildVariable> Guild_Variables { get; set; }
+
+    public DbSet<UserVariable> User_Variables { get; set; }
+
+    internal async ValueTask Commit(
+        bool commit = false,
+        CancellationToken cancellationToken = default(CancellationToken)
+    )
     {
-        /// <inheritdoc />
-        protected PlayerContext(DatabaseContextOptions databaseContextOptions) : base(databaseContextOptions) { }
-
-        public DbSet<User> Users { get; set; }
-
-        public DbSet<Mute> Mutes { get; set; }
-
-        public DbSet<Ban> Bans { get; set; }
-
-        public DbSet<RefreshToken> RefreshTokens { get; set; }
-
-        public DbSet<Player> Players { get; set; }
-
-        public DbSet<BankSlot> Player_Bank { get; set; }
-
-        public DbSet<Friend> Player_Friends { get; set; }
-
-        public DbSet<HotbarSlot> Player_Hotbar { get; set; }
-
-        public DbSet<InventorySlot> Player_Items { get; set; }
-
-        public DbSet<Quest> Player_Quests { get; set; }
-
-        public DbSet<SpellSlot> Player_Spells { get; set; }
-
-        public DbSet<PlayerVariable> Player_Variables { get; set; }
-
-        public DbSet<Bag> Bags { get; set; }
-
-        public DbSet<BagSlot> Bag_Items { get; set; }
-
-        public DbSet<Guild> Guilds { get; set; }
-
-        public DbSet<GuildBankSlot> Guild_Bank { get; set; }
-
-        public DbSet<GuildVariable> Guild_Variables { get; set; }
-
-        public DbSet<UserVariable> User_Variables { get; set; }
-
-        internal async ValueTask Commit(
-            bool commit = false,
-            CancellationToken cancellationToken = default(CancellationToken)
-        )
+        if (!commit)
         {
-            if (!commit)
-            {
-                return;
-            }
-
-            var task = SaveChangesAsync(cancellationToken);
-            if (task != null)
-            {
-                await task;
-            }
+            return;
         }
 
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        var task = SaveChangesAsync(cancellationToken);
+        if (task != null)
         {
-            modelBuilder.Entity<RefreshToken>().HasOne(token => token.User);
-
-            modelBuilder.Entity<Ban>().HasOne(b => b.User);
-            modelBuilder.Entity<Mute>().HasOne(b => b.User);
-
-            modelBuilder.Entity<User>().HasMany(b => b.Players).WithOne(p => p.User);
-
-            modelBuilder.Entity<Player>()
-                .HasMany(b => b.Friends)
-                .WithOne(p => p.Owner)
-                .OnDelete(DeleteBehavior.Cascade);
-
-            modelBuilder.Entity<Friend>().HasOne(b => b.Target).WithMany().OnDelete(DeleteBehavior.Cascade);
-
-            modelBuilder.Entity<Player>().HasMany(b => b.Spells).WithOne(p => p.Player);
-
-            modelBuilder.Entity<Player>().HasMany(b => b.Items).WithOne(p => p.Player);
-
-            modelBuilder.Entity<Player>().HasMany(b => b.Variables).WithOne(p => p.Player);
-            modelBuilder.Entity<PlayerVariable>().HasIndex(p => new { p.VariableId, p.PlayerId }).IsUnique();
-
-            modelBuilder.Entity<Player>().HasMany(b => b.Hotbar).WithOne(p => p.Player);
-
-            modelBuilder.Entity<Player>().HasMany(b => b.Quests).WithOne(p => p.Player);
-            modelBuilder.Entity<Quest>().HasIndex(p => new { p.QuestId, p.PlayerId }).IsUnique();
-
-            modelBuilder.Entity<Player>().HasMany(b => b.Bank).WithOne(p => p.Player);
-
-            modelBuilder.Entity<Bag>()
-                .HasMany(b => b.Slots)
-                .WithOne(p => p.ParentBag)
-                .HasForeignKey(p => p.ParentBagId);
-
-            modelBuilder.Entity<InventorySlot>().HasOne(b => b.Bag);
-            modelBuilder.Entity<BagSlot>().HasOne(b => b.Bag);
-            modelBuilder.Entity<BankSlot>().HasOne(b => b.Bag);
-
-            modelBuilder.Entity<Guild>().HasMany(b => b.Bank).WithOne(p => p.Guild);
-            modelBuilder.Entity<GuildBankSlot>().HasOne(b => b.Bag);
-
-            modelBuilder.Entity<Guild>().HasMany(b => b.Variables).WithOne(p => p.Guild);
-            modelBuilder.Entity<GuildVariable>().HasIndex(p => new { p.VariableId, p.GuildId }).IsUnique();
-
-            modelBuilder.Entity<User>().HasMany(b => b.Variables).WithOne(p => p.User);
-            modelBuilder.Entity<UserVariable>().HasIndex(p => new { p.VariableId, p.UserId }).IsUnique();
+            await task;
         }
+    }
 
-        public void Seed()
-        {
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<RefreshToken>().HasOne(token => token.User);
+
+        modelBuilder.Entity<Ban>().HasOne(b => b.User);
+        modelBuilder.Entity<Mute>().HasOne(b => b.User);
+
+        modelBuilder.Entity<User>().HasMany(b => b.Players).WithOne(p => p.User);
+
+        modelBuilder.Entity<Player>()
+            .HasMany(b => b.Friends)
+            .WithOne(p => p.Owner)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        modelBuilder.Entity<Friend>().HasOne(b => b.Target).WithMany().OnDelete(DeleteBehavior.Cascade);
+
+        modelBuilder.Entity<Player>().HasMany(b => b.Spells).WithOne(p => p.Player);
+
+        modelBuilder.Entity<Player>().HasMany(b => b.Items).WithOne(p => p.Player);
+
+        modelBuilder.Entity<Player>().HasMany(b => b.Variables).WithOne(p => p.Player);
+        modelBuilder.Entity<PlayerVariable>().HasIndex(p => new { p.VariableId, p.PlayerId }).IsUnique();
+
+        modelBuilder.Entity<Player>().HasMany(b => b.Hotbar).WithOne(p => p.Player);
+
+        modelBuilder.Entity<Player>().HasMany(b => b.Quests).WithOne(p => p.Player);
+        modelBuilder.Entity<Quest>().HasIndex(p => new { p.QuestId, p.PlayerId }).IsUnique();
+
+        modelBuilder.Entity<Player>().HasMany(b => b.Bank).WithOne(p => p.Player);
+
+        modelBuilder.Entity<Bag>()
+            .HasMany(b => b.Slots)
+            .WithOne(p => p.ParentBag)
+            .HasForeignKey(p => p.ParentBagId);
+
+        modelBuilder.Entity<InventorySlot>().HasOne(b => b.Bag);
+        modelBuilder.Entity<BagSlot>().HasOne(b => b.Bag);
+        modelBuilder.Entity<BankSlot>().HasOne(b => b.Bag);
+
+        modelBuilder.Entity<Guild>().HasMany(b => b.Bank).WithOne(p => p.Guild);
+        modelBuilder.Entity<GuildBankSlot>().HasOne(b => b.Bag);
+
+        modelBuilder.Entity<Guild>().HasMany(b => b.Variables).WithOne(p => p.Guild);
+        modelBuilder.Entity<GuildVariable>().HasIndex(p => new { p.VariableId, p.GuildId }).IsUnique();
+
+        modelBuilder.Entity<User>().HasMany(b => b.Variables).WithOne(p => p.User);
+        modelBuilder.Entity<UserVariable>().HasIndex(p => new { p.VariableId, p.UserId }).IsUnique();
+    }
+
+    public void Seed()
+    {
 #if DEBUG
-            new SeedUsers().SeedIfEmpty(this);
-            ChangeTracker.DetectChanges();
-            SaveChanges();
+        new SeedUsers().SeedIfEmpty(this);
+        ChangeTracker.DetectChanges();
+        SaveChanges();
 #endif
-        }
+    }
 
-        public override void OnSchemaMigrationsProcessed(string[] migrations)
+    public override void OnSchemaMigrationsProcessed(string[] migrations)
+    {
+        if (migrations.IndexOf("20220331140427_GuildBankMaxSlotsMigration") > -1)
         {
-            if (migrations.IndexOf("20220331140427_GuildBankMaxSlotsMigration") > -1)
+            GuildBankMaxSlotMigration.Run(this);
+        }
+    }
+
+    public void StopTrackingUsersExcept(User user)
+    {
+        //We don't want to be saving this players friends or anything....
+        var otherUsers = ChangeTracker.Entries().Where(e => (e.State == EntityState.Added || e.State == EntityState.Modified || e.State == EntityState.Deleted) && (e.Entity is User && e.Entity != user)).ToList();
+        foreach (var otherUser in otherUsers)
+        {
+            if (otherUser.Entity != null)
             {
-                GuildBankMaxSlotMigration.Run(this);
+                Entry(otherUser.Entity).State = EntityState.Detached;
             }
         }
 
-        public void StopTrackingUsersExcept(User user)
+        StopTrackingPlayersExcept(user.Players.ToArray());
+
+    }
+
+    public void StopTrackingPlayersExcept(Player[] players, bool trackUsers = true)
+    {
+        //We don't want to be saving this players friends or anything....
+        var otherPlayers = ChangeTracker.Entries().Where(e => (e.State == EntityState.Added || e.State == EntityState.Modified || e.State == EntityState.Deleted) && (e.Entity is Player && !players.Contains(e.Entity))).ToList();
+        foreach (var otherPlayer in otherPlayers)
         {
-            //We don't want to be saving this players friends or anything....
-            var otherUsers = ChangeTracker.Entries().Where(e => (e.State == EntityState.Added || e.State == EntityState.Modified || e.State == EntityState.Deleted) && (e.Entity is User && e.Entity != user)).ToList();
-            foreach (var otherUser in otherUsers)
+            if (otherPlayer.Entity != null)
             {
-                if (otherUser.Entity != null)
-                {
-                    Entry(otherUser.Entity).State = EntityState.Detached;
-                }
-            }
-
-            StopTrackingPlayersExcept(user.Players.ToArray());
-
-        }
-
-        public void StopTrackingPlayersExcept(Player[] players, bool trackUsers = true)
-        {
-            //We don't want to be saving this players friends or anything....
-            var otherPlayers = ChangeTracker.Entries().Where(e => (e.State == EntityState.Added || e.State == EntityState.Modified || e.State == EntityState.Deleted) && (e.Entity is Player && !players.Contains(e.Entity))).ToList();
-            foreach (var otherPlayer in otherPlayers)
-            {
-                if (otherPlayer.Entity != null)
-                {
-                    DetachPlayer((Player)otherPlayer.Entity);
-                }
+                DetachPlayer((Player)otherPlayer.Entity);
             }
         }
+    }
 
-        private void DetachPlayer(Player player)
-        {
-            Entry(player).State = EntityState.Detached;
+    private void DetachPlayer(Player player)
+    {
+        Entry(player).State = EntityState.Detached;
 
-            foreach (var itm in player.Friends)
-                Entry(itm).State = EntityState.Detached;
+        foreach (var itm in player.Friends)
+            Entry(itm).State = EntityState.Detached;
 
-            foreach (var itm in player.Spells)
-                Entry(itm).State = EntityState.Detached;
+        foreach (var itm in player.Spells)
+            Entry(itm).State = EntityState.Detached;
 
-            foreach (var itm in player.Items)
-                Entry(itm).State = EntityState.Detached;
+        foreach (var itm in player.Items)
+            Entry(itm).State = EntityState.Detached;
 
-            foreach (var itm in player.Variables)
-                Entry(itm).State = EntityState.Detached;
+        foreach (var itm in player.Variables)
+            Entry(itm).State = EntityState.Detached;
 
-            foreach (var itm in player.Hotbar)
-                Entry(itm).State = EntityState.Detached;
+        foreach (var itm in player.Hotbar)
+            Entry(itm).State = EntityState.Detached;
 
-            foreach (var itm in player.Quests)
-                Entry(itm).State = EntityState.Detached;
+        foreach (var itm in player.Quests)
+            Entry(itm).State = EntityState.Detached;
 
-            foreach (var itm in player.Bank)
-                Entry(itm).State = EntityState.Detached;
-        }
-
+        foreach (var itm in player.Bank)
+            Entry(itm).State = EntityState.Detached;
     }
 
 }

--- a/Intersect.Server.Core/Database/PlayerData/Players/Bag.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Players/Bag.cs
@@ -8,195 +8,193 @@ using Newtonsoft.Json;
 // ReSharper disable UnusedAutoPropertyAccessor.Local
 // ReSharper disable AutoPropertyCanBeMadeGetOnly.Local
 
-namespace Intersect.Server.Database.PlayerData.Players
+namespace Intersect.Server.Database.PlayerData.Players;
+
+
+public partial class Bag
 {
 
-    public partial class Bag
+    public Bag()
     {
+    }
 
-        public Bag()
+    public Bag(int slots)
+    {
+        SlotCount = slots;
+        ValidateSlots();
+        Save(create: true);
+    }
+
+    [JsonIgnore, NotMapped]
+    public bool IsEmpty => Slots?.All(slot => slot?.ItemId == default || ItemBase.Get(slot.ItemId) == default) ?? true;
+
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
+    public Guid Id { get; private set; } = Guid.NewGuid();
+
+    public int SlotCount { get; private set; }
+
+    public virtual List<BagSlot> Slots { get; set; } = new List<BagSlot>();
+
+    public void ValidateSlots(bool checkItemExistence = true)
+    {
+        if (Slots == null)
         {
+            Slots = new List<BagSlot>(SlotCount);
         }
 
-        public Bag(int slots)
-        {
-            SlotCount = slots;
-            ValidateSlots();
-            Save(create: true);
-        }
-
-        [JsonIgnore, NotMapped]
-        public bool IsEmpty => Slots?.All(slot => slot?.ItemId == default || ItemBase.Get(slot.ItemId) == default) ?? true;
-
-        [DatabaseGenerated(DatabaseGeneratedOption.None)]
-        public Guid Id { get; private set; } = Guid.NewGuid();
-
-        public int SlotCount { get; private set; }
-
-        public virtual List<BagSlot> Slots { get; set; } = new List<BagSlot>();
-
-        public void ValidateSlots(bool checkItemExistence = true)
-        {
-            if (Slots == null)
-            {
-                Slots = new List<BagSlot>(SlotCount);
-            }
-
-            var slots = Slots
-                .Where(bagSlot => bagSlot != null)
-                .OrderBy(bagSlot => bagSlot.Slot)
-                .Select(
-                    bagSlot =>
-                    {
-                        if (checkItemExistence && (bagSlot.ItemId == Guid.Empty || bagSlot.Descriptor == null))
-                        {
-                            bagSlot.Set(new Item());
-                        }
-
-                        return bagSlot;
-                    }
-                )
-                .ToList();
-
-            for (var slotIndex = 0; slotIndex < SlotCount; ++slotIndex)
-            {
-                if (slotIndex < slots.Count)
+        var slots = Slots
+            .Where(bagSlot => bagSlot != null)
+            .OrderBy(bagSlot => bagSlot.Slot)
+            .Select(
+                bagSlot =>
                 {
-                    var slot = slots[slotIndex];
-                    if (slot != null)
+                    if (checkItemExistence && (bagSlot.ItemId == Guid.Empty || bagSlot.Descriptor == null))
                     {
-                        if (slot.Slot != slotIndex)
-                        {
-                            slots.Insert(slotIndex, new BagSlot(slotIndex));
-                        }
+                        bagSlot.Set(new Item());
                     }
-                    else
+
+                    return bagSlot;
+                }
+            )
+            .ToList();
+
+        for (var slotIndex = 0; slotIndex < SlotCount; ++slotIndex)
+        {
+            if (slotIndex < slots.Count)
+            {
+                var slot = slots[slotIndex];
+                if (slot != null)
+                {
+                    if (slot.Slot != slotIndex)
                     {
-                        slots[slotIndex] = new BagSlot(slotIndex);
+                        slots.Insert(slotIndex, new BagSlot(slotIndex));
                     }
                 }
                 else
                 {
-                    slots.Add(new BagSlot(slotIndex));
+                    slots[slotIndex] = new BagSlot(slotIndex);
                 }
             }
-
-            Slots = slots;
+            else
+            {
+                slots.Add(new BagSlot(slotIndex));
+            }
         }
 
-        public static Bag GetBag(Guid id)
-        {
-            try
-            {
-                using (var context = DbInterface.CreatePlayerContext())
-                {
-                    var bag = context.Bags.Where(p => p.Id == id).Include(p => p.Slots).SingleOrDefault();
-                    if (bag != null)
-                    {
-                        bag.Slots = bag.Slots.OrderBy(p => p.Slot).ToList();
-                        bag.ValidateSlots();
+        Slots = slots;
+    }
 
-                        //Remove any items from this bag that have been removed from the game
-                        foreach (var itm in bag.Slots)
+    public static Bag GetBag(Guid id)
+    {
+        try
+        {
+            using (var context = DbInterface.CreatePlayerContext())
+            {
+                var bag = context.Bags.Where(p => p.Id == id).Include(p => p.Slots).SingleOrDefault();
+                if (bag != null)
+                {
+                    bag.Slots = bag.Slots.OrderBy(p => p.Slot).ToList();
+                    bag.ValidateSlots();
+
+                    //Remove any items from this bag that have been removed from the game
+                    foreach (var itm in bag.Slots)
+                    {
+                        if (itm.ItemId != Guid.Empty && ItemBase.Get(itm.ItemId) == null)
                         {
-                            if (itm.ItemId != Guid.Empty && ItemBase.Get(itm.ItemId) == null)
-                            {
-                                itm.Set(Item.None);
-                            }
+                            itm.Set(Item.None);
                         }
                     }
-
-                    return bag;
                 }
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex);
-                return null;
+
+                return bag;
             }
         }
-
-        public void Save (bool create = false)
+        catch (Exception ex)
         {
-            try
-            {
-                using (var context = DbInterface.CreatePlayerContext(readOnly: false))
-                {
-                    if (create)
-                    {
-                        context.Bags.Add(this);
-                    }
-                    else
-                    {
-                        context.Bags.Update(this);
-                    }
-                    context.ChangeTracker.DetectChanges();
-                    context.SaveChanges();
-                }
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex);
-            }
+            Log.Error(ex);
+            return null;
         }
+    }
 
-        /// <summary>
-        /// Finds all bag slots matching the desired item and quantity.
-        /// </summary>
-        /// <param name="itemId">The item Id to look for.</param>
-        /// <param name="quantity">The quantity of the item to look for.</param>
-        /// <returns>A list of <see cref="InventorySlot"/> containing the requested item.</returns>
-        public List<BagSlot> FindBagItemSlots(Guid itemId, int quantity = 1)
+    public void Save (bool create = false)
+    {
+        try
         {
-            var slots = new List<BagSlot>();
-
-            for (var i = 0; i < SlotCount; i++)
+            using (var context = DbInterface.CreatePlayerContext(readOnly: false))
             {
-                var item = Slots[i];
-                if (item?.ItemId != itemId)
+                if (create)
                 {
-                    continue;
+                    context.Bags.Add(this);
                 }
+                else
+                {
+                    context.Bags.Update(this);
+                }
+                context.ChangeTracker.DetectChanges();
+                context.SaveChanges();
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex);
+        }
+    }
 
-                if (item.Quantity >= quantity)
-                {
-                    slots.Add(item);
-                }
+    /// <summary>
+    /// Finds all bag slots matching the desired item and quantity.
+    /// </summary>
+    /// <param name="itemId">The item Id to look for.</param>
+    /// <param name="quantity">The quantity of the item to look for.</param>
+    /// <returns>A list of <see cref="InventorySlot"/> containing the requested item.</returns>
+    public List<BagSlot> FindBagItemSlots(Guid itemId, int quantity = 1)
+    {
+        var slots = new List<BagSlot>();
+
+        for (var i = 0; i < SlotCount; i++)
+        {
+            var item = Slots[i];
+            if (item?.ItemId != itemId)
+            {
+                continue;
             }
 
-            return slots;
-        }
-
-        /// <summary>
-        /// Retrieves a list of open bag slots for this bag.
-        /// </summary>
-        /// <returns>A list of <see cref="BagSlot"/></returns>
-        public List<BagSlot> FindOpenBagSlots()
-        {
-            var slots = new List<BagSlot>();
-
-            for (var i = 0; i < SlotCount; i++)
+            if (item.Quantity >= quantity)
             {
-                var inventorySlot = Slots[i];
-
-                if (inventorySlot != null && inventorySlot.ItemId == Guid.Empty)
-                {
-                    slots.Add(inventorySlot);
-                }
+                slots.Add(item);
             }
-            return slots;
         }
 
-        /// <summary>
-        /// Finds the index of a given <see cref="BagSlot"/> within this bag's Slots.
-        /// </summary>
-        /// <param name="slot">The <see cref="BagSlot"/>to search for</param>
-        /// <returns>The index if found, otherwise -1</returns>
-        public int FindSlotIndex(BagSlot slot)
+        return slots;
+    }
+
+    /// <summary>
+    /// Retrieves a list of open bag slots for this bag.
+    /// </summary>
+    /// <returns>A list of <see cref="BagSlot"/></returns>
+    public List<BagSlot> FindOpenBagSlots()
+    {
+        var slots = new List<BagSlot>();
+
+        for (var i = 0; i < SlotCount; i++)
         {
-            return Slots.FindIndex(sl => sl.Id == slot.Id);
-        }
+            var inventorySlot = Slots[i];
 
+            if (inventorySlot != null && inventorySlot.ItemId == Guid.Empty)
+            {
+                slots.Add(inventorySlot);
+            }
+        }
+        return slots;
+    }
+
+    /// <summary>
+    /// Finds the index of a given <see cref="BagSlot"/> within this bag's Slots.
+    /// </summary>
+    /// <param name="slot">The <see cref="BagSlot"/>to search for</param>
+    /// <returns>The index if found, otherwise -1</returns>
+    public int FindSlotIndex(BagSlot slot)
+    {
+        return Slots.FindIndex(sl => sl.Id == slot.Id);
     }
 
 }

--- a/Intersect.Server.Core/Database/PlayerData/Players/BagSlot.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Players/BagSlot.cs
@@ -5,32 +5,30 @@ using Newtonsoft.Json;
 // ReSharper disable UnusedAutoPropertyAccessor.Local
 // ReSharper disable AutoPropertyCanBeMadeGetOnly.Local
 
-namespace Intersect.Server.Database.PlayerData.Players
+namespace Intersect.Server.Database.PlayerData.Players;
+
+
+public partial class BagSlot : Item, ISlot
 {
 
-    public partial class BagSlot : Item, ISlot
+    public BagSlot()
     {
-
-        public BagSlot()
-        {
-        }
-
-        public BagSlot(int slot)
-        {
-            Slot = slot;
-        }
-
-        [DatabaseGenerated(DatabaseGeneratedOption.Identity), JsonIgnore]
-        public Guid Id { get; private set; }
-
-        [JsonIgnore]
-        public Guid ParentBagId { get; private set; }
-
-        [JsonIgnore]
-        public virtual Bag ParentBag { get; private set; }
-
-        public int Slot { get; private set; }
-
     }
+
+    public BagSlot(int slot)
+    {
+        Slot = slot;
+    }
+
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity), JsonIgnore]
+    public Guid Id { get; private set; }
+
+    [JsonIgnore]
+    public Guid ParentBagId { get; private set; }
+
+    [JsonIgnore]
+    public virtual Bag ParentBag { get; private set; }
+
+    public int Slot { get; private set; }
 
 }

--- a/Intersect.Server.Core/Database/PlayerData/Players/BankSlot.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Players/BankSlot.cs
@@ -7,32 +7,30 @@ using Newtonsoft.Json;
 // ReSharper disable UnusedAutoPropertyAccessor.Local
 // ReSharper disable AutoPropertyCanBeMadeGetOnly.Local
 
-namespace Intersect.Server.Database.PlayerData.Players
+namespace Intersect.Server.Database.PlayerData.Players;
+
+
+public partial class BankSlot : Item, ISlot, IPlayerOwned
 {
 
-    public partial class BankSlot : Item, ISlot, IPlayerOwned
+    public BankSlot()
     {
-
-        public BankSlot()
-        {
-        }
-
-        public BankSlot(int slot)
-        {
-            Slot = slot;
-        }
-
-        [DatabaseGenerated(DatabaseGeneratedOption.Identity), JsonIgnore]
-        public Guid Id { get; private set; }
-
-        [JsonIgnore]
-        public Guid PlayerId { get; private set; }
-
-        [JsonIgnore]
-        public virtual Player Player { get; private set; }
-
-        public int Slot { get; private set; }
-
     }
+
+    public BankSlot(int slot)
+    {
+        Slot = slot;
+    }
+
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity), JsonIgnore]
+    public Guid Id { get; private set; }
+
+    [JsonIgnore]
+    public Guid PlayerId { get; private set; }
+
+    [JsonIgnore]
+    public virtual Player Player { get; private set; }
+
+    public int Slot { get; private set; }
 
 }

--- a/Intersect.Server.Core/Database/PlayerData/Players/Friend.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Players/Friend.cs
@@ -7,43 +7,41 @@ using Newtonsoft.Json;
 // ReSharper disable AutoPropertyCanBeMadeGetOnly.Local
 // ReSharper disable UnusedAutoPropertyAccessor.Local
 
-namespace Intersect.Server.Database.PlayerData.Players
+namespace Intersect.Server.Database.PlayerData.Players;
+
+
+public partial class Friend
 {
 
-    public partial class Friend
+    public Friend()
     {
-
-        public Friend()
-        {
-        }
-
-        public Friend(Player me, Player friend)
-        {
-            Owner = me;
-            Target = friend;
-        }
-
-        [JsonProperty(nameof(Owner))]
-
-        // Note: Do not change to OwnerId or it collides with the hidden
-        // one that Entity Framework expects/creates under the covers.
-        private Guid JsonOwnerId => Owner?.Id ?? Guid.Empty;
-
-        [JsonProperty(nameof(Target))]
-
-        // Note: Do not change to TargetId or it collides with the hidden
-        // one that Entity Framework expects/creates under the covers.
-        private Guid JsonTargetId => Target?.Id ?? Guid.Empty;
-
-        [DatabaseGenerated(DatabaseGeneratedOption.None)]
-        public Guid Id { get; private set; } = Guid.NewGuid();
-
-        [JsonIgnore]
-        public virtual Player Owner { get; private set; }
-
-        [JsonIgnore]
-        public virtual Player Target { get; private set; }
-
     }
+
+    public Friend(Player me, Player friend)
+    {
+        Owner = me;
+        Target = friend;
+    }
+
+    [JsonProperty(nameof(Owner))]
+
+    // Note: Do not change to OwnerId or it collides with the hidden
+    // one that Entity Framework expects/creates under the covers.
+    private Guid JsonOwnerId => Owner?.Id ?? Guid.Empty;
+
+    [JsonProperty(nameof(Target))]
+
+    // Note: Do not change to TargetId or it collides with the hidden
+    // one that Entity Framework expects/creates under the covers.
+    private Guid JsonTargetId => Target?.Id ?? Guid.Empty;
+
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
+    public Guid Id { get; private set; } = Guid.NewGuid();
+
+    [JsonIgnore]
+    public virtual Player Owner { get; private set; }
+
+    [JsonIgnore]
+    public virtual Player Target { get; private set; }
 
 }

--- a/Intersect.Server.Core/Database/PlayerData/Players/Guild.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Players/Guild.cs
@@ -15,845 +15,844 @@ using Intersect.Server.Localization;
 using Intersect.Server.Web.RestApi.Payloads;
 using static Intersect.Server.Database.Logging.Entities.GuildHistory;
 
-namespace Intersect.Server.Database.PlayerData.Players
+namespace Intersect.Server.Database.PlayerData.Players;
+
+/// <summary>
+/// A class containing the definition of each guild, alongside the methods to use them.
+/// </summary>
+public partial class Guild
 {
-    /// <summary>
-    /// A class containing the definition of each guild, alongside the methods to use them.
-    /// </summary>
-    public partial class Guild
+
+    public static ConcurrentDictionary<Guid, Guild> Guilds = new ConcurrentDictionary<Guid, Guild>();
+
+    // Entity Framework Garbage.
+    public Guild()
     {
+    }
 
-        public static ConcurrentDictionary<Guid, Guild> Guilds = new ConcurrentDictionary<Guid, Guild>();
+    /// <summary>
+    /// The database Id of the guild.
+    /// </summary>
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
+    public Guid Id { get; private set; } = Guid.NewGuid();
 
-        // Entity Framework Garbage.
-        public Guild()
+    /// <summary>
+    /// The name of the guild.
+    /// </summary>
+    public string Name { get; private set; }
+
+    /// <summary>
+    /// The date on which this guild was founded.
+    /// </summary>
+    public DateTime FoundingDate { get; private set; }
+
+    /// <summary>
+    /// Guild bank slots
+    /// </summary>
+    [JsonIgnore]
+    public virtual List<GuildBankSlot> Bank { get; set; } = new List<GuildBankSlot>();
+
+    /// <summary>
+    /// Sets the number of bank slots alotted to this guild. Banks lots can only expand.
+    /// </summary>
+    public int BankSlotsCount { get; set; } = Options.Instance.Guild.InitialBankSlots;
+
+    /// <summary>
+    /// The guild's instance id. This is a unique identifier generated at guild creation time that
+    /// we can use to reference this guild alone when requesting a warp to a "Guild" instance, ensuring
+    /// that players in the same guild will be warped to the same instance.
+    /// </summary>
+    public Guid GuildInstanceId { get; private set; }
+
+    /// <summary>
+    /// Contains a record of all guild members
+    /// </summary>
+    [NotMapped]
+    [JsonIgnore]
+    public ConcurrentDictionary<Guid, GuildMember> Members { get; private set; } = new ConcurrentDictionary<Guid, GuildMember>();
+
+    /// <summary>
+    /// The last time this guilds status was updated and memberlist was send to online players
+    /// </summary>
+    [NotMapped]
+    [JsonIgnore]
+    public long LastUpdateTime { get; set; } = -1;
+
+    /// <summary>
+    /// Guild Variable Values
+    /// </summary>
+    [JsonIgnore]
+    public virtual List<GuildVariable> Variables { get; set; } = new List<GuildVariable>();
+
+    /// <summary>
+    /// Variables that have been updated for this guild which need to be saved to the db
+    /// </summary>
+    public ConcurrentDictionary<Guid, GuildVariableBase> UpdatedVariables = new ConcurrentDictionary<Guid, GuildVariableBase>();
+
+    /// <summary>
+    /// Locking context to prevent saving this guild to the db twice at the same time, and to prevent bank items from being withdrawed/deposited into by 2 threads at the same time
+    /// </summary>
+    [NotMapped]
+    [JsonIgnore]
+    private object mLock = new object();
+
+
+    /// <summary>
+    /// Create a new Guild instance.
+    /// </summary>
+    /// <param name="creator">The <see cref="Player"/> that created the guild.</param>
+    /// <param name="name">The Name of the guild.</param>
+    public static Guild CreateGuild(Player creator, string name)
+    {
+        name = name.Trim();
+
+        if (creator != null && FieldChecking.IsValidGuildName(name, Strings.Regex.guildname))
         {
-        }
-
-        /// <summary>
-        /// The database Id of the guild.
-        /// </summary>
-        [DatabaseGenerated(DatabaseGeneratedOption.None)]
-        public Guid Id { get; private set; } = Guid.NewGuid();
-
-        /// <summary>
-        /// The name of the guild.
-        /// </summary>
-        public string Name { get; private set; }
-
-        /// <summary>
-        /// The date on which this guild was founded.
-        /// </summary>
-        public DateTime FoundingDate { get; private set; }
-
-        /// <summary>
-        /// Guild bank slots
-        /// </summary>
-        [JsonIgnore]
-        public virtual List<GuildBankSlot> Bank { get; set; } = new List<GuildBankSlot>();
-
-        /// <summary>
-        /// Sets the number of bank slots alotted to this guild. Banks lots can only expand.
-        /// </summary>
-        public int BankSlotsCount { get; set; } = Options.Instance.Guild.InitialBankSlots;
-
-        /// <summary>
-        /// The guild's instance id. This is a unique identifier generated at guild creation time that
-        /// we can use to reference this guild alone when requesting a warp to a "Guild" instance, ensuring
-        /// that players in the same guild will be warped to the same instance.
-        /// </summary>
-        public Guid GuildInstanceId { get; private set; }
-
-        /// <summary>
-        /// Contains a record of all guild members
-        /// </summary>
-        [NotMapped]
-        [JsonIgnore]
-        public ConcurrentDictionary<Guid, GuildMember> Members { get; private set; } = new ConcurrentDictionary<Guid, GuildMember>();
-
-        /// <summary>
-        /// The last time this guilds status was updated and memberlist was send to online players
-        /// </summary>
-        [NotMapped]
-        [JsonIgnore]
-        public long LastUpdateTime { get; set; } = -1;
-
-        /// <summary>
-        /// Guild Variable Values
-        /// </summary>
-        [JsonIgnore]
-        public virtual List<GuildVariable> Variables { get; set; } = new List<GuildVariable>();
-
-        /// <summary>
-        /// Variables that have been updated for this guild which need to be saved to the db
-        /// </summary>
-        public ConcurrentDictionary<Guid, GuildVariableBase> UpdatedVariables = new ConcurrentDictionary<Guid, GuildVariableBase>();
-
-        /// <summary>
-        /// Locking context to prevent saving this guild to the db twice at the same time, and to prevent bank items from being withdrawed/deposited into by 2 threads at the same time
-        /// </summary>
-        [NotMapped]
-        [JsonIgnore]
-        private object mLock = new object();
-
-
-        /// <summary>
-        /// Create a new Guild instance.
-        /// </summary>
-        /// <param name="creator">The <see cref="Player"/> that created the guild.</param>
-        /// <param name="name">The Name of the guild.</param>
-        public static Guild CreateGuild(Player creator, string name)
-        {
-            name = name.Trim();
-
-            if (creator != null && FieldChecking.IsValidGuildName(name, Strings.Regex.guildname))
+            using (var context = DbInterface.CreatePlayerContext(readOnly: false))
             {
-                using (var context = DbInterface.CreatePlayerContext(readOnly: false))
+                var guild = new Guild()
                 {
-                    var guild = new Guild()
-                    {
-                        Name = name,
-                        FoundingDate = DateTime.UtcNow,
-                        GuildInstanceId = Guid.NewGuid()
-                    };
+                    Name = name,
+                    FoundingDate = DateTime.UtcNow,
+                    GuildInstanceId = Guid.NewGuid()
+                };
 
-                    SlotHelper.ValidateSlots(guild.Bank, Options.Instance.Guild.InitialBankSlots);
-                    guild.Bank = guild.Bank.OrderBy(bankSlot => bankSlot?.Slot).ToList();
-
-                    var player = context.Players.FirstOrDefault(p => p.Id == creator.Id);
-                    if (player != null)
-                    {
-                        player.DbGuild = guild;
-                        player.GuildRank = 0;
-                        player.GuildJoinDate = DateTime.UtcNow;
-
-
-                        context.ChangeTracker.DetectChanges();
-                        context.SaveChanges();
-
-                        var member = new GuildMember(player.Id, player.Name, player.GuildRank, player.Level, player.ClassName, player.MapName);
-                        guild.Members.AddOrUpdate(player.Id, member, (key, oldValue) => member);
-
-                        creator.Guild = guild;
-                        creator.GuildRank = 0;
-                        creator.GuildJoinDate = DateTime.UtcNow;
-
-                        // Send our entity data to nearby players.
-                        PacketSender.SendEntityDataToProximity(Player.FindOnline(creator.Id));
-
-                        Guilds.AddOrUpdate(guild.Id, guild, (key, oldValue) => guild);
-
-                        LogActivity(guild.Id, creator, null, GuildActivityType.Created, name);
-
-                        return guild;
-                    }
-                }
-            }
-            return null;
-
-        }
-
-        /// <summary>
-        /// Loads a guild and it's members from the database
-        /// </summary>
-        /// <param name="id"></param>
-        /// <returns></returns>
-        public static Guild LoadGuild(Guid id)
-        {
-            if (!Guilds.TryGetValue(id, out Guild found))
-            {
-                using var context = DbInterface.CreatePlayerContext();
-                var guild = context.Guilds.Where(g => g.Id == id)
-                    .Include(g => g.Bank)
-                    .Include(g => g.Variables)
-                    .AsSplitQuery()
-                    .FirstOrDefault();
-                if (guild == default)
-                {
-                    return default;
-                }
-
-                // Load Members
-                var members = context.Players.Where(p => p.DbGuild.Id == id).ToDictionary(t => t.Id, t => new Tuple<Guid, string, int, int, Guid, Guid>(t.Id, t.Name, t.GuildRank, t.Level, t.ClassId, t.MapId));
-                foreach (var member in members)
-                {
-                    var guildMember = new GuildMember(member.Value.Item1, member.Value.Item2, member.Value.Item3, member.Value.Item4, ClassBase.GetName(member.Value.Item5), MapBase.GetName(member.Value.Item6));
-                    guild.Members.AddOrUpdate(member.Key, guildMember, (key, oldValue) => guildMember);
-                }
-
-                SlotHelper.ValidateSlots(guild.Bank, guild.BankSlotsCount);
+                SlotHelper.ValidateSlots(guild.Bank, Options.Instance.Guild.InitialBankSlots);
                 guild.Bank = guild.Bank.OrderBy(bankSlot => bankSlot?.Slot).ToList();
 
-                Guilds.AddOrUpdate(id, guild, (key, oldValue) => guild);
+                var player = context.Players.FirstOrDefault(p => p.Id == creator.Id);
+                if (player != null)
+                {
+                    player.DbGuild = guild;
+                    player.GuildRank = 0;
+                    player.GuildJoinDate = DateTime.UtcNow;
 
-                return guild;
+
+                    context.ChangeTracker.DetectChanges();
+                    context.SaveChanges();
+
+                    var member = new GuildMember(player.Id, player.Name, player.GuildRank, player.Level, player.ClassName, player.MapName);
+                    guild.Members.AddOrUpdate(player.Id, member, (key, oldValue) => member);
+
+                    creator.Guild = guild;
+                    creator.GuildRank = 0;
+                    creator.GuildJoinDate = DateTime.UtcNow;
+
+                    // Send our entity data to nearby players.
+                    PacketSender.SendEntityDataToProximity(Player.FindOnline(creator.Id));
+
+                    Guilds.AddOrUpdate(guild.Id, guild, (key, oldValue) => guild);
+
+                    LogActivity(guild.Id, creator, null, GuildActivityType.Created, name);
+
+                    return guild;
+                }
+            }
+        }
+        return null;
+
+    }
+
+    /// <summary>
+    /// Loads a guild and it's members from the database
+    /// </summary>
+    /// <param name="id"></param>
+    /// <returns></returns>
+    public static Guild LoadGuild(Guid id)
+    {
+        if (!Guilds.TryGetValue(id, out Guild found))
+        {
+            using var context = DbInterface.CreatePlayerContext();
+            var guild = context.Guilds.Where(g => g.Id == id)
+                .Include(g => g.Bank)
+                .Include(g => g.Variables)
+                .AsSplitQuery()
+                .FirstOrDefault();
+            if (guild == default)
+            {
+                return default;
             }
 
-            return found;
+            // Load Members
+            var members = context.Players.Where(p => p.DbGuild.Id == id).ToDictionary(t => t.Id, t => new Tuple<Guid, string, int, int, Guid, Guid>(t.Id, t.Name, t.GuildRank, t.Level, t.ClassId, t.MapId));
+            foreach (var member in members)
+            {
+                var guildMember = new GuildMember(member.Value.Item1, member.Value.Item2, member.Value.Item3, member.Value.Item4, ClassBase.GetName(member.Value.Item5), MapBase.GetName(member.Value.Item6));
+                guild.Members.AddOrUpdate(member.Key, guildMember, (key, oldValue) => guildMember);
+            }
+
+            SlotHelper.ValidateSlots(guild.Bank, guild.BankSlotsCount);
+            guild.Bank = guild.Bank.OrderBy(bankSlot => bankSlot?.Slot).ToList();
+
+            Guilds.AddOrUpdate(id, guild, (key, oldValue) => guild);
+
+            return guild;
         }
 
-        /// <summary>
-        /// Find all online members of this guild.
-        /// </summary>
-        /// <returns>A list of online players.</returns>
-        public List<Player> FindOnlineMembers()
+        return found;
+    }
+
+    /// <summary>
+    /// Find all online members of this guild.
+    /// </summary>
+    /// <returns>A list of online players.</returns>
+    public List<Player> FindOnlineMembers()
+    {
+        var online = new List<Player>();
+        foreach (var member in Members)
         {
-            var online = new List<Player>();
-            foreach (var member in Members)
+            var plyr = Player.FindOnline(member.Key);
+            if (plyr != null)
+            {
+                //Update Cached Member List Values
+                member.Value.Name = plyr.Name;
+                member.Value.Class = plyr.ClassName;
+                member.Value.Level = plyr.Level;
+                member.Value.Map = plyr.MapName;
+                member.Value.Rank = plyr.GuildRank;
+
+                online.Add(plyr);
+            }
+        }
+
+        return online;
+    }
+
+    /// <summary>
+    /// Joins a player into the guild.
+    /// </summary>
+    /// <param name="player">The player to join into the guild.</param>
+    /// <param name="rank">Integer index of the rank to give this new member.</param>
+    /// <param name="initiator">The player who initiated this change (null if done by the api or some other method).</param>
+    public void AddMember(Player player, int rank, Player initiator = null)
+    {
+        if (player != null && !Members.Any(m => m.Key == player.Id))
+        {
+            using (var context = DbInterface.CreatePlayerContext(readOnly: false))
+            {
+                var dbPlayer = context.Players.FirstOrDefault(p => p.Id == player.Id);
+                if (dbPlayer != null)
+                {
+                    dbPlayer.DbGuild = this;
+                    dbPlayer.GuildRank = rank;
+                    dbPlayer.GuildJoinDate = DateTime.UtcNow;
+                    context.ChangeTracker.DetectChanges();
+                    DetachGuildFromDbContext(context, this);
+                    context.SaveChanges();
+
+                    player.Guild = this;
+                    player.GuildRank = rank;
+                    player.GuildJoinDate = DateTime.UtcNow;
+
+                    var member = new GuildMember(player.Id, player.Name, player.GuildRank, player.Level, player.ClassName, player.MapName);
+                    Members.AddOrUpdate(player.Id, member, (key, oldValue) => member);
+
+                    // Send our new guild list to everyone that's online.
+                    UpdateMemberList();
+
+                    // Send our entity data to nearby players.
+                    PacketSender.SendEntityDataToProximity(Player.FindOnline(player.Id));
+
+                    LogActivity(Id, player, initiator, GuildActivityType.Joined);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Removes a player from the guild.
+    /// </summary>
+    /// <param name="targetId">The ID of the player to remove from the guild.</param>
+    /// <param name="targetPlayer">The player to remove from the guild.</param>
+    /// <param name="initiator">The player who initiated this change (null if done by the api or some other method).</param>
+    public void RemoveMember(Guid targetId, Player targetPlayer, Player initiator = null, GuildActivityType action = GuildActivityType.Left)
+    {
+        if (targetPlayer == default)
+        {
+            targetPlayer = Player.Find(targetId);
+        }
+
+        using (var context = DbInterface.CreatePlayerContext(readOnly: false))
+        {
+            var dbPlayer = context.Players.Where(p => p.Id == targetId && p.DbGuild.Id == this.Id).Include(p => p.DbGuild).FirstOrDefault();
+            if (dbPlayer != default)
+            {
+                dbPlayer.DbGuild = default;
+                dbPlayer.GuildRank = 0;
+
+                context.ChangeTracker.DetectChanges();
+                context.SaveChanges();
+            }
+
+            if (targetPlayer != default)
+            {
+                targetPlayer.Guild = default;
+                targetPlayer.GuildRank = 0;
+                targetPlayer.GuildInvite = default;
+
+                if (targetPlayer.BankInterface != null && targetPlayer.GuildBank)
+                {
+                    targetPlayer.BankInterface.Dispose();
+                }
+            }
+
+
+            Members.TryRemove(targetId, out GuildMember _);
+
+            // Send our new guild list to everyone that's online.
+            UpdateMemberList();
+
+            // Send our entity data to nearby players.
+            PacketSender.SendEntityDataToProximity(Player.FindOnline(targetId));
+
+            LogActivity(Id, targetPlayer?.UserId ?? default, targetId, targetPlayer?.Client?.Ip ?? string.Empty, initiator, action);
+        }
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public void Update()
+    {
+        if (UpdatedVariables.Count > 0)
+        {
+            Save();
+            UpdatedVariables.Clear();
+        }
+        UpdateMemberList();
+    }
+
+    /// <summary>
+    /// Send an updated version of our guild's memberlist to each online member.
+    /// </summary>
+    public void UpdateMemberList()
+    {
+        foreach (var member in FindOnlineMembers())
+        {
+            PacketSender.SendGuild(member);
+        }
+        LastUpdateTime = Timing.Global.Milliseconds;
+    }
+
+    /// <summary>
+    /// Sets a player's guild rank.
+    /// </summary>
+    /// <param name="id">The player to set the rank for.</param>
+    /// <param name="rank">The integer index of the rank to assign.</param>
+    /// <param name="initiator">The player who initiated this change (null if done by the api or some other method).</param>
+    public void SetPlayerRank(Guid id, int rank, Player initiator = null) => SetPlayerRank(id, default, rank, initiator);
+
+    /// <summary>
+    /// Sets a player's guild rank.
+    /// </summary>
+    /// <param name="targetId">The player to set the rank for.</param>
+    /// <param name="targetPlayer">The player to set the rank for.</param>
+    /// <param name="rank">The integer index of the rank to assign.</param>
+    /// <param name="initiator">The player who initiated this change (null if done by the api or some other method).</param>
+    public void SetPlayerRank(Guid targetId, Player targetPlayer, int rank, Player initiator = null)
+    {
+        if (targetPlayer == default)
+        {
+            targetPlayer = Player.Find(targetId);
+        }
+
+        using (var context = DbInterface.CreatePlayerContext(readOnly: false))
+        {
+            var dbPlayer = context.Players.FirstOrDefault(p => p.Id == targetId && p.DbGuild.Id == this.Id);
+            var origRank = dbPlayer?.GuildRank;
+            if (dbPlayer != default)
+            {
+                dbPlayer.GuildRank = rank;
+
+                context.ChangeTracker.DetectChanges();
+                context.SaveChanges();
+            }
+
+            if (targetPlayer != default)
+            {
+                targetPlayer.GuildRank = rank;
+            }
+
+            if (Members.TryGetValue(targetId, out GuildMember val))
+            {
+                val.Rank = rank;
+            }
+
+            // Send our new guild list to everyone that's online.
+            UpdateMemberList();
+
+            // Send our entity data to nearby players.
+            PacketSender.SendEntityDataToProximity(Player.FindOnline(targetId));
+
+            //Log this change
+            if (!origRank.HasValue || origRank < rank)
+            {
+                LogActivity(
+                    Id,
+                    targetPlayer?.UserId ?? default,
+                    targetId,
+                    targetPlayer?.Client?.Ip ?? string.Empty,
+                    initiator,
+                    GuildActivityType.Demoted,
+                    rank.ToString()
+                );
+            }
+            else if (origRank > rank)
+            {
+                LogActivity(
+                    Id,
+                    targetPlayer?.UserId ?? default,
+                    targetId,
+                    targetPlayer?.Client?.Ip ?? string.Empty,
+                    initiator,
+                    GuildActivityType.Promoted,
+                    rank.ToString()
+                );
+            }
+        }
+    }
+
+    /// <summary>
+    /// Returns the rank of a player within this guild.
+    /// </summary>
+    /// <param name="id">The Id of the player to search for.</param>
+    /// <returns>Returns the integer index of the rank of a player within this guild.</returns>
+    public int GetPlayerRank(Guid id) => GetPlayerRank(Player.Find(id));
+
+    /// <summary>
+    /// Returns the rank of a player within this guild.
+    /// </summary>
+    /// <param name="player">The player to search for.</param>
+    /// <returns>Returns the integer index of the rank of a player within this guild.</returns>
+    public int GetPlayerRank(Player player) => player.GuildRank;
+
+    /// <summary>
+    /// Check whether a specified player is a member of this guild.
+    /// </summary>
+    /// <param name="id">The Id to check against.</param>
+    /// <returns>Whether or not this player is a member of this guild</returns>
+    public bool IsMember(Guid id) => IsMember(Player.Find(id));
+
+    /// <summary>
+    /// Check whether a specified player is a member of this guild.
+    /// </summary>
+    /// <param name="player">The player to check against.</param>
+    /// <returns>Whether or not this player is a member of this guild</returns>
+    public bool IsMember(Player player)
+    {
+        return Members.ContainsKey(player?.Id ?? Guid.Empty);
+    }
+
+    /// <summary>
+    /// Search for a guild by Id.
+    /// </summary>
+    /// <param name="id">The guild Id to search for.</param>
+    /// <returns>Returns a <see cref="Guild"/> that matches the Id, if any.</returns>
+    public static Guild GetGuild(Guid id)
+    {
+        using (var context = DbInterface.CreatePlayerContext())
+        {
+            var guild = context.Guilds.FirstOrDefault(g => g.Id == id);
+            if (guild != null)
+            {
+                return guild;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Search for a guild by Name.
+    /// </summary>
+    /// <param name="name">The guild Name to search for.</param>
+    /// <returns>Returns a <see cref="Guild"/> that matches the Name, if any.</returns>
+    public static Guild GetGuild(string name)
+    {
+        name = name.Trim();
+        using (var context = DbInterface.CreatePlayerContext())
+        {
+            var guild = context.Guilds.FirstOrDefault(g => g.Name.ToLower() == name.ToLower());
+            if (guild != null)
+            {
+                return guild;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Determines wether or not a guild already exists with a given name
+    /// </summary>
+    /// <param name="name">Guild name to check</param>
+    /// <returns></returns>
+    public static bool GuildExists(string name)
+    {
+        name = name.Trim().ToLower();
+        using (var context = DbInterface.CreatePlayerContext())
+        {
+            return context.Guilds.Any(g => g.Name.ToLower() == name.ToLower());
+        }
+    }
+
+    /// <summary>
+    /// Completely removes a guild from the game.
+    /// </summary>
+    /// <param name="guild">The <see cref="Guild"/> to delete.</param>
+    /// <param name="initiator">The player who initiated this change (null if done by the api or some other method).</param>
+    public static void DeleteGuild(Guild guild, Player initiator = null)
+    {
+        // Remove our members cleanly before deleting this from our database.
+        using (var context = DbInterface.CreatePlayerContext(readOnly: false))
+        {
+            foreach (var member in guild.Members)
             {
                 var plyr = Player.FindOnline(member.Key);
                 if (plyr != null)
                 {
-                    //Update Cached Member List Values
-                    member.Value.Name = plyr.Name;
-                    member.Value.Class = plyr.ClassName;
-                    member.Value.Level = plyr.Level;
-                    member.Value.Map = plyr.MapName;
-                    member.Value.Rank = plyr.GuildRank;
+                    plyr.Guild = null;
+                    plyr.GuildRank = 0;
 
-                    online.Add(plyr);
-                }
-            }
-
-            return online;
-        }
-
-        /// <summary>
-        /// Joins a player into the guild.
-        /// </summary>
-        /// <param name="player">The player to join into the guild.</param>
-        /// <param name="rank">Integer index of the rank to give this new member.</param>
-        /// <param name="initiator">The player who initiated this change (null if done by the api or some other method).</param>
-        public void AddMember(Player player, int rank, Player initiator = null)
-        {
-            if (player != null && !Members.Any(m => m.Key == player.Id))
-            {
-                using (var context = DbInterface.CreatePlayerContext(readOnly: false))
-                {
-                    var dbPlayer = context.Players.FirstOrDefault(p => p.Id == player.Id);
-                    if (dbPlayer != null)
+                    if (plyr.BankInterface != null && plyr.GuildBank)
                     {
-                        dbPlayer.DbGuild = this;
-                        dbPlayer.GuildRank = rank;
-                        dbPlayer.GuildJoinDate = DateTime.UtcNow;
-                        context.ChangeTracker.DetectChanges();
-                        DetachGuildFromDbContext(context, this);
-                        context.SaveChanges();
-
-                        player.Guild = this;
-                        player.GuildRank = rank;
-                        player.GuildJoinDate = DateTime.UtcNow;
-
-                        var member = new GuildMember(player.Id, player.Name, player.GuildRank, player.Level, player.ClassName, player.MapName);
-                        Members.AddOrUpdate(player.Id, member, (key, oldValue) => member);
-
-                        // Send our new guild list to everyone that's online.
-                        UpdateMemberList();
-
-                        // Send our entity data to nearby players.
-                        PacketSender.SendEntityDataToProximity(Player.FindOnline(player.Id));
-
-                        LogActivity(Id, player, initiator, GuildActivityType.Joined);
+                        plyr.BankInterface.Dispose();
                     }
+
+                    PacketSender.SendGuild(plyr);
+
+                    // Send our entity data to nearby players.
+                    PacketSender.SendEntityDataToProximity(plyr);
                 }
             }
-        }
 
-        /// <summary>
-        /// Removes a player from the guild.
-        /// </summary>
-        /// <param name="targetId">The ID of the player to remove from the guild.</param>
-        /// <param name="targetPlayer">The player to remove from the guild.</param>
-        /// <param name="initiator">The player who initiated this change (null if done by the api or some other method).</param>
-        public void RemoveMember(Guid targetId, Player targetPlayer, Player initiator = null, GuildActivityType action = GuildActivityType.Left)
-        {
-            if (targetPlayer == default)
+            foreach (var member in context.Players.Where(p => p.DbGuild.Id == guild.Id))
             {
-                targetPlayer = Player.Find(targetId);
+                member.DbGuild = null;
+                member.GuildRank = 0;
             }
 
+            context.Guilds.Remove(guild);
+
+            Guilds.TryRemove(guild.Id, out Guild removed);
+
+            context.ChangeTracker.DetectChanges();
+            context.SaveChanges();
+
+            LogActivity(guild.Id, initiator, null, GuildActivityType.Disbanded);
+        }
+    }
+
+
+    /// <summary>
+    /// Transfers guild ownership to another member
+    /// </summary>
+    /// <param name="newOwnerId">The new owner.</param>
+    /// <param name="initiator">The player who initiated this change (null if done by the api or some other method).</param>
+    public bool TransferOwnership(Player newOwner, Player initiator = null)
+    {
+        if (newOwner != null)
+        {
             using (var context = DbInterface.CreatePlayerContext(readOnly: false))
             {
-                var dbPlayer = context.Players.Where(p => p.Id == targetId && p.DbGuild.Id == this.Id).Include(p => p.DbGuild).FirstOrDefault();
-                if (dbPlayer != default)
+                //Find the current owner?
+                Player dbOwner = null;
+                var ownerPair = Members.Where(m => m.Value.Rank == 0).FirstOrDefault();
+
+                if (ownerPair.Key != Guid.Empty)
                 {
-                    dbPlayer.DbGuild = default;
-                    dbPlayer.GuildRank = 0;
+                    dbOwner = context.Players.Where(p => p.Id == ownerPair.Key && p.DbGuild.Id == this.Id && p.GuildRank == 0).FirstOrDefault();
+                }
+
+                var dbNewOwner = context.Players.Where(p => p.Id == newOwner.Id && p.DbGuild.Id == this.Id).FirstOrDefault();
+                if (dbNewOwner != null)
+                {
+                    if (dbOwner != null)
+                    {
+                        dbOwner.GuildRank = 1;
+                    }
+                    dbNewOwner.GuildRank = 0;
 
                     context.ChangeTracker.DetectChanges();
                     context.SaveChanges();
-                }
 
-                if (targetPlayer != default)
-                {
-                    targetPlayer.Guild = default;
-                    targetPlayer.GuildRank = 0;
-                    targetPlayer.GuildInvite = default;
-
-                    if (targetPlayer.BankInterface != null && targetPlayer.GuildBank)
+                    var onlineOwner = Player.FindOnline(ownerPair.Key);
+                    if (onlineOwner != null)
                     {
-                        targetPlayer.BankInterface.Dispose();
+                        onlineOwner.GuildRank = 1;
                     }
+                    newOwner.GuildRank = 0;
+
+
+                    if (Members.TryGetValue(ownerPair.Key, out GuildMember ownerMem))
+                    {
+                        ownerMem.Rank = 1;
+                    }
+
+                    if (Members.TryGetValue(newOwner.Id, out GuildMember newOwnerMem))
+                    {
+                        newOwnerMem.Rank = 0;
+                    }
+
+                    // Send our new guild list to everyone that's online.
+                    UpdateMemberList();
+
+                    // Send our entity data to nearby players.
+                    PacketSender.SendEntityDataToProximity(Player.FindOnline(newOwner.Id));
+
+                    // Send our entity data to nearby players.
+                    if (onlineOwner != null)
+                    {
+                        PacketSender.SendEntityDataToProximity(onlineOwner);
+                    }
+
+                    LogActivity(Id, newOwner, initiator, GuildActivityType.Transfer);
+
+                    return true;
                 }
-
-
-                Members.TryRemove(targetId, out GuildMember _);
-
-                // Send our new guild list to everyone that's online.
-                UpdateMemberList();
-
-                // Send our entity data to nearby players.
-                PacketSender.SendEntityDataToProximity(Player.FindOnline(targetId));
-
-                LogActivity(Id, targetPlayer?.UserId ?? default, targetId, targetPlayer?.Client?.Ip ?? string.Empty, initiator, action);
             }
         }
+        return false;
+    }
 
-        /// <summary>
-        /// 
-        /// </summary>
-        public void Update()
+    /// <summary>
+    /// Removes all guilds in which only have 1 member that haven't been online in the configured number of days
+    /// </summary>
+    public static void WipeStaleGuilds()
+    {
+        if (Options.Instance.Guild.DeleteStaleGuildsAfterDays > 0)
         {
-            if (UpdatedVariables.Count > 0)
-            {
-                Save();
-                UpdatedVariables.Clear();
-            }
-            UpdateMemberList();
-        }
-
-        /// <summary>
-        /// Send an updated version of our guild's memberlist to each online member.
-        /// </summary>
-        public void UpdateMemberList()
-        {
-            foreach (var member in FindOnlineMembers())
-            {
-                PacketSender.SendGuild(member);
-            }
-            LastUpdateTime = Timing.Global.Milliseconds;
-        }
-
-        /// <summary>
-        /// Sets a player's guild rank.
-        /// </summary>
-        /// <param name="id">The player to set the rank for.</param>
-        /// <param name="rank">The integer index of the rank to assign.</param>
-        /// <param name="initiator">The player who initiated this change (null if done by the api or some other method).</param>
-        public void SetPlayerRank(Guid id, int rank, Player initiator = null) => SetPlayerRank(id, default, rank, initiator);
-
-        /// <summary>
-        /// Sets a player's guild rank.
-        /// </summary>
-        /// <param name="targetId">The player to set the rank for.</param>
-        /// <param name="targetPlayer">The player to set the rank for.</param>
-        /// <param name="rank">The integer index of the rank to assign.</param>
-        /// <param name="initiator">The player who initiated this change (null if done by the api or some other method).</param>
-        public void SetPlayerRank(Guid targetId, Player targetPlayer, int rank, Player initiator = null)
-        {
-            if (targetPlayer == default)
-            {
-                targetPlayer = Player.Find(targetId);
-            }
-
             using (var context = DbInterface.CreatePlayerContext(readOnly: false))
             {
-                var dbPlayer = context.Players.FirstOrDefault(p => p.Id == targetId && p.DbGuild.Id == this.Id);
-                var origRank = dbPlayer?.GuildRank;
-                if (dbPlayer != default)
+                foreach (var guild in context.Guilds)
                 {
-                    dbPlayer.GuildRank = rank;
-
-                    context.ChangeTracker.DetectChanges();
-                    context.SaveChanges();
-                }
-
-                if (targetPlayer != default)
-                {
-                    targetPlayer.GuildRank = rank;
-                }
-
-                if (Members.TryGetValue(targetId, out GuildMember val))
-                {
-                    val.Rank = rank;
-                }
-
-                // Send our new guild list to everyone that's online.
-                UpdateMemberList();
-
-                // Send our entity data to nearby players.
-                PacketSender.SendEntityDataToProximity(Player.FindOnline(targetId));
-
-                //Log this change
-                if (!origRank.HasValue || origRank < rank)
-                {
-                    LogActivity(
-                        Id,
-                        targetPlayer?.UserId ?? default,
-                        targetId,
-                        targetPlayer?.Client?.Ip ?? string.Empty,
-                        initiator,
-                        GuildActivityType.Demoted,
-                        rank.ToString()
-                    );
-                }
-                else if (origRank > rank)
-                {
-                    LogActivity(
-                        Id,
-                        targetPlayer?.UserId ?? default,
-                        targetId,
-                        targetPlayer?.Client?.Ip ?? string.Empty,
-                        initiator,
-                        GuildActivityType.Promoted,
-                        rank.ToString()
-                    );
-                }
-            }
-        }
-
-        /// <summary>
-        /// Returns the rank of a player within this guild.
-        /// </summary>
-        /// <param name="id">The Id of the player to search for.</param>
-        /// <returns>Returns the integer index of the rank of a player within this guild.</returns>
-        public int GetPlayerRank(Guid id) => GetPlayerRank(Player.Find(id));
-
-        /// <summary>
-        /// Returns the rank of a player within this guild.
-        /// </summary>
-        /// <param name="player">The player to search for.</param>
-        /// <returns>Returns the integer index of the rank of a player within this guild.</returns>
-        public int GetPlayerRank(Player player) => player.GuildRank;
-
-        /// <summary>
-        /// Check whether a specified player is a member of this guild.
-        /// </summary>
-        /// <param name="id">The Id to check against.</param>
-        /// <returns>Whether or not this player is a member of this guild</returns>
-        public bool IsMember(Guid id) => IsMember(Player.Find(id));
-
-        /// <summary>
-        /// Check whether a specified player is a member of this guild.
-        /// </summary>
-        /// <param name="player">The player to check against.</param>
-        /// <returns>Whether or not this player is a member of this guild</returns>
-        public bool IsMember(Player player)
-        {
-            return Members.ContainsKey(player?.Id ?? Guid.Empty);
-        }
-
-        /// <summary>
-        /// Search for a guild by Id.
-        /// </summary>
-        /// <param name="id">The guild Id to search for.</param>
-        /// <returns>Returns a <see cref="Guild"/> that matches the Id, if any.</returns>
-        public static Guild GetGuild(Guid id)
-        {
-            using (var context = DbInterface.CreatePlayerContext())
-            {
-                var guild = context.Guilds.FirstOrDefault(g => g.Id == id);
-                if (guild != null)
-                {
-                    return guild;
-                }
-            }
-
-            return null;
-        }
-
-        /// <summary>
-        /// Search for a guild by Name.
-        /// </summary>
-        /// <param name="name">The guild Name to search for.</param>
-        /// <returns>Returns a <see cref="Guild"/> that matches the Name, if any.</returns>
-        public static Guild GetGuild(string name)
-        {
-            name = name.Trim();
-            using (var context = DbInterface.CreatePlayerContext())
-            {
-                var guild = context.Guilds.FirstOrDefault(g => g.Name.ToLower() == name.ToLower());
-                if (guild != null)
-                {
-                    return guild;
-                }
-            }
-
-            return null;
-        }
-
-        /// <summary>
-        /// Determines wether or not a guild already exists with a given name
-        /// </summary>
-        /// <param name="name">Guild name to check</param>
-        /// <returns></returns>
-        public static bool GuildExists(string name)
-        {
-            name = name.Trim().ToLower();
-            using (var context = DbInterface.CreatePlayerContext())
-            {
-                return context.Guilds.Any(g => g.Name.ToLower() == name.ToLower());
-            }
-        }
-
-        /// <summary>
-        /// Completely removes a guild from the game.
-        /// </summary>
-        /// <param name="guild">The <see cref="Guild"/> to delete.</param>
-        /// <param name="initiator">The player who initiated this change (null if done by the api or some other method).</param>
-        public static void DeleteGuild(Guild guild, Player initiator = null)
-        {
-            // Remove our members cleanly before deleting this from our database.
-            using (var context = DbInterface.CreatePlayerContext(readOnly: false))
-            {
-                foreach (var member in guild.Members)
-                {
-                    var plyr = Player.FindOnline(member.Key);
-                    if (plyr != null)
+                    var memberCount = context.Players.Where(p => p.DbGuild.Id == guild.Id).Count();
+                    if (memberCount == 0)
                     {
-                        plyr.Guild = null;
-                        plyr.GuildRank = 0;
-
-                        if (plyr.BankInterface != null && plyr.GuildBank)
-                        {
-                            plyr.BankInterface.Dispose();
-                        }
-
-                        PacketSender.SendGuild(plyr);
-
-                        // Send our entity data to nearby players.
-                        PacketSender.SendEntityDataToProximity(plyr);
+                        context.Entry(guild).State = EntityState.Deleted;
+                        LogActivity(guild.Id, null, null, GuildActivityType.Disbanded, "Stale");
                     }
-                }
-
-                foreach (var member in context.Players.Where(p => p.DbGuild.Id == guild.Id))
-                {
-                    member.DbGuild = null;
-                    member.GuildRank = 0;
-                }
-
-                context.Guilds.Remove(guild);
-
-                Guilds.TryRemove(guild.Id, out Guild removed);
-
-                context.ChangeTracker.DetectChanges();
-                context.SaveChanges();
-
-                LogActivity(guild.Id, initiator, null, GuildActivityType.Disbanded);
-            }
-        }
-
-
-        /// <summary>
-        /// Transfers guild ownership to another member
-        /// </summary>
-        /// <param name="newOwnerId">The new owner.</param>
-        /// <param name="initiator">The player who initiated this change (null if done by the api or some other method).</param>
-        public bool TransferOwnership(Player newOwner, Player initiator = null)
-        {
-            if (newOwner != null)
-            {
-                using (var context = DbInterface.CreatePlayerContext(readOnly: false))
-                {
-                    //Find the current owner?
-                    Player dbOwner = null;
-                    var ownerPair = Members.Where(m => m.Value.Rank == 0).FirstOrDefault();
-
-                    if (ownerPair.Key != Guid.Empty)
+                    else if (context.Players.Where(p => p.DbGuild.Id == guild.Id).Count() == 1)
                     {
-                        dbOwner = context.Players.Where(p => p.Id == ownerPair.Key && p.DbGuild.Id == this.Id && p.GuildRank == 0).FirstOrDefault();
-                    }
-
-                    var dbNewOwner = context.Players.Where(p => p.Id == newOwner.Id && p.DbGuild.Id == this.Id).FirstOrDefault();
-                    if (dbNewOwner != null)
-                    {
-                        if (dbOwner != null)
-                        {
-                            dbOwner.GuildRank = 1;
-                        }
-                        dbNewOwner.GuildRank = 0;
-
-                        context.ChangeTracker.DetectChanges();
-                        context.SaveChanges();
-
-                        var onlineOwner = Player.FindOnline(ownerPair.Key);
-                        if (onlineOwner != null)
-                        {
-                            onlineOwner.GuildRank = 1;
-                        }
-                        newOwner.GuildRank = 0;
-
-
-                        if (Members.TryGetValue(ownerPair.Key, out GuildMember ownerMem))
-                        {
-                            ownerMem.Rank = 1;
-                        }
-
-                        if (Members.TryGetValue(newOwner.Id, out GuildMember newOwnerMem))
-                        {
-                            newOwnerMem.Rank = 0;
-                        }
-
-                        // Send our new guild list to everyone that's online.
-                        UpdateMemberList();
-
-                        // Send our entity data to nearby players.
-                        PacketSender.SendEntityDataToProximity(Player.FindOnline(newOwner.Id));
-
-                        // Send our entity data to nearby players.
-                        if (onlineOwner != null)
-                        {
-                            PacketSender.SendEntityDataToProximity(onlineOwner);
-                        }
-
-                        LogActivity(Id, newOwner, initiator, GuildActivityType.Transfer);
-
-                        return true;
-                    }
-                }
-            }
-            return false;
-        }
-
-        /// <summary>
-        /// Removes all guilds in which only have 1 member that haven't been online in the configured number of days
-        /// </summary>
-        public static void WipeStaleGuilds()
-        {
-            if (Options.Instance.Guild.DeleteStaleGuildsAfterDays > 0)
-            {
-                using (var context = DbInterface.CreatePlayerContext(readOnly: false))
-                {
-                    foreach (var guild in context.Guilds)
-                    {
-                        var memberCount = context.Players.Where(p => p.DbGuild.Id == guild.Id).Count();
-                        if (memberCount == 0)
+                        var lastOnline = context.Players.FirstOrDefault(p => p.DbGuild.Id == guild.Id).LastOnline;
+                        if (lastOnline != null && DateTime.UtcNow - lastOnline > TimeSpan.FromDays(Options.Instance.Guild.DeleteStaleGuildsAfterDays))
                         {
                             context.Entry(guild).State = EntityState.Deleted;
                             LogActivity(guild.Id, null, null, GuildActivityType.Disbanded, "Stale");
                         }
-                        else if (context.Players.Where(p => p.DbGuild.Id == guild.Id).Count() == 1)
-                        {
-                            var lastOnline = context.Players.FirstOrDefault(p => p.DbGuild.Id == guild.Id).LastOnline;
-                            if (lastOnline != null && DateTime.UtcNow - lastOnline > TimeSpan.FromDays(Options.Instance.Guild.DeleteStaleGuildsAfterDays))
-                            {
-                                context.Entry(guild).State = EntityState.Deleted;
-                                LogActivity(guild.Id, null, null, GuildActivityType.Disbanded, "Stale");
-                            }
-                        }
                     }
-                    context.SaveChanges();
                 }
+                context.SaveChanges();
             }
         }
+    }
 
 
-        /// <summary>
-        /// Getter for the guild lock
-        /// </summary>
-        public object Lock => mLock;
+    /// <summary>
+    /// Getter for the guild lock
+    /// </summary>
+    public object Lock => mLock;
 
 
-        public static void DetachGuildFromDbContext(PlayerContext context, Guild guild)
+    public static void DetachGuildFromDbContext(PlayerContext context, Guild guild)
+    {
+        context.Entry(guild).State = EntityState.Detached;
+
+        foreach (var slot in guild.Bank)
         {
-            context.Entry(guild).State = EntityState.Detached;
-
-            foreach (var slot in guild.Bank)
-            {
-                context.Entry(slot).State = EntityState.Detached;
-            }
-
-            foreach (var variable in guild.Variables)
-            {
-                context.Entry(variable).State = EntityState.Detached;
-            }
+            context.Entry(slot).State = EntityState.Detached;
         }
 
-        /// <summary>
-        /// Send bank slot update to all players in this guild who are online and in the bank
-        /// </summary>
-        /// <param name="slot">Slot index to send the update for</param>
-        public void BankSlotUpdated(int slot)
+        foreach (var variable in guild.Variables)
         {
-            foreach (var player in FindOnlineMembers())
-            {
-                if (player.BankInterface != null && player.GuildBank)
-                {
-                    player.BankInterface.SendBankUpdate(slot, false);
-                }
-            }
+            context.Entry(variable).State = EntityState.Detached;
         }
+    }
 
-        /// <summary>
-        /// Updates the number of bank slots alotted to this guild for use, only expanding because we don't want to risk wiping items
-        /// </summary>
-        /// <param name="count"></param>
-        public void ExpandBankSlots(int count)
+    /// <summary>
+    /// Send bank slot update to all players in this guild who are online and in the bank
+    /// </summary>
+    /// <param name="slot">Slot index to send the update for</param>
+    public void BankSlotUpdated(int slot)
+    {
+        foreach (var player in FindOnlineMembers())
         {
-            if (BankSlotsCount < count && count <= Options.Instance.Bank.MaxSlots)
+            if (player.BankInterface != null && player.GuildBank)
             {
-                lock (mLock)
-                {
-                    BankSlotsCount = count;
-                    SlotHelper.ValidateSlots(Bank, BankSlotsCount);
-                    DbInterface.Pool.QueueWorkItem(Save);
-                }
+                player.BankInterface.SendBankUpdate(slot, false);
             }
         }
+    }
 
-        /// <summary>
-        /// Renames this guild and then saves the new name to the db
-        /// </summary>
-        /// <param name="name"></param>
-        /// <param name="initiator">The player who initiated this change (null if done by the api or some other method).</param>
-        public bool Rename(string name, Player initiator = null)
-        {
-            if (GuildExists(name) || !FieldChecking.IsValidGuildName(name, Strings.Regex.guildname))
-            {
-                return false;
-            }
-
-            Name = name;
-            foreach (var member in FindOnlineMembers())
-            {
-                PacketSender.SendEntityDataToProximity(member);
-            }
-            LogActivity(Id, initiator, null, GuildActivityType.Rename, name);
-            Save();
-
-            return true;
-        }
-
-
-        /// <summary>
-        /// Returns a variable object given a guild variable id
-        /// </summary>
-        /// <param name="id">Variable id</param>
-        /// <param name="createIfNull">Creates this variable for the guild if it hasn't been set yet</param>
-        /// <returns></returns>
-        public Variable GetVariable(Guid id, bool createIfNull = false)
-        {
-            foreach (var v in Variables)
-            {
-                if (v.VariableId == id)
-                {
-                    return v;
-                }
-            }
-
-            if (createIfNull)
-            {
-                return CreateVariable(id);
-            }
-
-            return null;
-        }
-
-        /// <summary>
-        /// Creates a variable for this guild with a given id if it doesn't already exist
-        /// </summary>
-        /// <param name="id">Variablke id</param>
-        /// <returns></returns>
-        private Variable CreateVariable(Guid id)
-        {
-            if (GuildVariableBase.Get(id) == null)
-            {
-                return null;
-            }
-
-            var variable = new GuildVariable(id);
-            Variables.Add(variable);
-
-            return variable;
-        }
-
-        /// <summary>
-        /// Gets the value of a guild variable given a variable id
-        /// </summary>
-        /// <param name="id">Variable id</param>
-        /// <returns></returns>
-        public GameObjects.Switches_and_Variables.VariableValue GetVariableValue(Guid id)
-        {
-            var v = GetVariable(id);
-            if (v == null)
-            {
-                v = CreateVariable(id);
-            }
-
-            if (v == null)
-            {
-                return new GameObjects.Switches_and_Variables.VariableValue();
-            }
-
-            return v.Value;
-        }
-
-
-        /// <summary>
-        /// Starts all common events with a specified trigger for all online guild members
-        /// </summary>
-        /// <param name="trigger">The common event trigger to run</param>
-        /// <param name="command">The command which started this common event</param>
-        /// <param name="param">Common event parameter</param>
-        public void StartCommonEventsWithTriggerForAll(CommonEventTrigger trigger, string command, string param)
-        {
-            foreach (var plyr in FindOnlineMembers())
-            {
-                plyr.StartCommonEventsWithTrigger(trigger, command, param);
-            }
-        }
-
-
-        /// <summary>
-        /// Updates the db with this guild state & bank slots
-        /// </summary>
-        public void Save()
+    /// <summary>
+    /// Updates the number of bank slots alotted to this guild for use, only expanding because we don't want to risk wiping items
+    /// </summary>
+    /// <param name="count"></param>
+    public void ExpandBankSlots(int count)
+    {
+        if (BankSlotsCount < count && count <= Options.Instance.Bank.MaxSlots)
         {
             lock (mLock)
             {
-                using (var context = DbInterface.CreatePlayerContext(readOnly: false))
-                {
-                    context.Update(this);
-                    context.ChangeTracker.DetectChanges();
-                    context.SaveChanges();
-                }
+                BankSlotsCount = count;
+                SlotHelper.ValidateSlots(Bank, BankSlotsCount);
+                DbInterface.Pool.QueueWorkItem(Save);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Renames this guild and then saves the new name to the db
+    /// </summary>
+    /// <param name="name"></param>
+    /// <param name="initiator">The player who initiated this change (null if done by the api or some other method).</param>
+    public bool Rename(string name, Player initiator = null)
+    {
+        if (GuildExists(name) || !FieldChecking.IsValidGuildName(name, Strings.Regex.guildname))
+        {
+            return false;
+        }
+
+        Name = name;
+        foreach (var member in FindOnlineMembers())
+        {
+            PacketSender.SendEntityDataToProximity(member);
+        }
+        LogActivity(Id, initiator, null, GuildActivityType.Rename, name);
+        Save();
+
+        return true;
+    }
+
+
+    /// <summary>
+    /// Returns a variable object given a guild variable id
+    /// </summary>
+    /// <param name="id">Variable id</param>
+    /// <param name="createIfNull">Creates this variable for the guild if it hasn't been set yet</param>
+    /// <returns></returns>
+    public Variable GetVariable(Guid id, bool createIfNull = false)
+    {
+        foreach (var v in Variables)
+        {
+            if (v.VariableId == id)
+            {
+                return v;
             }
         }
 
-        /// <summary>
-        /// Retrieves a list of guilds from the db as an IList
-        /// </summary>
-        public static IList<KeyValuePair<Guild, int>> List(string query, string sortBy, SortDirection sortDirection, int skip, int take, out int total)
+        if (createIfNull)
         {
-            try
+            return CreateVariable(id);
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Creates a variable for this guild with a given id if it doesn't already exist
+    /// </summary>
+    /// <param name="id">Variablke id</param>
+    /// <returns></returns>
+    private Variable CreateVariable(Guid id)
+    {
+        if (GuildVariableBase.Get(id) == null)
+        {
+            return null;
+        }
+
+        var variable = new GuildVariable(id);
+        Variables.Add(variable);
+
+        return variable;
+    }
+
+    /// <summary>
+    /// Gets the value of a guild variable given a variable id
+    /// </summary>
+    /// <param name="id">Variable id</param>
+    /// <returns></returns>
+    public GameObjects.Switches_and_Variables.VariableValue GetVariableValue(Guid id)
+    {
+        var v = GetVariable(id);
+        if (v == null)
+        {
+            v = CreateVariable(id);
+        }
+
+        if (v == null)
+        {
+            return new GameObjects.Switches_and_Variables.VariableValue();
+        }
+
+        return v.Value;
+    }
+
+
+    /// <summary>
+    /// Starts all common events with a specified trigger for all online guild members
+    /// </summary>
+    /// <param name="trigger">The common event trigger to run</param>
+    /// <param name="command">The command which started this common event</param>
+    /// <param name="param">Common event parameter</param>
+    public void StartCommonEventsWithTriggerForAll(CommonEventTrigger trigger, string command, string param)
+    {
+        foreach (var plyr in FindOnlineMembers())
+        {
+            plyr.StartCommonEventsWithTrigger(trigger, command, param);
+        }
+    }
+
+
+    /// <summary>
+    /// Updates the db with this guild state & bank slots
+    /// </summary>
+    public void Save()
+    {
+        lock (mLock)
+        {
+            using (var context = DbInterface.CreatePlayerContext(readOnly: false))
             {
-                using var context = DbInterface.CreatePlayerContext();
-                var compiledQuery = string.IsNullOrWhiteSpace(query) ? context.Guilds : context.Guilds.Where(p => EF.Functions.Like(p.Name, $"%{query}%"));
-
-                total = compiledQuery.Count();
-
-                switch (sortBy?.ToLower() ?? "")
-                {
-                    case "members":
-                        compiledQuery = sortDirection == SortDirection.Ascending ? compiledQuery.OrderBy(g => context.Players.Where(p => p.DbGuild.Id == g.Id).Count()) : compiledQuery.OrderByDescending(g => context.Players.Where(p => p.DbGuild.Id == g.Id).Count());
-                        break;
-                    case "foundingdate":
-                        compiledQuery = sortDirection == SortDirection.Ascending ? compiledQuery.OrderBy(u => u.FoundingDate) : compiledQuery.OrderByDescending(u => u.FoundingDate);
-                        break;
-                    case "name":
-                    default:
-                        compiledQuery = sortDirection == SortDirection.Ascending ? compiledQuery.OrderBy(u => u.Name.ToUpper()) : compiledQuery.OrderByDescending(u => u.Name.ToUpper());
-                        break;
-                }
-
-                return compiledQuery.Skip(skip).Take(take).Select(g => new KeyValuePair<Guild, int>(g, context.Players.Where(p => p.DbGuild.Id == g.Id).Count())).ToList();
+                context.Update(this);
+                context.ChangeTracker.DetectChanges();
+                context.SaveChanges();
             }
-            catch (Exception ex)
+        }
+    }
+
+    /// <summary>
+    /// Retrieves a list of guilds from the db as an IList
+    /// </summary>
+    public static IList<KeyValuePair<Guild, int>> List(string query, string sortBy, SortDirection sortDirection, int skip, int take, out int total)
+    {
+        try
+        {
+            using var context = DbInterface.CreatePlayerContext();
+            var compiledQuery = string.IsNullOrWhiteSpace(query) ? context.Guilds : context.Guilds.Where(p => EF.Functions.Like(p.Name, $"%{query}%"));
+
+            total = compiledQuery.Count();
+
+            switch (sortBy?.ToLower() ?? "")
             {
-                Log.Error(ex);
-                total = 0;
-                return null;
+                case "members":
+                    compiledQuery = sortDirection == SortDirection.Ascending ? compiledQuery.OrderBy(g => context.Players.Where(p => p.DbGuild.Id == g.Id).Count()) : compiledQuery.OrderByDescending(g => context.Players.Where(p => p.DbGuild.Id == g.Id).Count());
+                    break;
+                case "foundingdate":
+                    compiledQuery = sortDirection == SortDirection.Ascending ? compiledQuery.OrderBy(u => u.FoundingDate) : compiledQuery.OrderByDescending(u => u.FoundingDate);
+                    break;
+                case "name":
+                default:
+                    compiledQuery = sortDirection == SortDirection.Ascending ? compiledQuery.OrderBy(u => u.Name.ToUpper()) : compiledQuery.OrderByDescending(u => u.Name.ToUpper());
+                    break;
             }
+
+            return compiledQuery.Skip(skip).Take(take).Select(g => new KeyValuePair<Guild, int>(g, context.Players.Where(p => p.DbGuild.Id == g.Id).Count())).ToList();
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex);
+            total = 0;
+            return null;
         }
     }
 }

--- a/Intersect.Server.Core/Database/PlayerData/Players/GuildBankSlot.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Players/GuildBankSlot.cs
@@ -5,32 +5,30 @@ using Newtonsoft.Json;
 // ReSharper disable UnusedAutoPropertyAccessor.Local
 // ReSharper disable AutoPropertyCanBeMadeGetOnly.Local
 
-namespace Intersect.Server.Database.PlayerData.Players
+namespace Intersect.Server.Database.PlayerData.Players;
+
+
+public partial class GuildBankSlot : Item, ISlot
 {
 
-    public partial class GuildBankSlot : Item, ISlot
+    public GuildBankSlot()
     {
-
-        public GuildBankSlot()
-        {
-        }
-
-        public GuildBankSlot(int slot)
-        {
-            Slot = slot;
-        }
-
-        [DatabaseGenerated(DatabaseGeneratedOption.Identity), JsonIgnore]
-        public Guid Id { get; private set; }
-
-        [JsonIgnore]
-        public Guid GuildId { get; private set; }
-
-        [JsonIgnore]
-        public virtual Guild Guild { get; private set; }
-
-        public int Slot { get; private set; }
-
     }
+
+    public GuildBankSlot(int slot)
+    {
+        Slot = slot;
+    }
+
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity), JsonIgnore]
+    public Guid Id { get; private set; }
+
+    [JsonIgnore]
+    public Guid GuildId { get; private set; }
+
+    [JsonIgnore]
+    public virtual Guild Guild { get; private set; }
+
+    public int Slot { get; private set; }
 
 }

--- a/Intersect.Server.Core/Database/PlayerData/Players/GuildVariable.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Players/GuildVariable.cs
@@ -2,25 +2,24 @@
 using Newtonsoft.Json;
 using System.ComponentModel.DataAnnotations.Schema;
 
-namespace Intersect.Server.Database.PlayerData.Players
+namespace Intersect.Server.Database.PlayerData.Players;
+
+public partial class GuildVariable : Variable
 {
-    public partial class GuildVariable : Variable
+    public GuildVariable() : this(Guid.Empty) { }
+
+    public GuildVariable(Guid id)
     {
-        public GuildVariable() : this(Guid.Empty) { }
-
-        public GuildVariable(Guid id)
-        {
-            VariableId = id;
-        }
-
-        [NotMapped]
-        public string VariableName => GuildVariableBase.GetName(VariableId);
-
-        [DatabaseGenerated(DatabaseGeneratedOption.None)]
-        [JsonIgnore]
-        public Guid GuildId { get; protected set; }
-
-        [JsonIgnore]
-        public virtual Guild Guild { get; protected set; }
+        VariableId = id;
     }
+
+    [NotMapped]
+    public string VariableName => GuildVariableBase.GetName(VariableId);
+
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
+    [JsonIgnore]
+    public Guid GuildId { get; protected set; }
+
+    [JsonIgnore]
+    public virtual Guild Guild { get; protected set; }
 }

--- a/Intersect.Server.Core/Database/PlayerData/Players/HotbarSlot.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Players/HotbarSlot.cs
@@ -9,53 +9,51 @@ using Newtonsoft.Json;
 // ReSharper disable UnusedAutoPropertyAccessor.Local
 // ReSharper disable AutoPropertyCanBeMadeGetOnly.Local
 
-namespace Intersect.Server.Database.PlayerData.Players
+namespace Intersect.Server.Database.PlayerData.Players;
+
+
+public partial class HotbarSlot : ISlot, IPlayerOwned
 {
 
-    public partial class HotbarSlot : ISlot, IPlayerOwned
+    public HotbarSlot()
     {
+    }
 
-        public HotbarSlot()
-        {
-        }
+    public HotbarSlot(int slot)
+    {
+        Slot = slot;
+    }
 
-        public HotbarSlot(int slot)
-        {
-            Slot = slot;
-        }
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity), JsonIgnore]
+    public Guid Id { get; private set; }
 
-        [DatabaseGenerated(DatabaseGeneratedOption.Identity), JsonIgnore]
-        public Guid Id { get; private set; }
+    public Guid ItemOrSpellId { get; set; } = Guid.Empty;
 
-        public Guid ItemOrSpellId { get; set; } = Guid.Empty;
+    public Guid BagId { get; set; } = Guid.Empty;
 
-        public Guid BagId { get; set; } = Guid.Empty;
+    [Column("PreferredStatBuffs")]
+    [JsonIgnore]
+    public string StatBuffsJson
+    {
+        get => DatabaseUtils.SaveIntArray(PreferredStatBuffs, Enum.GetValues<Stat>().Length);
+        set => PreferredStatBuffs = DatabaseUtils.LoadIntArray(value, Enum.GetValues<Stat>().Length);
+    }
 
-        [Column("PreferredStatBuffs")]
-        [JsonIgnore]
-        public string StatBuffsJson
-        {
-            get => DatabaseUtils.SaveIntArray(PreferredStatBuffs, Enum.GetValues<Stat>().Length);
-            set => PreferredStatBuffs = DatabaseUtils.LoadIntArray(value, Enum.GetValues<Stat>().Length);
-        }
+    [NotMapped]
+    public int[] PreferredStatBuffs { get; set; } = new int[Enum.GetValues<Stat>().Length];
 
-        [NotMapped]
-        public int[] PreferredStatBuffs { get; set; } = new int[Enum.GetValues<Stat>().Length];
+    [JsonIgnore]
+    public Guid PlayerId { get; private set; }
 
-        [JsonIgnore]
-        public Guid PlayerId { get; private set; }
+    [JsonIgnore]
+    public virtual Player Player { get; private set; }
 
-        [JsonIgnore]
-        public virtual Player Player { get; private set; }
+    [JsonIgnore]
+    public int Slot { get; private set; }
 
-        [JsonIgnore]
-        public int Slot { get; private set; }
-
-        public string Data()
-        {
-            return JsonConvert.SerializeObject(this);
-        }
-
+    public string Data()
+    {
+        return JsonConvert.SerializeObject(this);
     }
 
 }

--- a/Intersect.Server.Core/Database/PlayerData/Players/IPlayerOwned.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Players/IPlayerOwned.cs
@@ -1,15 +1,13 @@
 ﻿using Intersect.Server.Entities;
 
-namespace Intersect.Server.Database.PlayerData.Players
+namespace Intersect.Server.Database.PlayerData.Players;
+
+
+public interface IPlayerOwned
 {
 
-    public interface IPlayerOwned
-    {
+    Player Player { get; }
 
-        Player Player { get; }
-
-        Guid PlayerId { get; }
-
-    }
+    Guid PlayerId { get; }
 
 }

--- a/Intersect.Server.Core/Database/PlayerData/Players/ISlot.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Players/ISlot.cs
@@ -1,11 +1,9 @@
-﻿namespace Intersect.Server.Database.PlayerData.Players
+﻿namespace Intersect.Server.Database.PlayerData.Players;
+
+
+public interface ISlot
 {
 
-    public interface ISlot
-    {
-
-        int Slot { get; }
-
-    }
+    int Slot { get; }
 
 }

--- a/Intersect.Server.Core/Database/PlayerData/Players/InventorySlot.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Players/InventorySlot.cs
@@ -7,32 +7,30 @@ using Newtonsoft.Json;
 // ReSharper disable UnusedAutoPropertyAccessor.Local
 // ReSharper disable AutoPropertyCanBeMadeGetOnly.Local
 
-namespace Intersect.Server.Database.PlayerData.Players
+namespace Intersect.Server.Database.PlayerData.Players;
+
+
+public partial class InventorySlot : Item, ISlot, IPlayerOwned
 {
 
-    public partial class InventorySlot : Item, ISlot, IPlayerOwned
+    public InventorySlot()
     {
-
-        public InventorySlot()
-        {
-        }
-
-        public InventorySlot(int slot)
-        {
-            Slot = slot;
-        }
-
-        [DatabaseGenerated(DatabaseGeneratedOption.Identity), JsonIgnore]
-        public Guid Id { get; private set; }
-
-        [JsonIgnore]
-        public Guid PlayerId { get; private set; }
-
-        [JsonIgnore]
-        public virtual Player Player { get; private set; }
-
-        public int Slot { get; private set; }
-
     }
+
+    public InventorySlot(int slot)
+    {
+        Slot = slot;
+    }
+
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity), JsonIgnore]
+    public Guid Id { get; private set; }
+
+    [JsonIgnore]
+    public Guid PlayerId { get; private set; }
+
+    [JsonIgnore]
+    public virtual Player Player { get; private set; }
+
+    public int Slot { get; private set; }
 
 }

--- a/Intersect.Server.Core/Database/PlayerData/Players/PlayerVariable.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Players/PlayerVariable.cs
@@ -4,29 +4,27 @@ using Intersect.Server.Entities;
 
 using Newtonsoft.Json;
 
-namespace Intersect.Server.Database.PlayerData.Players
+namespace Intersect.Server.Database.PlayerData.Players;
+
+
+public partial class PlayerVariable : Variable, IPlayerOwned
 {
 
-    public partial class PlayerVariable : Variable, IPlayerOwned
+    public PlayerVariable() : this(Guid.Empty) { }
+
+    public PlayerVariable(Guid id)
     {
-
-        public PlayerVariable() : this(Guid.Empty) { }
-
-        public PlayerVariable(Guid id)
-        {
-            VariableId = id;
-        }
-
-        [NotMapped]
-        public string VariableName => PlayerVariableBase.GetName(VariableId);
-
-        [DatabaseGenerated(DatabaseGeneratedOption.None)]
-        [JsonIgnore]
-        public Guid PlayerId { get; protected set; }
-
-        [JsonIgnore]
-        public virtual Player Player { get; protected set; }
-
+        VariableId = id;
     }
+
+    [NotMapped]
+    public string VariableName => PlayerVariableBase.GetName(VariableId);
+
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
+    [JsonIgnore]
+    public Guid PlayerId { get; protected set; }
+
+    [JsonIgnore]
+    public virtual Player Player { get; protected set; }
 
 }

--- a/Intersect.Server.Core/Database/PlayerData/Players/Quest.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Players/Quest.cs
@@ -7,44 +7,42 @@ using Newtonsoft.Json;
 // ReSharper disable UnusedAutoPropertyAccessor.Local
 // ReSharper disable AutoPropertyCanBeMadeGetOnly.Local
 
-namespace Intersect.Server.Database.PlayerData.Players
+namespace Intersect.Server.Database.PlayerData.Players;
+
+
+public partial class Quest : IPlayerOwned
 {
 
-    public partial class Quest : IPlayerOwned
+    public Quest()
     {
+    }
 
-        public Quest()
-        {
-        }
+    public Quest(Guid id)
+    {
+        QuestId = id;
+    }
 
-        public Quest(Guid id)
-        {
-            QuestId = id;
-        }
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity), JsonIgnore]
+    public Guid Id { get; private set; }
 
-        [DatabaseGenerated(DatabaseGeneratedOption.Identity), JsonIgnore]
-        public Guid Id { get; private set; }
+    [JsonIgnore]
+    public Guid QuestId { get; private set; }
 
-        [JsonIgnore]
-        public Guid QuestId { get; private set; }
+    public Guid TaskId { get; set; }
 
-        public Guid TaskId { get; set; }
+    public int TaskProgress { get; set; }
 
-        public int TaskProgress { get; set; }
+    public bool Completed { get; set; }
 
-        public bool Completed { get; set; }
+    [JsonIgnore]
+    public Guid PlayerId { get; private set; }
 
-        [JsonIgnore]
-        public Guid PlayerId { get; private set; }
+    [JsonIgnore]
+    public virtual Player Player { get; private set; }
 
-        [JsonIgnore]
-        public virtual Player Player { get; private set; }
-
-        public string Data()
-        {
-            return JsonConvert.SerializeObject(this);
-        }
-
+    public string Data()
+    {
+        return JsonConvert.SerializeObject(this);
     }
 
 }

--- a/Intersect.Server.Core/Database/PlayerData/Players/SlotHelper.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Players/SlotHelper.cs
@@ -1,97 +1,95 @@
-﻿namespace Intersect.Server.Database.PlayerData.Players
+﻿namespace Intersect.Server.Database.PlayerData.Players;
+
+
+public static partial class SlotHelper
 {
 
-    public static partial class SlotHelper
+    public static List<TSlot> Sort<TSlot>(List<TSlot> slots) where TSlot : ISlot
     {
+        slots.Sort(CompareSlotIndex);
 
-        public static List<TSlot> Sort<TSlot>(List<TSlot> slots) where TSlot : ISlot
+        return slots;
+    }
+
+    public static int CompareSlotIndex<TSlot>(TSlot a, TSlot b) where TSlot : ISlot
+    {
+        if (a == null || b == null)
         {
-            slots.Sort(CompareSlotIndex);
-
-            return slots;
+            return 0;
         }
 
-        public static int CompareSlotIndex<TSlot>(TSlot a, TSlot b) where TSlot : ISlot
-        {
-            if (a == null || b == null)
-            {
-                return 0;
-            }
+        return a.Slot - b.Slot;
+    }
 
-            return a.Slot - b.Slot;
+    public static TSlot ConstructSlot<TSlot>(int slotIndex) where TSlot : ISlot
+    {
+        var type = typeof(TSlot);
+        var constructor = type.GetConstructor(new[] {typeof(int)});
+
+        if (constructor == null)
+        {
+            throw new MissingMethodException($@"No constructor matching the signature {type.FullName}(int).");
         }
 
-        public static TSlot ConstructSlot<TSlot>(int slotIndex) where TSlot : ISlot
+        try
         {
-            var type = typeof(TSlot);
-            var constructor = type.GetConstructor(new[] {typeof(int)});
+            return (TSlot) constructor.Invoke(new object[] {slotIndex});
+        }
+        catch (Exception exception)
+        {
+            throw new Exception($@"Exception occurred creating slot with index {slotIndex}.", exception);
+        }
+    }
 
-            if (constructor == null)
-            {
-                throw new MissingMethodException($@"No constructor matching the signature {type.FullName}(int).");
-            }
-
-            try
-            {
-                return (TSlot) constructor.Invoke(new object[] {slotIndex});
-            }
-            catch (Exception exception)
-            {
-                throw new Exception($@"Exception occurred creating slot with index {slotIndex}.", exception);
-            }
+    public static bool ValidateSlots<TSlot>(
+        List<TSlot> slots,
+        int targetCount,
+        Func<int, TSlot> factory = null
+    ) where TSlot : ISlot
+    {
+        if (slots.Count >= targetCount)
+        {
+            return false;
         }
 
-        public static bool ValidateSlots<TSlot>(
-            List<TSlot> slots,
-            int targetCount,
-            Func<int, TSlot> factory = null
-        ) where TSlot : ISlot
+        Sort(slots);
+
+        for (var slotIndex = 0; slotIndex < targetCount; ++slotIndex)
         {
-            if (slots.Count >= targetCount)
+            if (ValidateSlot(slots, slotIndex))
             {
-                return false;
+                continue;
             }
 
-            Sort(slots);
+            slots.Add(factory == null ? ConstructSlot<TSlot>(slotIndex) : factory.Invoke(slotIndex));
+        }
 
-            for (var slotIndex = 0; slotIndex < targetCount; ++slotIndex)
-            {
-                if (ValidateSlot(slots, slotIndex))
-                {
-                    continue;
-                }
+        return true;
+    }
 
-                slots.Add(factory == null ? ConstructSlot<TSlot>(slotIndex) : factory.Invoke(slotIndex));
-            }
+    public static bool ValidateSlot<TSlot>(List<TSlot> slots, int slotIndex) where TSlot : ISlot
+    {
+        // If we are outside the bounds of the slot collection
+        // we don't expect to find anything, and realistically
+        // in the case that this return is hit this method
+        // never really needed to be called in the first place.
+        if (slots.Count <= slotIndex || slotIndex < 0)
+        {
+            return false;
+        }
 
+        // If somehow there is a null value in the slot, or if
+        // the index is mismatched there is a chance we may have
+        // detected data corruption and we absolutely want to
+        // blow up. This is the real reason this method exists.
+        if ((slots[slotIndex]?.Slot ?? -1) == slotIndex)
+        {
             return true;
         }
 
-        public static bool ValidateSlot<TSlot>(List<TSlot> slots, int slotIndex) where TSlot : ISlot
-        {
-            // If we are outside the bounds of the slot collection
-            // we don't expect to find anything, and realistically
-            // in the case that this return is hit this method
-            // never really needed to be called in the first place.
-            if (slots.Count <= slotIndex || slotIndex < 0)
-            {
-                return false;
-            }
-
-            // If somehow there is a null value in the slot, or if
-            // the index is mismatched there is a chance we may have
-            // detected data corruption and we absolutely want to
-            // blow up. This is the real reason this method exists.
-            if ((slots[slotIndex]?.Slot ?? -1) == slotIndex)
-            {
-                return true;
-            }
-
-            throw new InvalidOperationException(
-                $@"Slot {slotIndex} was was expected to be filled but is either empty or mismatched. Potential data corruption."
-            );
-        }
-
+        throw new InvalidOperationException(
+            $@"Slot {slotIndex} was was expected to be filled but is either empty or mismatched. Potential data corruption."
+        );
     }
 
 }

--- a/Intersect.Server.Core/Database/PlayerData/Players/SpellSlot.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Players/SpellSlot.cs
@@ -7,32 +7,30 @@ using Newtonsoft.Json;
 // ReSharper disable UnusedAutoPropertyAccessor.Local
 // ReSharper disable AutoPropertyCanBeMadeGetOnly.Local
 
-namespace Intersect.Server.Database.PlayerData.Players
+namespace Intersect.Server.Database.PlayerData.Players;
+
+
+public partial class SpellSlot : Spell, ISlot, IPlayerOwned
 {
 
-    public partial class SpellSlot : Spell, ISlot, IPlayerOwned
+    public SpellSlot()
     {
-
-        public SpellSlot()
-        {
-        }
-
-        public SpellSlot(int slot)
-        {
-            Slot = slot;
-        }
-
-        [DatabaseGenerated(DatabaseGeneratedOption.Identity), JsonIgnore]
-        public Guid Id { get; private set; }
-
-        [JsonIgnore]
-        public Guid PlayerId { get; private set; }
-
-        [JsonIgnore]
-        public virtual Player Player { get; private set; }
-
-        public int Slot { get; private set; }
-
     }
+
+    public SpellSlot(int slot)
+    {
+        Slot = slot;
+    }
+
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity), JsonIgnore]
+    public Guid Id { get; private set; }
+
+    [JsonIgnore]
+    public Guid PlayerId { get; private set; }
+
+    [JsonIgnore]
+    public virtual Player Player { get; private set; }
+
+    public int Slot { get; private set; }
 
 }

--- a/Intersect.Server.Core/Database/PlayerData/Players/Switch.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Players/Switch.cs
@@ -7,33 +7,31 @@ using Newtonsoft.Json;
 // ReSharper disable UnusedAutoPropertyAccessor.Local
 // ReSharper disable AutoPropertyCanBeMadeGetOnly.Local
 
-namespace Intersect.Server.Database.PlayerData.Players
+namespace Intersect.Server.Database.PlayerData.Players;
+
+
+public partial class Switch : IPlayerOwned
 {
 
-    public partial class Switch : IPlayerOwned
+    public Switch()
     {
-
-        public Switch()
-        {
-        }
-
-        public Switch(Guid id)
-        {
-            SwitchId = id;
-        }
-
-        [DatabaseGenerated(DatabaseGeneratedOption.None)]
-        public Guid Id { get; private set; } = Guid.NewGuid();
-
-        public Guid SwitchId { get; private set; }
-
-        public bool Value { get; set; }
-
-        public Guid PlayerId { get; private set; }
-
-        [JsonIgnore]
-        public virtual Player Player { get; private set; }
-
     }
+
+    public Switch(Guid id)
+    {
+        SwitchId = id;
+    }
+
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
+    public Guid Id { get; private set; } = Guid.NewGuid();
+
+    public Guid SwitchId { get; private set; }
+
+    public bool Value { get; set; }
+
+    public Guid PlayerId { get; private set; }
+
+    [JsonIgnore]
+    public virtual Player Player { get; private set; }
 
 }

--- a/Intersect.Server.Core/Database/PlayerData/Players/UserVariable.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Players/UserVariable.cs
@@ -2,25 +2,24 @@ using Intersect.GameObjects;
 using Newtonsoft.Json;
 using System.ComponentModel.DataAnnotations.Schema;
 
-namespace Intersect.Server.Database.PlayerData.Players
+namespace Intersect.Server.Database.PlayerData.Players;
+
+public partial class UserVariable : Variable
 {
-    public partial class UserVariable : Variable
+    public UserVariable() : this(Guid.Empty) { }
+
+    public UserVariable(Guid userVariableBaseId)
     {
-        public UserVariable() : this(Guid.Empty) { }
-
-        public UserVariable(Guid userVariableBaseId)
-        {
-            VariableId = userVariableBaseId;
-        }
-
-        [NotMapped]
-        public string VariableName => UserVariableBase.GetName(VariableId);
-
-        [DatabaseGenerated(DatabaseGeneratedOption.None)]
-        [JsonIgnore]
-        public Guid UserId { get; protected set; }
-
-        [JsonIgnore]
-        public virtual User User { get; protected set; }
+        VariableId = userVariableBaseId;
     }
+
+    [NotMapped]
+    public string VariableName => UserVariableBase.GetName(VariableId);
+
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
+    [JsonIgnore]
+    public Guid UserId { get; protected set; }
+
+    [JsonIgnore]
+    public virtual User User { get; protected set; }
 }

--- a/Intersect.Server.Core/Database/PlayerData/Players/Variable.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Players/Variable.cs
@@ -2,36 +2,35 @@
 using Newtonsoft.Json;
 using System.ComponentModel.DataAnnotations.Schema;
 
-namespace Intersect.Server.Database.PlayerData.Players
+namespace Intersect.Server.Database.PlayerData.Players;
+
+public partial class Variable
 {
-    public partial class Variable
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+    [JsonIgnore]
+    public Guid Id { get; set; }
+
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
+    public Guid VariableId { get; protected set; }
+
+    [NotMapped]
+    [JsonIgnore]
+    public VariableValue Value { get; set; } = new();
+
+    [NotMapped]
+    [JsonProperty("Value")]
+    public dynamic ValueData => Value.Value;
+
+    [Column(nameof(Value))]
+    [JsonIgnore]
+    public string Json
     {
-        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
-        [JsonIgnore]
-        public Guid Id { get; set; }
-
-        [DatabaseGenerated(DatabaseGeneratedOption.None)]
-        public Guid VariableId { get; protected set; }
-
-        [NotMapped]
-        [JsonIgnore]
-        public VariableValue Value { get; set; } = new();
-
-        [NotMapped]
-        [JsonProperty("Value")]
-        public dynamic ValueData => Value.Value;
-
-        [Column(nameof(Value))]
-        [JsonIgnore]
-        public string Json
+        get => Value.Json.ToString(Formatting.None);
+        private set
         {
-            get => Value.Json.ToString(Formatting.None);
-            private set
+            if (VariableValue.TryParse(value, out var json))
             {
-                if (VariableValue.TryParse(value, out var json))
-                {
-                    Value.Json = json;
-                }
+                Value.Json = json;
             }
         }
     }

--- a/Intersect.Server.Core/Database/PlayerData/Security/UserRights.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Security/UserRights.cs
@@ -5,172 +5,171 @@ using Intersect.Enums;
 
 using Newtonsoft.Json;
 
-namespace Intersect.Server.Database.PlayerData.Security
+namespace Intersect.Server.Database.PlayerData.Security;
+
+public sealed partial class UserRights : IComparable<UserRights>, IEquatable<UserRights>
 {
-    public sealed partial class UserRights : IComparable<UserRights>, IEquatable<UserRights>
+    private static readonly Type ApiRolesType = typeof(ApiRoles);
+
+    private static readonly List<PropertyInfo> ApiRolesPermissions = ApiRolesType
+        .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+        .Where(propertyInfo => propertyInfo.CanWrite)
+        .Where(propertyInfo => propertyInfo.PropertyType == typeof(bool))
+        .ToList();
+
+    private static readonly Type UserRightsType = typeof(UserRights);
+
+    private static readonly List<PropertyInfo> UserRightsPermissions = UserRightsType
+        .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+        .Where(propertyInfo => propertyInfo.CanWrite)
+        .Where(propertyInfo => propertyInfo.PropertyType == typeof(bool))
+        .ToList();
+
+    private readonly int mHashCode = new Random().Next();
+
+    public bool Editor { get; set; }
+
+    public bool Ban { get; set; }
+
+    public bool Kick { get; set; }
+
+    public bool Mute { get; set; }
+
+    public bool Api { get; set; }
+
+    public ApiRoles ApiRoles { get; set; } = new ApiRoles();
+
+    [JsonIgnore]
+    public bool IsModerator => Ban || Mute || Kick;
+
+    [JsonIgnore]
+    public bool IsAdmin => Ban && Mute && Kick && Editor;
+
+    public static UserRights None => new UserRights();
+
+    public static UserRights Moderation => new UserRights
     {
-        private static readonly Type ApiRolesType = typeof(ApiRoles);
+        Ban = true,
+        Kick = true,
+        Mute = true
+    };
 
-        private static readonly List<PropertyInfo> ApiRolesPermissions = ApiRolesType
-            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
-            .Where(propertyInfo => propertyInfo.CanWrite)
-            .Where(propertyInfo => propertyInfo.PropertyType == typeof(bool))
-            .ToList();
+    public static UserRights Admin => new UserRights
+    {
+        Editor = true,
+        Ban = true,
+        Kick = true,
+        Mute = true
+    };
 
-        private static readonly Type UserRightsType = typeof(UserRights);
+    [JsonIgnore]
+    public ImmutableList<string> Roles => EnumeratePermissions();
 
-        private static readonly List<PropertyInfo> UserRightsPermissions = UserRightsType
-            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
-            .Where(propertyInfo => propertyInfo.CanWrite)
-            .Where(propertyInfo => propertyInfo.PropertyType == typeof(bool))
-            .ToList();
-
-        private readonly int mHashCode = new Random().Next();
-
-        public bool Editor { get; set; }
-
-        public bool Ban { get; set; }
-
-        public bool Kick { get; set; }
-
-        public bool Mute { get; set; }
-
-        public bool Api { get; set; }
-
-        public ApiRoles ApiRoles { get; set; } = new ApiRoles();
-
-        [JsonIgnore]
-        public bool IsModerator => Ban || Mute || Kick;
-
-        [JsonIgnore]
-        public bool IsAdmin => Ban && Mute && Kick && Editor;
-
-        public static UserRights None => new UserRights();
-
-        public static UserRights Moderation => new UserRights
+    public static bool operator ==(UserRights b1, UserRights b2)
+    {
+        if (b1 is null || b2 is null)
         {
-            Ban = true,
-            Kick = true,
-            Mute = true
-        };
-
-        public static UserRights Admin => new UserRights
-        {
-            Editor = true,
-            Ban = true,
-            Kick = true,
-            Mute = true
-        };
-
-        [JsonIgnore]
-        public ImmutableList<string> Roles => EnumeratePermissions();
-
-        public static bool operator ==(UserRights b1, UserRights b2)
-        {
-            if (b1 is null || b2 is null)
-            {
-                return b1 is null && b2 is null;
-            }
-
-            return b1.Equals(b2);
+            return b1 is null && b2 is null;
         }
 
-        public static bool operator !=(UserRights b1, UserRights b2)
-        {
-            return !(b1 == b2);
-        }
-
-        protected int ComputePowerScore()
-        {
-            var score = 0;
-            score |= Convert.ToInt32(Editor) << 0;
-            score |= Convert.ToInt32(Mute) << 1;
-            score |= Convert.ToInt32(Kick) << 2;
-            score |= Convert.ToInt32(Ban) << 3;
-
-            return score;
-        }
-
-        public int CompareTo(UserRights other)
-        {
-            if (other == default)
-            {
-                return 1;
-            }
-
-            return ComputePowerScore() - other.ComputePowerScore();
-        }
-
-        public override bool Equals(object obj)
-        {
-            return obj is UserRights userRights && Equals(userRights);
-        }
-
-        public bool Equals(UserRights other)
-        {
-            var permissions = EnumeratePermissions();
-            var otherPermissions = other.EnumeratePermissions();
-
-            if (permissions.Count != otherPermissions.Count)
-            {
-                return false;
-            }
-
-            return permissions.IsEmpty || otherPermissions.All(permission => permissions.Contains(permission));
-        }
-
-        public override int GetHashCode()
-        {
-            return mHashCode;
-        }
-
-        internal ImmutableList<string> EnumeratePermissions(bool permitted = true)
-        {
-            var userRights = UserRightsPermissions
-                                 .Where(property => permitted == (bool) (property?.GetValue(this, null) ?? false))
-                                 .Select(property => property?.Name)
-                                 .ToList() ??
-                             throw new InvalidOperationException();
-
-            var apiRoles = ApiRolesPermissions
-                               .Where(
-                                   property => permitted == (bool) (property?.GetValue(this.ApiRoles, null) ?? false)
-                               )
-                               .Select(property => property?.Name)
-                               .ToList() ??
-                           throw new InvalidOperationException();
-
-            userRights.AddRange(apiRoles);
-
-            return userRights.ToImmutableList();
-        }
+        return b1.Equals(b2);
     }
 
-    public static partial class AccessExtensions
+    public static bool operator !=(UserRights b1, UserRights b2)
     {
-        public static UserRights AsUserRights(this Access access)
+        return !(b1 == b2);
+    }
+
+    protected int ComputePowerScore()
+    {
+        var score = 0;
+        score |= Convert.ToInt32(Editor) << 0;
+        score |= Convert.ToInt32(Mute) << 1;
+        score |= Convert.ToInt32(Kick) << 2;
+        score |= Convert.ToInt32(Ban) << 3;
+
+        return score;
+    }
+
+    public int CompareTo(UserRights other)
+    {
+        if (other == default)
         {
-            switch (access)
-            {
-                case Access.Admin:
-                    return UserRights.Admin;
+            return 1;
+        }
 
-                case Access.Moderator:
-                    return UserRights.Moderation;
+        return ComputePowerScore() - other.ComputePowerScore();
+    }
 
-                case Access.None:
-                    return UserRights.None;
+    public override bool Equals(object obj)
+    {
+        return obj is UserRights userRights && Equals(userRights);
+    }
 
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(access), access, null);
-            }
+    public bool Equals(UserRights other)
+    {
+        var permissions = EnumeratePermissions();
+        var otherPermissions = other.EnumeratePermissions();
+
+        if (permissions.Count != otherPermissions.Count)
+        {
+            return false;
+        }
+
+        return permissions.IsEmpty || otherPermissions.All(permission => permissions.Contains(permission));
+    }
+
+    public override int GetHashCode()
+    {
+        return mHashCode;
+    }
+
+    internal ImmutableList<string> EnumeratePermissions(bool permitted = true)
+    {
+        var userRights = UserRightsPermissions
+                             .Where(property => permitted == (bool) (property?.GetValue(this, null) ?? false))
+                             .Select(property => property?.Name)
+                             .ToList() ??
+                         throw new InvalidOperationException();
+
+        var apiRoles = ApiRolesPermissions
+                           .Where(
+                               property => permitted == (bool) (property?.GetValue(this.ApiRoles, null) ?? false)
+                           )
+                           .Select(property => property?.Name)
+                           .ToList() ??
+                       throw new InvalidOperationException();
+
+        userRights.AddRange(apiRoles);
+
+        return userRights.ToImmutableList();
+    }
+}
+
+public static partial class AccessExtensions
+{
+    public static UserRights AsUserRights(this Access access)
+    {
+        switch (access)
+        {
+            case Access.Admin:
+                return UserRights.Admin;
+
+            case Access.Moderator:
+                return UserRights.Moderation;
+
+            case Access.None:
+                return UserRights.None;
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(access), access, null);
         }
     }
+}
 
-    public partial class ApiRoles
-    {
-        public bool UserQuery { get; set; }
+public partial class ApiRoles
+{
+    public bool UserQuery { get; set; }
 
-        public bool UserManage { get; set; }
-    }
+    public bool UserManage { get; set; }
 }

--- a/Intersect.Server.Core/Database/PlayerData/SeedData/SeedUsers.cs
+++ b/Intersect.Server.Core/Database/PlayerData/SeedData/SeedUsers.cs
@@ -7,155 +7,153 @@ using Intersect.Server.Entities;
 
 using Microsoft.EntityFrameworkCore;
 
-namespace Intersect.Server.Database.PlayerData.SeedData
+namespace Intersect.Server.Database.PlayerData.SeedData;
+
+
+public partial class SeedUsers : SeedData<User>
 {
 
-    public partial class SeedUsers : SeedData<User>
+    private static string GenerateSalt(RandomNumberGenerator rng)
     {
+        var buffer = new byte[32];
+        rng.GetBytes(buffer);
 
-        private static string GenerateSalt(RandomNumberGenerator rng)
-        {
-            var buffer = new byte[32];
-            rng.GetBytes(buffer);
-
-            return BitConverter.ToString(buffer).Replace("-", "");
-        }
-
-        private static string HashPassword(string salt, string password)
-        {
-            using (var algorithm = new SHA256Managed())
-            {
-                var hash = algorithm.ComputeHash(Encoding.UTF8.GetBytes(password));
-                var salted = $@"{BitConverter.ToString(hash).Replace("-", "")}{salt}";
-                var saltedHash = algorithm.ComputeHash(Encoding.UTF8.GetBytes(salted));
-
-                return BitConverter.ToString(saltedHash).Replace("-", "");
-            }
-        }
-
-        public override void Seed(DbSet<User> dbSet)
-        {
-            var emptyBytes = new byte[] { 0, 0, 0, 0, 0, 0, 0, 1 };
-            using (var rng = new RNGCryptoServiceProvider())
-            {
-                for (var n = 0; n < 300; ++n)
-                {
-                    var salt = GenerateSalt(rng);
-
-                    var userRights = UserRights.None;
-                    if (n < 10)
-                    {
-                        userRights = new UserRights
-                        {
-                            Editor = true,
-                            Ban = true,
-                            Kick = true,
-                            Mute = true,
-                            Api = true,
-                            ApiRoles = new ApiRoles
-                            {
-                                UserManage = true,
-                                UserQuery = true
-                            }
-                        };
-                    }
-                    else if (n < 20)
-                    {
-                        userRights = new UserRights
-                        {
-                            Editor = true,
-                            Ban = true,
-                            Kick = true,
-                            Mute = true,
-                            Api = true,
-                            ApiRoles = new ApiRoles
-                            {
-                                UserManage = true,
-                                UserQuery = true
-                            }
-                        };
-                    }
-                    else if (n < 100)
-                    {
-                        userRights = UserRights.Admin;
-                    }
-                    else if (n < 200)
-                    {
-                        userRights = UserRights.Moderation;
-                    }
-
-                    var id = new Guid(n, 0, 0, emptyBytes);
-                    var user = new User
-                    {
-                        Name = n == 0 ? "test" : $@"test{n:D3}",
-                        Email = $@"test{n:D3}@test.test",
-                        Salt = salt,
-                        Password = HashPassword(salt, "test"),
-                        Power = userRights
-                    };
-
-                    typeof(User).GetProperty("Id")?.SetValue(user, id);
-
-                    dbSet.Add(user);
-
-                    var player = new Player
-                    {
-                        Id = new Guid(n, 0, 0, emptyBytes),
-                        Name = n == 0 ? "test" : $@"test{n:D3}",
-                        ClassId = Guid.Empty,
-                        Gender = n % 2 == 0 ? Gender.Male : Gender.Female,
-                        Level = 1,
-                        Exp = 0,
-                        StatPoints = 0,
-
-                        Sprite = "1.png",
-                        Face = null
-                    };
-
-                    for (var i = 0; i < Options.EquipmentSlots.Count; i++)
-                    {
-                        player.Equipment[i] = -1;
-                    }
-
-                    player.SetVital(Vital.Health, 10);
-                    player.SetVital(Vital.Mana, 10);
-
-                    for (var i = 0; i < Enum.GetValues<Stat>().Length; i++)
-                    {
-                        player.Stat[i].BaseStat = 0;
-                    }
-
-                    user.Players?.Add(player);
-                    player.ValidateLists();
-                }
-            }
-        }
-
+        return BitConverter.ToString(buffer).Replace("-", "");
     }
 
-    public static partial class RandomNumberGeneratorExtensions
+    private static string HashPassword(string salt, string password)
     {
-
-        public static int NextInt(
-            this RandomNumberGenerator rng,
-            int min = int.MinValue,
-            int max = int.MaxValue
-        )
+        using (var algorithm = new SHA256Managed())
         {
-            var buffer = new byte[4];
-            rng.GetBytes(buffer);
+            var hash = algorithm.ComputeHash(Encoding.UTF8.GetBytes(password));
+            var salted = $@"{BitConverter.ToString(hash).Replace("-", "")}{salt}";
+            var saltedHash = algorithm.ComputeHash(Encoding.UTF8.GetBytes(salted));
 
-            return Math.Max(Math.Min(BitConverter.ToInt32(buffer, 0), max), min);
+            return BitConverter.ToString(saltedHash).Replace("-", "");
         }
+    }
 
-        public static uint NextUInt(this RandomNumberGenerator rng)
+    public override void Seed(DbSet<User> dbSet)
+    {
+        var emptyBytes = new byte[] { 0, 0, 0, 0, 0, 0, 0, 1 };
+        using (var rng = new RNGCryptoServiceProvider())
         {
-            var buffer = new byte[4];
-            rng.GetBytes(buffer);
+            for (var n = 0; n < 300; ++n)
+            {
+                var salt = GenerateSalt(rng);
 
-            return BitConverter.ToUInt32(buffer, 0);
+                var userRights = UserRights.None;
+                if (n < 10)
+                {
+                    userRights = new UserRights
+                    {
+                        Editor = true,
+                        Ban = true,
+                        Kick = true,
+                        Mute = true,
+                        Api = true,
+                        ApiRoles = new ApiRoles
+                        {
+                            UserManage = true,
+                            UserQuery = true
+                        }
+                    };
+                }
+                else if (n < 20)
+                {
+                    userRights = new UserRights
+                    {
+                        Editor = true,
+                        Ban = true,
+                        Kick = true,
+                        Mute = true,
+                        Api = true,
+                        ApiRoles = new ApiRoles
+                        {
+                            UserManage = true,
+                            UserQuery = true
+                        }
+                    };
+                }
+                else if (n < 100)
+                {
+                    userRights = UserRights.Admin;
+                }
+                else if (n < 200)
+                {
+                    userRights = UserRights.Moderation;
+                }
+
+                var id = new Guid(n, 0, 0, emptyBytes);
+                var user = new User
+                {
+                    Name = n == 0 ? "test" : $@"test{n:D3}",
+                    Email = $@"test{n:D3}@test.test",
+                    Salt = salt,
+                    Password = HashPassword(salt, "test"),
+                    Power = userRights
+                };
+
+                typeof(User).GetProperty("Id")?.SetValue(user, id);
+
+                dbSet.Add(user);
+
+                var player = new Player
+                {
+                    Id = new Guid(n, 0, 0, emptyBytes),
+                    Name = n == 0 ? "test" : $@"test{n:D3}",
+                    ClassId = Guid.Empty,
+                    Gender = n % 2 == 0 ? Gender.Male : Gender.Female,
+                    Level = 1,
+                    Exp = 0,
+                    StatPoints = 0,
+
+                    Sprite = "1.png",
+                    Face = null
+                };
+
+                for (var i = 0; i < Options.EquipmentSlots.Count; i++)
+                {
+                    player.Equipment[i] = -1;
+                }
+
+                player.SetVital(Vital.Health, 10);
+                player.SetVital(Vital.Mana, 10);
+
+                for (var i = 0; i < Enum.GetValues<Stat>().Length; i++)
+                {
+                    player.Stat[i].BaseStat = 0;
+                }
+
+                user.Players?.Add(player);
+                player.ValidateLists();
+            }
         }
+    }
 
+}
+
+public static partial class RandomNumberGeneratorExtensions
+{
+
+    public static int NextInt(
+        this RandomNumberGenerator rng,
+        int min = int.MinValue,
+        int max = int.MaxValue
+    )
+    {
+        var buffer = new byte[4];
+        rng.GetBytes(buffer);
+
+        return Math.Max(Math.Min(BitConverter.ToInt32(buffer, 0), max), min);
+    }
+
+    public static uint NextUInt(this RandomNumberGenerator rng)
+    {
+        var buffer = new byte[4];
+        rng.GetBytes(buffer);
+
+        return BitConverter.ToUInt32(buffer, 0);
     }
 
 }

--- a/Intersect.Server.Core/Database/PlayerData/User.cs
+++ b/Intersect.Server.Core/Database/PlayerData/User.cs
@@ -26,1091 +26,1089 @@ using VariableValue = Intersect.GameObjects.Switches_and_Variables.VariableValue
 
 // ReSharper disable UnusedAutoPropertyAccessor.Local
 
-namespace Intersect.Server.Database.PlayerData
+namespace Intersect.Server.Database.PlayerData;
+
+
+[ApiVisibility(ApiVisibility.Restricted | ApiVisibility.Private)]
+public partial class User
 {
+    private long _lastSave;
+    private readonly object _lastSaveLock = new();
 
-    [ApiVisibility(ApiVisibility.Restricted | ApiVisibility.Private)]
-    public partial class User
+    private static readonly ConcurrentDictionary<Guid, User> OnlineUsers = new();
+
+    [JsonIgnore][NotMapped] private readonly object mSavingLock = new();
+
+    /// <summary>
+    ///     Variables that have been updated for this account which need to be saved to the db
+    /// </summary>
+    [JsonIgnore]
+    public ConcurrentDictionary<Guid, UserVariableBase> UpdatedVariables = new();
+
+    public static int OnlineCount => OnlineUsers.Count;
+
+    public static List<User> OnlineList => OnlineUsers.Values.ToList();
+
+    [Column(Order = 0)]
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
+    // ReSharper disable once AutoPropertyCanBeMadeGetOnly.Local
+    public Guid Id { get; private set; } = Guid.NewGuid();
+
+    [Column(Order = 1)] public string Name { get; set; }
+
+    [JsonIgnore] public string Salt { get; set; }
+
+    [JsonIgnore] public string Password { get; set; }
+
+    [Column(Order = 2)] public string Email { get; set; }
+
+    [Column("Power")]
+    [JsonIgnore]
+    public string PowerJson
     {
-        private long _lastSave;
-        private readonly object _lastSaveLock = new();
+        get => JsonConvert.SerializeObject(Power);
+        set => Power = JsonConvert.DeserializeObject<UserRights>(value);
+    }
 
-        private static readonly ConcurrentDictionary<Guid, User> OnlineUsers = new();
+    [NotMapped] public UserRights Power { get; set; }
 
-        [JsonIgnore][NotMapped] private readonly object mSavingLock = new();
+    [JsonIgnore] public virtual List<Player> Players { get; set; } = new();
 
-        /// <summary>
-        ///     Variables that have been updated for this account which need to be saved to the db
-        /// </summary>
-        [JsonIgnore]
-        public ConcurrentDictionary<Guid, UserVariableBase> UpdatedVariables = new();
+    [JsonIgnore] public virtual List<RefreshToken> RefreshTokens { get; set; } = new();
 
-        public static int OnlineCount => OnlineUsers.Count;
+    public string PasswordResetCode { get; set; }
 
-        public static List<User> OnlineList => OnlineUsers.Values.ToList();
+    [JsonIgnore] public DateTime? PasswordResetTime { get; set; }
 
-        [Column(Order = 0)]
-        [DatabaseGenerated(DatabaseGeneratedOption.None)]
-        // ReSharper disable once AutoPropertyCanBeMadeGetOnly.Local
-        public Guid Id { get; private set; } = Guid.NewGuid();
+    public DateTime? RegistrationDate { get; set; } = DateTime.UtcNow;
 
-        [Column(Order = 1)] public string Name { get; set; }
+    private ulong mLoadedPlaytime { get; set; }
 
-        [JsonIgnore] public string Salt { get; set; }
+    public ulong PlayTimeSeconds
+    {
+        get =>
+            mLoadedPlaytime +
+            (ulong)(LoginTime != null ? DateTime.UtcNow - (DateTime)LoginTime : TimeSpan.Zero).TotalSeconds;
 
-        [JsonIgnore] public string Password { get; set; }
+        set => mLoadedPlaytime = value;
+    }
 
-        [Column(Order = 2)] public string Email { get; set; }
+    /// <summary>
+    ///     User Variable Values
+    /// </summary>
+    [JsonIgnore]
+    public virtual List<UserVariable> Variables { get; set; } = new();
 
-        [Column("Power")]
-        [JsonIgnore]
-        public string PowerJson
+    [NotMapped] public DateTime? LoginTime { get; set; }
+
+    public string LastIp { get; set; }
+
+    public static User FindOnline(Guid id) => OnlineUsers.ContainsKey(id) ? OnlineUsers[id] : null;
+
+    public static User FindOnline(string username) =>
+        OnlineUsers.Values.FirstOrDefault(s => s.Name.ToLower().Trim() == username.ToLower().Trim());
+
+    public static User FindOnlineFromEmail(string email) =>
+        OnlineUsers.Values.FirstOrDefault(s => s.Email.ToLower().Trim() == email.ToLower().Trim());
+
+    public static void Login(User user, string ip)
+    {
+        if (!OnlineUsers.ContainsKey(user.Id))
         {
-            get => JsonConvert.SerializeObject(Power);
-            set => Power = JsonConvert.DeserializeObject<UserRights>(value);
+            OnlineUsers.TryAdd(user.Id, user);
         }
 
-        [NotMapped] public UserRights Power { get; set; }
+        user.LastIp = ip;
+    }
 
-        [JsonIgnore] public virtual List<Player> Players { get; set; } = new();
-
-        [JsonIgnore] public virtual List<RefreshToken> RefreshTokens { get; set; } = new();
-
-        public string PasswordResetCode { get; set; }
-
-        [JsonIgnore] public DateTime? PasswordResetTime { get; set; }
-
-        public DateTime? RegistrationDate { get; set; } = DateTime.UtcNow;
-
-        private ulong mLoadedPlaytime { get; set; }
-
-        public ulong PlayTimeSeconds
+    public void TryLogout(bool softLogout = false)
+    {
+        //If we still have a character online (probably being held up in combat) then don't logout yet.
+        foreach (var chr in Players)
         {
-            get =>
-                mLoadedPlaytime +
-                (ulong)(LoginTime != null ? DateTime.UtcNow - (DateTime)LoginTime : TimeSpan.Zero).TotalSeconds;
-
-            set => mLoadedPlaytime = value;
-        }
-
-        /// <summary>
-        ///     User Variable Values
-        /// </summary>
-        [JsonIgnore]
-        public virtual List<UserVariable> Variables { get; set; } = new();
-
-        [NotMapped] public DateTime? LoginTime { get; set; }
-
-        public string LastIp { get; set; }
-
-        public static User FindOnline(Guid id) => OnlineUsers.ContainsKey(id) ? OnlineUsers[id] : null;
-
-        public static User FindOnline(string username) =>
-            OnlineUsers.Values.FirstOrDefault(s => s.Name.ToLower().Trim() == username.ToLower().Trim());
-
-        public static User FindOnlineFromEmail(string email) =>
-            OnlineUsers.Values.FirstOrDefault(s => s.Email.ToLower().Trim() == email.ToLower().Trim());
-
-        public static void Login(User user, string ip)
-        {
-            if (!OnlineUsers.ContainsKey(user.Id))
-            {
-                OnlineUsers.TryAdd(user.Id, user);
-            }
-
-            user.LastIp = ip;
-        }
-
-        public void TryLogout(bool softLogout = false)
-        {
-            //If we still have a character online (probably being held up in combat) then don't logout yet.
-            foreach (var chr in Players)
-            {
-                if (Player.FindOnline(chr.Id) != null)
-                {
-                    return;
-                }
-            }
-
-            if (!softLogout && OnlineUsers.ContainsKey(Id))
-            {
-                OnlineUsers.TryRemove(Id, out var removed);
-            }
-        }
-
-        public static string GenerateSalt(ushort sizeInBits = 256)
-        {
-            return Convert.ToHexString(RandomNumberGenerator.GetBytes(sizeInBits >> 3));
-        }
-
-        public static string SaltPasswordHash(string passwordHash, string salt)
-        {
-            return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(passwordHash.ToUpperInvariant() + salt)));
-        }
-
-        public bool IsPasswordValid(string passwordHash)
-        {
-            if (string.IsNullOrWhiteSpace(passwordHash) || string.IsNullOrWhiteSpace(Salt))
-            {
-                return false;
-            }
-
-            var saltedPasswordHash = SaltPasswordHash(passwordHash, Salt);
-
-            return string.Equals(Password, saltedPasswordHash, StringComparison.Ordinal);
-        }
-
-        public bool TryChangePassword(string oldPassword, string newPassword) =>
-            IsPasswordValid(oldPassword) && TrySetPassword(newPassword);
-
-        public bool TrySetPassword(string passwordHash)
-        {
-            var salt = GenerateSalt();
-            SaltPasswordHash(passwordHash, salt);
-
-            Salt = salt;
-            Password = SaltPasswordHash(passwordHash, salt);
-
-            if (Save() != UserSaveResult.DatabaseFailure)
-            {
-                return true;
-            }
-
-            var client = Globals.ClientLookup.Values.FirstOrDefault(c => c.User.Id == Id);
-            client?.LogAndDisconnect(default, nameof(TrySetPassword));
-            return false;
-        }
-
-        public bool TryAddCharacter(Player? newCharacter)
-        {
-            if (newCharacter == default)
-            {
-                return false;
-            }
-
-            //No passing in custom contexts here.. they may already have this user in the change tracker and things just get weird.
-            //The cost of making a new context is almost nil.
-            try
-            {
-                lock (mSavingLock)
-                {
-                    using var context = DbInterface.CreatePlayerContext(false);
-                    context.Users.Update(this);
-
-                    Players.Add(newCharacter);
-
-                    Player.Validate(newCharacter);
-
-                    context.ChangeTracker.DetectChanges();
-
-                    context.StopTrackingUsersExcept(this);
-
-                    //If we have a new character, intersect already generated the id.. which means the change tracker is gonna see them as modified and not added.. we need to manually set their state
-                    context.Entry(newCharacter).State = EntityState.Added;
-
-                    return context.SaveChanges() > -1;
-                }
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, $"Failed to save user while adding character: {Name}");
-                ServerContext.DispatchUnhandledException(
-                    new Exception("Failed to save user, shutting down to prevent rollbacks!")
-                );
-                return false;
-            }
-        }
-
-        public bool TryDeleteCharacter(Player deleteCharacter)
-        {
-            //No passing in custom contexts here.. they may already have this user in the change tracker and things just get weird.
-            //The cost of making a new context is almost nil.
-            try
-            {
-                lock (mSavingLock)
-                {
-                    using var context = DbInterface.CreatePlayerContext(false);
-
-                    context.Users.Update(this);
-
-                    Players.Remove(deleteCharacter);
-
-                    context.ChangeTracker.DetectChanges();
-
-                    context.StopTrackingUsersExcept(this);
-
-                    context.Entry(deleteCharacter).State = EntityState.Deleted;
-
-                    return context.SaveChanges() > -1;
-                }
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, "Failed to save user while deleting character: " + Name);
-                return false;
-            }
-        }
-
-        public bool TryDelete()
-        {
-            //No passing in custom contexts here.. they may already have this user in the change tracker and things just get weird.
-            //The cost of making a new context is almost nil.
-            try
-            {
-                lock (mSavingLock)
-                {
-                    using var context = DbInterface.CreatePlayerContext(false);
-
-                    context.Users.Remove(this);
-
-                    context.ChangeTracker.DetectChanges();
-
-                    context.StopTrackingUsersExcept(this);
-
-                    context.Entry(this).State = EntityState.Deleted;
-
-                    return context.SaveChanges() > -1;
-                }
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, "Failed to delete user: " + Name);
-                return false;
-            }
-        }
-
-        public async Task<UserSaveResult> SaveAsync(
-            bool force = false,
-            PlayerContext? playerContext = default,
-            CancellationToken cancellationToken = default
-        ) => Save(playerContext, force);
-
-        public void SaveWithDebounce(long debounceMs = 5000)
-        {
-            lock (_lastSaveLock)
-            {
-                if (_lastSave < debounceMs + Timing.Global.MillisecondsUtc)
-                {
-                    Log.Debug("Skipping save due to debounce");
-                    return;
-                }
-            }
-
-            if (Save() != UserSaveResult.DatabaseFailure)
+            if (Player.FindOnline(chr.Id) != null)
             {
                 return;
             }
-
-            var client = Globals.ClientLookup.Values.FirstOrDefault(c => c.User.Id == Id);
-            client?.LogAndDisconnect(default, nameof(SaveWithDebounce));
         }
 
-        public UserSaveResult Save(bool force) => Save(force: force, create: false);
-
-        public UserSaveResult Save(bool force = false, bool create = false) => Save(default, force, create);
-
-#if DIAGNOSTIC
-        private int _saveCounter = 0;
-#endif
-
-        private UserSaveResult Save(PlayerContext? playerContext, bool force = false, bool create = false)
+        if (!softLogout && OnlineUsers.ContainsKey(Id))
         {
-            lock (_lastSaveLock)
-            {
-                _lastSave = Timing.Global.MillisecondsUtc;
-            }
-
-#if DIAGNOSTIC
-            var currentExecutionId = _saveCounter++;
-#endif
-
-            //No passing in custom contexts here.. they may already have this user in the change tracker and things just get weird.
-            //The cost of making a new context is almost nil.
-            var lockTaken = false;
-            PlayerContext? createdContext = default;
-            try
-            {
-                if (force)
-                {
-                    Monitor.Enter(mSavingLock);
-                    lockTaken = true;
-                }
-                else
-                {
-                    Monitor.TryEnter(mSavingLock, 0, ref lockTaken);
-                }
-
-                if (!lockTaken)
-                {
-#if DIAGNOSTIC
-                    Log.Debug($"Failed to take lock {Environment.StackTrace}");
-#endif
-                    return UserSaveResult.SkippedCouldNotTakeLock;
-                }
-
-#if DIAGNOSTIC
-                Log.Debug($"DBOP-A Save({playerContext}, {force}, {create}) #{currentExecutionId} {Name} ({Id})");
-#endif
-
-                if (playerContext == null)
-                {
-                    createdContext = DbInterface.CreatePlayerContext(false);
-                    playerContext = createdContext;
-                }
-
-                if (create)
-                {
-                    playerContext.Users.Add(this);
-                }
-                else
-                {
-                    // playerContext.Attach(this);
-                    try
-                    {
-                        playerContext.Users.Update(this);
-                    }
-                    catch (InvalidOperationException invalidOperationException)
-                    {
-                        // ReSharper disable once ConstantConditionalAccessQualifier
-                        // ReSharper disable once ConstantNullCoalescingCondition
-                        if (invalidOperationException.Message?.Contains("Collection was modified") ?? false)
-                        {
-                            try
-                            {
-                                playerContext.Users.Update(this);
-                                Log.Warn(invalidOperationException, $"Successfully recovered from {nameof(InvalidOperationException)}");
-                            }
-                            catch (Exception exception)
-                            {
-                                throw new AggregateException(
-                                    $"Failed to recover from {nameof(InvalidOperationException)}",
-                                    invalidOperationException,
-                                    exception
-                                );
-                            }
-                        }
-                        else
-                        {
-                            throw;
-                        }
-                    }
-                }
-
-                playerContext.ChangeTracker.DetectChanges();
-
-                playerContext.StopTrackingUsersExcept(this);
-
-                if (UserBan != null)
-                {
-                    playerContext.Entry(UserBan).State = EntityState.Detached;
-                }
-
-                if (UserMute != null)
-                {
-                    playerContext.Entry(UserMute).State = EntityState.Detached;
-                }
-
-                if (playerContext.SaveChanges() > -1)
-                {
-                    return UserSaveResult.Completed;
-                }
-
-#if DIAGNOSTIC
-                Log.Debug($"DBOP-B Save({playerContext}, {force}, {create}) #{currentExecutionId} {Name} ({Id})");
-#endif
-
-                var client = Globals.ClientLookup.Values.FirstOrDefault(c => c.User.Id == Id);
-                client?.LogAndDisconnect(default, "User.Save");
-
-                return UserSaveResult.DatabaseFailure;
-            }
-            catch (DbUpdateConcurrencyException ex)
-            {
-                var concurrencyErrors = new StringBuilder();
-                foreach (var entry in ex.Entries)
-                {
-                    var type = entry.GetType().FullName;
-                    concurrencyErrors.AppendLine($"Entry Type [{type} / {entry.State}]");
-                    concurrencyErrors.AppendLine("--------------------");
-                    concurrencyErrors.AppendLine($"Type: {entry.Entity.GetFullishName()}");
-
-                    var proposedValues = entry.CurrentValues;
-                    var databaseValues = entry.GetDatabaseValues();
-
-                    var propertyNameColumnSize = proposedValues.Properties.Max(property => property.Name.Length);
-
-                    foreach (var property in proposedValues.Properties)
-                    {
-                        concurrencyErrors.AppendLine(
-                            $"\t{property.Name:propertyNameColumnSize} (Token: {property.IsConcurrencyToken}): Proposed: {proposedValues[property]}  Original Value: {entry.OriginalValues[property]}  Database Value: {(databaseValues != null ? databaseValues[property] : "null")}"
-                        );
-                    }
-
-                    concurrencyErrors.AppendLine("");
-                    concurrencyErrors.AppendLine("");
-                }
-
-                var suffix = string.Empty;
-#if DIAGNOSTIC
-                suffix = $"#{currentExecutionId}";
-#endif
-                Log.Error(ex, $"Jackpot! Concurrency Bug For {Name} in {(createdContext == default ? "Existing" : "Created")} Context {suffix}");
-                Log.Error(concurrencyErrors.ToString());
-
-#if DIAGNOSTIC
-                Log.Debug($"DBOP-C Save({playerContext}, {force}, {create}) #{currentExecutionId} {Name} ({Id})");
-#endif
-
-                var client = Globals.ClientLookup.Values.FirstOrDefault(c => c.User.Id == Id);
-                client?.LogAndDisconnect(default, "User.Save");
-
-                if (Options.Instance.PlayerDatabase.KillServerOnConcurrencyException)
-                {
-                    ServerContext.DispatchUnhandledException(
-                        new Exception("Failed to save user, shutting down to prevent rollbacks!")
-                    );
-                }
-
-                return UserSaveResult.DatabaseFailure;
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, "Failed to save user: " + Name);
-
-#if DIAGNOSTIC
-                Log.Debug($"DBOP-C Save({playerContext}, {force}, {create}) #{currentExecutionId} {Name} ({Id})");
-#endif
-
-                var client = Globals.ClientLookup.Values.FirstOrDefault(c => c.User.Id == Id);
-                client?.LogAndDisconnect(default, "User.Save");
-
-                if (Options.Instance.PlayerDatabase.KillServerOnConcurrencyException)
-                {
-                    ServerContext.DispatchUnhandledException(
-                        new Exception("Failed to save user, shutting down to prevent rollbacks!")
-                    );
-                }
-
-                return UserSaveResult.DatabaseFailure;
-            }
-            finally
-            {
-                if (lockTaken)
-                {
-                    createdContext?.Dispose();
-                    Monitor.Exit(mSavingLock);
-                }
-            }
+            OnlineUsers.TryRemove(Id, out var removed);
         }
+    }
 
-        [return: NotNullIfNotNull(nameof(user))]
-        public static User? PostLoad(User? user, PlayerContext? playerContext = default)
+    public static string GenerateSalt(ushort sizeInBits = 256)
+    {
+        return Convert.ToHexString(RandomNumberGenerator.GetBytes(sizeInBits >> 3));
+    }
+
+    public static string SaltPasswordHash(string passwordHash, string salt)
+    {
+        return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(passwordHash.ToUpperInvariant() + salt)));
+    }
+
+    public bool IsPasswordValid(string passwordHash)
+    {
+        if (string.IsNullOrWhiteSpace(passwordHash) || string.IsNullOrWhiteSpace(Salt))
         {
-            if (user == default)
-            {
-                return user;
-            }
-
-            if (playerContext == default)
-            {
-                using var context = DbInterface.CreatePlayerContext();
-                if (context == default)
-                {
-                    throw new InvalidOperationException();
-                }
-
-                // ReSharper disable once TailRecursiveCall
-                return PostLoad(user, context);
-            }
-
-            var entityEntry = playerContext.Users.Attach(user);
-            entityEntry.Collection(u => u.Variables).Load();
-
-            return user;
-        }
-
-        public static Tuple<Client, User> Fetch(Guid userId)
-        {
-            var client = Globals.Clients.Find(queryClient => userId == queryClient?.User?.Id);
-
-            return new Tuple<Client, User>(client, client?.User ?? FindById(userId));
-        }
-
-        public static Tuple<Client, User> Fetch(string userName)
-        {
-            var client = Globals.Clients.Find(queryClient => Entity.CompareName(userName, queryClient?.User?.Name));
-
-            return new Tuple<Client, User>(client, client?.User ?? Find(userName));
-        }
-
-        public static User TryLogin(string username, string ptPassword)
-        {
-            var user = FindOnline(username);
-            if (user != null)
-            {
-                var hashedPassword = SaltPasswordHash(ptPassword, user.Salt);
-                if (string.Equals(user.Password, hashedPassword, StringComparison.Ordinal))
-                {
-                    return PostLoad(user);
-                }
-            }
-            else
-            {
-                try
-                {
-                    using var context = DbInterface.CreatePlayerContext();
-                    var salt = GetUserSalt(username);
-                    if (!string.IsNullOrWhiteSpace(salt))
-                    {
-                        var pass = SaltPasswordHash(ptPassword, salt);
-                        var queriedUser = QueryUserByNameAndPasswordShallow(context, username, pass);
-                        return PostLoad(queriedUser, context);
-                    }
-                }
-                catch (Exception exception)
-                {
-                    Log.Error(exception);
-                }
-            }
-
-            return null;
-        }
-
-        public static User FindById(Guid userId)
-        {
-            using var playerContext = DbInterface.CreatePlayerContext();
-            return FindById(userId, playerContext);
-        }
-
-        public static User FindById(Guid userId, PlayerContext playerContext)
-        {
-            if (userId == Guid.Empty)
-            {
-                return null;
-            }
-
-            var user = FindOnline(userId);
-
-            if (user != null)
-            {
-                return user;
-            }
-
-            try
-            {
-                using var context = DbInterface.CreatePlayerContext();
-                return QueryUserByIdShallow(playerContext, userId);
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex);
-                return null;
-            }
-        }
-
-        public static User Find(string username)
-        {
-            if (string.IsNullOrWhiteSpace(username))
-            {
-                return null;
-            }
-
-            var user = FindOnline(username);
-
-            if (user != null)
-            {
-                return user;
-            }
-
-            try
-            {
-                using var context = DbInterface.CreatePlayerContext();
-                var queriedUser = QueryUserByNameShallow(context, username);
-                return queriedUser;
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex);
-                return null;
-            }
-        }
-
-        public static User FindFromNameOrEmail(string nameOrEmail)
-        {
-            using var playerContext = DbInterface.CreatePlayerContext();
-            return FindByNameOrEmail(nameOrEmail, playerContext);
-        }
-
-        public static User FindByNameOrEmail(string nameOrEmail, PlayerContext playerContext)
-        {
-            if (string.IsNullOrWhiteSpace(nameOrEmail))
-            {
-                return null;
-            }
-
-            var user = FindOnlineFromEmail(nameOrEmail);
-            if (user != null)
-            {
-                return user;
-            }
-
-            user = FindOnline(nameOrEmail);
-            if (user != null)
-            {
-                return user;
-            }
-
-            try
-            {
-                var queriedUser = QueryUserByNameOrEmailShallow(playerContext, nameOrEmail);
-                return queriedUser;
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex);
-                return null;
-            }
-        }
-
-        public static User FindByEmail(string email)
-        {
-            using var context = DbInterface.CreatePlayerContext();
-            return FindByEmail(email);
-        }
-
-        public static User FindByEmail(string email, PlayerContext playerContext)
-        {
-            if (string.IsNullOrWhiteSpace(email))
-            {
-                return null;
-            }
-
-            var user = FindOnlineFromEmail(email);
-
-            if (user != null)
-            {
-                return user;
-            }
-
-            try
-            {
-                return QueryUserByEmailShallow(playerContext, email);
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex);
-                return null;
-            }
-        }
-
-        public static string GetUserSalt(string userName)
-        {
-            if (string.IsNullOrWhiteSpace(userName))
-            {
-                return null;
-            }
-
-            var user = FindOnline(userName);
-            if (user != null)
-            {
-                return user.Salt;
-            }
-
-            try
-            {
-                using (var context = DbInterface.CreatePlayerContext())
-                {
-                    return SaltByName(context, userName);
-                }
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex);
-                return null;
-            }
-        }
-
-        public static bool UserExists(string nameOrEmail)
-        {
-            if (string.IsNullOrWhiteSpace(nameOrEmail))
-            {
-                return false;
-            }
-
-            var user = FindOnlineFromEmail(nameOrEmail);
-            if (user != null)
-            {
-                return true;
-            }
-
-            user = FindOnline(nameOrEmail);
-            if (user != null)
-            {
-                return true;
-            }
-
-            try
-            {
-                using (var context = DbInterface.CreatePlayerContext())
-                {
-                    return AnyUserByNameOrEmail(context, nameOrEmail);
-                }
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex);
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// </summary>
-        public void Update()
-        {
-            // ReSharper disable once InvertIf
-            if (UpdatedVariables.Count > 0)
-            {
-                if (Save() == UserSaveResult.DatabaseFailure)
-                {
-                    var client = Globals.ClientLookup.Values.FirstOrDefault(c => c.User.Id == Id);
-                    client?.LogAndDisconnect(default, "User.Save");
-                }
-
-                UpdatedVariables.Clear();
-            }
-        }
-
-        /// <summary>
-        ///     Returns a variable object given a user variable id
-        /// </summary>
-        /// <param name="id">Variable id</param>
-        /// <param name="createIfNull">Creates this variable for the user if it hasn't been set yet</param>
-        /// <returns></returns>
-        public Variable GetVariable(Guid id, bool createIfNull = false)
-        {
-            foreach (var v in Variables)
-            {
-                if (v.VariableId == id)
-                {
-                    return v;
-                }
-            }
-
-            if (createIfNull)
-            {
-                return CreateVariable(id);
-            }
-
-            return null;
-        }
-
-        /// <summary>
-        ///     Creates a variable for this user with a given id if it doesn't already exist
-        /// </summary>
-        /// <param name="id">Variablke id</param>
-        /// <returns></returns>
-        private Variable CreateVariable(Guid id)
-        {
-            if (UserVariableBase.Get(id) == null)
-            {
-                return null;
-            }
-
-            var variable = new UserVariable(id);
-            Variables.Add(variable);
-
-            return variable;
-        }
-
-        /// <summary>
-        ///     Gets the value of a account variable given a variable id
-        /// </summary>
-        /// <param name="id">Variable id</param>
-        /// <returns></returns>
-        public VariableValue GetVariableValue(Guid id)
-        {
-            var v = GetVariable(id, true);
-
-            if (v == null)
-            {
-                return new VariableValue();
-            }
-
-            return v.Value;
-        }
-
-        /// <summary>
-        ///     Starts all common events with a specified trigger for any character online of this account
-        /// </summary>
-        /// <param name="trigger">The common event trigger to run</param>
-        /// <param name="command">The command which started this common event</param>
-        /// <param name="param">Common event parameter</param>
-        public void StartCommonEventsWithTriggerForAll(CommonEventTrigger trigger, string command, string param)
-        {
-            foreach (var plyr in Players)
-            {
-                if (Player.FindOnline(plyr.Id) != null)
-                {
-                    plyr.StartCommonEventsWithTrigger(trigger, command, param);
-                }
-            }
-        }
-
-        public static bool TryRegister(
-            RegistrationActor actor,
-            string username,
-            string email,
-            string password,
-            [NotNullWhen(false)] out string error,
-            [NotNullWhen(true)] out User user
-        )
-        {
-            error = default;
-            user = default;
-
-            if (Options.BlockClientRegistrations)
-            {
-                error = Strings.Account.registrationsblocked;
-                return false;
-            }
-
-            if (!FieldChecking.IsValidUsername(username, Strings.Regex.username))
-            {
-                error = Strings.Account.invalidname;
-                return false;
-            }
-
-            if (!FieldChecking.IsWellformedEmailAddress(email, Strings.Regex.email))
-            {
-                error = Strings.Account.invalidemail;
-                return false;
-            }
-
-            if (Ban.IsBanned(actor.IpAddress, out var message))
-            {
-                error = message;
-                return false;
-            }
-
-            if (UserExists(username))
-            {
-                error = Strings.Account.exists;
-                return false;
-            }
-
-            if (UserExists(email))
-            {
-                error = Strings.Account.emailexists;
-                return false;
-            }
-
-            UserActivityHistory.LogActivity(
-                Guid.Empty,
-                Guid.Empty,
-                actor.IpAddress.ToString(),
-                actor.PeerType,
-                UserActivityHistory.UserAction.Create,
-                string.Empty
-            );
-
-            if (DbInterface.TryRegister(username, email, password, out user))
-            {
-                return true;
-            }
-
-            error = Strings.Account.UnknownError;
             return false;
         }
 
-        public sealed record RegistrationActor(IPAddress IpAddress, UserActivityHistory.PeerType PeerType);
+        var saltedPasswordHash = SaltPasswordHash(passwordHash, Salt);
 
-        #region Instance Variables
+        return string.Equals(Password, saltedPasswordHash, StringComparison.Ordinal);
+    }
 
-        [NotMapped]
-        [ApiVisibility(ApiVisibility.Restricted | ApiVisibility.Private)]
-        public bool IsBanned => Ban != null;
+    public bool TryChangePassword(string oldPassword, string newPassword) =>
+        IsPasswordValid(oldPassword) && TrySetPassword(newPassword);
 
-        [NotMapped]
-        [ApiVisibility(ApiVisibility.Restricted | ApiVisibility.Private)]
-        public bool IsMuted => Mute != null;
+    public bool TrySetPassword(string passwordHash)
+    {
+        var salt = GenerateSalt();
+        SaltPasswordHash(passwordHash, salt);
 
-        [ApiVisibility(ApiVisibility.Restricted)]
-        public Ban Ban
+        Salt = salt;
+        Password = SaltPasswordHash(passwordHash, salt);
+
+        if (Save() != UserSaveResult.DatabaseFailure)
         {
-            get => UserBan ?? IpBan;
-            set => UserBan = value;
+            return true;
         }
 
-        [ApiVisibility(ApiVisibility.Restricted)]
-        public Mute Mute
+        var client = Globals.ClientLookup.Values.FirstOrDefault(c => c.User.Id == Id);
+        client?.LogAndDisconnect(default, nameof(TrySetPassword));
+        return false;
+    }
+
+    public bool TryAddCharacter(Player? newCharacter)
+    {
+        if (newCharacter == default)
         {
-            get => UserMute ?? IpMute;
-            set => UserMute = value;
+            return false;
         }
 
-        [NotMapped] public Ban IpBan { get; set; }
-
-        [NotMapped] public Mute IpMute { get; set; }
-
-        [ApiVisibility(ApiVisibility.Restricted)]
-        [NotMapped]
-        public Ban UserBan { get; set; }
-
-        [ApiVisibility(ApiVisibility.Restricted)]
-        [NotMapped]
-        public Mute UserMute { get; set; }
-
-        #endregion
-
-        #region Listing
-
-        public static int Count()
+        //No passing in custom contexts here.. they may already have this user in the change tracker and things just get weird.
+        //The cost of making a new context is almost nil.
+        try
         {
-            using (var context = DbInterface.CreatePlayerContext())
+            lock (mSavingLock)
             {
-                return context.Users.Count();
+                using var context = DbInterface.CreatePlayerContext(false);
+                context.Users.Update(this);
+
+                Players.Add(newCharacter);
+
+                Player.Validate(newCharacter);
+
+                context.ChangeTracker.DetectChanges();
+
+                context.StopTrackingUsersExcept(this);
+
+                //If we have a new character, intersect already generated the id.. which means the change tracker is gonna see them as modified and not added.. we need to manually set their state
+                context.Entry(newCharacter).State = EntityState.Added;
+
+                return context.SaveChanges() > -1;
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, $"Failed to save user while adding character: {Name}");
+            ServerContext.DispatchUnhandledException(
+                new Exception("Failed to save user, shutting down to prevent rollbacks!")
+            );
+            return false;
+        }
+    }
+
+    public bool TryDeleteCharacter(Player deleteCharacter)
+    {
+        //No passing in custom contexts here.. they may already have this user in the change tracker and things just get weird.
+        //The cost of making a new context is almost nil.
+        try
+        {
+            lock (mSavingLock)
+            {
+                using var context = DbInterface.CreatePlayerContext(false);
+
+                context.Users.Update(this);
+
+                Players.Remove(deleteCharacter);
+
+                context.ChangeTracker.DetectChanges();
+
+                context.StopTrackingUsersExcept(this);
+
+                context.Entry(deleteCharacter).State = EntityState.Deleted;
+
+                return context.SaveChanges() > -1;
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Failed to save user while deleting character: " + Name);
+            return false;
+        }
+    }
+
+    public bool TryDelete()
+    {
+        //No passing in custom contexts here.. they may already have this user in the change tracker and things just get weird.
+        //The cost of making a new context is almost nil.
+        try
+        {
+            lock (mSavingLock)
+            {
+                using var context = DbInterface.CreatePlayerContext(false);
+
+                context.Users.Remove(this);
+
+                context.ChangeTracker.DetectChanges();
+
+                context.StopTrackingUsersExcept(this);
+
+                context.Entry(this).State = EntityState.Deleted;
+
+                return context.SaveChanges() > -1;
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Failed to delete user: " + Name);
+            return false;
+        }
+    }
+
+    public async Task<UserSaveResult> SaveAsync(
+        bool force = false,
+        PlayerContext? playerContext = default,
+        CancellationToken cancellationToken = default
+    ) => Save(playerContext, force);
+
+    public void SaveWithDebounce(long debounceMs = 5000)
+    {
+        lock (_lastSaveLock)
+        {
+            if (_lastSave < debounceMs + Timing.Global.MillisecondsUtc)
+            {
+                Log.Debug("Skipping save due to debounce");
+                return;
             }
         }
 
-        public static IList<User> List(
-            string query,
-            string sortBy,
-            SortDirection sortDirection,
-            int skip,
-            int take,
-            out int total
-        )
+        if (Save() != UserSaveResult.DatabaseFailure)
+        {
+            return;
+        }
+
+        var client = Globals.ClientLookup.Values.FirstOrDefault(c => c.User.Id == Id);
+        client?.LogAndDisconnect(default, nameof(SaveWithDebounce));
+    }
+
+    public UserSaveResult Save(bool force) => Save(force: force, create: false);
+
+    public UserSaveResult Save(bool force = false, bool create = false) => Save(default, force, create);
+
+#if DIAGNOSTIC
+    private int _saveCounter = 0;
+#endif
+
+    private UserSaveResult Save(PlayerContext? playerContext, bool force = false, bool create = false)
+    {
+        lock (_lastSaveLock)
+        {
+            _lastSave = Timing.Global.MillisecondsUtc;
+        }
+
+#if DIAGNOSTIC
+        var currentExecutionId = _saveCounter++;
+#endif
+
+        //No passing in custom contexts here.. they may already have this user in the change tracker and things just get weird.
+        //The cost of making a new context is almost nil.
+        var lockTaken = false;
+        PlayerContext? createdContext = default;
+        try
+        {
+            if (force)
+            {
+                Monitor.Enter(mSavingLock);
+                lockTaken = true;
+            }
+            else
+            {
+                Monitor.TryEnter(mSavingLock, 0, ref lockTaken);
+            }
+
+            if (!lockTaken)
+            {
+#if DIAGNOSTIC
+                Log.Debug($"Failed to take lock {Environment.StackTrace}");
+#endif
+                return UserSaveResult.SkippedCouldNotTakeLock;
+            }
+
+#if DIAGNOSTIC
+            Log.Debug($"DBOP-A Save({playerContext}, {force}, {create}) #{currentExecutionId} {Name} ({Id})");
+#endif
+
+            if (playerContext == null)
+            {
+                createdContext = DbInterface.CreatePlayerContext(false);
+                playerContext = createdContext;
+            }
+
+            if (create)
+            {
+                playerContext.Users.Add(this);
+            }
+            else
+            {
+                // playerContext.Attach(this);
+                try
+                {
+                    playerContext.Users.Update(this);
+                }
+                catch (InvalidOperationException invalidOperationException)
+                {
+                    // ReSharper disable once ConstantConditionalAccessQualifier
+                    // ReSharper disable once ConstantNullCoalescingCondition
+                    if (invalidOperationException.Message?.Contains("Collection was modified") ?? false)
+                    {
+                        try
+                        {
+                            playerContext.Users.Update(this);
+                            Log.Warn(invalidOperationException, $"Successfully recovered from {nameof(InvalidOperationException)}");
+                        }
+                        catch (Exception exception)
+                        {
+                            throw new AggregateException(
+                                $"Failed to recover from {nameof(InvalidOperationException)}",
+                                invalidOperationException,
+                                exception
+                            );
+                        }
+                    }
+                    else
+                    {
+                        throw;
+                    }
+                }
+            }
+
+            playerContext.ChangeTracker.DetectChanges();
+
+            playerContext.StopTrackingUsersExcept(this);
+
+            if (UserBan != null)
+            {
+                playerContext.Entry(UserBan).State = EntityState.Detached;
+            }
+
+            if (UserMute != null)
+            {
+                playerContext.Entry(UserMute).State = EntityState.Detached;
+            }
+
+            if (playerContext.SaveChanges() > -1)
+            {
+                return UserSaveResult.Completed;
+            }
+
+#if DIAGNOSTIC
+            Log.Debug($"DBOP-B Save({playerContext}, {force}, {create}) #{currentExecutionId} {Name} ({Id})");
+#endif
+
+            var client = Globals.ClientLookup.Values.FirstOrDefault(c => c.User.Id == Id);
+            client?.LogAndDisconnect(default, "User.Save");
+
+            return UserSaveResult.DatabaseFailure;
+        }
+        catch (DbUpdateConcurrencyException ex)
+        {
+            var concurrencyErrors = new StringBuilder();
+            foreach (var entry in ex.Entries)
+            {
+                var type = entry.GetType().FullName;
+                concurrencyErrors.AppendLine($"Entry Type [{type} / {entry.State}]");
+                concurrencyErrors.AppendLine("--------------------");
+                concurrencyErrors.AppendLine($"Type: {entry.Entity.GetFullishName()}");
+
+                var proposedValues = entry.CurrentValues;
+                var databaseValues = entry.GetDatabaseValues();
+
+                var propertyNameColumnSize = proposedValues.Properties.Max(property => property.Name.Length);
+
+                foreach (var property in proposedValues.Properties)
+                {
+                    concurrencyErrors.AppendLine(
+                        $"\t{property.Name:propertyNameColumnSize} (Token: {property.IsConcurrencyToken}): Proposed: {proposedValues[property]}  Original Value: {entry.OriginalValues[property]}  Database Value: {(databaseValues != null ? databaseValues[property] : "null")}"
+                    );
+                }
+
+                concurrencyErrors.AppendLine("");
+                concurrencyErrors.AppendLine("");
+            }
+
+            var suffix = string.Empty;
+#if DIAGNOSTIC
+            suffix = $"#{currentExecutionId}";
+#endif
+            Log.Error(ex, $"Jackpot! Concurrency Bug For {Name} in {(createdContext == default ? "Existing" : "Created")} Context {suffix}");
+            Log.Error(concurrencyErrors.ToString());
+
+#if DIAGNOSTIC
+            Log.Debug($"DBOP-C Save({playerContext}, {force}, {create}) #{currentExecutionId} {Name} ({Id})");
+#endif
+
+            var client = Globals.ClientLookup.Values.FirstOrDefault(c => c.User.Id == Id);
+            client?.LogAndDisconnect(default, "User.Save");
+
+            if (Options.Instance.PlayerDatabase.KillServerOnConcurrencyException)
+            {
+                ServerContext.DispatchUnhandledException(
+                    new Exception("Failed to save user, shutting down to prevent rollbacks!")
+                );
+            }
+
+            return UserSaveResult.DatabaseFailure;
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Failed to save user: " + Name);
+
+#if DIAGNOSTIC
+            Log.Debug($"DBOP-C Save({playerContext}, {force}, {create}) #{currentExecutionId} {Name} ({Id})");
+#endif
+
+            var client = Globals.ClientLookup.Values.FirstOrDefault(c => c.User.Id == Id);
+            client?.LogAndDisconnect(default, "User.Save");
+
+            if (Options.Instance.PlayerDatabase.KillServerOnConcurrencyException)
+            {
+                ServerContext.DispatchUnhandledException(
+                    new Exception("Failed to save user, shutting down to prevent rollbacks!")
+                );
+            }
+
+            return UserSaveResult.DatabaseFailure;
+        }
+        finally
+        {
+            if (lockTaken)
+            {
+                createdContext?.Dispose();
+                Monitor.Exit(mSavingLock);
+            }
+        }
+    }
+
+    [return: NotNullIfNotNull(nameof(user))]
+    public static User? PostLoad(User? user, PlayerContext? playerContext = default)
+    {
+        if (user == default)
+        {
+            return user;
+        }
+
+        if (playerContext == default)
+        {
+            using var context = DbInterface.CreatePlayerContext();
+            if (context == default)
+            {
+                throw new InvalidOperationException();
+            }
+
+            // ReSharper disable once TailRecursiveCall
+            return PostLoad(user, context);
+        }
+
+        var entityEntry = playerContext.Users.Attach(user);
+        entityEntry.Collection(u => u.Variables).Load();
+
+        return user;
+    }
+
+    public static Tuple<Client, User> Fetch(Guid userId)
+    {
+        var client = Globals.Clients.Find(queryClient => userId == queryClient?.User?.Id);
+
+        return new Tuple<Client, User>(client, client?.User ?? FindById(userId));
+    }
+
+    public static Tuple<Client, User> Fetch(string userName)
+    {
+        var client = Globals.Clients.Find(queryClient => Entity.CompareName(userName, queryClient?.User?.Name));
+
+        return new Tuple<Client, User>(client, client?.User ?? Find(userName));
+    }
+
+    public static User TryLogin(string username, string ptPassword)
+    {
+        var user = FindOnline(username);
+        if (user != null)
+        {
+            var hashedPassword = SaltPasswordHash(ptPassword, user.Salt);
+            if (string.Equals(user.Password, hashedPassword, StringComparison.Ordinal))
+            {
+                return PostLoad(user);
+            }
+        }
+        else
         {
             try
             {
-                using (var context = DbInterface.CreatePlayerContext())
+                using var context = DbInterface.CreatePlayerContext();
+                var salt = GetUserSalt(username);
+                if (!string.IsNullOrWhiteSpace(salt))
                 {
-                    foreach (var user in Globals.OnlineList.Select(p => p.User))
-                    {
-                        if (user != default)
-                        {
-                            context.Entry(user).State = EntityState.Unchanged;
-                        }
-                    }
-
-                    var compiledQuery = string.IsNullOrWhiteSpace(query)
-                        ? context.Users.Include(p => p.Ban).Include(p => p.Mute) : context.Users.Where(
-                            u => EF.Functions.Like(u.Name, $"%{query}%") || EF.Functions.Like(u.Email, $"%{query}%")
-                        );
-
-                    total = compiledQuery.Count();
-
-                    switch (sortBy?.ToLower() ?? "")
-                    {
-                        case "email":
-                            compiledQuery = sortDirection == SortDirection.Ascending
-                                ? compiledQuery.OrderBy(u => u.Email.ToUpper())
-                                : compiledQuery.OrderByDescending(u => u.Email.ToUpper());
-                            break;
-                        case "registrationdate":
-                            compiledQuery = sortDirection == SortDirection.Ascending
-                                ? compiledQuery.OrderBy(u => u.RegistrationDate)
-                                : compiledQuery.OrderByDescending(u => u.RegistrationDate);
-                            break;
-                        case "playtime":
-                            compiledQuery = sortDirection == SortDirection.Ascending
-                                ? compiledQuery.OrderBy(u => u.PlayTimeSeconds)
-                                : compiledQuery.OrderByDescending(u => u.PlayTimeSeconds);
-                            break;
-                        case "name":
-                        default:
-                            compiledQuery = sortDirection == SortDirection.Ascending
-                                ? compiledQuery.OrderBy(u => u.Name.ToUpper())
-                                : compiledQuery.OrderByDescending(u => u.Name.ToUpper());
-                            break;
-                    }
-
-                    var users = compiledQuery.Skip(skip).Take(take).AsTracking().ToList();
-                    return users;
+                    var pass = SaltPasswordHash(ptPassword, salt);
+                    var queriedUser = QueryUserByNameAndPasswordShallow(context, username, pass);
+                    return PostLoad(queriedUser, context);
                 }
             }
-            catch (Exception ex)
+            catch (Exception exception)
             {
-                Log.Error(ex);
-                total = 0;
-                return null;
+                Log.Error(exception);
             }
         }
 
-        #endregion
+        return null;
+    }
 
-        #region Compiled Queries
+    public static User FindById(Guid userId)
+    {
+        using var playerContext = DbInterface.CreatePlayerContext();
+        return FindById(userId, playerContext);
+    }
 
-        private static readonly Func<PlayerContext, string, User> QueryUserByNameShallow = EF.CompileQuery(
-                // ReSharper disable once SpecifyStringComparison
-                (PlayerContext context, string username) => context.Users.Where(u => u.Name == username)
-                    .Include(p => p.Ban)
-                    .Include(p => p.Mute)
-                    .Include(p => p.Players)
-                    .AsSplitQuery()
-                    .FirstOrDefault()
-            ) ??
-            throw new InvalidOperationException();
+    public static User FindById(Guid userId, PlayerContext playerContext)
+    {
+        if (userId == Guid.Empty)
+        {
+            return null;
+        }
 
-        private static readonly Func<PlayerContext, string, User> QueryUserByNameOrEmailShallow = EF.CompileQuery(
-                // ReSharper disable once SpecifyStringComparison
-                (PlayerContext context, string usernameOrEmail) => context.Users
-                    .Where(u => u.Name == usernameOrEmail || u.Email == usernameOrEmail)
-                    .Include(p => p.Ban)
-                    .Include(p => p.Mute)
-                    .Include(p => p.Players)
-                    .AsSplitQuery()
-                    .FirstOrDefault()
-            ) ??
-            throw new InvalidOperationException();
+        var user = FindOnline(userId);
 
-        private static readonly Func<PlayerContext, string, string, User> QueryUserByNameAndPasswordShallow =
-            EF.CompileQuery(
-                // ReSharper disable once SpecifyStringComparison
-                (PlayerContext context, string username, string password) => context.Users
-                    .Where(u => u.Name == username && u.Password == password)
-                    .Include(p => p.Ban)
-                    .Include(p => p.Mute)
-                    .Include(p => p.Players)
-                    .AsSplitQuery()
-                    .FirstOrDefault()
-            ) ??
-            throw new InvalidOperationException();
+        if (user != null)
+        {
+            return user;
+        }
 
-        private static readonly Func<PlayerContext, Guid, User> QueryUserByIdShallow = EF.CompileQuery(
-                (PlayerContext context, Guid id) => context.Users.Where(u => u.Id == id)
-                    .Include(p => p.Ban)
-                    .Include(p => p.Mute)
-                    .Include(p => p.Players)
-                    .AsSplitQuery()
-                    .FirstOrDefault()
-            ) ??
-            throw new InvalidOperationException();
+        try
+        {
+            using var context = DbInterface.CreatePlayerContext();
+            return QueryUserByIdShallow(playerContext, userId);
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex);
+            return null;
+        }
+    }
 
-        private static readonly Func<PlayerContext, string, bool> AnyUserByNameOrEmail = EF.CompileQuery(
-            // ReSharper disable once SpecifyStringComparison
-            (PlayerContext context, string nameOrEmail) =>
-                context.Users.Where(u => u.Name == nameOrEmail || u.Email == nameOrEmail).Any()
+    public static User Find(string username)
+    {
+        if (string.IsNullOrWhiteSpace(username))
+        {
+            return null;
+        }
+
+        var user = FindOnline(username);
+
+        if (user != null)
+        {
+            return user;
+        }
+
+        try
+        {
+            using var context = DbInterface.CreatePlayerContext();
+            var queriedUser = QueryUserByNameShallow(context, username);
+            return queriedUser;
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex);
+            return null;
+        }
+    }
+
+    public static User FindFromNameOrEmail(string nameOrEmail)
+    {
+        using var playerContext = DbInterface.CreatePlayerContext();
+        return FindByNameOrEmail(nameOrEmail, playerContext);
+    }
+
+    public static User FindByNameOrEmail(string nameOrEmail, PlayerContext playerContext)
+    {
+        if (string.IsNullOrWhiteSpace(nameOrEmail))
+        {
+            return null;
+        }
+
+        var user = FindOnlineFromEmail(nameOrEmail);
+        if (user != null)
+        {
+            return user;
+        }
+
+        user = FindOnline(nameOrEmail);
+        if (user != null)
+        {
+            return user;
+        }
+
+        try
+        {
+            var queriedUser = QueryUserByNameOrEmailShallow(playerContext, nameOrEmail);
+            return queriedUser;
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex);
+            return null;
+        }
+    }
+
+    public static User FindByEmail(string email)
+    {
+        using var context = DbInterface.CreatePlayerContext();
+        return FindByEmail(email);
+    }
+
+    public static User FindByEmail(string email, PlayerContext playerContext)
+    {
+        if (string.IsNullOrWhiteSpace(email))
+        {
+            return null;
+        }
+
+        var user = FindOnlineFromEmail(email);
+
+        if (user != null)
+        {
+            return user;
+        }
+
+        try
+        {
+            return QueryUserByEmailShallow(playerContext, email);
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex);
+            return null;
+        }
+    }
+
+    public static string GetUserSalt(string userName)
+    {
+        if (string.IsNullOrWhiteSpace(userName))
+        {
+            return null;
+        }
+
+        var user = FindOnline(userName);
+        if (user != null)
+        {
+            return user.Salt;
+        }
+
+        try
+        {
+            using (var context = DbInterface.CreatePlayerContext())
+            {
+                return SaltByName(context, userName);
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex);
+            return null;
+        }
+    }
+
+    public static bool UserExists(string nameOrEmail)
+    {
+        if (string.IsNullOrWhiteSpace(nameOrEmail))
+        {
+            return false;
+        }
+
+        var user = FindOnlineFromEmail(nameOrEmail);
+        if (user != null)
+        {
+            return true;
+        }
+
+        user = FindOnline(nameOrEmail);
+        if (user != null)
+        {
+            return true;
+        }
+
+        try
+        {
+            using (var context = DbInterface.CreatePlayerContext())
+            {
+                return AnyUserByNameOrEmail(context, nameOrEmail);
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex);
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// </summary>
+    public void Update()
+    {
+        // ReSharper disable once InvertIf
+        if (UpdatedVariables.Count > 0)
+        {
+            if (Save() == UserSaveResult.DatabaseFailure)
+            {
+                var client = Globals.ClientLookup.Values.FirstOrDefault(c => c.User.Id == Id);
+                client?.LogAndDisconnect(default, "User.Save");
+            }
+
+            UpdatedVariables.Clear();
+        }
+    }
+
+    /// <summary>
+    ///     Returns a variable object given a user variable id
+    /// </summary>
+    /// <param name="id">Variable id</param>
+    /// <param name="createIfNull">Creates this variable for the user if it hasn't been set yet</param>
+    /// <returns></returns>
+    public Variable GetVariable(Guid id, bool createIfNull = false)
+    {
+        foreach (var v in Variables)
+        {
+            if (v.VariableId == id)
+            {
+                return v;
+            }
+        }
+
+        if (createIfNull)
+        {
+            return CreateVariable(id);
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    ///     Creates a variable for this user with a given id if it doesn't already exist
+    /// </summary>
+    /// <param name="id">Variablke id</param>
+    /// <returns></returns>
+    private Variable CreateVariable(Guid id)
+    {
+        if (UserVariableBase.Get(id) == null)
+        {
+            return null;
+        }
+
+        var variable = new UserVariable(id);
+        Variables.Add(variable);
+
+        return variable;
+    }
+
+    /// <summary>
+    ///     Gets the value of a account variable given a variable id
+    /// </summary>
+    /// <param name="id">Variable id</param>
+    /// <returns></returns>
+    public VariableValue GetVariableValue(Guid id)
+    {
+        var v = GetVariable(id, true);
+
+        if (v == null)
+        {
+            return new VariableValue();
+        }
+
+        return v.Value;
+    }
+
+    /// <summary>
+    ///     Starts all common events with a specified trigger for any character online of this account
+    /// </summary>
+    /// <param name="trigger">The common event trigger to run</param>
+    /// <param name="command">The command which started this common event</param>
+    /// <param name="param">Common event parameter</param>
+    public void StartCommonEventsWithTriggerForAll(CommonEventTrigger trigger, string command, string param)
+    {
+        foreach (var plyr in Players)
+        {
+            if (Player.FindOnline(plyr.Id) != null)
+            {
+                plyr.StartCommonEventsWithTrigger(trigger, command, param);
+            }
+        }
+    }
+
+    public static bool TryRegister(
+        RegistrationActor actor,
+        string username,
+        string email,
+        string password,
+        [NotNullWhen(false)] out string error,
+        [NotNullWhen(true)] out User user
+    )
+    {
+        error = default;
+        user = default;
+
+        if (Options.BlockClientRegistrations)
+        {
+            error = Strings.Account.registrationsblocked;
+            return false;
+        }
+
+        if (!FieldChecking.IsValidUsername(username, Strings.Regex.username))
+        {
+            error = Strings.Account.invalidname;
+            return false;
+        }
+
+        if (!FieldChecking.IsWellformedEmailAddress(email, Strings.Regex.email))
+        {
+            error = Strings.Account.invalidemail;
+            return false;
+        }
+
+        if (Ban.IsBanned(actor.IpAddress, out var message))
+        {
+            error = message;
+            return false;
+        }
+
+        if (UserExists(username))
+        {
+            error = Strings.Account.exists;
+            return false;
+        }
+
+        if (UserExists(email))
+        {
+            error = Strings.Account.emailexists;
+            return false;
+        }
+
+        UserActivityHistory.LogActivity(
+            Guid.Empty,
+            Guid.Empty,
+            actor.IpAddress.ToString(),
+            actor.PeerType,
+            UserActivityHistory.UserAction.Create,
+            string.Empty
         );
 
-        private static readonly Func<PlayerContext, string, string> SaltByName = EF.CompileQuery(
-            // ReSharper disable once SpecifyStringComparison
-            (PlayerContext context, string userName) =>
-                context.Users.Where(u => u.Name == userName).Select(u => u.Salt).FirstOrDefault()
-        );
+        if (DbInterface.TryRegister(username, email, password, out user))
+        {
+            return true;
+        }
 
-        private static readonly Func<PlayerContext, string, User> QueryUserByEmailShallow = EF.CompileQuery(
-                // ReSharper disable once SpecifyStringComparison
-                (PlayerContext context, string email) => context.Users.Where(u => u.Email == email)
-                    .Include(p => p.Ban)
-                    .Include(p => p.Mute)
-                    .Include(p => p.Players)
-                    .AsSplitQuery()
-                    .FirstOrDefault()
+        error = Strings.Account.UnknownError;
+        return false;
+    }
+
+    public sealed record RegistrationActor(IPAddress IpAddress, UserActivityHistory.PeerType PeerType);
+
+    #region Instance Variables
+
+    [NotMapped]
+    [ApiVisibility(ApiVisibility.Restricted | ApiVisibility.Private)]
+    public bool IsBanned => Ban != null;
+
+    [NotMapped]
+    [ApiVisibility(ApiVisibility.Restricted | ApiVisibility.Private)]
+    public bool IsMuted => Mute != null;
+
+    [ApiVisibility(ApiVisibility.Restricted)]
+    public Ban Ban
+    {
+        get => UserBan ?? IpBan;
+        set => UserBan = value;
+    }
+
+    [ApiVisibility(ApiVisibility.Restricted)]
+    public Mute Mute
+    {
+        get => UserMute ?? IpMute;
+        set => UserMute = value;
+    }
+
+    [NotMapped] public Ban IpBan { get; set; }
+
+    [NotMapped] public Mute IpMute { get; set; }
+
+    [ApiVisibility(ApiVisibility.Restricted)]
+    [NotMapped]
+    public Ban UserBan { get; set; }
+
+    [ApiVisibility(ApiVisibility.Restricted)]
+    [NotMapped]
+    public Mute UserMute { get; set; }
+
+    #endregion
+
+    #region Listing
+
+    public static int Count()
+    {
+        using (var context = DbInterface.CreatePlayerContext())
+        {
+            return context.Users.Count();
+        }
+    }
+
+    public static IList<User> List(
+        string query,
+        string sortBy,
+        SortDirection sortDirection,
+        int skip,
+        int take,
+        out int total
+    )
+    {
+        try
+        {
+            using (var context = DbInterface.CreatePlayerContext())
+            {
+                foreach (var user in Globals.OnlineList.Select(p => p.User))
+                {
+                    if (user != default)
+                    {
+                        context.Entry(user).State = EntityState.Unchanged;
+                    }
+                }
+
+                var compiledQuery = string.IsNullOrWhiteSpace(query)
+                    ? context.Users.Include(p => p.Ban).Include(p => p.Mute) : context.Users.Where(
+                        u => EF.Functions.Like(u.Name, $"%{query}%") || EF.Functions.Like(u.Email, $"%{query}%")
+                    );
+
+                total = compiledQuery.Count();
+
+                switch (sortBy?.ToLower() ?? "")
+                {
+                    case "email":
+                        compiledQuery = sortDirection == SortDirection.Ascending
+                            ? compiledQuery.OrderBy(u => u.Email.ToUpper())
+                            : compiledQuery.OrderByDescending(u => u.Email.ToUpper());
+                        break;
+                    case "registrationdate":
+                        compiledQuery = sortDirection == SortDirection.Ascending
+                            ? compiledQuery.OrderBy(u => u.RegistrationDate)
+                            : compiledQuery.OrderByDescending(u => u.RegistrationDate);
+                        break;
+                    case "playtime":
+                        compiledQuery = sortDirection == SortDirection.Ascending
+                            ? compiledQuery.OrderBy(u => u.PlayTimeSeconds)
+                            : compiledQuery.OrderByDescending(u => u.PlayTimeSeconds);
+                        break;
+                    case "name":
+                    default:
+                        compiledQuery = sortDirection == SortDirection.Ascending
+                            ? compiledQuery.OrderBy(u => u.Name.ToUpper())
+                            : compiledQuery.OrderByDescending(u => u.Name.ToUpper());
+                        break;
+                }
+
+                var users = compiledQuery.Skip(skip).Take(take).AsTracking().ToList();
+                return users;
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex);
+            total = 0;
+            return null;
+        }
+    }
+
+    #endregion
+
+    #region Compiled Queries
+
+    private static readonly Func<PlayerContext, string, User> QueryUserByNameShallow = EF.CompileQuery(
+            // ReSharper disable once SpecifyStringComparison
+            (PlayerContext context, string username) => context.Users.Where(u => u.Name == username)
+                .Include(p => p.Ban)
+                .Include(p => p.Mute)
+                .Include(p => p.Players)
+                .AsSplitQuery()
+                .FirstOrDefault()
         ) ??
         throw new InvalidOperationException();
 
-        #endregion
-    }
+    private static readonly Func<PlayerContext, string, User> QueryUserByNameOrEmailShallow = EF.CompileQuery(
+            // ReSharper disable once SpecifyStringComparison
+            (PlayerContext context, string usernameOrEmail) => context.Users
+                .Where(u => u.Name == usernameOrEmail || u.Email == usernameOrEmail)
+                .Include(p => p.Ban)
+                .Include(p => p.Mute)
+                .Include(p => p.Players)
+                .AsSplitQuery()
+                .FirstOrDefault()
+        ) ??
+        throw new InvalidOperationException();
 
+    private static readonly Func<PlayerContext, string, string, User> QueryUserByNameAndPasswordShallow =
+        EF.CompileQuery(
+            // ReSharper disable once SpecifyStringComparison
+            (PlayerContext context, string username, string password) => context.Users
+                .Where(u => u.Name == username && u.Password == password)
+                .Include(p => p.Ban)
+                .Include(p => p.Mute)
+                .Include(p => p.Players)
+                .AsSplitQuery()
+                .FirstOrDefault()
+        ) ??
+        throw new InvalidOperationException();
+
+    private static readonly Func<PlayerContext, Guid, User> QueryUserByIdShallow = EF.CompileQuery(
+            (PlayerContext context, Guid id) => context.Users.Where(u => u.Id == id)
+                .Include(p => p.Ban)
+                .Include(p => p.Mute)
+                .Include(p => p.Players)
+                .AsSplitQuery()
+                .FirstOrDefault()
+        ) ??
+        throw new InvalidOperationException();
+
+    private static readonly Func<PlayerContext, string, bool> AnyUserByNameOrEmail = EF.CompileQuery(
+        // ReSharper disable once SpecifyStringComparison
+        (PlayerContext context, string nameOrEmail) =>
+            context.Users.Where(u => u.Name == nameOrEmail || u.Email == nameOrEmail).Any()
+    );
+
+    private static readonly Func<PlayerContext, string, string> SaltByName = EF.CompileQuery(
+        // ReSharper disable once SpecifyStringComparison
+        (PlayerContext context, string userName) =>
+            context.Users.Where(u => u.Name == userName).Select(u => u.Salt).FirstOrDefault()
+    );
+
+    private static readonly Func<PlayerContext, string, User> QueryUserByEmailShallow = EF.CompileQuery(
+            // ReSharper disable once SpecifyStringComparison
+            (PlayerContext context, string email) => context.Users.Where(u => u.Email == email)
+                .Include(p => p.Ban)
+                .Include(p => p.Mute)
+                .Include(p => p.Players)
+                .AsSplitQuery()
+                .FirstOrDefault()
+    ) ??
+    throw new InvalidOperationException();
+
+    #endregion
 }

--- a/Intersect.Server.Core/Database/SeedData.cs
+++ b/Intersect.Server.Core/Database/SeedData.cs
@@ -1,30 +1,28 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace Intersect.Server.Database
+namespace Intersect.Server.Database;
+
+
+public abstract partial class SeedData<TType> where TType : class
 {
 
-    public abstract partial class SeedData<TType> where TType : class
+    public void SeedIfEmpty(ISeedableContext context)
     {
+        var dbSet = context.GetDbSet<TType>();
 
-        public void SeedIfEmpty(ISeedableContext context)
+        if (dbSet == null)
         {
-            var dbSet = context.GetDbSet<TType>();
-
-            if (dbSet == null)
-            {
-                return;
-            }
-
-            if (dbSet.FirstOrDefault() != null)
-            {
-                return;
-            }
-
-            Seed(dbSet);
+            return;
         }
 
-        public abstract void Seed(DbSet<TType> dbSet);
+        if (dbSet.FirstOrDefault() != null)
+        {
+            return;
+        }
 
+        Seed(dbSet);
     }
+
+    public abstract void Seed(DbSet<TType> dbSet);
 
 }

--- a/Intersect.Server.Core/Database/Spell.cs
+++ b/Intersect.Server.Core/Database/Spell.cs
@@ -1,43 +1,41 @@
 using System.ComponentModel.DataAnnotations.Schema;
 using Intersect.GameObjects;
 
-namespace Intersect.Server.Database
+namespace Intersect.Server.Database;
+
+
+public partial class Spell
 {
 
-    public partial class Spell
+    public Spell()
     {
+    }
 
-        public Spell()
+    public Spell(Guid spellId)
+    {
+        SpellId = spellId;
+    }
+
+    public Guid SpellId { get; set; }
+
+    [NotMapped]
+    public string SpellName => SpellBase.GetName(SpellId);
+
+    public static Spell None => new Spell(Guid.Empty);
+
+    public Spell Clone()
+    {
+        var newSpell = new Spell()
         {
-        }
+            SpellId = SpellId
+        };
 
-        public Spell(Guid spellId)
-        {
-            SpellId = spellId;
-        }
+        return newSpell;
+    }
 
-        public Guid SpellId { get; set; }
-
-        [NotMapped]
-        public string SpellName => SpellBase.GetName(SpellId);
-
-        public static Spell None => new Spell(Guid.Empty);
-
-        public Spell Clone()
-        {
-            var newSpell = new Spell()
-            {
-                SpellId = SpellId
-            };
-
-            return newSpell;
-        }
-
-        public virtual void Set(Spell spell)
-        {
-            SpellId = spell.SpellId;
-        }
-
+    public virtual void Set(Spell spell)
+    {
+        SpellId = spell.SpellId;
     }
 
 }

--- a/Intersect.Server.Core/Database/SqliteNetCoreGuidPatch.cs
+++ b/Intersect.Server.Core/Database/SqliteNetCoreGuidPatch.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using Dapper;
 using Intersect.Config;
 using Intersect.Logging;

--- a/Intersect.Server.Core/Entities/BankInterface.cs
+++ b/Intersect.Server.Core/Entities/BankInterface.cs
@@ -8,65 +8,38 @@ using Intersect.Server.Networking;
 using System.Diagnostics;
 using Log = Intersect.Logging.Log;
 
-namespace Intersect.Server.Entities
+namespace Intersect.Server.Entities;
+
+public partial class BankInterface
 {
-    public partial class BankInterface
+    private Player mPlayer;
+
+    private IList<Item> mBank;
+
+    private Guild mGuild;
+
+    private object mLock;
+
+    private int mMaxSlots;
+
+    public BankInterface(Player player, IList<Item> bank, object bankLock, Guild guild, int maxSlots)
     {
-        private Player mPlayer;
+        mPlayer = player;
+        mBank = bank;
+        mGuild = guild;
+        mLock = bankLock;
+        mMaxSlots = maxSlots;
+    }
 
-        private IList<Item> mBank;
+    public void SendOpenBank()
+    {
+        var items = new List<BankUpdatePacket>();
 
-        private Guild mGuild;
-
-        private object mLock;
-
-        private int mMaxSlots;
-
-        public BankInterface(Player player, IList<Item> bank, object bankLock, Guild guild, int maxSlots)
+        for (var slot = 0; slot < mMaxSlots; slot++)
         {
-            mPlayer = player;
-            mBank = bank;
-            mGuild = guild;
-            mLock = bankLock;
-            mMaxSlots = maxSlots;
-        }
-
-        public void SendOpenBank()
-        {
-            var items = new List<BankUpdatePacket>();
-
-            for (var slot = 0; slot < mMaxSlots; slot++)
-            {
-                if (mBank[slot] != null && mBank[slot].ItemId != Guid.Empty && mBank[slot].Quantity > 0)
-                {
-                    items.Add(
-                        new BankUpdatePacket(
-                            slot, mBank[slot].ItemId, mBank[slot].Quantity, mBank[slot].BagId,
-                            mBank[slot].Properties
-                        )
-                    );
-                }
-                else
-                {
-                    items.Add(new BankUpdatePacket(slot, Guid.Empty, 0, null, null));
-                }
-            }
-
-            mPlayer?.SendPacket(new BankPacket(false, mGuild != null, mMaxSlots, items.ToArray()));
-        }
-
-        //BankUpdatePacket
-        public void SendBankUpdate(int slot, bool sendToAll = true)
-        {
-            if (sendToAll && mGuild != null)
-            {
-                mGuild.BankSlotUpdated(slot);
-                return;
-            }
-
             if (mBank[slot] != null && mBank[slot].ItemId != Guid.Empty && mBank[slot].Quantity > 0)
             {
-                mPlayer?.SendPacket(
+                items.Add(
                     new BankUpdatePacket(
                         slot, mBank[slot].ItemId, mBank[slot].Quantity, mBank[slot].BagId,
                         mBank[slot].Properties
@@ -75,250 +48,120 @@ namespace Intersect.Server.Entities
             }
             else
             {
-                mPlayer?.SendPacket(new BankUpdatePacket(slot, Guid.Empty, 0, null, null));
+                items.Add(new BankUpdatePacket(slot, Guid.Empty, 0, null, null));
             }
         }
 
-        public void SendCloseBank()
+        mPlayer?.SendPacket(new BankPacket(false, mGuild != null, mMaxSlots, items.ToArray()));
+    }
+
+    //BankUpdatePacket
+    public void SendBankUpdate(int slot, bool sendToAll = true)
+    {
+        if (sendToAll && mGuild != null)
         {
-            mPlayer?.SendPacket(new BankPacket(true, false, -1, null));
+            mGuild.BankSlotUpdated(slot);
+            return;
         }
 
-        public bool TryDepositItem(Item? slot, int inventorySlotIndex, int quantityHint, int bankSlotIndex = -1, bool sendUpdate = true)
+        if (mBank[slot] != null && mBank[slot].ItemId != Guid.Empty && mBank[slot].Quantity > 0)
         {
-            //Permission Check
-            if (mGuild != null)
+            mPlayer?.SendPacket(
+                new BankUpdatePacket(
+                    slot, mBank[slot].ItemId, mBank[slot].Quantity, mBank[slot].BagId,
+                    mBank[slot].Properties
+                )
+            );
+        }
+        else
+        {
+            mPlayer?.SendPacket(new BankUpdatePacket(slot, Guid.Empty, 0, null, null));
+        }
+    }
+
+    public void SendCloseBank()
+    {
+        mPlayer?.SendPacket(new BankPacket(true, false, -1, null));
+    }
+
+    public bool TryDepositItem(Item? slot, int inventorySlotIndex, int quantityHint, int bankSlotIndex = -1, bool sendUpdate = true)
+    {
+        //Permission Check
+        if (mGuild != null)
+        {
+            var rank = Options.Instance.Guild.Ranks[Math.Max(0, Math.Min(Options.Instance.Guild.Ranks.Length - 1, mPlayer.GuildRank))];
+            if (!rank.Permissions.BankDeposit && mPlayer.GuildRank != 0)
             {
-                var rank = Options.Instance.Guild.Ranks[Math.Max(0, Math.Min(Options.Instance.Guild.Ranks.Length - 1, mPlayer.GuildRank))];
-                if (!rank.Permissions.BankDeposit && mPlayer.GuildRank != 0)
-                {
-                    PacketSender.SendChatMsg(mPlayer, Strings.Guilds.NotAllowedDeposit.ToString(mGuild.Name), ChatMessageType.Bank, CustomColors.Alerts.Error);
-                    return false;
-                }
+                PacketSender.SendChatMsg(mPlayer, Strings.Guilds.NotAllowedDeposit.ToString(mGuild.Name), ChatMessageType.Bank, CustomColors.Alerts.Error);
+                return false;
             }
+        }
 
-            slot ??= mPlayer.Items[inventorySlotIndex];
-            if (!ItemBase.TryGet(slot.ItemId, out var itemDescriptor))
+        slot ??= mPlayer.Items[inventorySlotIndex];
+        if (!ItemBase.TryGet(slot.ItemId, out var itemDescriptor))
+        {
+            PacketSender.SendChatMsg(
+                mPlayer,
+                Strings.Banks.depositinvalid,
+                ChatMessageType.Bank,
+                CustomColors.Alerts.Error
+            );
+            return false;
+        }
+
+        var canBank = (itemDescriptor.CanBank && mGuild == default) ||
+                      (itemDescriptor.CanGuildBank && mGuild != default);
+
+        if (!canBank)
+        {
+            PacketSender.SendChatMsg(mPlayer, Strings.Items.nobank, ChatMessageType.Bank, CustomColors.Items.Bound);
+            return false;
+        }
+
+        var sourceSlots = mPlayer.Items.ToArray();
+        var maximumStack = itemDescriptor.Stackable ? itemDescriptor.MaxBankStack : 1;
+        var sourceQuantity = Item.FindQuantityOfItem(itemDescriptor.Id, sourceSlots);
+
+        var targetSlots = mBank.ToArray();
+
+        lock (mLock)
+        {
+            var movableQuantity = Item.FindSpaceForItem(
+                itemDescriptor.Id,
+                itemDescriptor.ItemType,
+                maximumStack,
+                bankSlotIndex,
+                quantityHint < 0 ? sourceQuantity : quantityHint,
+                targetSlots
+            );
+
+            if (movableQuantity < 1)
             {
                 PacketSender.SendChatMsg(
                     mPlayer,
-                    Strings.Banks.depositinvalid,
+                    Strings.Banks.banknospace,
                     ChatMessageType.Bank,
                     CustomColors.Alerts.Error
                 );
                 return false;
             }
 
-            var canBank = (itemDescriptor.CanBank && mGuild == default) ||
-                          (itemDescriptor.CanGuildBank && mGuild != default);
+            var slotIndicesToFill = Item.FindCompatibleSlotsForItem(
+                itemDescriptor.Id,
+                itemDescriptor.ItemType,
+                maximumStack,
+                bankSlotIndex,
+                movableQuantity,
+                targetSlots
+            );
 
-            if (!canBank)
-            {
-                PacketSender.SendChatMsg(mPlayer, Strings.Items.nobank, ChatMessageType.Bank, CustomColors.Items.Bound);
-                return false;
-            }
-
-            var sourceSlots = mPlayer.Items.ToArray();
-            var maximumStack = itemDescriptor.Stackable ? itemDescriptor.MaxBankStack : 1;
-            var sourceQuantity = Item.FindQuantityOfItem(itemDescriptor.Id, sourceSlots);
-
-            var targetSlots = mBank.ToArray();
-
-            lock (mLock)
-            {
-                var movableQuantity = Item.FindSpaceForItem(
+            if (!Item.TryFindSourceSlotsForItem(
                     itemDescriptor.Id,
-                    itemDescriptor.ItemType,
-                    maximumStack,
-                    bankSlotIndex,
-                    quantityHint < 0 ? sourceQuantity : quantityHint,
-                    targetSlots
-                );
-
-                if (movableQuantity < 1)
-                {
-                    PacketSender.SendChatMsg(
-                        mPlayer,
-                        Strings.Banks.banknospace,
-                        ChatMessageType.Bank,
-                        CustomColors.Alerts.Error
-                    );
-                    return false;
-                }
-
-                var slotIndicesToFill = Item.FindCompatibleSlotsForItem(
-                    itemDescriptor.Id,
-                    itemDescriptor.ItemType,
-                    maximumStack,
-                    bankSlotIndex,
+                    inventorySlotIndex,
                     movableQuantity,
-                    targetSlots
-                );
-
-                if (!Item.TryFindSourceSlotsForItem(
-                        itemDescriptor.Id,
-                        inventorySlotIndex,
-                        movableQuantity,
-                        sourceSlots,
-                        out var slotIndicesToRemoveFrom
-                    ))
-                {
-                    PacketSender.SendChatMsg(
-                        mPlayer,
-                        Strings.Banks.withdrawinvalid,
-                        ChatMessageType.Bank,
-                        CustomColors.Alerts.Error
-                    );
-                    return false;
-                }
-
-                var nextSlotIndexToRemoveFrom = 0;
-                var remainingQuantity = movableQuantity;
-                foreach (var slotIndexToFill in slotIndicesToFill)
-                {
-                    if (slotIndicesToRemoveFrom.Length <= nextSlotIndexToRemoveFrom)
-                    {
-                        Log.Warn($"Ran out of slots to remove from for {mPlayer.Id}");
-                        break;
-                    }
-
-                    if (remainingQuantity < 1)
-                    {
-                        break;
-                    }
-
-                    var slotToFill = targetSlots[slotIndexToFill];
-                    Debug.Assert(slotToFill != default);
-                    var quantityToStoreInSlot = Math.Min(remainingQuantity, maximumStack - slotToFill.Quantity);
-
-                    if (slotToFill.ItemId == default && maximumStack <= 1)
-                    {
-                        if (slotIndicesToRemoveFrom.Length <= nextSlotIndexToRemoveFrom)
-                        {
-                            break;
-                        }
-
-                        var slotIndexToRemoveFrom = slotIndicesToRemoveFrom[nextSlotIndexToRemoveFrom++];
-                        var sourceSlot = sourceSlots[slotIndexToRemoveFrom];
-                        slotToFill.Set(sourceSlot);
-                        remainingQuantity -= 1;
-                        continue;
-                    }
-
-                    if (itemDescriptor.ItemType == ItemType.Equipment || maximumStack <= 1)
-                    {
-                        Log.Warn($"{nameof(Item.FindCompatibleSlotsForItem)}() returned incompatible slots for {nameof(ItemBase)} {itemDescriptor.Id}");
-                        break;
-                    }
-
-                    slotToFill.ItemId = itemDescriptor.Id;
-                    slotToFill.Quantity += quantityToStoreInSlot;
-                    remainingQuantity -= quantityToStoreInSlot;
-                }
-
-                var remainingQuantityToRemove = movableQuantity;
-                foreach (var slotIndexToRemoveFrom in slotIndicesToRemoveFrom)
-                {
-                    if (remainingQuantityToRemove < 1)
-                    {
-                        Log.Error($"Potential inventory corruption for {mPlayer.Id}");
-                    }
-
-                    var slotToRemoveFrom = sourceSlots[slotIndexToRemoveFrom];
-                    Debug.Assert(slotToRemoveFrom != default);
-                    var quantityToRemoveFromSlot = Math.Min(remainingQuantityToRemove, slotToRemoveFrom.Quantity);
-                    slotToRemoveFrom.Quantity -= quantityToRemoveFromSlot;
-
-                    // If the item is equipped equipment, we need to unequip it before taking it out of the inventory.
-                    if (itemDescriptor.ItemType == ItemType.Equipment && slotIndexToRemoveFrom > -1)
-                    {
-                        mPlayer.EquipmentProcessItemLoss(slotIndexToRemoveFrom);
-                    }
-
-                    if (slotToRemoveFrom.Quantity < 1)
-                    {
-                        slotToRemoveFrom.Set(Item.None);
-                    }
-
-                    remainingQuantityToRemove -= quantityToRemoveFromSlot;
-                }
-
-                // ReSharper disable once ConvertIfStatementToSwitchStatement
-                if (remainingQuantity < 0)
-                {
-                    Log.Error($"{mPlayer.Id} was accidentally given {-remainingQuantity}x extra {itemDescriptor.Id}");
-                }
-                else if (remainingQuantity > 0)
-                {
-                    Log.Error($"{mPlayer.Id} was not given {remainingQuantity}x {itemDescriptor.Id}");
-                }
-
-                // ReSharper disable once ConvertIfStatementToSwitchStatement
-                if (remainingQuantityToRemove < 0)
-                {
-                    Log.Error($"{mPlayer.Id} was scammed {-remainingQuantity}x {itemDescriptor.Id}");
-                }
-                else if (remainingQuantityToRemove > 0)
-                {
-                    Log.Error($"{mPlayer.Id} did not have {remainingQuantity}x {itemDescriptor.Id} taken");
-                }
-
-                if (sendUpdate)
-                {
-                    foreach (var slotIndexToUpdate in slotIndicesToRemoveFrom)
-                    {
-                        PacketSender.SendInventoryItemUpdate(mPlayer, slotIndexToUpdate);
-                    }
-
-                    foreach (var slotIndexToFill in slotIndicesToFill)
-                    {
-                        SendBankUpdate(slotIndexToFill);
-                    }
-
-                    if (inventorySlotIndex > -1)
-                    {
-                        PacketSender.SendInventoryItemUpdate(mPlayer, inventorySlotIndex);
-                    }
-                }
-
-                if (mGuild != null)
-                {
-                    DbInterface.Pool.QueueWorkItem(mGuild.Save);
-                }
-
-                var successMessage = movableQuantity > 1
-                    ? Strings.Banks.DepositSuccessStackable.ToString(movableQuantity, itemDescriptor.Name)
-                    : Strings.Banks.DepositSuccessNonStackable.ToString(itemDescriptor.Name);
-
-                PacketSender.SendChatMsg(mPlayer, successMessage, ChatMessageType.Bank, CustomColors.Alerts.Success);
-
-                return true;
-            }
-        }
-
-        public bool TryDepositItem(Item item, bool sendUpdate = true) =>
-            TryDepositItem(item, -1, item.Quantity, -1, sendUpdate);
-
-        public bool TryWithdrawItem(Item? slot, int bankSlotIndex, int quantityHint, int inventorySlotIndex = -1)
-        {
-            //Permission Check
-            if (mGuild != null)
-            {
-                var rank = Options.Instance.Guild.Ranks[Math.Max(0, Math.Min(Options.Instance.Guild.Ranks.Length - 1, mPlayer.GuildRank))];
-                if (!rank.Permissions.BankRetrieve && mPlayer.GuildRank != 0)
-                {
-                    PacketSender.SendChatMsg(
-                        mPlayer,
-                        Strings.Guilds.NotAllowedWithdraw.ToString(mGuild.Name),
-                        ChatMessageType.Bank,
-                        CustomColors.Alerts.Error
-                    );
-                    return false;
-                }
-            }
-
-            slot ??= mBank[bankSlotIndex];
-            if (!ItemBase.TryGet(slot.ItemId, out var itemDescriptor))
+                    sourceSlots,
+                    out var slotIndicesToRemoveFrom
+                ))
             {
                 PacketSender.SendChatMsg(
                     mPlayer,
@@ -329,288 +172,444 @@ namespace Intersect.Server.Entities
                 return false;
             }
 
-            var maximumStack = itemDescriptor.Stackable ? itemDescriptor.MaxInventoryStack : 1;
-            var sourceSlots = mBank.ToArray();
-            var sourceQuantity = Item.FindQuantityOfItem(itemDescriptor.Id, sourceSlots);
-
-            var targetSlots = mPlayer.Items.ToArray();
-
-            lock (mLock)
+            var nextSlotIndexToRemoveFrom = 0;
+            var remainingQuantity = movableQuantity;
+            foreach (var slotIndexToFill in slotIndicesToFill)
             {
-                var movableQuantity = Item.FindSpaceForItem(
-                    itemDescriptor.Id,
-                    itemDescriptor.ItemType,
-                    maximumStack,
-                    inventorySlotIndex,
-                    quantityHint < 0 ? sourceQuantity : quantityHint,
-                    targetSlots
-                );
-
-                if (movableQuantity < 1)
+                if (slotIndicesToRemoveFrom.Length <= nextSlotIndexToRemoveFrom)
                 {
-                    PacketSender.SendChatMsg(
-                        mPlayer,
-                        Strings.Banks.inventorynospace,
-                        ChatMessageType.Inventory,
-                        CustomColors.Alerts.Error
-                    );
-                    return false;
+                    Log.Warn($"Ran out of slots to remove from for {mPlayer.Id}");
+                    break;
                 }
 
-                var slotIndicesToFill = Item.FindCompatibleSlotsForItem(
-                    itemDescriptor.Id,
-                    itemDescriptor.ItemType,
-                    maximumStack,
-                    inventorySlotIndex,
-                    movableQuantity,
-                    targetSlots
-                );
-
-                if (!Item.TryFindSourceSlotsForItem(
-                        itemDescriptor.Id,
-                        bankSlotIndex,
-                        movableQuantity,
-                        sourceSlots,
-                        out var slotIndicesToRemoveFrom
-                    ))
+                if (remainingQuantity < 1)
                 {
-                    PacketSender.SendChatMsg(
-                        mPlayer,
-                        Strings.Banks.withdrawinvalid,
-                        ChatMessageType.Bank,
-                        CustomColors.Alerts.Error
-                    );
-                    return false;
+                    break;
                 }
 
-                var nextSlotIndexToRemoveFrom = 0;
-                var remainingQuantity = movableQuantity;
-                foreach (var slotIndexToFill in slotIndicesToFill)
+                var slotToFill = targetSlots[slotIndexToFill];
+                Debug.Assert(slotToFill != default);
+                var quantityToStoreInSlot = Math.Min(remainingQuantity, maximumStack - slotToFill.Quantity);
+
+                if (slotToFill.ItemId == default && maximumStack <= 1)
                 {
                     if (slotIndicesToRemoveFrom.Length <= nextSlotIndexToRemoveFrom)
                     {
-                        Log.Warn($"Ran out of slots to remove from for {mPlayer.Id}");
                         break;
                     }
 
-                    if (remainingQuantity < 1)
-                    {
-                        break;
-                    }
-
-                    var slotToFill = targetSlots[slotIndexToFill];
-                    Debug.Assert(slotToFill != default);
-                    var quantityToStoreInSlot = Math.Min(remainingQuantity, maximumStack - slotToFill.Quantity);
-
-                    if (slotToFill.ItemId == default && maximumStack <= 1)
-                    {
-                        if (slotIndicesToRemoveFrom.Length <= nextSlotIndexToRemoveFrom)
-                        {
-                            break;
-                        }
-
-                        var slotIndexToRemoveFrom = slotIndicesToRemoveFrom[nextSlotIndexToRemoveFrom];
-                        var sourceSlot = sourceSlots[slotIndexToRemoveFrom];
-                        if (sourceSlot.Quantity <= maximumStack)
-                        {
-                            nextSlotIndexToRemoveFrom++;
-                        }
-                        slotToFill.Set(sourceSlot);
-                        slotToFill.Quantity = 1;
-                        remainingQuantity -= 1;
-                        continue;
-                    }
-
-                    if (itemDescriptor.ItemType == ItemType.Equipment || maximumStack <= 1)
-                    {
-                        Log.Warn($"{nameof(Item.FindCompatibleSlotsForItem)}() returned incompatible slots for {nameof(ItemBase)} {itemDescriptor.Id}");
-                        break;
-                    }
-
-                    slotToFill.ItemId = itemDescriptor.Id;
-                    slotToFill.Quantity += quantityToStoreInSlot;
-                    remainingQuantity -= quantityToStoreInSlot;
+                    var slotIndexToRemoveFrom = slotIndicesToRemoveFrom[nextSlotIndexToRemoveFrom++];
+                    var sourceSlot = sourceSlots[slotIndexToRemoveFrom];
+                    slotToFill.Set(sourceSlot);
+                    remainingQuantity -= 1;
+                    continue;
                 }
 
-                var remainingQuantityToRemove = movableQuantity;
-                foreach (var slotIndexToRemoveFrom in slotIndicesToRemoveFrom)
+                if (itemDescriptor.ItemType == ItemType.Equipment || maximumStack <= 1)
                 {
-                    if (remainingQuantityToRemove < 1)
-                    {
-                        Log.Error($"Potential bank corruption for {mPlayer.Id}");
-                    }
-
-                    var slotToRemoveFrom = sourceSlots[slotIndexToRemoveFrom];
-                    Debug.Assert(slotToRemoveFrom != default);
-                    var quantityToRemoveFromSlot = Math.Min(remainingQuantityToRemove, slotToRemoveFrom.Quantity);
-                    slotToRemoveFrom.Quantity -= quantityToRemoveFromSlot;
-                    if (slotToRemoveFrom.Quantity < 1)
-                    {
-                        slotToRemoveFrom.Set(Item.None);
-                    }
-
-                    remainingQuantityToRemove -= quantityToRemoveFromSlot;
+                    Log.Warn($"{nameof(Item.FindCompatibleSlotsForItem)}() returned incompatible slots for {nameof(ItemBase)} {itemDescriptor.Id}");
+                    break;
                 }
 
-                // ReSharper disable once ConvertIfStatementToSwitchStatement
-                if (remainingQuantity < 0)
+                slotToFill.ItemId = itemDescriptor.Id;
+                slotToFill.Quantity += quantityToStoreInSlot;
+                remainingQuantity -= quantityToStoreInSlot;
+            }
+
+            var remainingQuantityToRemove = movableQuantity;
+            foreach (var slotIndexToRemoveFrom in slotIndicesToRemoveFrom)
+            {
+                if (remainingQuantityToRemove < 1)
                 {
-                    Log.Error($"{mPlayer.Id} was accidentally given {-remainingQuantity}x extra {itemDescriptor.Id}");
-                }
-                else if (remainingQuantity > 0)
-                {
-                    Log.Error($"{mPlayer.Id} was not given {remainingQuantity}x {itemDescriptor.Id}");
+                    Log.Error($"Potential inventory corruption for {mPlayer.Id}");
                 }
 
-                // ReSharper disable once ConvertIfStatementToSwitchStatement
-                if (remainingQuantityToRemove < 0)
+                var slotToRemoveFrom = sourceSlots[slotIndexToRemoveFrom];
+                Debug.Assert(slotToRemoveFrom != default);
+                var quantityToRemoveFromSlot = Math.Min(remainingQuantityToRemove, slotToRemoveFrom.Quantity);
+                slotToRemoveFrom.Quantity -= quantityToRemoveFromSlot;
+
+                // If the item is equipped equipment, we need to unequip it before taking it out of the inventory.
+                if (itemDescriptor.ItemType == ItemType.Equipment && slotIndexToRemoveFrom > -1)
                 {
-                    Log.Error($"{mPlayer.Id} was scammed {-remainingQuantity}x {itemDescriptor.Id}");
-                }
-                else if (remainingQuantityToRemove > 0)
-                {
-                    Log.Error($"{mPlayer.Id} did not have {remainingQuantity}x {itemDescriptor.Id} taken");
+                    mPlayer.EquipmentProcessItemLoss(slotIndexToRemoveFrom);
                 }
 
-                foreach (var slotIndexToUpdate in slotIndicesToFill)
+                if (slotToRemoveFrom.Quantity < 1)
+                {
+                    slotToRemoveFrom.Set(Item.None);
+                }
+
+                remainingQuantityToRemove -= quantityToRemoveFromSlot;
+            }
+
+            // ReSharper disable once ConvertIfStatementToSwitchStatement
+            if (remainingQuantity < 0)
+            {
+                Log.Error($"{mPlayer.Id} was accidentally given {-remainingQuantity}x extra {itemDescriptor.Id}");
+            }
+            else if (remainingQuantity > 0)
+            {
+                Log.Error($"{mPlayer.Id} was not given {remainingQuantity}x {itemDescriptor.Id}");
+            }
+
+            // ReSharper disable once ConvertIfStatementToSwitchStatement
+            if (remainingQuantityToRemove < 0)
+            {
+                Log.Error($"{mPlayer.Id} was scammed {-remainingQuantity}x {itemDescriptor.Id}");
+            }
+            else if (remainingQuantityToRemove > 0)
+            {
+                Log.Error($"{mPlayer.Id} did not have {remainingQuantity}x {itemDescriptor.Id} taken");
+            }
+
+            if (sendUpdate)
+            {
+                foreach (var slotIndexToUpdate in slotIndicesToRemoveFrom)
                 {
                     PacketSender.SendInventoryItemUpdate(mPlayer, slotIndexToUpdate);
                 }
 
-                foreach (var slotIndexToUpdate in slotIndicesToRemoveFrom)
+                foreach (var slotIndexToFill in slotIndicesToFill)
                 {
-                    SendBankUpdate(slotIndexToUpdate);
+                    SendBankUpdate(slotIndexToFill);
                 }
 
-                if (mGuild != null)
+                if (inventorySlotIndex > -1)
                 {
-                    DbInterface.Pool.QueueWorkItem(mGuild.Save);
+                    PacketSender.SendInventoryItemUpdate(mPlayer, inventorySlotIndex);
                 }
-
-                var successMessage = movableQuantity > 1
-                    ? Strings.Banks.WithdrawSuccessStackable.ToString(quantityHint, itemDescriptor.Name)
-                    : Strings.Banks.WithdrawSuccessNonStackable.ToString(itemDescriptor.Name);
-
-                PacketSender.SendChatMsg(mPlayer, successMessage, ChatMessageType.Bank, CustomColors.Alerts.Success);
-
-                return true;
             }
-        }
 
-        public void SwapBankItems(int slotFrom, int slotTo)
-        {
-            var bank = mBank;
-            if (bank == null)
+            if (mGuild != null)
             {
-                Log.Error($"SwapBankItems() called on invalid bank for {mPlayer.Id}");
-                return;
+                DbInterface.Pool.QueueWorkItem(mGuild.Save);
             }
 
-            if (Math.Clamp(slotFrom, 0, bank.Count - 1) != slotFrom || Math.Clamp(slotTo, 0, bank.Count - 1) != slotTo)
+            var successMessage = movableQuantity > 1
+                ? Strings.Banks.DepositSuccessStackable.ToString(movableQuantity, itemDescriptor.Name)
+                : Strings.Banks.DepositSuccessNonStackable.ToString(itemDescriptor.Name);
+
+            PacketSender.SendChatMsg(mPlayer, successMessage, ChatMessageType.Bank, CustomColors.Alerts.Success);
+
+            return true;
+        }
+    }
+
+    public bool TryDepositItem(Item item, bool sendUpdate = true) =>
+        TryDepositItem(item, -1, item.Quantity, -1, sendUpdate);
+
+    public bool TryWithdrawItem(Item? slot, int bankSlotIndex, int quantityHint, int inventorySlotIndex = -1)
+    {
+        //Permission Check
+        if (mGuild != null)
+        {
+            var rank = Options.Instance.Guild.Ranks[Math.Max(0, Math.Min(Options.Instance.Guild.Ranks.Length - 1, mPlayer.GuildRank))];
+            if (!rank.Permissions.BankRetrieve && mPlayer.GuildRank != 0)
             {
                 PacketSender.SendChatMsg(
                     mPlayer,
-                    Strings.Banks.InvalidSlotToSwap,
+                    Strings.Guilds.NotAllowedWithdraw.ToString(mGuild.Name),
                     ChatMessageType.Bank,
                     CustomColors.Alerts.Error
                 );
-                Log.Error($"Invalid slot indices SwapBankItems({slotFrom}, {slotTo}) ({bank.Count}, {mPlayer.Id})");
-                return;
+                return false;
+            }
+        }
+
+        slot ??= mBank[bankSlotIndex];
+        if (!ItemBase.TryGet(slot.ItemId, out var itemDescriptor))
+        {
+            PacketSender.SendChatMsg(
+                mPlayer,
+                Strings.Banks.withdrawinvalid,
+                ChatMessageType.Bank,
+                CustomColors.Alerts.Error
+            );
+            return false;
+        }
+
+        var maximumStack = itemDescriptor.Stackable ? itemDescriptor.MaxInventoryStack : 1;
+        var sourceSlots = mBank.ToArray();
+        var sourceQuantity = Item.FindQuantityOfItem(itemDescriptor.Id, sourceSlots);
+
+        var targetSlots = mPlayer.Items.ToArray();
+
+        lock (mLock)
+        {
+            var movableQuantity = Item.FindSpaceForItem(
+                itemDescriptor.Id,
+                itemDescriptor.ItemType,
+                maximumStack,
+                inventorySlotIndex,
+                quantityHint < 0 ? sourceQuantity : quantityHint,
+                targetSlots
+            );
+
+            if (movableQuantity < 1)
+            {
+                PacketSender.SendChatMsg(
+                    mPlayer,
+                    Strings.Banks.inventorynospace,
+                    ChatMessageType.Inventory,
+                    CustomColors.Alerts.Error
+                );
+                return false;
             }
 
-            //Permission Check
+            var slotIndicesToFill = Item.FindCompatibleSlotsForItem(
+                itemDescriptor.Id,
+                itemDescriptor.ItemType,
+                maximumStack,
+                inventorySlotIndex,
+                movableQuantity,
+                targetSlots
+            );
+
+            if (!Item.TryFindSourceSlotsForItem(
+                    itemDescriptor.Id,
+                    bankSlotIndex,
+                    movableQuantity,
+                    sourceSlots,
+                    out var slotIndicesToRemoveFrom
+                ))
+            {
+                PacketSender.SendChatMsg(
+                    mPlayer,
+                    Strings.Banks.withdrawinvalid,
+                    ChatMessageType.Bank,
+                    CustomColors.Alerts.Error
+                );
+                return false;
+            }
+
+            var nextSlotIndexToRemoveFrom = 0;
+            var remainingQuantity = movableQuantity;
+            foreach (var slotIndexToFill in slotIndicesToFill)
+            {
+                if (slotIndicesToRemoveFrom.Length <= nextSlotIndexToRemoveFrom)
+                {
+                    Log.Warn($"Ran out of slots to remove from for {mPlayer.Id}");
+                    break;
+                }
+
+                if (remainingQuantity < 1)
+                {
+                    break;
+                }
+
+                var slotToFill = targetSlots[slotIndexToFill];
+                Debug.Assert(slotToFill != default);
+                var quantityToStoreInSlot = Math.Min(remainingQuantity, maximumStack - slotToFill.Quantity);
+
+                if (slotToFill.ItemId == default && maximumStack <= 1)
+                {
+                    if (slotIndicesToRemoveFrom.Length <= nextSlotIndexToRemoveFrom)
+                    {
+                        break;
+                    }
+
+                    var slotIndexToRemoveFrom = slotIndicesToRemoveFrom[nextSlotIndexToRemoveFrom];
+                    var sourceSlot = sourceSlots[slotIndexToRemoveFrom];
+                    if (sourceSlot.Quantity <= maximumStack)
+                    {
+                        nextSlotIndexToRemoveFrom++;
+                    }
+                    slotToFill.Set(sourceSlot);
+                    slotToFill.Quantity = 1;
+                    remainingQuantity -= 1;
+                    continue;
+                }
+
+                if (itemDescriptor.ItemType == ItemType.Equipment || maximumStack <= 1)
+                {
+                    Log.Warn($"{nameof(Item.FindCompatibleSlotsForItem)}() returned incompatible slots for {nameof(ItemBase)} {itemDescriptor.Id}");
+                    break;
+                }
+
+                slotToFill.ItemId = itemDescriptor.Id;
+                slotToFill.Quantity += quantityToStoreInSlot;
+                remainingQuantity -= quantityToStoreInSlot;
+            }
+
+            var remainingQuantityToRemove = movableQuantity;
+            foreach (var slotIndexToRemoveFrom in slotIndicesToRemoveFrom)
+            {
+                if (remainingQuantityToRemove < 1)
+                {
+                    Log.Error($"Potential bank corruption for {mPlayer.Id}");
+                }
+
+                var slotToRemoveFrom = sourceSlots[slotIndexToRemoveFrom];
+                Debug.Assert(slotToRemoveFrom != default);
+                var quantityToRemoveFromSlot = Math.Min(remainingQuantityToRemove, slotToRemoveFrom.Quantity);
+                slotToRemoveFrom.Quantity -= quantityToRemoveFromSlot;
+                if (slotToRemoveFrom.Quantity < 1)
+                {
+                    slotToRemoveFrom.Set(Item.None);
+                }
+
+                remainingQuantityToRemove -= quantityToRemoveFromSlot;
+            }
+
+            // ReSharper disable once ConvertIfStatementToSwitchStatement
+            if (remainingQuantity < 0)
+            {
+                Log.Error($"{mPlayer.Id} was accidentally given {-remainingQuantity}x extra {itemDescriptor.Id}");
+            }
+            else if (remainingQuantity > 0)
+            {
+                Log.Error($"{mPlayer.Id} was not given {remainingQuantity}x {itemDescriptor.Id}");
+            }
+
+            // ReSharper disable once ConvertIfStatementToSwitchStatement
+            if (remainingQuantityToRemove < 0)
+            {
+                Log.Error($"{mPlayer.Id} was scammed {-remainingQuantity}x {itemDescriptor.Id}");
+            }
+            else if (remainingQuantityToRemove > 0)
+            {
+                Log.Error($"{mPlayer.Id} did not have {remainingQuantity}x {itemDescriptor.Id} taken");
+            }
+
+            foreach (var slotIndexToUpdate in slotIndicesToFill)
+            {
+                PacketSender.SendInventoryItemUpdate(mPlayer, slotIndexToUpdate);
+            }
+
+            foreach (var slotIndexToUpdate in slotIndicesToRemoveFrom)
+            {
+                SendBankUpdate(slotIndexToUpdate);
+            }
+
             if (mGuild != null)
             {
-                var ranks = Options.Instance.Guild.Ranks;
-                var rankIndex = Math.Clamp(mPlayer.GuildRank, 0, ranks.Length - 1);
-                var rank = ranks[rankIndex];
-                if (mPlayer.GuildRank != rankIndex || (!rank.Permissions.BankMove && mPlayer.GuildRank != 0))
-                {
-                    PacketSender.SendChatMsg(
-                        mPlayer,
-                        Strings.Guilds.NotAllowedSwap.ToString(mGuild.Name),
-                        ChatMessageType.Bank,
-                        CustomColors.Alerts.Error
-                    );
-                    return;
-                }
+                DbInterface.Pool.QueueWorkItem(mGuild.Save);
             }
 
-            lock (mLock)
+            var successMessage = movableQuantity > 1
+                ? Strings.Banks.WithdrawSuccessStackable.ToString(quantityHint, itemDescriptor.Name)
+                : Strings.Banks.WithdrawSuccessNonStackable.ToString(itemDescriptor.Name);
+
+            PacketSender.SendChatMsg(mPlayer, successMessage, ChatMessageType.Bank, CustomColors.Alerts.Success);
+
+            return true;
+        }
+    }
+
+    public void SwapBankItems(int slotFrom, int slotTo)
+    {
+        var bank = mBank;
+        if (bank == null)
+        {
+            Log.Error($"SwapBankItems() called on invalid bank for {mPlayer.Id}");
+            return;
+        }
+
+        if (Math.Clamp(slotFrom, 0, bank.Count - 1) != slotFrom || Math.Clamp(slotTo, 0, bank.Count - 1) != slotTo)
+        {
+            PacketSender.SendChatMsg(
+                mPlayer,
+                Strings.Banks.InvalidSlotToSwap,
+                ChatMessageType.Bank,
+                CustomColors.Alerts.Error
+            );
+            Log.Error($"Invalid slot indices SwapBankItems({slotFrom}, {slotTo}) ({bank.Count}, {mPlayer.Id})");
+            return;
+        }
+
+        //Permission Check
+        if (mGuild != null)
+        {
+            var ranks = Options.Instance.Guild.Ranks;
+            var rankIndex = Math.Clamp(mPlayer.GuildRank, 0, ranks.Length - 1);
+            var rank = ranks[rankIndex];
+            if (mPlayer.GuildRank != rankIndex || (!rank.Permissions.BankMove && mPlayer.GuildRank != 0))
             {
-                try
+                PacketSender.SendChatMsg(
+                    mPlayer,
+                    Strings.Guilds.NotAllowedSwap.ToString(mGuild.Name),
+                    ChatMessageType.Bank,
+                    CustomColors.Alerts.Error
+                );
+                return;
+            }
+        }
+
+        lock (mLock)
+        {
+            try
+            {
+                var destinationSlot = (bank[slotTo] ??= Item.None);
+                var sourceSlot = (bank[slotFrom] ??= Item.None);
+                var temporarySlot = destinationSlot.Clone();
+
+                if (destinationSlot.ItemId == sourceSlot.ItemId)
                 {
-                    var destinationSlot = (bank[slotTo] ??= Item.None);
-                    var sourceSlot = (bank[slotFrom] ??= Item.None);
-                    var temporarySlot = destinationSlot.Clone();
-
-                    if (destinationSlot.ItemId == sourceSlot.ItemId)
+                    if (sourceSlot.ItemId == default)
                     {
-                        if (sourceSlot.ItemId == default)
-                        {
-                            Log.Warn($"SwapBankItems({slotFrom}, {slotTo}) for {mPlayer.Id} with empty item ID");
-                            return;
-                        }
+                        Log.Warn($"SwapBankItems({slotFrom}, {slotTo}) for {mPlayer.Id} with empty item ID");
+                        return;
+                    }
 
-                        /* Items are the same, move the maximum quantity */
-                        if (!ItemBase.TryGet(sourceSlot.ItemId, out var itemDescriptor))
-                        {
-                            Log.Error($"SwapBankItems({slotFrom}, {slotTo}) for {mPlayer.Id} failed due to missing item {sourceSlot.ItemId}");
-                            return;
-                        }
+                    /* Items are the same, move the maximum quantity */
+                    if (!ItemBase.TryGet(sourceSlot.ItemId, out var itemDescriptor))
+                    {
+                        Log.Error($"SwapBankItems({slotFrom}, {slotTo}) for {mPlayer.Id} failed due to missing item {sourceSlot.ItemId}");
+                        return;
+                    }
 
-                        if (itemDescriptor.Stackable)
-                        {
-                            var moveQuantity = Math.Clamp(
-                                sourceSlot.Quantity,
-                                0,
-                                itemDescriptor.MaxBankStack - destinationSlot.Quantity
-                            );
+                    if (itemDescriptor.Stackable)
+                    {
+                        var moveQuantity = Math.Clamp(
+                            sourceSlot.Quantity,
+                            0,
+                            itemDescriptor.MaxBankStack - destinationSlot.Quantity
+                        );
 
-                            destinationSlot.Quantity += moveQuantity;
-                            sourceSlot.Quantity -= moveQuantity;
+                        destinationSlot.Quantity += moveQuantity;
+                        sourceSlot.Quantity -= moveQuantity;
 
-                            if (sourceSlot.Quantity < 1)
-                            {
-                                sourceSlot.Set(Item.None);
-                            }
-                        }
-                        else
+                        if (sourceSlot.Quantity < 1)
                         {
-                            /* Items are not stackable, swap them */
-                            destinationSlot.Set(sourceSlot);
-                            sourceSlot.Set(temporarySlot);
+                            sourceSlot.Set(Item.None);
                         }
                     }
                     else
                     {
-                        /* Items are different, swap them */
+                        /* Items are not stackable, swap them */
                         destinationSlot.Set(sourceSlot);
                         sourceSlot.Set(temporarySlot);
                     }
                 }
-                catch (Exception exception)
+                else
                 {
-                    Log.Error(exception, $"Error in SwapBankItems({slotFrom}, {slotTo}) for {mPlayer.Id}");
-                    return;
-                }
-
-                if (mGuild != null)
-                {
-                    DbInterface.Pool.QueueWorkItem(mGuild.Save);
+                    /* Items are different, swap them */
+                    destinationSlot.Set(sourceSlot);
+                    sourceSlot.Set(temporarySlot);
                 }
             }
+            catch (Exception exception)
+            {
+                Log.Error(exception, $"Error in SwapBankItems({slotFrom}, {slotTo}) for {mPlayer.Id}");
+                return;
+            }
 
-            SendBankUpdate(slotFrom);
-            SendBankUpdate(slotTo);
+            if (mGuild != null)
+            {
+                DbInterface.Pool.QueueWorkItem(mGuild.Save);
+            }
         }
 
+        SendBankUpdate(slotFrom);
+        SendBankUpdate(slotTo);
+    }
 
-        public void Dispose()
-        {
-            SendCloseBank();
-            mPlayer.GuildBank = false;
-            mPlayer.BankInterface = null;
-        }
+
+    public void Dispose()
+    {
+        SendCloseBank();
+        mPlayer.GuildBank = false;
+        mPlayer.BankInterface = null;
     }
 }

--- a/Intersect.Server.Core/Entities/Combat/Buff.cs
+++ b/Intersect.Server.Core/Entities/Combat/Buff.cs
@@ -1,32 +1,30 @@
 using Intersect.GameObjects;
 
-namespace Intersect.Server.Entities.Combat
+namespace Intersect.Server.Entities.Combat;
+
+
+public partial class Buff
 {
 
-    public partial class Buff
+    public int FlatStatcount;
+
+    public int PercentageStatcount;
+
+    public long ExpireTime;
+
+    public SpellBase Spell;
+
+    public Buff(SpellBase spell, int flatStats, int percentageStats, long expireTime)
     {
+        Spell = spell;
+        FlatStatcount = flatStats;
+        PercentageStatcount = percentageStats;
+        ExpireTime = expireTime;
+    }
 
-        public int FlatStatcount;
-
-        public int PercentageStatcount;
-
-        public long ExpireTime;
-
-        public SpellBase Spell;
-
-        public Buff(SpellBase spell, int flatStats, int percentageStats, long expireTime)
-        {
-            Spell = spell;
-            FlatStatcount = flatStats;
-            PercentageStatcount = percentageStats;
-            ExpireTime = expireTime;
-        }
-
-        public override string ToString()
-        {
-            return $"[{typeof(Buff).FullName}{{ExpireTime={ExpireTime}, FlatStatcount={FlatStatcount}, PercentageStatcount={PercentageStatcount}, Spell={Spell.Id}}}]";
-        }
-
+    public override string ToString()
+    {
+        return $"[{typeof(Buff).FullName}{{ExpireTime={ExpireTime}, FlatStatcount={FlatStatcount}, PercentageStatcount={PercentageStatcount}, Spell={Spell.Id}}}]";
     }
 
 }

--- a/Intersect.Server.Core/Entities/Combat/DoT.cs
+++ b/Intersect.Server.Core/Entities/Combat/DoT.cs
@@ -2,123 +2,121 @@ using Intersect.Enums;
 using Intersect.GameObjects;
 using Intersect.Utilities;
 
-namespace Intersect.Server.Entities.Combat
+namespace Intersect.Server.Entities.Combat;
+
+
+public partial class DoT
 {
+    public Guid Id = Guid.NewGuid();
 
-    public partial class DoT
+    public Entity Attacker;
+
+    public int Count;
+
+    private long mInterval;
+
+    public SpellBase SpellBase;
+
+    public DoT(Entity attacker, Guid spellId, Entity target)
     {
-        public Guid Id = Guid.NewGuid();
+        SpellBase = SpellBase.Get(spellId);
 
-        public Entity Attacker;
+        Attacker = attacker;
+        Target = target;
 
-        public int Count;
-
-        private long mInterval;
-
-        public SpellBase SpellBase;
-
-        public DoT(Entity attacker, Guid spellId, Entity target)
+        if (SpellBase == null || SpellBase.Combat.HotDotInterval < 1)
         {
-            SpellBase = SpellBase.Get(spellId);
+            return;
+        }
 
-            Attacker = attacker;
-            Target = target;
-
-            if (SpellBase == null || SpellBase.Combat.HotDotInterval < 1)
+        // Does target have a cleanse buff? If so, do not allow this DoT when spell is unfriendly.
+        if (!SpellBase.Combat.Friendly)
+        {
+            foreach (var status in Target.CachedStatuses)
             {
-                return;
-            }
-
-            // Does target have a cleanse buff? If so, do not allow this DoT when spell is unfriendly.
-            if (!SpellBase.Combat.Friendly)
-            {
-                foreach (var status in Target.CachedStatuses)
+                if (status.Type == SpellEffect.Cleanse)
                 {
-                    if (status.Type == SpellEffect.Cleanse)
-                    {
-                        return;
-                    }
+                    return;
                 }
             }
-            
-
-            mInterval = Timing.Global.Milliseconds + SpellBase.Combat.HotDotInterval;
-            Count = (SpellBase.Combat.Duration + SpellBase.Combat.HotDotInterval - 1) / SpellBase.Combat.HotDotInterval;
-            target.DoT.TryAdd(Id, this);
-            target.CachedDots = target.DoT.Values.ToArray();
-
-            //Subtract 1 since the first tick always occurs when the spell is cast.
         }
+        
 
-        public Entity Target { get; }
+        mInterval = Timing.Global.Milliseconds + SpellBase.Combat.HotDotInterval;
+        Count = (SpellBase.Combat.Duration + SpellBase.Combat.HotDotInterval - 1) / SpellBase.Combat.HotDotInterval;
+        target.DoT.TryAdd(Id, this);
+        target.CachedDots = target.DoT.Values.ToArray();
 
-        public void Expire()
+        //Subtract 1 since the first tick always occurs when the spell is cast.
+    }
+
+    public Entity Target { get; }
+
+    public void Expire()
+    {
+        if (Target != null)
         {
-            if (Target != null)
-            {
-                Target.DoT?.TryRemove(Id, out DoT val);
-                Target.CachedDots = Target.DoT?.Values.ToArray() ?? new DoT[0];
-            }
+            Target.DoT?.TryRemove(Id, out DoT val);
+            Target.CachedDots = Target.DoT?.Values.ToArray() ?? new DoT[0];
         }
+    }
 
-        public bool CheckExpired()
+    public bool CheckExpired()
+    {
+        if (Target != null && !Target.DoT.ContainsKey(Id))
         {
-            if (Target != null && !Target.DoT.ContainsKey(Id))
-            {
-                return false;
-            }
-
-            if (SpellBase == null || Count > 0)
-            {
-                return false;
-            }
-
-            Expire();
-
-            return true;
+            return false;
         }
 
-        public void Tick()
+        if (SpellBase == null || Count > 0)
         {
-            if (CheckExpired())
-            {
-                return;
-            }
-
-            if (mInterval > Timing.Global.Milliseconds)
-            {
-                return;
-            }
-
-            var deadAnimations = new List<KeyValuePair<Guid, Direction>>();
-            var aliveAnimations = new List<KeyValuePair<Guid, Direction>>();
-            if (SpellBase.TickAnimationId != Guid.Empty)
-            {
-                var animation = new KeyValuePair<Guid, Direction>(SpellBase.TickAnimationId, Direction.Up);
-                deadAnimations.Add(animation);
-                aliveAnimations.Add(animation);
-            }
-            else if (SpellBase.HitAnimationId != Guid.Empty)
-            {
-                var animation = new KeyValuePair<Guid, Direction>(SpellBase.HitAnimationId, Direction.Up);
-                deadAnimations.Add(animation);
-                aliveAnimations.Add(animation);
-            }
-
-            var damageHealth = SpellBase.Combat.VitalDiff[(int)Vital.Health];
-            var damageMana = SpellBase.Combat.VitalDiff[(int)Vital.Mana];
-
-            Attacker?.Attack(
-                Target, damageHealth, damageMana,
-                (DamageType)SpellBase.Combat.DamageType, (Enums.Stat)SpellBase.Combat.ScalingStat,
-                SpellBase.Combat.Scaling, SpellBase.Combat.CritChance, SpellBase.Combat.CritMultiplier, deadAnimations,
-                aliveAnimations, false
-            );
-
-            mInterval = Timing.Global.Milliseconds + SpellBase.Combat.HotDotInterval;
-            Count--;
+            return false;
         }
 
+        Expire();
+
+        return true;
+    }
+
+    public void Tick()
+    {
+        if (CheckExpired())
+        {
+            return;
+        }
+
+        if (mInterval > Timing.Global.Milliseconds)
+        {
+            return;
+        }
+
+        var deadAnimations = new List<KeyValuePair<Guid, Direction>>();
+        var aliveAnimations = new List<KeyValuePair<Guid, Direction>>();
+        if (SpellBase.TickAnimationId != Guid.Empty)
+        {
+            var animation = new KeyValuePair<Guid, Direction>(SpellBase.TickAnimationId, Direction.Up);
+            deadAnimations.Add(animation);
+            aliveAnimations.Add(animation);
+        }
+        else if (SpellBase.HitAnimationId != Guid.Empty)
+        {
+            var animation = new KeyValuePair<Guid, Direction>(SpellBase.HitAnimationId, Direction.Up);
+            deadAnimations.Add(animation);
+            aliveAnimations.Add(animation);
+        }
+
+        var damageHealth = SpellBase.Combat.VitalDiff[(int)Vital.Health];
+        var damageMana = SpellBase.Combat.VitalDiff[(int)Vital.Mana];
+
+        Attacker?.Attack(
+            Target, damageHealth, damageMana,
+            (DamageType)SpellBase.Combat.DamageType, (Enums.Stat)SpellBase.Combat.ScalingStat,
+            SpellBase.Combat.Scaling, SpellBase.Combat.CritChance, SpellBase.Combat.CritMultiplier, deadAnimations,
+            aliveAnimations, false
+        );
+
+        mInterval = Timing.Global.Milliseconds + SpellBase.Combat.HotDotInterval;
+        Count--;
     }
 
 }

--- a/Intersect.Server.Core/Entities/Combat/Stat.cs
+++ b/Intersect.Server.Core/Entities/Combat/Stat.cs
@@ -1,109 +1,107 @@
 using System.Collections.Concurrent;
 using Intersect.GameObjects;
 
-namespace Intersect.Server.Entities.Combat
+namespace Intersect.Server.Entities.Combat;
+
+
+public partial class Stat
 {
 
-    public partial class Stat
+    private ConcurrentDictionary<SpellBase, Buff> mBuff = new ConcurrentDictionary<SpellBase, Buff>();
+
+    private Buff[] mCachedBuffs = new Buff[0];
+
+    private bool mChanged;
+
+    private Entity mOwner;
+
+    private Enums.Stat mStatType;
+
+    public override string ToString()
     {
+        var cachedBuffs = string.Join(",\n", mCachedBuffs.Select(buff => $"\t\t{buff}"));
+        return $"[{typeof(Stat).FullName}{{Owner={(mOwner?.GetType().Name ?? "UNKNOWN")}, StatType={mStatType}, Changed={mChanged}, CachedBuffs=[\n{cachedBuffs}\n\t], Buff.Count={mBuff.Count} }}]";
+    }
 
-        private ConcurrentDictionary<SpellBase, Buff> mBuff = new ConcurrentDictionary<SpellBase, Buff>();
+    public Stat(Enums.Stat statType, Entity owner)
+    {
+        mOwner = owner;
+        mStatType = statType;
+    }
 
-        private Buff[] mCachedBuffs = new Buff[0];
+    public int BaseStat
+    {
+        get => mOwner.BaseStats[(int)mStatType];
+        set => mOwner.BaseStats[(int)mStatType] = value;
+    }
 
-        private bool mChanged;
+    public int Value()
+    {
+        // Get our base flat and percentage stats to calculate with.
+        var flatStats = BaseStat + mOwner.StatPointAllocations[(int)mStatType];
+        var percentageStats = 0;
 
-        private Entity mOwner;
-
-        private Enums.Stat mStatType;
-
-        public override string ToString()
+        // Add item buffs
+        if (mOwner is Player player)
         {
-            var cachedBuffs = string.Join(",\n", mCachedBuffs.Select(buff => $"\t\t{buff}"));
-            return $"[{typeof(Stat).FullName}{{Owner={(mOwner?.GetType().Name ?? "UNKNOWN")}, StatType={mStatType}, Changed={mChanged}, CachedBuffs=[\n{cachedBuffs}\n\t], Buff.Count={mBuff.Count} }}]";
+            var statBuffs = player.GetItemStatBuffs(mStatType);
+            flatStats += statBuffs.Item1;
+            percentageStats += statBuffs.Item2;
         }
 
-        public Stat(Enums.Stat statType, Entity owner)
+        //Add spell buffs
+        foreach (var buff in mCachedBuffs)
         {
-            mOwner = owner;
-            mStatType = statType;
+            flatStats += buff.FlatStatcount;
+            percentageStats += buff.PercentageStatcount;
         }
 
-        public int BaseStat
+        // Calculate our final stat
+        var finalStat = (int)Math.Ceiling(flatStats + (flatStats * (percentageStats / 100f)));
+        if (finalStat <= 0)
         {
-            get => mOwner.BaseStats[(int)mStatType];
-            set => mOwner.BaseStats[(int)mStatType] = value;
+            finalStat = 1; //No 0 or negative stats, will give errors elsewhere in the code (especially divide by 0 errors).
         }
 
-        public int Value()
-        {
-            // Get our base flat and percentage stats to calculate with.
-            var flatStats = BaseStat + mOwner.StatPointAllocations[(int)mStatType];
-            var percentageStats = 0;
+        return finalStat;
+    }
 
-            // Add item buffs
-            if (mOwner is Player player)
+    public bool Update(long time)
+    {
+        var origVal = Value();
+        var changed = false;
+        foreach (var buff in mBuff)
+        {
+            if (buff.Value.ExpireTime <= time)
             {
-                var statBuffs = player.GetItemStatBuffs(mStatType);
-                flatStats += statBuffs.Item1;
-                percentageStats += statBuffs.Item2;
+                changed |= mBuff.TryRemove(buff.Key, out Buff result);
             }
-
-            //Add spell buffs
-            foreach (var buff in mCachedBuffs)
-            {
-                flatStats += buff.FlatStatcount;
-                percentageStats += buff.PercentageStatcount;
-            }
-
-            // Calculate our final stat
-            var finalStat = (int)Math.Ceiling(flatStats + (flatStats * (percentageStats / 100f)));
-            if (finalStat <= 0)
-            {
-                finalStat = 1; //No 0 or negative stats, will give errors elsewhere in the code (especially divide by 0 errors).
-            }
-
-            return finalStat;
         }
 
-        public bool Update(long time)
+        if (changed)
         {
-            var origVal = Value();
-            var changed = false;
-            foreach (var buff in mBuff)
-            {
-                if (buff.Value.ExpireTime <= time)
-                {
-                    changed |= mBuff.TryRemove(buff.Key, out Buff result);
-                }
-            }
-
-            if (changed)
-            {
-                mCachedBuffs = mBuff.Values.ToArray();
-            }
-
-            changed |= Value() != origVal;
-            changed |= mChanged;
-            mChanged = false;
-
-            return changed;
-        }
-
-        public void AddBuff(Buff buff)
-        {
-            var origVal = Value();
-            mBuff.AddOrUpdate(buff.Spell, buff, (key, val) => buff);
-            mCachedBuffs = mBuff.Values.ToArray();
-            mChanged = Value() != origVal;
-        }
-
-        public void Reset()
-        {
-            mBuff.Clear();
             mCachedBuffs = mBuff.Values.ToArray();
         }
 
+        changed |= Value() != origVal;
+        changed |= mChanged;
+        mChanged = false;
+
+        return changed;
+    }
+
+    public void AddBuff(Buff buff)
+    {
+        var origVal = Value();
+        mBuff.AddOrUpdate(buff.Spell, buff, (key, val) => buff);
+        mCachedBuffs = mBuff.Values.ToArray();
+        mChanged = Value() != origVal;
+    }
+
+    public void Reset()
+    {
+        mBuff.Clear();
+        mCachedBuffs = mBuff.Values.ToArray();
     }
 
 }

--- a/Intersect.Server.Core/Entities/Combat/Status.cs
+++ b/Intersect.Server.Core/Entities/Combat/Status.cs
@@ -4,264 +4,262 @@ using Intersect.Server.General;
 using Intersect.Server.Networking;
 using Intersect.Utilities;
 
-namespace Intersect.Server.Entities.Combat
+namespace Intersect.Server.Entities.Combat;
+
+
+public partial class Status
 {
 
-    public partial class Status
+    public string Data = "";
+
+    public long Duration;
+
+    private Entity mEntity;
+
+    public Entity Attacker;
+
+    public SpellBase Spell;
+
+    public long StartTime;
+
+    public SpellEffect Type;
+
+    public static List<SpellEffect> TenacityExcluded = new List<SpellEffect>()
     {
+        SpellEffect.None,
+        SpellEffect.Stealth,
+        SpellEffect.Cleanse,
+        SpellEffect.Invulnerable,
+        SpellEffect.OnHit,
+        SpellEffect.Shield,
+        SpellEffect.Transform,
+    };
 
-        public string Data = "";
+    public static List<SpellEffect> InterruptStatusses = new List<SpellEffect>()
+    {
+        SpellEffect.Silence,
+        SpellEffect.Sleep,
+        SpellEffect.Stun,
+    };
 
-        public long Duration;
+    public Status(Entity en, Entity attacker, SpellBase spell, SpellEffect type, int duration, string data)
+    {
+        mEntity = en;
+        Attacker = attacker;
+        Spell = spell;
+        Type = type;
+        Data = data;
 
-        private Entity mEntity;
-
-        public Entity Attacker;
-
-        public SpellBase Spell;
-
-        public long StartTime;
-
-        public SpellEffect Type;
-
-        public static List<SpellEffect> TenacityExcluded = new List<SpellEffect>()
+        // Handle Player specific stuff, such as interrupting spellcasts
+        var tenacity = 0f;
+        if (en is Player player)
         {
-            SpellEffect.None,
-            SpellEffect.Stealth,
-            SpellEffect.Cleanse,
-            SpellEffect.Invulnerable,
-            SpellEffect.OnHit,
-            SpellEffect.Shield,
-            SpellEffect.Transform,
-        };
-
-        public static List<SpellEffect> InterruptStatusses = new List<SpellEffect>()
-        {
-            SpellEffect.Silence,
-            SpellEffect.Sleep,
-            SpellEffect.Stun,
-        };
-
-        public Status(Entity en, Entity attacker, SpellBase spell, SpellEffect type, int duration, string data)
-        {
-            mEntity = en;
-            Attacker = attacker;
-            Spell = spell;
-            Type = type;
-            Data = data;
-
-            // Handle Player specific stuff, such as interrupting spellcasts
-            var tenacity = 0f;
-            if (en is Player player)
+            // Get our player's Tenacity stat!
+            if (!TenacityExcluded.Contains(type))
             {
-                // Get our player's Tenacity stat!
-                if (!TenacityExcluded.Contains(type))
-                {
-                    tenacity = player.GetEquipmentBonusEffect(ItemEffect.Tenacity);
-                }
-
-                // Interrupt their spellcast if we are running a Silence, Sleep or Stun!
-                if (Status.InterruptStatusses.Contains(type))
-                {
-                    player.CastTime = 0;
-                    player.CastTarget = null;
-                    player.SpellCastSlot = -1;
-                    PacketSender.SendEntityCancelCast(player);
-                }
-            }
-            else if (en is Npc thisNpc)
-            {
-                // Get our NPC's Tenacity stat
-                if (!Status.TenacityExcluded.Contains(type))
-                {
-                    tenacity = (float)thisNpc.Base.Tenacity;
-                }
-            }
-
-            // Handle Npc specific stuff, such as loot tables!
-            if (en is Npc npc)
-            {
-                // Add to loot map if not already eligible.
-                if (!npc.LootMap.ContainsKey(Attacker.Id))
-                {
-                    npc.LootMap.TryAdd(Attacker.Id, true);
-                    npc.LootMapCache = npc.LootMap.Keys.ToArray();
-                }
+                tenacity = player.GetEquipmentBonusEffect(ItemEffect.Tenacity);
             }
 
             // Interrupt their spellcast if we are running a Silence, Sleep or Stun!
-            if (InterruptStatusses.Contains(type))
+            if (Status.InterruptStatusses.Contains(type))
             {
-                en.CastTime = 0;
-                en.CastTarget = null;
-                en.SpellCastSlot = -1;
-                PacketSender.SendEntityCancelCast(en);
+                player.CastTime = 0;
+                player.CastTarget = null;
+                player.SpellCastSlot = -1;
+                PacketSender.SendEntityCancelCast(player);
             }
-
-            // If we're adding a shield, actually add that according to the settings.
-            if (type == SpellEffect.Shield)
+        }
+        else if (en is Npc thisNpc)
+        {
+            // Get our NPC's Tenacity stat
+            if (!Status.TenacityExcluded.Contains(type))
             {
-                foreach (var vital in Enum.GetValues<Vital>())
+                tenacity = (float)thisNpc.Base.Tenacity;
+            }
+        }
+
+        // Handle Npc specific stuff, such as loot tables!
+        if (en is Npc npc)
+        {
+            // Add to loot map if not already eligible.
+            if (!npc.LootMap.ContainsKey(Attacker.Id))
+            {
+                npc.LootMap.TryAdd(Attacker.Id, true);
+                npc.LootMapCache = npc.LootMap.Keys.ToArray();
+            }
+        }
+
+        // Interrupt their spellcast if we are running a Silence, Sleep or Stun!
+        if (InterruptStatusses.Contains(type))
+        {
+            en.CastTime = 0;
+            en.CastTarget = null;
+            en.SpellCastSlot = -1;
+            PacketSender.SendEntityCancelCast(en);
+        }
+
+        // If we're adding a shield, actually add that according to the settings.
+        if (type == SpellEffect.Shield)
+        {
+            foreach (var vital in Enum.GetValues<Vital>())
+            {
+                long vitalDiff = Math.Abs(spell.Combat.VitalDiff[(int)vital]);
+
+                // If the user did not configure for this vital to have a mana shield, ignore it
+                if (vitalDiff == 0 && vital == Vital.Mana)
                 {
-                    long vitalDiff = Math.Abs(spell.Combat.VitalDiff[(int)vital]);
+                    continue;
+                }
 
-                    // If the user did not configure for this vital to have a mana shield, ignore it
-                    if (vitalDiff == 0 && vital == Vital.Mana)
-                    {
-                        continue;
-                    }
+                var shieldAmount = Formulas.CalculateDamage(
+                    vitalDiff, (DamageType)spell.Combat.DamageType, (Enums.Stat)spell.Combat.ScalingStat, spell.Combat.Scaling, 1.0, attacker, en
+                );
 
-                    var shieldAmount = Formulas.CalculateDamage(
-                        vitalDiff, (DamageType)spell.Combat.DamageType, (Enums.Stat)spell.Combat.ScalingStat, spell.Combat.Scaling, 1.0, attacker, en
-                    );
+                Shield[(int)vital] = Math.Abs(shieldAmount);
+            }
+        }
 
-                    Shield[(int)vital] = Math.Abs(shieldAmount);
+        // If new Cleanse spell, remove all opposite statusses. (ie friendly dispels unfriendly and vice versa)
+        if (Type == SpellEffect.Cleanse)
+        {
+            foreach (var status in en.CachedStatuses)
+            {
+                if (spell.Combat.Friendly != status.Spell.Combat.Friendly)
+                {
+                    status.RemoveStatus();
                 }
             }
 
-            // If new Cleanse spell, remove all opposite statusses. (ie friendly dispels unfriendly and vice versa)
-            if (Type == SpellEffect.Cleanse)
+            foreach (var dot in en.CachedDots)
             {
-                foreach (var status in en.CachedStatuses)
+                if (spell.Combat.Friendly != dot.SpellBase.Combat.Friendly)
                 {
-                    if (spell.Combat.Friendly != status.Spell.Combat.Friendly)
-                    {
-                        status.RemoveStatus();
-                    }
-                }
-
-                foreach (var dot in en.CachedDots)
-                {
-                    if (spell.Combat.Friendly != dot.SpellBase.Combat.Friendly)
-                    {
-                        dot.Expire();
-                    }
+                    dot.Expire();
                 }
             }
+        }
 
-            // Remove existing taunts if this is one and there are any others.
-            // We'll be overwriting it, baby!
-            if (Type == SpellEffect.Taunt)
+        // Remove existing taunts if this is one and there are any others.
+        // We'll be overwriting it, baby!
+        if (Type == SpellEffect.Taunt)
+        {
+            foreach (var status in en.CachedStatuses)
             {
-                foreach (var status in en.CachedStatuses)
+                if (status.Type == SpellEffect.Taunt)
                 {
-                    if (status.Type == SpellEffect.Taunt)
-                    {
-                        status.RemoveStatus();
-                    }
+                    status.RemoveStatus();
                 }
             }
+        }
 
-            // Calculate our final duration and pass it on!
-            var finalDuration = duration - (duration * (tenacity / 100f));
-            if (en.Statuses.ContainsKey(spell))
+        // Calculate our final duration and pass it on!
+        var finalDuration = duration - (duration * (tenacity / 100f));
+        if (en.Statuses.ContainsKey(spell))
+        {
+            en.Statuses[spell].StartTime = Timing.Global.Milliseconds;
+            en.Statuses[spell].Duration = Timing.Global.Milliseconds + (long)finalDuration;
+            en.Statuses[spell].StartTime = StartTime;
+            en.CachedStatuses = en.Statuses.Values.ToArray();
+        }
+        else
+        {
+            StartTime = Timing.Global.Milliseconds;
+            Duration = Timing.Global.Milliseconds + (long)finalDuration;
+            en.Statuses.TryAdd(Spell, this);
+            en.CachedStatuses = en.Statuses.Values.ToArray();
+        }
+
+        // If this is a taunt, force the target properly for players and NPCs
+        if (Type == SpellEffect.Taunt)
+        {
+
+            // If player, force send target!
+            if (en is Player targetPlayer)
             {
-                en.Statuses[spell].StartTime = Timing.Global.Milliseconds;
-                en.Statuses[spell].Duration = Timing.Global.Milliseconds + (long)finalDuration;
-                en.Statuses[spell].StartTime = StartTime;
-                en.CachedStatuses = en.Statuses.Values.ToArray();
+                en.Target = Attacker;
+                PacketSender.SetPlayerTarget(targetPlayer, Attacker.Id);
             }
-            else
+            // If NPC, force assign target and make sure we have the highest threat +1 so we in theory have the highest threat.. for now..
+            else if (en is Npc targetNpc)
             {
-                StartTime = Timing.Global.Milliseconds;
-                Duration = Timing.Global.Milliseconds + (long)finalDuration;
-                en.Statuses.TryAdd(Spell, this);
-                en.CachedStatuses = en.Statuses.Values.ToArray();
-            }
+                targetNpc.AssignTarget(Attacker);
 
-            // If this is a taunt, force the target properly for players and NPCs
-            if (Type == SpellEffect.Taunt)
-            {
-
-                // If player, force send target!
-                if (en is Player targetPlayer)
+                if (!targetNpc.DamageMap.ContainsKey(Attacker))
                 {
-                    en.Target = Attacker;
-                    PacketSender.SetPlayerTarget(targetPlayer, Attacker.Id);
-                }
-                // If NPC, force assign target and make sure we have the highest threat +1 so we in theory have the highest threat.. for now..
-                else if (en is Npc targetNpc)
-                {
-                    targetNpc.AssignTarget(Attacker);
-
-                    if (!targetNpc.DamageMap.ContainsKey(Attacker))
+                    if (targetNpc.DamageMap.Count > 0)
                     {
-                        if (targetNpc.DamageMap.Count > 0)
-                        {
-                            targetNpc.DamageMap.TryAdd(Attacker, targetNpc.DamageMap.ToArray().Max(x => x.Value) + 1);
-                        }
-                        else
-                        {
-                            targetNpc.DamageMap.TryAdd(Attacker, 1);
-                        }
+                        targetNpc.DamageMap.TryAdd(Attacker, targetNpc.DamageMap.ToArray().Max(x => x.Value) + 1);
                     }
                     else
                     {
-                        targetNpc.DamageMap[Attacker] = targetNpc.DamageMap.ToArray().Max(x => x.Value) + 1;
+                        targetNpc.DamageMap.TryAdd(Attacker, 1);
                     }
                 }
                 else
                 {
-                    en.Target = Attacker;
+                    targetNpc.DamageMap[Attacker] = targetNpc.DamageMap.ToArray().Max(x => x.Value) + 1;
                 }
-
             }
+            else
+            {
+                en.Target = Attacker;
+            }
+
         }
+    }
 
-        public long[] Shield { get; set; } = new long[Enum.GetValues<Vital>().Length];
+    public long[] Shield { get; set; } = new long[Enum.GetValues<Vital>().Length];
 
-        public void TryRemoveStatus()
+    public void TryRemoveStatus()
+    {
+        if (Duration <= Timing.Global.Milliseconds) //Check the timer
         {
-            if (Duration <= Timing.Global.Milliseconds) //Check the timer
-            {
-                RemoveStatus();
-            }
-
-            //If shield check for out of hp
-            if (Type == SpellEffect.Shield)
-            {
-                for (var i = (int)Vital.Health; i < Enum.GetValues<Vital>().Length; i++)
-                {
-                    if (Shield[i] > 0)
-                    {
-                        return;
-                    }
-                }
-
-                RemoveStatus();
-            }
+            RemoveStatus();
         }
 
-        public void RemoveStatus()
+        //If shield check for out of hp
+        if (Type == SpellEffect.Shield)
         {
-            mEntity.Statuses.TryRemove(Spell, out Status val);
-            mEntity.CachedStatuses = mEntity.Statuses.Values.ToArray();
-
-            // if this was a taunt status being removed, we have to scan for a new target!
-            if (mEntity is Npc npc && Type == SpellEffect.Taunt)
+            for (var i = (int)Vital.Health; i < Enum.GetValues<Vital>().Length; i++)
             {
-                npc.TryFindNewTarget(0, Guid.Empty, true);
+                if (Shield[i] > 0)
+                {
+                    return;
+                }
             }
-        }
 
-        public void DamageShield(Vital vital, ref long amount)
+            RemoveStatus();
+        }
+    }
+
+    public void RemoveStatus()
+    {
+        mEntity.Statuses.TryRemove(Spell, out Status val);
+        mEntity.CachedStatuses = mEntity.Statuses.Values.ToArray();
+
+        // if this was a taunt status being removed, we have to scan for a new target!
+        if (mEntity is Npc npc && Type == SpellEffect.Taunt)
         {
-            if (Type == SpellEffect.Shield)
+            npc.TryFindNewTarget(0, Guid.Empty, true);
+        }
+    }
+
+    public void DamageShield(Vital vital, ref long amount)
+    {
+        if (Type == SpellEffect.Shield)
+        {
+            Shield[(int)vital] -= amount;
+            if (Shield[(int)vital] <= 0)
             {
-                Shield[(int)vital] -= amount;
-                if (Shield[(int)vital] <= 0)
-                {
-                    amount = -Shield[(int)vital]; //Return piercing damage.
-                    Shield[(int)vital] = 0;
-                    TryRemoveStatus();
-                }
-                else
-                {
-                    amount = 0; //Sheild is stronger than the damage dealt, so no piercing damage.
-                }
+                amount = -Shield[(int)vital]; //Return piercing damage.
+                Shield[(int)vital] = 0;
+                TryRemoveStatus();
+            }
+            else
+            {
+                amount = 0; //Sheild is stronger than the damage dealt, so no piercing damage.
             }
         }
-
     }
 
 }

--- a/Intersect.Server.Core/Entities/Entity.Comparison.cs
+++ b/Intersect.Server.Core/Entities/Entity.Comparison.cs
@@ -1,29 +1,27 @@
-namespace Intersect.Server.Entities
+namespace Intersect.Server.Entities;
+
+
+public partial class Entity
 {
 
-    public partial class Entity
+    #region Comparison
+
+    /// <summary>
+    /// Compares two player names, returning if they are equivalent.
+    /// </summary>
+    /// <param name="name">a name</param>
+    /// <param name="nameOther">a name to compare with</param>
+    /// <returns><code>false</code> if <code>null</code> or non-byte-equal ignoring case</returns>
+    public static bool CompareName(string name, string nameOther)
     {
-
-        #region Comparison
-
-        /// <summary>
-        /// Compares two player names, returning if they are equivalent.
-        /// </summary>
-        /// <param name="name">a name</param>
-        /// <param name="nameOther">a name to compare with</param>
-        /// <returns><code>false</code> if <code>null</code> or non-byte-equal ignoring case</returns>
-        public static bool CompareName(string name, string nameOther)
+        if (string.IsNullOrEmpty(name) || string.IsNullOrEmpty(nameOther))
         {
-            if (string.IsNullOrEmpty(name) || string.IsNullOrEmpty(nameOther))
-            {
-                return false;
-            }
-
-            return string.Equals(name, nameOther, StringComparison.OrdinalIgnoreCase);
+            return false;
         }
 
-        #endregion
-
+        return string.Equals(name, nameOther, StringComparison.OrdinalIgnoreCase);
     }
+
+    #endregion
 
 }

--- a/Intersect.Server.Core/Entities/Entity.cs
+++ b/Intersect.Server.Core/Entities/Entity.cs
@@ -19,1519 +19,1699 @@ using Newtonsoft.Json;
 using MapAttribute = Intersect.Enums.MapAttribute;
 using Stat = Intersect.Enums.Stat;
 
-namespace Intersect.Server.Entities
+namespace Intersect.Server.Entities;
+
+public abstract partial class Entity : IDisposable
 {
-    public abstract partial class Entity : IDisposable
+    //Instance Values
+    private Guid _id = Guid.NewGuid();
+
+    public Guid MapInstanceId = Guid.Empty;
+
+    [JsonProperty("MaxVitals"), NotMapped] private long[] _maxVital = new long[Enum.GetValues<Vital>().Length];
+
+    [NotMapped, JsonIgnore] public Combat.Stat[] Stat = new Combat.Stat[Enum.GetValues<Stat>().Length];
+
+    [NotMapped, JsonIgnore] public Entity Target { get; set; } = null;
+
+    public Entity() : this(Guid.NewGuid(), Guid.Empty)
     {
-        //Instance Values
-        private Guid _id = Guid.NewGuid();
+    }
 
-        public Guid MapInstanceId = Guid.Empty;
-
-        [JsonProperty("MaxVitals"), NotMapped] private long[] _maxVital = new long[Enum.GetValues<Vital>().Length];
-
-        [NotMapped, JsonIgnore] public Combat.Stat[] Stat = new Combat.Stat[Enum.GetValues<Stat>().Length];
-
-        [NotMapped, JsonIgnore] public Entity Target { get; set; } = null;
-
-        public Entity() : this(Guid.NewGuid(), Guid.Empty)
+    //Initialization
+    public Entity(Guid instanceId, Guid mapInstanceId)
+    {
+        if (!(this is EventPageInstance) && !(this is Projectile))
         {
-        }
-
-        //Initialization
-        public Entity(Guid instanceId, Guid mapInstanceId)
-        {
-            if (!(this is EventPageInstance) && !(this is Projectile))
+            for (var i = 0; i < Enum.GetValues<Stat>().Length; i++)
             {
-                for (var i = 0; i < Enum.GetValues<Stat>().Length; i++)
+                Stat[i] = new Combat.Stat((Stat)i, this);
+            }
+        }
+        MapInstanceId = mapInstanceId;
+
+        Id = instanceId;
+    }
+
+    [Column(Order = 1), JsonProperty(Order = -2)]
+    public string Name { get; set; }
+
+    public Guid MapId { get; set; }
+
+    [NotMapped]
+    public string MapName => MapController.GetName(MapId);
+
+    [JsonIgnore]
+    [NotMapped]
+    public MapController Map => MapController.Get(MapId);
+
+    public int X { get; set; }
+
+    public int Y { get; set; }
+
+    public int Z { get; set; }
+
+    public Direction Dir { get; set; }
+
+    public string Sprite { get; set; }
+
+    /// <summary>
+    /// The database compatible version of <see cref="Color"/>
+    /// </summary>
+    [JsonIgnore, Column(nameof(Color))]
+    public string JsonColor
+    {
+        get => JsonConvert.SerializeObject(Color);
+        set => Color = !string.IsNullOrWhiteSpace(value) ? JsonConvert.DeserializeObject<Color>(value) : Color.White;
+    }
+
+    /// <summary>
+    /// Defines the ARGB color settings for this Entity.
+    /// </summary>
+    [NotMapped]
+    public Color Color { get; set; } = new Color(255, 255, 255, 255);
+
+    public string Face { get; set; }
+
+    public int Level { get; set; }
+
+    [JsonIgnore, Column("Vitals")]
+    public string VitalsJson
+    {
+        get => DatabaseUtils.SaveLongArray(mVitals, Enum.GetValues<Vital>().Length);
+        set => mVitals = DatabaseUtils.LoadLongArray(value, Enum.GetValues<Vital>().Length);
+    }
+
+    [JsonProperty("Vitals"), NotMapped]
+    private long[] mVitals { get; set; } = new long[Enum.GetValues<Vital>().Length];
+
+    [JsonIgnore, NotMapped]
+    private long[] mOldVitals { get; set; } = new long[Enum.GetValues<Vital>().Length];
+
+    [JsonIgnore, NotMapped]
+    private long[] mOldMaxVitals { get; set; } = new long[Enum.GetValues<Vital>().Length];
+
+    //Stats based on npc settings, class settings, etc for quick calculations
+    [JsonIgnore, Column(nameof(BaseStats))]
+    public string StatsJson
+    {
+        get => DatabaseUtils.SaveIntArray(BaseStats, Enum.GetValues<Stat>().Length);
+        set => BaseStats = DatabaseUtils.LoadIntArray(value, Enum.GetValues<Stat>().Length);
+    }
+
+    // TODO: Why can this be BaseStats while Vitals is _vital and MaxVitals is _maxVital?
+    [NotMapped]
+    public int[] BaseStats { get; set; } = new int[Enum.GetValues<Stat>().Length];
+
+    [JsonIgnore, Column(nameof(StatPointAllocations))]
+    public string StatPointsJson
+    {
+        get => DatabaseUtils.SaveIntArray(StatPointAllocations, Enum.GetValues<Stat>().Length);
+        set => StatPointAllocations = DatabaseUtils.LoadIntArray(value, Enum.GetValues<Stat>().Length);
+    }
+
+    [NotMapped]
+    public int[] StatPointAllocations { get; set; } = new int[Enum.GetValues<Stat>().Length];
+
+    //Inventory
+    [JsonIgnore]
+    public virtual List<InventorySlot> Items { get; set; } = new List<InventorySlot>();
+
+    //Spells
+    [JsonIgnore]
+    public virtual List<SpellSlot> Spells { get; set; } = new List<SpellSlot>();
+
+    [JsonIgnore, Column(nameof(NameColor))]
+    public string NameColorJson
+    {
+        get => DatabaseUtils.SaveColor(NameColor);
+        set => NameColor = DatabaseUtils.LoadColor(value);
+    }
+
+    [NotMapped]
+    public Color NameColor { get; set; }
+
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
+    [Column(Order = 0)]
+    public Guid Id { get => _id; set => _id = value; }
+
+    [NotMapped]
+    public Label HeaderLabel { get; set; }
+
+    [JsonIgnore, Column(nameof(HeaderLabel))]
+    public string HeaderLabelJson
+    {
+        get => JsonConvert.SerializeObject(HeaderLabel);
+        set => HeaderLabel = value != null ? JsonConvert.DeserializeObject<Label>(value) : new Label();
+    }
+
+    [NotMapped]
+    public Label FooterLabel { get; set; }
+
+    [JsonIgnore, Column(nameof(FooterLabel))]
+    public string FooterLabelJson
+    {
+        get => JsonConvert.SerializeObject(FooterLabel);
+        set => FooterLabel = value != null ? JsonConvert.DeserializeObject<Label>(value) : new Label();
+    }
+
+    [NotMapped]
+    public bool Dead { get; set; }
+
+    //Combat
+    [NotMapped, JsonIgnore]
+    public long CastTime { get; set; }
+
+    [NotMapped, JsonIgnore]
+    public long AttackTimer { get; set; }
+
+    [NotMapped, JsonIgnore]
+    public Entity CastTarget { get; set; }
+
+    [NotMapped, JsonIgnore]
+    public Guid CollisionIndex { get; set; }
+
+    [NotMapped, JsonIgnore]
+    public long CombatTimer { get; set; }
+
+    //Combat Status
+    [NotMapped, JsonIgnore]
+    public bool IsAttacking => AttackTimer > Timing.Global.Milliseconds;
+
+    [NotMapped, JsonIgnore]
+    public bool IsBlocking { get; set; }
+
+    [NotMapped, JsonIgnore]
+    public bool IsCasting => CastTime > Timing.Global.Milliseconds;
+
+    [NotMapped, JsonIgnore]
+    public bool IsTurnAroundWhileCastingDisabled => !Options.Instance.CombatOpts.EnableTurnAroundWhileCasting && IsCasting;
+
+    //Visuals
+    [NotMapped, JsonIgnore]
+    public bool HideName { get; set; }
+
+    [NotMapped, JsonIgnore]
+    public bool HideEntity { get; set; } = false;
+
+    [NotMapped, JsonIgnore]
+    public List<Guid> Animations { get; set; } = new List<Guid>();
+
+    //DoT/HoT Spells
+    [NotMapped, JsonIgnore]
+    public ConcurrentDictionary<Guid, DoT> DoT { get; set; } = new ConcurrentDictionary<Guid, DoT>();
+
+    [NotMapped, JsonIgnore]
+    public DoT[] CachedDots { get; set; } = new DoT[0];
+
+    [NotMapped, JsonIgnore]
+    public EventMoveRoute MoveRoute { get; set; } = null;
+
+    [NotMapped, JsonIgnore]
+    public EventPageInstance MoveRouteSetter { get; set; } = null;
+
+    [NotMapped, JsonIgnore]
+    public long MoveTimer { get; set; }
+
+    [NotMapped, JsonIgnore]
+    public bool Passable { get; set; } = false;
+
+    [NotMapped, JsonIgnore]
+    public long RegenTimer { get; set; } = Timing.Global.Milliseconds;
+
+    [NotMapped, JsonIgnore]
+    public int SpellCastSlot { get; set; } = 0;
+
+    //Status effects
+    [NotMapped, JsonIgnore]
+    public ConcurrentDictionary<SpellBase, Status> Statuses { get; } = new ConcurrentDictionary<SpellBase, Status>();
+
+    [JsonIgnore, NotMapped]
+    public Status[] CachedStatuses = new Status[0];
+
+    [JsonIgnore, NotMapped]
+    private Status[] mOldStatuses = new Status[0];
+
+    [JsonIgnore, NotMapped]
+    public List<SpellEffect> Immunities = new List<SpellEffect>();
+
+    [NotMapped, JsonIgnore]
+    public bool IsDisposed { get; protected set; }
+
+    [NotMapped, JsonIgnore]
+    public object EntityLock = new object();
+
+    [NotMapped, JsonIgnore]
+    public bool VitalsUpdated
+    {
+        get => !GetVitals().SequenceEqual(mOldVitals) || !GetMaxVitals().SequenceEqual(mOldMaxVitals);
+
+        set
+        {
+            if (value == false)
+            {
+                mOldVitals = GetVitals();
+                mOldMaxVitals = GetMaxVitals();
+            }
+        }
+    }
+
+    [NotMapped, JsonIgnore]
+    public bool StatusesUpdated
+    {
+        get => CachedStatuses != mOldStatuses; //The whole CachedStatuses assignment gets changed when a status is added, removed, or updated (time remaining changes, so we only check for reference equivity here)
+
+        set
+        {
+            if (value == false)
+            {
+                mOldStatuses = CachedStatuses;
+            }
+        }
+    }
+
+    public virtual void Dispose()
+    {
+        if (!IsDisposed)
+        {
+            IsDisposed = true;
+        }
+    }
+
+    public virtual void Update(long timeMs)
+    {
+        var lockObtained = false;
+        try
+        {
+            Monitor.TryEnter(EntityLock, ref lockObtained);
+            if (lockObtained)
+            {
+                if (Target?.IsDisposed ?? false)
                 {
-                    Stat[i] = new Combat.Stat((Stat)i, this);
-                }
-            }
-            MapInstanceId = mapInstanceId;
-
-            Id = instanceId;
-        }
-
-        [Column(Order = 1), JsonProperty(Order = -2)]
-        public string Name { get; set; }
-
-        public Guid MapId { get; set; }
-
-        [NotMapped]
-        public string MapName => MapController.GetName(MapId);
-
-        [JsonIgnore]
-        [NotMapped]
-        public MapController Map => MapController.Get(MapId);
-
-        public int X { get; set; }
-
-        public int Y { get; set; }
-
-        public int Z { get; set; }
-
-        public Direction Dir { get; set; }
-
-        public string Sprite { get; set; }
-
-        /// <summary>
-        /// The database compatible version of <see cref="Color"/>
-        /// </summary>
-        [JsonIgnore, Column(nameof(Color))]
-        public string JsonColor
-        {
-            get => JsonConvert.SerializeObject(Color);
-            set => Color = !string.IsNullOrWhiteSpace(value) ? JsonConvert.DeserializeObject<Color>(value) : Color.White;
-        }
-
-        /// <summary>
-        /// Defines the ARGB color settings for this Entity.
-        /// </summary>
-        [NotMapped]
-        public Color Color { get; set; } = new Color(255, 255, 255, 255);
-
-        public string Face { get; set; }
-
-        public int Level { get; set; }
-
-        [JsonIgnore, Column("Vitals")]
-        public string VitalsJson
-        {
-            get => DatabaseUtils.SaveLongArray(mVitals, Enum.GetValues<Vital>().Length);
-            set => mVitals = DatabaseUtils.LoadLongArray(value, Enum.GetValues<Vital>().Length);
-        }
-
-        [JsonProperty("Vitals"), NotMapped]
-        private long[] mVitals { get; set; } = new long[Enum.GetValues<Vital>().Length];
-
-        [JsonIgnore, NotMapped]
-        private long[] mOldVitals { get; set; } = new long[Enum.GetValues<Vital>().Length];
-
-        [JsonIgnore, NotMapped]
-        private long[] mOldMaxVitals { get; set; } = new long[Enum.GetValues<Vital>().Length];
-
-        //Stats based on npc settings, class settings, etc for quick calculations
-        [JsonIgnore, Column(nameof(BaseStats))]
-        public string StatsJson
-        {
-            get => DatabaseUtils.SaveIntArray(BaseStats, Enum.GetValues<Stat>().Length);
-            set => BaseStats = DatabaseUtils.LoadIntArray(value, Enum.GetValues<Stat>().Length);
-        }
-
-        // TODO: Why can this be BaseStats while Vitals is _vital and MaxVitals is _maxVital?
-        [NotMapped]
-        public int[] BaseStats { get; set; } = new int[Enum.GetValues<Stat>().Length];
-
-        [JsonIgnore, Column(nameof(StatPointAllocations))]
-        public string StatPointsJson
-        {
-            get => DatabaseUtils.SaveIntArray(StatPointAllocations, Enum.GetValues<Stat>().Length);
-            set => StatPointAllocations = DatabaseUtils.LoadIntArray(value, Enum.GetValues<Stat>().Length);
-        }
-
-        [NotMapped]
-        public int[] StatPointAllocations { get; set; } = new int[Enum.GetValues<Stat>().Length];
-
-        //Inventory
-        [JsonIgnore]
-        public virtual List<InventorySlot> Items { get; set; } = new List<InventorySlot>();
-
-        //Spells
-        [JsonIgnore]
-        public virtual List<SpellSlot> Spells { get; set; } = new List<SpellSlot>();
-
-        [JsonIgnore, Column(nameof(NameColor))]
-        public string NameColorJson
-        {
-            get => DatabaseUtils.SaveColor(NameColor);
-            set => NameColor = DatabaseUtils.LoadColor(value);
-        }
-
-        [NotMapped]
-        public Color NameColor { get; set; }
-
-        [DatabaseGenerated(DatabaseGeneratedOption.None)]
-        [Column(Order = 0)]
-        public Guid Id { get => _id; set => _id = value; }
-
-        [NotMapped]
-        public Label HeaderLabel { get; set; }
-
-        [JsonIgnore, Column(nameof(HeaderLabel))]
-        public string HeaderLabelJson
-        {
-            get => JsonConvert.SerializeObject(HeaderLabel);
-            set => HeaderLabel = value != null ? JsonConvert.DeserializeObject<Label>(value) : new Label();
-        }
-
-        [NotMapped]
-        public Label FooterLabel { get; set; }
-
-        [JsonIgnore, Column(nameof(FooterLabel))]
-        public string FooterLabelJson
-        {
-            get => JsonConvert.SerializeObject(FooterLabel);
-            set => FooterLabel = value != null ? JsonConvert.DeserializeObject<Label>(value) : new Label();
-        }
-
-        [NotMapped]
-        public bool Dead { get; set; }
-
-        //Combat
-        [NotMapped, JsonIgnore]
-        public long CastTime { get; set; }
-
-        [NotMapped, JsonIgnore]
-        public long AttackTimer { get; set; }
-
-        [NotMapped, JsonIgnore]
-        public Entity CastTarget { get; set; }
-
-        [NotMapped, JsonIgnore]
-        public Guid CollisionIndex { get; set; }
-
-        [NotMapped, JsonIgnore]
-        public long CombatTimer { get; set; }
-
-        //Combat Status
-        [NotMapped, JsonIgnore]
-        public bool IsAttacking => AttackTimer > Timing.Global.Milliseconds;
-
-        [NotMapped, JsonIgnore]
-        public bool IsBlocking { get; set; }
-
-        [NotMapped, JsonIgnore]
-        public bool IsCasting => CastTime > Timing.Global.Milliseconds;
-
-        [NotMapped, JsonIgnore]
-        public bool IsTurnAroundWhileCastingDisabled => !Options.Instance.CombatOpts.EnableTurnAroundWhileCasting && IsCasting;
-
-        //Visuals
-        [NotMapped, JsonIgnore]
-        public bool HideName { get; set; }
-
-        [NotMapped, JsonIgnore]
-        public bool HideEntity { get; set; } = false;
-
-        [NotMapped, JsonIgnore]
-        public List<Guid> Animations { get; set; } = new List<Guid>();
-
-        //DoT/HoT Spells
-        [NotMapped, JsonIgnore]
-        public ConcurrentDictionary<Guid, DoT> DoT { get; set; } = new ConcurrentDictionary<Guid, DoT>();
-
-        [NotMapped, JsonIgnore]
-        public DoT[] CachedDots { get; set; } = new DoT[0];
-
-        [NotMapped, JsonIgnore]
-        public EventMoveRoute MoveRoute { get; set; } = null;
-
-        [NotMapped, JsonIgnore]
-        public EventPageInstance MoveRouteSetter { get; set; } = null;
-
-        [NotMapped, JsonIgnore]
-        public long MoveTimer { get; set; }
-
-        [NotMapped, JsonIgnore]
-        public bool Passable { get; set; } = false;
-
-        [NotMapped, JsonIgnore]
-        public long RegenTimer { get; set; } = Timing.Global.Milliseconds;
-
-        [NotMapped, JsonIgnore]
-        public int SpellCastSlot { get; set; } = 0;
-
-        //Status effects
-        [NotMapped, JsonIgnore]
-        public ConcurrentDictionary<SpellBase, Status> Statuses { get; } = new ConcurrentDictionary<SpellBase, Status>();
-
-        [JsonIgnore, NotMapped]
-        public Status[] CachedStatuses = new Status[0];
-
-        [JsonIgnore, NotMapped]
-        private Status[] mOldStatuses = new Status[0];
-
-        [JsonIgnore, NotMapped]
-        public List<SpellEffect> Immunities = new List<SpellEffect>();
-
-        [NotMapped, JsonIgnore]
-        public bool IsDisposed { get; protected set; }
-
-        [NotMapped, JsonIgnore]
-        public object EntityLock = new object();
-
-        [NotMapped, JsonIgnore]
-        public bool VitalsUpdated
-        {
-            get => !GetVitals().SequenceEqual(mOldVitals) || !GetMaxVitals().SequenceEqual(mOldMaxVitals);
-
-            set
-            {
-                if (value == false)
-                {
-                    mOldVitals = GetVitals();
-                    mOldMaxVitals = GetMaxVitals();
-                }
-            }
-        }
-
-        [NotMapped, JsonIgnore]
-        public bool StatusesUpdated
-        {
-            get => CachedStatuses != mOldStatuses; //The whole CachedStatuses assignment gets changed when a status is added, removed, or updated (time remaining changes, so we only check for reference equivity here)
-
-            set
-            {
-                if (value == false)
-                {
-                    mOldStatuses = CachedStatuses;
-                }
-            }
-        }
-
-        public virtual void Dispose()
-        {
-            if (!IsDisposed)
-            {
-                IsDisposed = true;
-            }
-        }
-
-        public virtual void Update(long timeMs)
-        {
-            var lockObtained = false;
-            try
-            {
-                Monitor.TryEnter(EntityLock, ref lockObtained);
-                if (lockObtained)
-                {
-                    if (Target?.IsDisposed ?? false)
-                    {
-                        Target = default;
-                    }
-
-                    //Cast timers
-                    if (CastTime != 0 && !IsCasting && SpellCastSlot < Spells.Count && SpellCastSlot >= 0)
-                    {
-                        CastTime = 0;
-                        CastSpell(Spells[SpellCastSlot].SpellId, SpellCastSlot);
-                        CastTarget = null;
-                    }
-
-                    //DoT/HoT timers
-                    foreach (var dot in CachedDots)
-                    {
-                        dot.Tick();
-                    }
-
-                    if (!(this is EventPageInstance) && !(this is Projectile))
-                    {
-                        var statsUpdated = false;
-                        var statTime = Timing.Global.Milliseconds;
-                        for (var i = 0; i < Enum.GetValues<Stat>().Length; i++)
-                        {
-                            var stat = Stat[i];
-                            if (stat == default)
-                            {
-                                var allStats = string.Join(",\n", Stat.Select(s => s == default ? "\tnull" : $"\t{s}"));
-                                Log.Error($"Stat[{i}] == default for '{GetType().FullName}', Stat=[\n{allStats}\n]");
-                            }
-                            statsUpdated |= stat.Update(statTime);
-                        }
-
-                        if (statsUpdated)
-                        {
-                            PacketSender.SendEntityStats(this);
-                        }
-                    }
-
-                    //Regen Timers and regen in combat validation
-                    if ((timeMs > CombatTimer || Options.Instance.CombatOpts.RegenVitalsInCombat) && timeMs > RegenTimer)
-                    {
-                        ProcessRegen();
-                        RegenTimer = timeMs + Options.RegenTime;
-                    }
-
-                    //Status timers
-                    var statusArray = CachedStatuses;
-                    foreach (var status in statusArray)
-                    {
-                        status.TryRemoveStatus();
-                    }
-
-                    //Blocking timers
-                    if (IsBlocking && !IsAttacking)
-                    {
-                        IsBlocking = false;
-                        PacketSender.SendEntityAttack(this, -1);
-                    }
-                }
-            }
-            finally
-            {
-                if (lockObtained)
-                {
-                    Monitor.Exit(EntityLock);
-                }
-            }
-        }
-
-        /// <summary>
-        ///     Updates the entity's spell cooldown for the specified <paramref name="spellBase"/>.
-        ///     <para> This method is called when a spell is casted by an entity. </para>
-        /// </summary>
-        public virtual void UpdateSpellCooldown(SpellBase spellBase, int spellSlot)
-        {
-            if (spellSlot < 0 || spellSlot >= Options.MaxPlayerSkills)
-            {
-                return;
-            }
-
-            SpellCooldowns[Spells[spellSlot].SpellId] = Timing.Global.MillisecondsUtc + spellBase.CooldownDuration;
-        }
-
-        /// <summary>
-        ///     Determines if this entity can move in the specified <paramref name="direction"/>.
-        /// </summary>
-        /// <param name="direction">The <see cref="Direction"/> the entity is attempting to move in.</param>
-        /// <returns>If the entity is able to move in the specified direction.</returns>
-        public bool CanMoveInDirection(Direction direction) => CanMoveInDirection(direction, out _, out _);
-
-        /// <summary>
-        ///     Determines if this entity can move in the specified <paramref name="direction"/>.
-        /// </summary>
-        /// <param name="direction">The <see cref="Direction"/> the entity is attempting to move in.</param>
-        /// <param name="blockerType">The type of blocker, if any.</param>
-        /// <param name="entityType">
-        ///     The type of entity that is blocking movement, if <paramref name="blockerType"/> is set to <see cref="MovementBlockerType.Entity"/>.
-        /// </param>
-        /// <returns>If the entity is able to move in the specified direction.</returns>
-        public virtual bool CanMoveInDirection(
-            Direction direction,
-            out MovementBlockerType blockerType,
-            out EntityType entityType
-        )
-        {
-            entityType = default;
-
-            var xOffset = 0;
-            var yOffset = 0;
-
-            var tileHelper = new TileHelper(MapId, X, Y);
-            switch (direction)
-            {
-                case Direction.Up:
-                    yOffset--;
-                    break;
-
-                case Direction.Down:
-                    yOffset++;
-                    break;
-
-                case Direction.Left:
-                    xOffset--;
-                    break;
-
-                case Direction.Right:
-                    xOffset++;
-                    break;
-
-                case Direction.UpLeft:
-                    yOffset--;
-                    xOffset--;
-                    break;
-
-                case Direction.UpRight:
-                    yOffset--;
-                    xOffset++;
-                    break;
-
-                case Direction.DownRight:
-                    yOffset++;
-                    xOffset++;
-                    break;
-
-                case Direction.DownLeft:
-                    yOffset++;
-                    xOffset--;
-                    break;
-
-                case Direction.None:
-                    break;
-
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(direction), direction, null);
-            }
-
-            if (!tileHelper.Translate(xOffset, yOffset))
-            {
-                blockerType = MovementBlockerType.OutOfBounds;
-                return false;
-            }
-
-            if (!MapController.TryGet(tileHelper.GetMapId(), out var mapController))
-            {
-                blockerType = MovementBlockerType.OutOfBounds;
-                return false;
-            }
-
-            int tileX = tileHelper.GetX();
-            int tileY = tileHelper.GetY();
-
-            if (IsBlockedByMapAttribute(direction, mapController.Attributes[tileX, tileY], out blockerType))
-            {
-                return false;
-            }
-
-            var enableCrossingDiagonalBlocks = Options.Instance.MapOpts.EnableCrossingDiagonalBlocks;
-            if (!enableCrossingDiagonalBlocks && direction.IsDiagonal())
-            {
-                MovementBlockerType componentBlockerType = default;
-                EntityType componentBlockingEntityType = default;
-
-                if (direction.GetComponentDirections()
-                    .All(
-                        componentDirection => !CanMoveInDirection(
-                            componentDirection,
-                            out componentBlockerType,
-                            out componentBlockingEntityType
-                        )
-                    ))
-                {
-                    blockerType = componentBlockerType;
-                    entityType = componentBlockingEntityType;
-                    return false;
-                }
-            }
-
-            if (Passable)
-            {
-                return !TryGetBlockerOnTile(
-                    tileHelper.GetMap(),
-                    tileX,
-                    tileY,
-                    Z,
-                    out blockerType,
-                    out entityType
-                );
-            }
-
-            var mapEntities = new List<Entity>();
-            if (mapController.TryGetInstance(MapInstanceId, out var mapInstance))
-            {
-                mapEntities.AddRange(mapInstance.GetCachedEntities().Where(entity => entity != default && !entity.Passable));
-            }
-
-            foreach (var mapEntity in mapEntities.Where(en => en.X == tileHelper.GetX() && en.Y == tileHelper.GetY() && en.Z == Z))
-            {
-                // Set a target if a projectile
-                CollisionIndex = mapEntity.Id;
-                switch (mapEntity)
-                {
-                    case Player _ when !CanPassPlayer(mapController):
-                        blockerType = MovementBlockerType.Entity;
-                        entityType = EntityType.Player;
-                        return false;
-                    case Npc _:
-                        // There should honestly be an Npc EntityType...
-                        blockerType = MovementBlockerType.Entity;
-                        entityType = EntityType.Player;
-                        return false;
-                    case Resource resource when !resource.IsPassable():
-                        blockerType = MovementBlockerType.Entity;
-                        entityType = EntityType.Resource;
-                        return false;
-                }
-            }
-
-            if (IsBlockedByEvent(mapInstance, tileHelper.GetX(), tileHelper.GetY()))
-            {
-                blockerType = MovementBlockerType.Entity;
-                entityType = EntityType.Event;
-                return false;
-            }
-
-            if (TryGetBlockerOnTile(
-                    tileHelper.GetMap(),
-                    tileHelper.GetX(),
-                    tileHelper.GetY(),
-                    Z,
-                    out blockerType,
-                    out entityType
-                ))
-            {
-                return false;
-            }
-
-            return blockerType == MovementBlockerType.NotBlocked;
-        }
-
-        protected virtual bool CanMoveOntoSlide(Direction movementDirection, Direction slideDirection) =>
-            !movementDirection.IsOppositeOf(slideDirection);
-
-        protected virtual bool IgnoresNpcAvoid => true;
-
-        private bool IsBlockedByMapAttribute(
-            Direction direction,
-            Intersect.GameObjects.Maps.MapAttribute mapAttribute,
-            out MovementBlockerType blockerType
-        )
-        {
-            blockerType = MovementBlockerType.NotBlocked;
-            if (mapAttribute == default)
-            {
-                return false;
-            }
-
-            switch (mapAttribute)
-            {
-                case MapBlockedAttribute _:
-                case MapAnimationAttribute animationAttribute when animationAttribute.IsBlock:
-                case MapNpcAvoidAttribute _ when !IgnoresNpcAvoid:
-                    blockerType = MovementBlockerType.MapAttribute;
-                    break;
-
-                case MapZDimensionAttribute zDimensionAttribute when zDimensionAttribute.BlockedLevel > 0 && zDimensionAttribute.BlockedLevel - 1 == Z:
-                    blockerType = MovementBlockerType.ZDimension;
-                    break;
-
-                case MapSlideAttribute slideAttribute when !CanMoveOntoSlide(direction, slideAttribute.Direction):
-                    blockerType = MovementBlockerType.Slide;
-                    break;
-            }
-
-            return blockerType != MovementBlockerType.NotBlocked;
-        }
-
-        protected virtual bool CanPassPlayer(MapController targetMap) => false;
-
-        protected virtual bool IsBlockedByEvent(MapInstance mapInstance, int tileX, int tileY)
-        {
-            if (mapInstance == default)
-            {
-                return false;
-            }
-
-            return mapInstance.GlobalEventInstances.Values
-                .SelectMany(globalEventInstance => globalEventInstance.GlobalPageInstance)
-                .Where(instance => instance != default && !instance.Passable)
-                .Any(instance => instance.X == tileX && instance.Y == tileY && instance.Z == Z);
-        }
-
-        protected virtual bool TryGetBlockerOnTile(
-            MapController map,
-            int x,
-            int y,
-            int z,
-            out MovementBlockerType blockerType,
-            out EntityType entityType
-        )
-        {
-            blockerType = map == default ? MovementBlockerType.OutOfBounds : MovementBlockerType.NotBlocked;
-            entityType = default;
-            return blockerType != MovementBlockerType.NotBlocked;
-        }
-
-        protected virtual bool ProcessMoveRoute(Player forPlayer, long timeMs)
-        {
-            var moved = false;
-            Direction lookDir = 0;
-            Direction moveDir = 0;
-            if (MoveRoute.ActionIndex < MoveRoute.Actions.Count)
-            {
-                switch (MoveRoute.Actions[MoveRoute.ActionIndex].Type)
-                {
-                    case MoveRouteEnum.MoveUp:
-                        if (CanMoveInDirection(Direction.Up))
-                        {
-                            Move(Direction.Up, forPlayer, false, true);
-                            moved = true;
-                        }
-
-                        break;
-                    case MoveRouteEnum.MoveDown:
-                        if (CanMoveInDirection(Direction.Down))
-                        {
-                            Move(Direction.Down, forPlayer, false, true);
-                            moved = true;
-                        }
-
-                        break;
-                    case MoveRouteEnum.MoveLeft:
-                        if (CanMoveInDirection(Direction.Left))
-                        {
-                            Move(Direction.Left, forPlayer, false, true);
-                            moved = true;
-                        }
-
-                        break;
-                    case MoveRouteEnum.MoveRight:
-                        if (CanMoveInDirection(Direction.Right))
-                        {
-                            Move(Direction.Right, forPlayer, false, true);
-                            moved = true;
-                        }
-
-                        break;
-                    case MoveRouteEnum.MoveUpLeft:
-                        if (CanMoveInDirection(Direction.UpLeft))
-                        {
-                            Move(Direction.UpLeft, forPlayer, false, true);
-                            moved = true;
-                        }
-
-                        break;
-                    case MoveRouteEnum.MoveUpRight:
-                        if (CanMoveInDirection(Direction.UpRight))
-                        {
-                            Move(Direction.UpRight, forPlayer, false, true);
-                            moved = true;
-                        }
-
-                        break;
-                    case MoveRouteEnum.MoveDownRight:
-                        if (CanMoveInDirection(Direction.DownRight))
-                        {
-                            Move(Direction.DownRight, forPlayer, false, true);
-                            moved = true;
-                        }
-
-                        break;
-                    case MoveRouteEnum.MoveDownLeft:
-                        if (CanMoveInDirection(Direction.DownLeft))
-                        {
-                            Move(Direction.DownLeft, forPlayer, false, true);
-                            moved = true;
-                        }
-
-                        break;
-                    case MoveRouteEnum.MoveRandomly:
-                        var dir = Randomization.NextDirection();
-                        if (CanMoveInDirection(dir))
-                        {
-                            Move(dir, forPlayer);
-                            moved = true;
-                        }
-
-                        break;
-                    case MoveRouteEnum.StepForward:
-                        if (CanMoveInDirection(Dir))
-                        {
-                            Move(Dir, forPlayer, false, true);
-                            moved = true;
-                        }
-
-                        break;
-                    case MoveRouteEnum.StepBack:
-                        switch (Dir)
-                        {
-                            case Direction.Up:
-                                moveDir = Direction.Down;
-
-                                break;
-                            case Direction.Down:
-                                moveDir = Direction.Up;
-
-                                break;
-                            case Direction.Left:
-                                moveDir = Direction.Right;
-
-                                break;
-                            case Direction.Right:
-                                moveDir = Direction.Left;
-
-                                break;
-                            case Direction.UpLeft:
-                                moveDir = Direction.DownRight;
-
-                                break;
-                            case Direction.UpRight:
-                                moveDir = Direction.DownLeft;
-
-                                break;
-                            case Direction.DownRight:
-                                moveDir = Direction.UpLeft;
-
-                                break;
-                            case Direction.DownLeft:
-                                moveDir = Direction.UpRight;
-
-                                break;
-                        }
-
-                        if (CanMoveInDirection(moveDir))
-                        {
-                            Move(moveDir, forPlayer, false, true);
-                            moved = true;
-                        }
-
-                        break;
-                    case MoveRouteEnum.FaceUp:
-                        ChangeDir(Direction.Up);
-                        moved = true;
-
-                        break;
-                    case MoveRouteEnum.FaceDown:
-                        ChangeDir(Direction.Down);
-                        moved = true;
-
-                        break;
-                    case MoveRouteEnum.FaceLeft:
-                        ChangeDir(Direction.Left);
-                        moved = true;
-
-                        break;
-                    case MoveRouteEnum.FaceRight:
-                        ChangeDir(Direction.Right);
-                        moved = true;
-
-                        break;
-                    case MoveRouteEnum.Turn90Clockwise:
-                        switch (Dir)
-                        {
-                            case Direction.Up:
-                                lookDir = Direction.Right;
-
-                                break;
-                            case Direction.Down:
-                                lookDir = Direction.Left;
-
-                                break;
-                            case Direction.Left:
-                                lookDir = Direction.Up;
-
-                                break;
-                            case Direction.Right:
-                                lookDir = Direction.Down;
-
-                                break;
-                            case Direction.UpLeft:
-                                lookDir = Direction.UpRight;
-
-                                break;
-                            case Direction.UpRight:
-                                lookDir = Direction.DownRight;
-
-                                break;
-                            case Direction.DownRight:
-                                lookDir = Direction.DownLeft;
-
-                                break;
-                            case Direction.DownLeft:
-                                lookDir = Direction.UpLeft;
-
-                                break;
-                        }
-
-                        ChangeDir(lookDir);
-                        moved = true;
-
-                        break;
-                    case MoveRouteEnum.Turn90CounterClockwise:
-                        switch (Dir)
-                        {
-                            case Direction.Up:
-                                lookDir = Direction.Left;
-
-                                break;
-                            case Direction.Down:
-                                lookDir = Direction.Right;
-
-                                break;
-                            case Direction.Left:
-                                lookDir = Direction.Down;
-
-                                break;
-                            case Direction.Right:
-                                lookDir = Direction.Up;
-
-                                break;
-                            case Direction.UpLeft:
-                                lookDir = Direction.DownLeft;
-
-                                break;
-                            case Direction.UpRight:
-                                lookDir = Direction.UpLeft;
-
-                                break;
-                            case Direction.DownRight:
-                                lookDir = Direction.UpRight;
-
-                                break;
-                            case Direction.DownLeft:
-                                lookDir = Direction.DownRight;
-
-                                break;
-                        }
-
-                        ChangeDir(lookDir);
-                        moved = true;
-
-                        break;
-                    case MoveRouteEnum.Turn180:
-                        switch (Dir)
-                        {
-                            case Direction.Up:
-                                lookDir = Direction.Down;
-
-                                break;
-                            case Direction.Down:
-                                lookDir = Direction.Up;
-
-                                break;
-                            case Direction.Left:
-                                lookDir = Direction.Right;
-
-                                break;
-                            case Direction.Right:
-                                lookDir = Direction.Left;
-
-                                break;
-                            case Direction.UpLeft:
-                                lookDir = Direction.DownRight;
-
-                                break;
-                            case Direction.UpRight:
-                                lookDir = Direction.DownLeft;
-
-                                break;
-                            case Direction.DownRight:
-                                lookDir = Direction.UpLeft;
-
-                                break;
-                            case Direction.DownLeft:
-                                lookDir = Direction.UpRight;
-
-                                break;
-                        }
-
-                        ChangeDir(lookDir);
-                        moved = true;
-
-                        break;
-                    case MoveRouteEnum.TurnRandomly:
-                        ChangeDir(Randomization.NextDirection());
-                        moved = true;
-
-                        break;
-                    case MoveRouteEnum.Wait100:
-                        MoveTimer = Timing.Global.Milliseconds + 100;
-                        moved = true;
-
-                        break;
-                    case MoveRouteEnum.Wait500:
-                        MoveTimer = Timing.Global.Milliseconds + 500;
-                        moved = true;
-
-                        break;
-                    case MoveRouteEnum.Wait1000:
-                        MoveTimer = Timing.Global.Milliseconds + 1000;
-                        moved = true;
-
-                        break;
-                    default:
-                        //Gonna end up returning false because command not found
-                        return false;
+                    Target = default;
                 }
 
-                if (moved || MoveRoute.IgnoreIfBlocked)
-                {
-                    MoveRoute.ActionIndex++;
-                    if (MoveRoute.ActionIndex >= MoveRoute.Actions.Count)
-                    {
-                        if (MoveRoute.RepeatRoute)
-                        {
-                            MoveRoute.ActionIndex = 0;
-                        }
-
-                        MoveRoute.Complete = true;
-                    }
-                }
-
-                if (moved && MoveTimer < Timing.Global.Milliseconds)
-                {
-                    MoveTimer = Timing.Global.Milliseconds + (long)GetMovementTime();
-                }
-            }
-
-            return true;
-        }
-
-        public virtual bool IsPassable()
-        {
-            return Passable;
-        }
-
-        //Returns the amount of time required to traverse 1 tile
-        public virtual float GetMovementTime()
-        {
-            var time = 1000f / (float)(1 + Math.Log(Stat[(int)Enums.Stat.Speed].Value()));
-            if (Dir > Direction.Right)
-            {
-                time *= MathHelper.UnitDiagonalLength;
-            }
-
-            if (IsBlocking)
-            {
-                time += time * Options.BlockingSlow;
-            }
-
-            return Math.Min(1000f, time);
-        }
-
-        public virtual EntityType GetEntityType()
-        {
-            return EntityType.GlobalEntity;
-        }
-
-        public virtual void Move(Direction moveDir, Player forPlayer, bool doNotUpdate = false,
-            bool correction = false)
-        {
-            if (Timing.Global.Milliseconds < MoveTimer || (!Options.Combat.MovementCancelsCast && IsCasting))
-            {
-                return;
-            }
-
-            lock (EntityLock)
-            {
-                if (this is Player && IsCasting && Options.Combat.MovementCancelsCast)
+                //Cast timers
+                if (CastTime != 0 && !IsCasting && SpellCastSlot < Spells.Count && SpellCastSlot >= 0)
                 {
                     CastTime = 0;
+                    CastSpell(Spells[SpellCastSlot].SpellId, SpellCastSlot);
                     CastTarget = null;
                 }
 
-                var xOffset = 0;
-                var yOffset = 0;
-                switch (moveDir)
+                //DoT/HoT timers
+                foreach (var dot in CachedDots)
                 {
-                    case Direction.Up:
-                        --yOffset;
-
-                        break;
-                    case Direction.Down:
-                        ++yOffset;
-
-                        break;
-                    case Direction.Left:
-                        --xOffset;
-
-                        break;
-                    case Direction.Right:
-                        ++xOffset;
-
-                        break;
-                    case Direction.UpLeft:
-                        --yOffset;
-                        --xOffset;
-
-                        break;
-                    case Direction.UpRight:
-                        --yOffset;
-                        ++xOffset;
-
-                        break;
-                    case Direction.DownRight:
-                        ++yOffset;
-                        ++xOffset;
-
-                        break;
-                    case Direction.DownLeft:
-                        ++yOffset;
-                        --xOffset;
-
-                        break;
-
-                    default:
-                        Log.Warn(
-                            new ArgumentOutOfRangeException(nameof(moveDir), $@"Bogus move attempt in direction {moveDir}.")
-                        );
-
-                        return;
+                    dot.Tick();
                 }
 
-                Dir = moveDir;
-
-
-                var tile = new TileHelper(MapId, X, Y);
-
-                // ReSharper disable once InvertIf
-                if (tile.Translate(xOffset, yOffset))
+                if (!(this is EventPageInstance) && !(this is Projectile))
                 {
-                    X = tile.GetX();
-                    Y = tile.GetY();
-
-                    var currentMap = MapController.Get(tile.GetMapId());
-                    if (MapId != tile.GetMapId())
+                    var statsUpdated = false;
+                    var statTime = Timing.Global.Milliseconds;
+                    for (var i = 0; i < Enum.GetValues<Stat>().Length; i++)
                     {
-                        var oldMap = MapController.Get(MapId);
-                        if (oldMap.TryGetInstance(MapInstanceId, out var oldInstance))
+                        var stat = Stat[i];
+                        if (stat == default)
                         {
-                            oldInstance.RemoveEntity(this);
+                            var allStats = string.Join(",\n", Stat.Select(s => s == default ? "\tnull" : $"\t{s}"));
+                            Log.Error($"Stat[{i}] == default for '{GetType().FullName}', Stat=[\n{allStats}\n]");
                         }
+                        statsUpdated |= stat.Update(statTime);
+                    }
 
-                        if (currentMap.TryGetInstance(MapInstanceId, out var newInstance))
+                    if (statsUpdated)
+                    {
+                        PacketSender.SendEntityStats(this);
+                    }
+                }
+
+                //Regen Timers and regen in combat validation
+                if ((timeMs > CombatTimer || Options.Instance.CombatOpts.RegenVitalsInCombat) && timeMs > RegenTimer)
+                {
+                    ProcessRegen();
+                    RegenTimer = timeMs + Options.RegenTime;
+                }
+
+                //Status timers
+                var statusArray = CachedStatuses;
+                foreach (var status in statusArray)
+                {
+                    status.TryRemoveStatus();
+                }
+
+                //Blocking timers
+                if (IsBlocking && !IsAttacking)
+                {
+                    IsBlocking = false;
+                    PacketSender.SendEntityAttack(this, -1);
+                }
+            }
+        }
+        finally
+        {
+            if (lockObtained)
+            {
+                Monitor.Exit(EntityLock);
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Updates the entity's spell cooldown for the specified <paramref name="spellBase"/>.
+    ///     <para> This method is called when a spell is casted by an entity. </para>
+    /// </summary>
+    public virtual void UpdateSpellCooldown(SpellBase spellBase, int spellSlot)
+    {
+        if (spellSlot < 0 || spellSlot >= Options.MaxPlayerSkills)
+        {
+            return;
+        }
+
+        SpellCooldowns[Spells[spellSlot].SpellId] = Timing.Global.MillisecondsUtc + spellBase.CooldownDuration;
+    }
+
+    /// <summary>
+    ///     Determines if this entity can move in the specified <paramref name="direction"/>.
+    /// </summary>
+    /// <param name="direction">The <see cref="Direction"/> the entity is attempting to move in.</param>
+    /// <returns>If the entity is able to move in the specified direction.</returns>
+    public bool CanMoveInDirection(Direction direction) => CanMoveInDirection(direction, out _, out _);
+
+    /// <summary>
+    ///     Determines if this entity can move in the specified <paramref name="direction"/>.
+    /// </summary>
+    /// <param name="direction">The <see cref="Direction"/> the entity is attempting to move in.</param>
+    /// <param name="blockerType">The type of blocker, if any.</param>
+    /// <param name="entityType">
+    ///     The type of entity that is blocking movement, if <paramref name="blockerType"/> is set to <see cref="MovementBlockerType.Entity"/>.
+    /// </param>
+    /// <returns>If the entity is able to move in the specified direction.</returns>
+    public virtual bool CanMoveInDirection(
+        Direction direction,
+        out MovementBlockerType blockerType,
+        out EntityType entityType
+    )
+    {
+        entityType = default;
+
+        var xOffset = 0;
+        var yOffset = 0;
+
+        var tileHelper = new TileHelper(MapId, X, Y);
+        switch (direction)
+        {
+            case Direction.Up:
+                yOffset--;
+                break;
+
+            case Direction.Down:
+                yOffset++;
+                break;
+
+            case Direction.Left:
+                xOffset--;
+                break;
+
+            case Direction.Right:
+                xOffset++;
+                break;
+
+            case Direction.UpLeft:
+                yOffset--;
+                xOffset--;
+                break;
+
+            case Direction.UpRight:
+                yOffset--;
+                xOffset++;
+                break;
+
+            case Direction.DownRight:
+                yOffset++;
+                xOffset++;
+                break;
+
+            case Direction.DownLeft:
+                yOffset++;
+                xOffset--;
+                break;
+
+            case Direction.None:
+                break;
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(direction), direction, null);
+        }
+
+        if (!tileHelper.Translate(xOffset, yOffset))
+        {
+            blockerType = MovementBlockerType.OutOfBounds;
+            return false;
+        }
+
+        if (!MapController.TryGet(tileHelper.GetMapId(), out var mapController))
+        {
+            blockerType = MovementBlockerType.OutOfBounds;
+            return false;
+        }
+
+        int tileX = tileHelper.GetX();
+        int tileY = tileHelper.GetY();
+
+        if (IsBlockedByMapAttribute(direction, mapController.Attributes[tileX, tileY], out blockerType))
+        {
+            return false;
+        }
+
+        var enableCrossingDiagonalBlocks = Options.Instance.MapOpts.EnableCrossingDiagonalBlocks;
+        if (!enableCrossingDiagonalBlocks && direction.IsDiagonal())
+        {
+            MovementBlockerType componentBlockerType = default;
+            EntityType componentBlockingEntityType = default;
+
+            if (direction.GetComponentDirections()
+                .All(
+                    componentDirection => !CanMoveInDirection(
+                        componentDirection,
+                        out componentBlockerType,
+                        out componentBlockingEntityType
+                    )
+                ))
+            {
+                blockerType = componentBlockerType;
+                entityType = componentBlockingEntityType;
+                return false;
+            }
+        }
+
+        if (Passable)
+        {
+            return !TryGetBlockerOnTile(
+                tileHelper.GetMap(),
+                tileX,
+                tileY,
+                Z,
+                out blockerType,
+                out entityType
+            );
+        }
+
+        var mapEntities = new List<Entity>();
+        if (mapController.TryGetInstance(MapInstanceId, out var mapInstance))
+        {
+            mapEntities.AddRange(mapInstance.GetCachedEntities().Where(entity => entity != default && !entity.Passable));
+        }
+
+        foreach (var mapEntity in mapEntities.Where(en => en.X == tileHelper.GetX() && en.Y == tileHelper.GetY() && en.Z == Z))
+        {
+            // Set a target if a projectile
+            CollisionIndex = mapEntity.Id;
+            switch (mapEntity)
+            {
+                case Player _ when !CanPassPlayer(mapController):
+                    blockerType = MovementBlockerType.Entity;
+                    entityType = EntityType.Player;
+                    return false;
+                case Npc _:
+                    // There should honestly be an Npc EntityType...
+                    blockerType = MovementBlockerType.Entity;
+                    entityType = EntityType.Player;
+                    return false;
+                case Resource resource when !resource.IsPassable():
+                    blockerType = MovementBlockerType.Entity;
+                    entityType = EntityType.Resource;
+                    return false;
+            }
+        }
+
+        if (IsBlockedByEvent(mapInstance, tileHelper.GetX(), tileHelper.GetY()))
+        {
+            blockerType = MovementBlockerType.Entity;
+            entityType = EntityType.Event;
+            return false;
+        }
+
+        if (TryGetBlockerOnTile(
+                tileHelper.GetMap(),
+                tileHelper.GetX(),
+                tileHelper.GetY(),
+                Z,
+                out blockerType,
+                out entityType
+            ))
+        {
+            return false;
+        }
+
+        return blockerType == MovementBlockerType.NotBlocked;
+    }
+
+    protected virtual bool CanMoveOntoSlide(Direction movementDirection, Direction slideDirection) =>
+        !movementDirection.IsOppositeOf(slideDirection);
+
+    protected virtual bool IgnoresNpcAvoid => true;
+
+    private bool IsBlockedByMapAttribute(
+        Direction direction,
+        Intersect.GameObjects.Maps.MapAttribute mapAttribute,
+        out MovementBlockerType blockerType
+    )
+    {
+        blockerType = MovementBlockerType.NotBlocked;
+        if (mapAttribute == default)
+        {
+            return false;
+        }
+
+        switch (mapAttribute)
+        {
+            case MapBlockedAttribute _:
+            case MapAnimationAttribute animationAttribute when animationAttribute.IsBlock:
+            case MapNpcAvoidAttribute _ when !IgnoresNpcAvoid:
+                blockerType = MovementBlockerType.MapAttribute;
+                break;
+
+            case MapZDimensionAttribute zDimensionAttribute when zDimensionAttribute.BlockedLevel > 0 && zDimensionAttribute.BlockedLevel - 1 == Z:
+                blockerType = MovementBlockerType.ZDimension;
+                break;
+
+            case MapSlideAttribute slideAttribute when !CanMoveOntoSlide(direction, slideAttribute.Direction):
+                blockerType = MovementBlockerType.Slide;
+                break;
+        }
+
+        return blockerType != MovementBlockerType.NotBlocked;
+    }
+
+    protected virtual bool CanPassPlayer(MapController targetMap) => false;
+
+    protected virtual bool IsBlockedByEvent(MapInstance mapInstance, int tileX, int tileY)
+    {
+        if (mapInstance == default)
+        {
+            return false;
+        }
+
+        return mapInstance.GlobalEventInstances.Values
+            .SelectMany(globalEventInstance => globalEventInstance.GlobalPageInstance)
+            .Where(instance => instance != default && !instance.Passable)
+            .Any(instance => instance.X == tileX && instance.Y == tileY && instance.Z == Z);
+    }
+
+    protected virtual bool TryGetBlockerOnTile(
+        MapController map,
+        int x,
+        int y,
+        int z,
+        out MovementBlockerType blockerType,
+        out EntityType entityType
+    )
+    {
+        blockerType = map == default ? MovementBlockerType.OutOfBounds : MovementBlockerType.NotBlocked;
+        entityType = default;
+        return blockerType != MovementBlockerType.NotBlocked;
+    }
+
+    protected virtual bool ProcessMoveRoute(Player forPlayer, long timeMs)
+    {
+        var moved = false;
+        Direction lookDir = 0;
+        Direction moveDir = 0;
+        if (MoveRoute.ActionIndex < MoveRoute.Actions.Count)
+        {
+            switch (MoveRoute.Actions[MoveRoute.ActionIndex].Type)
+            {
+                case MoveRouteEnum.MoveUp:
+                    if (CanMoveInDirection(Direction.Up))
+                    {
+                        Move(Direction.Up, forPlayer, false, true);
+                        moved = true;
+                    }
+
+                    break;
+                case MoveRouteEnum.MoveDown:
+                    if (CanMoveInDirection(Direction.Down))
+                    {
+                        Move(Direction.Down, forPlayer, false, true);
+                        moved = true;
+                    }
+
+                    break;
+                case MoveRouteEnum.MoveLeft:
+                    if (CanMoveInDirection(Direction.Left))
+                    {
+                        Move(Direction.Left, forPlayer, false, true);
+                        moved = true;
+                    }
+
+                    break;
+                case MoveRouteEnum.MoveRight:
+                    if (CanMoveInDirection(Direction.Right))
+                    {
+                        Move(Direction.Right, forPlayer, false, true);
+                        moved = true;
+                    }
+
+                    break;
+                case MoveRouteEnum.MoveUpLeft:
+                    if (CanMoveInDirection(Direction.UpLeft))
+                    {
+                        Move(Direction.UpLeft, forPlayer, false, true);
+                        moved = true;
+                    }
+
+                    break;
+                case MoveRouteEnum.MoveUpRight:
+                    if (CanMoveInDirection(Direction.UpRight))
+                    {
+                        Move(Direction.UpRight, forPlayer, false, true);
+                        moved = true;
+                    }
+
+                    break;
+                case MoveRouteEnum.MoveDownRight:
+                    if (CanMoveInDirection(Direction.DownRight))
+                    {
+                        Move(Direction.DownRight, forPlayer, false, true);
+                        moved = true;
+                    }
+
+                    break;
+                case MoveRouteEnum.MoveDownLeft:
+                    if (CanMoveInDirection(Direction.DownLeft))
+                    {
+                        Move(Direction.DownLeft, forPlayer, false, true);
+                        moved = true;
+                    }
+
+                    break;
+                case MoveRouteEnum.MoveRandomly:
+                    var dir = Randomization.NextDirection();
+                    if (CanMoveInDirection(dir))
+                    {
+                        Move(dir, forPlayer);
+                        moved = true;
+                    }
+
+                    break;
+                case MoveRouteEnum.StepForward:
+                    if (CanMoveInDirection(Dir))
+                    {
+                        Move(Dir, forPlayer, false, true);
+                        moved = true;
+                    }
+
+                    break;
+                case MoveRouteEnum.StepBack:
+                    switch (Dir)
+                    {
+                        case Direction.Up:
+                            moveDir = Direction.Down;
+
+                            break;
+                        case Direction.Down:
+                            moveDir = Direction.Up;
+
+                            break;
+                        case Direction.Left:
+                            moveDir = Direction.Right;
+
+                            break;
+                        case Direction.Right:
+                            moveDir = Direction.Left;
+
+                            break;
+                        case Direction.UpLeft:
+                            moveDir = Direction.DownRight;
+
+                            break;
+                        case Direction.UpRight:
+                            moveDir = Direction.DownLeft;
+
+                            break;
+                        case Direction.DownRight:
+                            moveDir = Direction.UpLeft;
+
+                            break;
+                        case Direction.DownLeft:
+                            moveDir = Direction.UpRight;
+
+                            break;
+                    }
+
+                    if (CanMoveInDirection(moveDir))
+                    {
+                        Move(moveDir, forPlayer, false, true);
+                        moved = true;
+                    }
+
+                    break;
+                case MoveRouteEnum.FaceUp:
+                    ChangeDir(Direction.Up);
+                    moved = true;
+
+                    break;
+                case MoveRouteEnum.FaceDown:
+                    ChangeDir(Direction.Down);
+                    moved = true;
+
+                    break;
+                case MoveRouteEnum.FaceLeft:
+                    ChangeDir(Direction.Left);
+                    moved = true;
+
+                    break;
+                case MoveRouteEnum.FaceRight:
+                    ChangeDir(Direction.Right);
+                    moved = true;
+
+                    break;
+                case MoveRouteEnum.Turn90Clockwise:
+                    switch (Dir)
+                    {
+                        case Direction.Up:
+                            lookDir = Direction.Right;
+
+                            break;
+                        case Direction.Down:
+                            lookDir = Direction.Left;
+
+                            break;
+                        case Direction.Left:
+                            lookDir = Direction.Up;
+
+                            break;
+                        case Direction.Right:
+                            lookDir = Direction.Down;
+
+                            break;
+                        case Direction.UpLeft:
+                            lookDir = Direction.UpRight;
+
+                            break;
+                        case Direction.UpRight:
+                            lookDir = Direction.DownRight;
+
+                            break;
+                        case Direction.DownRight:
+                            lookDir = Direction.DownLeft;
+
+                            break;
+                        case Direction.DownLeft:
+                            lookDir = Direction.UpLeft;
+
+                            break;
+                    }
+
+                    ChangeDir(lookDir);
+                    moved = true;
+
+                    break;
+                case MoveRouteEnum.Turn90CounterClockwise:
+                    switch (Dir)
+                    {
+                        case Direction.Up:
+                            lookDir = Direction.Left;
+
+                            break;
+                        case Direction.Down:
+                            lookDir = Direction.Right;
+
+                            break;
+                        case Direction.Left:
+                            lookDir = Direction.Down;
+
+                            break;
+                        case Direction.Right:
+                            lookDir = Direction.Up;
+
+                            break;
+                        case Direction.UpLeft:
+                            lookDir = Direction.DownLeft;
+
+                            break;
+                        case Direction.UpRight:
+                            lookDir = Direction.UpLeft;
+
+                            break;
+                        case Direction.DownRight:
+                            lookDir = Direction.UpRight;
+
+                            break;
+                        case Direction.DownLeft:
+                            lookDir = Direction.DownRight;
+
+                            break;
+                    }
+
+                    ChangeDir(lookDir);
+                    moved = true;
+
+                    break;
+                case MoveRouteEnum.Turn180:
+                    switch (Dir)
+                    {
+                        case Direction.Up:
+                            lookDir = Direction.Down;
+
+                            break;
+                        case Direction.Down:
+                            lookDir = Direction.Up;
+
+                            break;
+                        case Direction.Left:
+                            lookDir = Direction.Right;
+
+                            break;
+                        case Direction.Right:
+                            lookDir = Direction.Left;
+
+                            break;
+                        case Direction.UpLeft:
+                            lookDir = Direction.DownRight;
+
+                            break;
+                        case Direction.UpRight:
+                            lookDir = Direction.DownLeft;
+
+                            break;
+                        case Direction.DownRight:
+                            lookDir = Direction.UpLeft;
+
+                            break;
+                        case Direction.DownLeft:
+                            lookDir = Direction.UpRight;
+
+                            break;
+                    }
+
+                    ChangeDir(lookDir);
+                    moved = true;
+
+                    break;
+                case MoveRouteEnum.TurnRandomly:
+                    ChangeDir(Randomization.NextDirection());
+                    moved = true;
+
+                    break;
+                case MoveRouteEnum.Wait100:
+                    MoveTimer = Timing.Global.Milliseconds + 100;
+                    moved = true;
+
+                    break;
+                case MoveRouteEnum.Wait500:
+                    MoveTimer = Timing.Global.Milliseconds + 500;
+                    moved = true;
+
+                    break;
+                case MoveRouteEnum.Wait1000:
+                    MoveTimer = Timing.Global.Milliseconds + 1000;
+                    moved = true;
+
+                    break;
+                default:
+                    //Gonna end up returning false because command not found
+                    return false;
+            }
+
+            if (moved || MoveRoute.IgnoreIfBlocked)
+            {
+                MoveRoute.ActionIndex++;
+                if (MoveRoute.ActionIndex >= MoveRoute.Actions.Count)
+                {
+                    if (MoveRoute.RepeatRoute)
+                    {
+                        MoveRoute.ActionIndex = 0;
+                    }
+
+                    MoveRoute.Complete = true;
+                }
+            }
+
+            if (moved && MoveTimer < Timing.Global.Milliseconds)
+            {
+                MoveTimer = Timing.Global.Milliseconds + (long)GetMovementTime();
+            }
+        }
+
+        return true;
+    }
+
+    public virtual bool IsPassable()
+    {
+        return Passable;
+    }
+
+    //Returns the amount of time required to traverse 1 tile
+    public virtual float GetMovementTime()
+    {
+        var time = 1000f / (float)(1 + Math.Log(Stat[(int)Enums.Stat.Speed].Value()));
+        if (Dir > Direction.Right)
+        {
+            time *= MathHelper.UnitDiagonalLength;
+        }
+
+        if (IsBlocking)
+        {
+            time += time * Options.BlockingSlow;
+        }
+
+        return Math.Min(1000f, time);
+    }
+
+    public virtual EntityType GetEntityType()
+    {
+        return EntityType.GlobalEntity;
+    }
+
+    public virtual void Move(Direction moveDir, Player forPlayer, bool doNotUpdate = false,
+        bool correction = false)
+    {
+        if (Timing.Global.Milliseconds < MoveTimer || (!Options.Combat.MovementCancelsCast && IsCasting))
+        {
+            return;
+        }
+
+        lock (EntityLock)
+        {
+            if (this is Player && IsCasting && Options.Combat.MovementCancelsCast)
+            {
+                CastTime = 0;
+                CastTarget = null;
+            }
+
+            var xOffset = 0;
+            var yOffset = 0;
+            switch (moveDir)
+            {
+                case Direction.Up:
+                    --yOffset;
+
+                    break;
+                case Direction.Down:
+                    ++yOffset;
+
+                    break;
+                case Direction.Left:
+                    --xOffset;
+
+                    break;
+                case Direction.Right:
+                    ++xOffset;
+
+                    break;
+                case Direction.UpLeft:
+                    --yOffset;
+                    --xOffset;
+
+                    break;
+                case Direction.UpRight:
+                    --yOffset;
+                    ++xOffset;
+
+                    break;
+                case Direction.DownRight:
+                    ++yOffset;
+                    ++xOffset;
+
+                    break;
+                case Direction.DownLeft:
+                    ++yOffset;
+                    --xOffset;
+
+                    break;
+
+                default:
+                    Log.Warn(
+                        new ArgumentOutOfRangeException(nameof(moveDir), $@"Bogus move attempt in direction {moveDir}.")
+                    );
+
+                    return;
+            }
+
+            Dir = moveDir;
+
+
+            var tile = new TileHelper(MapId, X, Y);
+
+            // ReSharper disable once InvertIf
+            if (tile.Translate(xOffset, yOffset))
+            {
+                X = tile.GetX();
+                Y = tile.GetY();
+
+                var currentMap = MapController.Get(tile.GetMapId());
+                if (MapId != tile.GetMapId())
+                {
+                    var oldMap = MapController.Get(MapId);
+                    if (oldMap.TryGetInstance(MapInstanceId, out var oldInstance))
+                    {
+                        oldInstance.RemoveEntity(this);
+                    }
+
+                    if (currentMap.TryGetInstance(MapInstanceId, out var newInstance))
+                    {
+                        newInstance.AddEntity(this);
+                    }
+
+                    //Send Left Map Packet To the Maps that we are no longer with
+                    var oldMaps = oldMap?.GetSurroundingMaps(true);
+                    var newMaps = currentMap?.GetSurroundingMaps(true);
+
+                    MapId = tile.GetMapId();
+
+                    if (oldMaps != null)
+                    {
+                        foreach (var map in oldMaps)
                         {
-                            newInstance.AddEntity(this);
-                        }
-
-                        //Send Left Map Packet To the Maps that we are no longer with
-                        var oldMaps = oldMap?.GetSurroundingMaps(true);
-                        var newMaps = currentMap?.GetSurroundingMaps(true);
-
-                        MapId = tile.GetMapId();
-
-                        if (oldMaps != null)
-                        {
-                            foreach (var map in oldMaps)
+                            if (newMaps == null || !newMaps.Contains(map))
                             {
-                                if (newMaps == null || !newMaps.Contains(map))
-                                {
-                                    PacketSender.SendEntityLeaveMap(this, map.Id);
-                                }
+                                PacketSender.SendEntityLeaveMap(this, map.Id);
                             }
                         }
-
-
-                        if (newMaps != null)
-                        {
-                            foreach (var map in newMaps)
-                            {
-                                if (oldMaps == null || !oldMaps.Contains(map))
-                                {
-                                    PacketSender.SendEntityDataToMap(this, map, this as Player);
-                                }
-                            }
-                        }
-
                     }
 
 
-
-                    if (doNotUpdate == false)
+                    if (newMaps != null)
                     {
-                        if (this is EventPageInstance)
+                        foreach (var map in newMaps)
                         {
-                            if (forPlayer != null)
+                            if (oldMaps == null || !oldMaps.Contains(map))
                             {
-                                PacketSender.SendEntityMoveTo(forPlayer, this, correction);
+                                PacketSender.SendEntityDataToMap(this, map, this as Player);
                             }
-                            else
-                            {
-                                PacketSender.SendEntityMove(this, correction);
-                            }
+                        }
+                    }
+
+                }
+
+
+
+                if (doNotUpdate == false)
+                {
+                    if (this is EventPageInstance)
+                    {
+                        if (forPlayer != null)
+                        {
+                            PacketSender.SendEntityMoveTo(forPlayer, this, correction);
                         }
                         else
                         {
                             PacketSender.SendEntityMove(this, correction);
                         }
+                    }
+                    else
+                    {
+                        PacketSender.SendEntityMove(this, correction);
+                    }
 
-                        //Check if moving into a projectile.. if so this npc needs to be hit
-                        if (currentMap != null)
+                    //Check if moving into a projectile.. if so this npc needs to be hit
+                    if (currentMap != null)
+                    {
+                        foreach (var instance in MapController.GetSurroundingMapInstances(currentMap.Id, MapInstanceId, true))
                         {
-                            foreach (var instance in MapController.GetSurroundingMapInstances(currentMap.Id, MapInstanceId, true))
+                            var projectiles = instance.MapProjectilesCached;
+                            foreach (var projectile in projectiles)
                             {
-                                var projectiles = instance.MapProjectilesCached;
-                                foreach (var projectile in projectiles)
+                                var spawns = projectile?.Spawns?.ToArray() ?? Array.Empty<ProjectileSpawn>();
+                                foreach (var spawn in spawns)
                                 {
-                                    var spawns = projectile?.Spawns?.ToArray() ?? Array.Empty<ProjectileSpawn>();
-                                    foreach (var spawn in spawns)
+                                    // TODO: Filter in Spawns variable, there should be no nulls. See #78 for evidence it is null.
+                                    if (spawn == null)
                                     {
-                                        // TODO: Filter in Spawns variable, there should be no nulls. See #78 for evidence it is null.
-                                        if (spawn == null)
-                                        {
-                                            continue;
-                                        }
+                                        continue;
+                                    }
 
-                                        if (spawn.IsAtLocation(MapId, X, Y, Z) && spawn.HitEntity(this))
-                                        {
-                                            spawn.Dead = true;
-                                        }
+                                    if (spawn.IsAtLocation(MapId, X, Y, Z) && spawn.HitEntity(this))
+                                    {
+                                        spawn.Dead = true;
                                     }
                                 }
                             }
                         }
-
-                        MoveTimer = Timing.Global.Milliseconds + (long)GetMovementTime();
                     }
 
-                    if (TryToChangeDimension() && doNotUpdate == true)
-                    {
-                        PacketSender.UpdateEntityZDimension(this, (byte)Z);
-                    }
+                    MoveTimer = Timing.Global.Milliseconds + (long)GetMovementTime();
+                }
 
-                    //Check for traps
-                    if (MapController.TryGetInstanceFromMap(currentMap.Id, MapInstanceId, out var mapInstance))
+                if (TryToChangeDimension() && doNotUpdate == true)
+                {
+                    PacketSender.UpdateEntityZDimension(this, (byte)Z);
+                }
+
+                //Check for traps
+                if (MapController.TryGetInstanceFromMap(currentMap.Id, MapInstanceId, out var mapInstance))
+                {
+                    foreach (var trap in mapInstance.MapTrapsCached)
                     {
-                        foreach (var trap in mapInstance.MapTrapsCached)
+                        trap.CheckEntityHasDetonatedTrap(this);
+                    }
+                }
+
+                // TODO: Why was this scoped to only Event entities?
+                //                if (currentMap != null && this is EventPageInstance)
+                var attribute = currentMap?.Attributes[X, Y];
+
+                // ReSharper disable once InvertIf
+                //Check for slide tiles
+                if (attribute?.Type == MapAttribute.Slide)
+                {
+                    // If sets direction, set it.
+                    if (((MapSlideAttribute)attribute).Direction > 0)
+                    {
+                        //Check for slide tiles
+                        if (attribute != null && attribute.Type == MapAttribute.Slide)
                         {
-                            trap.CheckEntityHasDetonatedTrap(this);
-                        }
-                    }
-
-                    // TODO: Why was this scoped to only Event entities?
-                    //                if (currentMap != null && this is EventPageInstance)
-                    var attribute = currentMap?.Attributes[X, Y];
-
-                    // ReSharper disable once InvertIf
-                    //Check for slide tiles
-                    if (attribute?.Type == MapAttribute.Slide)
-                    {
-                        // If sets direction, set it.
-                        if (((MapSlideAttribute)attribute).Direction > 0)
-                        {
-                            //Check for slide tiles
-                            if (attribute != null && attribute.Type == MapAttribute.Slide)
+                            if (((MapSlideAttribute)attribute).Direction > 0)
                             {
-                                if (((MapSlideAttribute)attribute).Direction > 0)
-                                {
-                                    Dir = (Direction)(((MapSlideAttribute)attribute).Direction - 1);
-                                }
+                                Dir = (Direction)(((MapSlideAttribute)attribute).Direction - 1);
                             }
                         }
-
-                        var dash = new Dash(this, 1, Dir);
                     }
+
+                    var dash = new Dash(this, 1, Dir);
                 }
             }
         }
+    }
 
-        protected virtual bool CanLookInDirection(Direction direction) => true;
+    protected virtual bool CanLookInDirection(Direction direction) => true;
 
-        public void ChangeDir(Direction dir)
+    public void ChangeDir(Direction dir)
+    {
+        if (!CanLookInDirection(dir))
         {
-            if (!CanLookInDirection(dir))
-            {
-                return;
-            }
+            return;
+        }
 
-            if (dir == Direction.None || Dir == dir)
-            {
-                return;
-            }
+        if (dir == Direction.None || Dir == dir)
+        {
+            return;
+        }
 
-            Dir = dir;
+        Dir = dir;
 
-            if (this is EventPageInstance eventPageInstance && eventPageInstance.Player != null)
+        if (this is EventPageInstance eventPageInstance && eventPageInstance.Player != null)
+        {
+            if (((EventPageInstance)this).Player != null)
             {
-                if (((EventPageInstance)this).Player != null)
-                {
-                    PacketSender.SendEntityDirTo(((EventPageInstance)this).Player, this);
-                }
-                else
-                {
-                    PacketSender.SendEntityDir(this);
-                }
+                PacketSender.SendEntityDirTo(((EventPageInstance)this).Player, this);
             }
             else
             {
                 PacketSender.SendEntityDir(this);
             }
         }
-
-        // Change the dimension if the player is on a gateway
-        public bool TryToChangeDimension()
+        else
         {
-            if (X < Options.MapWidth && X >= 0)
-            {
-                if (Y < Options.MapHeight && Y >= 0)
-                {
-                    var attribute = MapController.Get(MapId).Attributes[X, Y];
-                    if (attribute != null && attribute.Type == MapAttribute.ZDimension)
-                    {
-                        if (((MapZDimensionAttribute)attribute).GatewayTo > 0)
-                        {
-                            Z = (byte)(((MapZDimensionAttribute)attribute).GatewayTo - 1);
+            PacketSender.SendEntityDir(this);
+        }
+    }
 
-                            return true;
-                        }
+    // Change the dimension if the player is on a gateway
+    public bool TryToChangeDimension()
+    {
+        if (X < Options.MapWidth && X >= 0)
+        {
+            if (Y < Options.MapHeight && Y >= 0)
+            {
+                var attribute = MapController.Get(MapId).Attributes[X, Y];
+                if (attribute != null && attribute.Type == MapAttribute.ZDimension)
+                {
+                    if (((MapZDimensionAttribute)attribute).GatewayTo > 0)
+                    {
+                        Z = (byte)(((MapZDimensionAttribute)attribute).GatewayTo - 1);
+
+                        return true;
                     }
                 }
             }
-
-            return false;
         }
 
-        //Misc
-        public Direction GetDirectionTo(Entity target)
+        return false;
+    }
+
+    //Misc
+    public Direction GetDirectionTo(Entity target)
+    {
+        int xDiff = 0, yDiff = 0;
+
+        var map = MapController.Get(MapId);
+        var gridId = map.MapGrid;
+        var grid = DbInterface.GetGrid(gridId);
+
+        //Loop through surrouding maps to generate a array of open and blocked points.
+        for (var x = map.MapGridX - 1; x <= map.MapGridX + 1; x++)
         {
-            int xDiff = 0, yDiff = 0;
-
-            var map = MapController.Get(MapId);
-            var gridId = map.MapGrid;
-            var grid = DbInterface.GetGrid(gridId);
-
-            //Loop through surrouding maps to generate a array of open and blocked points.
-            for (var x = map.MapGridX - 1; x <= map.MapGridX + 1; x++)
+            if (x == -1 || x >= grid.Width)
             {
-                if (x == -1 || x >= grid.Width)
+                continue;
+            }
+
+            for (var y = map.MapGridY - 1; y <= map.MapGridY + 1; y++)
+            {
+                if (y == -1 || y >= grid.Height)
                 {
                     continue;
                 }
 
-                for (var y = map.MapGridY - 1; y <= map.MapGridY + 1; y++)
+                if (grid.MapIdGrid[x, y] != Guid.Empty &&
+                    grid.MapIdGrid[x, y] == target.MapId)
                 {
-                    if (y == -1 || y >= grid.Height)
+                    xDiff = (x - map.MapGridX) * Options.MapWidth + target.X - X;
+                    yDiff = (y - map.MapGridY) * Options.MapHeight + target.Y - Y;
+                    if (Math.Abs(xDiff) > Math.Abs(yDiff))
                     {
-                        continue;
-                    }
-
-                    if (grid.MapIdGrid[x, y] != Guid.Empty &&
-                        grid.MapIdGrid[x, y] == target.MapId)
-                    {
-                        xDiff = (x - map.MapGridX) * Options.MapWidth + target.X - X;
-                        yDiff = (y - map.MapGridY) * Options.MapHeight + target.Y - Y;
-                        if (Math.Abs(xDiff) > Math.Abs(yDiff))
+                        if (xDiff < 0)
                         {
-                            if (xDiff < 0)
-                            {
-                                return Direction.Left;
-                            }
-
-                            if (xDiff > 0)
-                            {
-                                return Direction.Right;
-                            }
+                            return Direction.Left;
                         }
-                        else
-                        {
-                            if (yDiff < 0)
-                            {
-                                return Direction.Up;
-                            }
 
-                            if (yDiff > 0)
-                            {
-                                return Direction.Down;
-                            }
+                        if (xDiff > 0)
+                        {
+                            return Direction.Right;
+                        }
+                    }
+                    else
+                    {
+                        if (yDiff < 0)
+                        {
+                            return Direction.Up;
+                        }
+
+                        if (yDiff > 0)
+                        {
+                            return Direction.Down;
                         }
                     }
                 }
             }
-
-            return default;
         }
 
-        //Combat
-        public virtual int CalculateAttackTime()
-        {
-            return (int)(Options.MaxAttackRate +
-                          (Options.MinAttackRate - Options.MaxAttackRate) *
-                          (((float)Options.MaxStatValue - Stat[(int)Enums.Stat.Speed].Value()) /
-                           Options.MaxStatValue));
-        }
+        return default;
+    }
 
-        public void TryBlock(bool blocking)
-        {
-            if (IsAttacking)
-            {
-                return;
-            }
+    //Combat
+    public virtual int CalculateAttackTime()
+    {
+        return (int)(Options.MaxAttackRate +
+                      (Options.MinAttackRate - Options.MaxAttackRate) *
+                      (((float)Options.MaxStatValue - Stat[(int)Enums.Stat.Speed].Value()) /
+                       Options.MaxStatValue));
+    }
 
-            if (!blocking || IsBlocking)
-            {
-                return;
-            }
-
-            IsBlocking = true;
-            AttackTimer = Timing.Global.Milliseconds + CalculateAttackTime();
-            PacketSender.SendEntityAttack(this, CalculateAttackTime(), true);
-        }
-
-        public virtual int GetWeaponDamage()
-        {
-            return 0;
-        }
-
-        public virtual bool CanAttack(Entity entity, SpellBase spell) => !IsCasting;
-
-        public virtual void ProcessRegen()
-        {
-        }
-
-        public long GetVital(int vital)
-        {
-            return mVitals[vital];
-        }
-
-        public long[] GetVitals()
-        {
-            var vitals = new long[Enum.GetValues<Vital>().Length];
-            Array.Copy(mVitals, 0, vitals, 0, Enum.GetValues<Vital>().Length);
-
-            return vitals;
-        }
-
-        public long GetVital(Vital vital)
-        {
-            return GetVital((int)vital);
-        }
-
-        public void SetVital(int vital, long value)
-        {
-            if (value < 0)
-            {
-                value = 0;
-            }
-
-            if (GetMaxVital(vital) < value)
-            {
-                value = GetMaxVital(vital);
-            }
-
-            mVitals[vital] = value;
-        }
-
-        public void SetVital(Vital vital, long value)
-        {
-            SetVital((int)vital, value);
-        }
-
-        public virtual long GetMaxVital(int vital)
-        {
-            return _maxVital[vital];
-        }
-
-        public virtual long GetMaxVital(Vital vital)
-        {
-            return GetMaxVital((int)vital);
-        }
-
-        public long[] GetMaxVitals()
-        {
-            var vitals = new long[Enum.GetValues<Vital>().Length];
-            for (var vitalIndex = 0; vitalIndex < vitals.Length; ++vitalIndex)
-            {
-                vitals[vitalIndex] = GetMaxVital(vitalIndex);
-            }
-
-            return vitals;
-        }
-
-        public void SetMaxVital(int vital, long value)
-        {
-            if (value <= 0 && vital == (int)Vital.Health)
-            {
-                value = 1; //Must have at least 1 hp
-            }
-
-            if (value < 0 && vital == (int)Vital.Mana)
-            {
-                value = 0; //Can't have less than 0 mana
-            }
-
-            _maxVital[vital] = value;
-            if (value < GetVital(vital))
-            {
-                SetVital(vital, value);
-            }
-        }
-
-        public void SetMaxVital(Vital vital, long value)
-        {
-            SetMaxVital((int)vital, value);
-        }
-
-        public bool HasVital(Vital vital)
-        {
-            return GetVital(vital) > 0;
-        }
-
-        public bool IsFullVital(Vital vital)
-        {
-            return GetVital(vital) == GetMaxVital(vital);
-        }
-
-        //Vitals
-        public void RestoreVital(Vital vital)
-        {
-            SetVital(vital, GetMaxVital(vital));
-        }
-
-        public void AddVital(Vital vital, long amount)
-        {
-            if (!Enum.IsDefined(vital))
-            {
-                return;
-            }
-
-            var vitalId = (int)vital;
-            var maxVitalValue = GetMaxVital(vitalId);
-            var safeAmount = Math.Min(amount, long.MaxValue - maxVitalValue);
-            SetVital(vital, GetVital(vital) + safeAmount);
-        }
-
-        public void SubVital(Vital vital, long amount)
-        {
-            if (!Enum.IsDefined(vital))
-            {
-                return;
-            }
-
-            //Check for any shields.
-            foreach (var status in CachedStatuses)
-            {
-                if (status.Type == SpellEffect.Shield)
-                {
-                    status.DamageShield(vital, ref amount);
-                }
-            }
-
-            var vitalId = (int)vital;
-            var maxVitalValue = GetMaxVital(vitalId);
-            var safeAmount = Math.Min(amount, GetVital(vital));
-            SetVital(vital, GetVital(vital) - safeAmount);
-            ReactToDamage(vital);
-        }
-
-        protected virtual void ReactToDamage(Vital vital)
+    public void TryBlock(bool blocking)
+    {
+        if (IsAttacking)
         {
             return;
         }
 
-        public virtual int[] GetStatValues()
+        if (!blocking || IsBlocking)
         {
-            var stats = new int[Enum.GetValues<Stat>().Length];
-            for (var i = 0; i < Enum.GetValues<Stat>().Length; i++)
+            return;
+        }
+
+        IsBlocking = true;
+        AttackTimer = Timing.Global.Milliseconds + CalculateAttackTime();
+        PacketSender.SendEntityAttack(this, CalculateAttackTime(), true);
+    }
+
+    public virtual int GetWeaponDamage()
+    {
+        return 0;
+    }
+
+    public virtual bool CanAttack(Entity entity, SpellBase spell) => !IsCasting;
+
+    public virtual void ProcessRegen()
+    {
+    }
+
+    public long GetVital(int vital)
+    {
+        return mVitals[vital];
+    }
+
+    public long[] GetVitals()
+    {
+        var vitals = new long[Enum.GetValues<Vital>().Length];
+        Array.Copy(mVitals, 0, vitals, 0, Enum.GetValues<Vital>().Length);
+
+        return vitals;
+    }
+
+    public long GetVital(Vital vital)
+    {
+        return GetVital((int)vital);
+    }
+
+    public void SetVital(int vital, long value)
+    {
+        if (value < 0)
+        {
+            value = 0;
+        }
+
+        if (GetMaxVital(vital) < value)
+        {
+            value = GetMaxVital(vital);
+        }
+
+        mVitals[vital] = value;
+    }
+
+    public void SetVital(Vital vital, long value)
+    {
+        SetVital((int)vital, value);
+    }
+
+    public virtual long GetMaxVital(int vital)
+    {
+        return _maxVital[vital];
+    }
+
+    public virtual long GetMaxVital(Vital vital)
+    {
+        return GetMaxVital((int)vital);
+    }
+
+    public long[] GetMaxVitals()
+    {
+        var vitals = new long[Enum.GetValues<Vital>().Length];
+        for (var vitalIndex = 0; vitalIndex < vitals.Length; ++vitalIndex)
+        {
+            vitals[vitalIndex] = GetMaxVital(vitalIndex);
+        }
+
+        return vitals;
+    }
+
+    public void SetMaxVital(int vital, long value)
+    {
+        if (value <= 0 && vital == (int)Vital.Health)
+        {
+            value = 1; //Must have at least 1 hp
+        }
+
+        if (value < 0 && vital == (int)Vital.Mana)
+        {
+            value = 0; //Can't have less than 0 mana
+        }
+
+        _maxVital[vital] = value;
+        if (value < GetVital(vital))
+        {
+            SetVital(vital, value);
+        }
+    }
+
+    public void SetMaxVital(Vital vital, long value)
+    {
+        SetMaxVital((int)vital, value);
+    }
+
+    public bool HasVital(Vital vital)
+    {
+        return GetVital(vital) > 0;
+    }
+
+    public bool IsFullVital(Vital vital)
+    {
+        return GetVital(vital) == GetMaxVital(vital);
+    }
+
+    //Vitals
+    public void RestoreVital(Vital vital)
+    {
+        SetVital(vital, GetMaxVital(vital));
+    }
+
+    public void AddVital(Vital vital, long amount)
+    {
+        if (!Enum.IsDefined(vital))
+        {
+            return;
+        }
+
+        var vitalId = (int)vital;
+        var maxVitalValue = GetMaxVital(vitalId);
+        var safeAmount = Math.Min(amount, long.MaxValue - maxVitalValue);
+        SetVital(vital, GetVital(vital) + safeAmount);
+    }
+
+    public void SubVital(Vital vital, long amount)
+    {
+        if (!Enum.IsDefined(vital))
+        {
+            return;
+        }
+
+        //Check for any shields.
+        foreach (var status in CachedStatuses)
+        {
+            if (status.Type == SpellEffect.Shield)
             {
-                stats[i] = Stat[i].Value();
+                status.DamageShield(vital, ref amount);
+            }
+        }
+
+        var vitalId = (int)vital;
+        var maxVitalValue = GetMaxVital(vitalId);
+        var safeAmount = Math.Min(amount, GetVital(vital));
+        SetVital(vital, GetVital(vital) - safeAmount);
+        ReactToDamage(vital);
+    }
+
+    protected virtual void ReactToDamage(Vital vital)
+    {
+        return;
+    }
+
+    public virtual int[] GetStatValues()
+    {
+        var stats = new int[Enum.GetValues<Stat>().Length];
+        for (var i = 0; i < Enum.GetValues<Stat>().Length; i++)
+        {
+            stats[i] = Stat[i].Value();
+        }
+
+        return stats;
+    }
+
+    public virtual bool IsAllyOf(Entity otherEntity)
+    {
+        return this == otherEntity;
+    }
+
+    //Attacking with projectile
+    public virtual void TryAttack(Entity target,
+        ProjectileBase projectile,
+        SpellBase parentSpell,
+        ItemBase parentItem,
+        Direction projectileDir)
+    {
+        if (target is Resource && parentSpell != null)
+        {
+            return;
+        }
+
+        if (parentSpell != null)
+        {
+            TryAttack(target, parentSpell);
+        }
+
+        var targetPlayer = target as Player;
+
+        if (this is Player player && targetPlayer != null)
+        {
+            //Player interaction common events
+            if (projectile == null && parentSpell == null)
+            {
+                targetPlayer.StartCommonEventsWithTrigger(CommonEventTrigger.PlayerInteract, "", this.Name);
             }
 
-            return stats;
-        }
-
-        public virtual bool IsAllyOf(Entity otherEntity)
-        {
-            return this == otherEntity;
-        }
-
-        //Attacking with projectile
-        public virtual void TryAttack(Entity target,
-            ProjectileBase projectile,
-            SpellBase parentSpell,
-            ItemBase parentItem,
-            Direction projectileDir)
-        {
-            if (target is Resource && parentSpell != null)
+            if (MapController.Get(MapId).ZoneType == MapZone.Safe)
             {
                 return;
             }
 
-            if (parentSpell != null)
+            if (MapController.Get(target.MapId).ZoneType == MapZone.Safe)
             {
-                TryAttack(target, parentSpell);
+                return;
             }
 
-            var targetPlayer = target as Player;
-
-            if (this is Player player && targetPlayer != null)
+            if (player.InParty(targetPlayer))
             {
-                //Player interaction common events
-                if (projectile == null && parentSpell == null)
+                return;
+            }
+        }
+
+        if (parentSpell == null)
+        {
+            Attack(
+                target, parentItem.Damage, 0, (DamageType)parentItem.DamageType, (Stat)parentItem.ScalingStat,
+                parentItem.Scaling, parentItem.CritChance, parentItem.CritMultiplier, null, null, true
+            );
+        }
+
+        //If projectile, check if a splash spell is applied
+        if (projectile == null)
+        {
+            return;
+        }
+
+        if (projectile.SpellId != Guid.Empty)
+        {
+            var s = projectile.Spell;
+            if (s != null)
+            {
+                HandleAoESpell(projectile.SpellId, s.Combat.HitRadius, target.MapId, target.X, target.Y, null);
+            }
+
+            //Check that the npc has not been destroyed by the splash spell
+            //TODO: Actually implement this, since null check is wrong.
+            if (target == null)
+            {
+                return;
+            }
+        }
+
+        if (targetPlayer == null && !(target is Npc) || target.IsDead())
+        {
+            return;
+        }
+
+        if (projectile.HomingBehavior || projectile.DirectShotBehavior)
+        {
+            // we need to get the direction based on the shooter's position and the target's position and angle between them
+            double angle = 0;
+            if (target.MapId == MapId)
+            {
+                angle = Math.Atan2(target.Y - Y, target.X - X);
+            }
+            else
+            {
+                var grid = DbInterface.GetGrid(Map.MapGrid);
+                bool angleFound = false;
+
+                for (var y = Map.MapGridY - 1; y <= Map.MapGridY + 1; y++)
                 {
-                    targetPlayer.StartCommonEventsWithTrigger(CommonEventTrigger.PlayerInteract, "", this.Name);
+                    for (var x = Map.MapGridX - 1; x <= Map.MapGridX + 1; x++)
+                    {
+                        if (x < 0 || x >= grid.MapIdGrid.GetLength(0) || y < 0 || y >= grid.MapIdGrid.GetLength(1))
+                        {
+                            continue;
+                        }
+
+                        if (grid.MapIdGrid[x, y] == target.MapId)
+                        {
+                            int targetAbsoluteX = target.X + (x * Options.MapWidth);
+                            int targetAbsoluteY = target.Y + (y * Options.MapHeight);
+                            int playerAbsoluteX = X + (Map.MapGridX * Options.MapWidth);
+                            int playerAbsoluteY = Y + (Map.MapGridY * Options.MapHeight);
+
+                            angle = Math.Atan2(targetAbsoluteY - playerAbsoluteY, targetAbsoluteX - playerAbsoluteX);
+                            angleFound = true;
+                            break;
+                        }
+                    }
+
+                    if (angleFound) break;
+                }
+            }
+
+            var angleDegrees = angle * (180 / Math.PI);
+            if (angleDegrees >= -30 && angleDegrees <= 30)
+            {
+                projectileDir = Direction.Right;
+            }
+            else if (angleDegrees >= 30 && angleDegrees <= 60)
+            {
+                projectileDir = Direction.DownRight;
+            }
+            else if (angleDegrees >= 60 && angleDegrees <= 120)
+            {
+                projectileDir = Direction.Down;
+            }
+            else if (angleDegrees >= 120 && angleDegrees <= 150)
+            {
+                projectileDir = Direction.DownLeft;
+            }
+            else if (angleDegrees >= 150 || angleDegrees <= -150)
+            {
+                projectileDir = Direction.Left;
+            }
+            else if (angleDegrees >= -150 && angleDegrees <= -120)
+            {
+                projectileDir = Direction.UpLeft;
+            }
+            else if (angleDegrees >= -120 && angleDegrees <= -60)
+            {
+                projectileDir = Direction.Up;
+            }
+            else if (angleDegrees >= -60 && angleDegrees <= -30)
+            {
+                projectileDir = Direction.UpRight;
+            }
+        }
+
+        // If there is knock-back: knock them backwards.
+        if (projectile.Knockback > 0 && ((int)projectileDir < Options.Instance.MapOpts.MovementDirections) && !target.Immunities.Contains(SpellEffect.Knockback))
+        {
+            var dash = new Dash(target, projectile.Knockback, projectileDir, false, false, false, false);
+        }
+    }
+
+    //Attacking with spell
+    public virtual void TryAttack(
+        Entity target,
+        SpellBase spellBase,
+        bool onHitTrigger = false,
+        bool trapTrigger = false
+    )
+    {
+        if (target is Resource || target is EventPageInstance)
+        {
+            return;
+        }
+
+        if (spellBase == null)
+        {
+            return;
+        }
+
+        var deadAnimations = new List<KeyValuePair<Guid, Direction>>();
+        var aliveAnimations = new List<KeyValuePair<Guid, Direction>>();
+
+        //Only count safe zones and friendly fire if its a dangerous spell! (If one has been used)
+        if (!spellBase.Combat.Friendly &&
+            (spellBase.Combat.TargetType != (int)SpellTargetType.Self || onHitTrigger))
+        {
+            //If about to hit self with an unfriendly spell (maybe aoe?) return
+            if (target == this && spellBase.Combat.Effect != SpellEffect.OnHit)
+            {
+                return;
+            }
+
+            //Check for parties and safe zones, friendly fire off (unless its healing)
+            if (target is Npc && this is Npc npc)
+            {
+                if (!npc.CanNpcCombat(target, spellBase.Combat.Friendly))
+                {
+                    return;
+                }
+            }
+
+            if (target is Player targetPlayer && this is Player player)
+            {
+                if (player.IsAllyOf(targetPlayer))
+                {
+                    return;
                 }
 
+                // Check if either the attacker or the defender is in a "safe zone" (Only apply if combat is PVP)
                 if (MapController.Get(MapId).ZoneType == MapZone.Safe)
                 {
                     return;
@@ -1541,1636 +1721,1454 @@ namespace Intersect.Server.Entities
                 {
                     return;
                 }
-
-                if (player.InParty(targetPlayer))
-                {
-                    return;
-                }
             }
 
-            if (parentSpell == null)
+            if (!CanAttack(target, spellBase))
             {
-                Attack(
-                    target, parentItem.Damage, 0, (DamageType)parentItem.DamageType, (Stat)parentItem.ScalingStat,
-                    parentItem.Scaling, parentItem.CritChance, parentItem.CritMultiplier, null, null, true
+                return;
+            }
+        }
+        else
+        {
+            // Friendly Spell! Do not attack other players/npcs around us.
+            switch (target)
+            {
+                case Player targetPlayer
+                    when this is Player player && !IsAllyOf(targetPlayer) && this != target:
+                case Npc _ when this is Npc npc && !npc.CanNpcCombat(target, spellBase.Combat.Friendly):
+                    return;
+            }
+
+            if (target?.GetType() != GetType())
+            {
+                return; // Don't let players aoe heal npcs. Don't let npcs aoe heal players.
+            }
+        }
+
+        if (spellBase.HitAnimationId != Guid.Empty &&
+            (spellBase.Combat.Effect != SpellEffect.OnHit || onHitTrigger))
+        {
+            deadAnimations.Add(new KeyValuePair<Guid, Direction>(spellBase.HitAnimationId, Direction.Up));
+            aliveAnimations.Add(new KeyValuePair<Guid, Direction>(spellBase.HitAnimationId, Direction.Up));
+        }
+
+        var statBuffTime = -1;
+        var expireTime = Timing.Global.Milliseconds + spellBase.Combat.Duration;
+        for (var i = 0; i < Enum.GetValues<Stat>().Length; i++)
+        {
+            target.Stat[i]
+                .AddBuff(
+                    new Buff(spellBase, spellBase.Combat.StatDiff[i], spellBase.Combat.PercentageStatDiff[i], expireTime)
                 );
-            }
 
-            //If projectile, check if a splash spell is applied
-            if (projectile == null)
+            if (spellBase.Combat.StatDiff[i] != 0 || spellBase.Combat.PercentageStatDiff[i] != 0)
             {
-                return;
+                statBuffTime = spellBase.Combat.Duration;
             }
+        }
 
-            if (projectile.SpellId != Guid.Empty)
+        if (statBuffTime == -1)
+        {
+            if (spellBase.Combat.HoTDoT && spellBase.Combat.HotDotInterval > 0)
             {
-                var s = projectile.Spell;
-                if (s != null)
+                statBuffTime = spellBase.Combat.Duration;
+            }
+        }
+
+        var damageHealth = spellBase.Combat.VitalDiff[(int)Vital.Health];
+        var damageMana = spellBase.Combat.VitalDiff[(int)Vital.Mana];
+
+        if ((spellBase.Combat.Effect != SpellEffect.OnHit || onHitTrigger) &&
+            spellBase.Combat.Effect != SpellEffect.Shield)
+        {
+            Attack(
+                target, damageHealth, damageMana, (DamageType)spellBase.Combat.DamageType,
+                (Stat)spellBase.Combat.ScalingStat, spellBase.Combat.Scaling, spellBase.Combat.CritChance,
+                spellBase.Combat.CritMultiplier, deadAnimations, aliveAnimations, false
+            );
+        }
+
+        if (spellBase.Combat.Effect > 0) //Handle status effects
+        {
+            //Check for onhit effect to avoid the onhit effect recycling.
+            if (!(onHitTrigger && spellBase.Combat.Effect == SpellEffect.OnHit))
+            {
+                // If the entity is immune to some status, then just inform the client of such
+                if (target.Immunities.Contains(spellBase.Combat.Effect))
                 {
-                    HandleAoESpell(projectile.SpellId, s.Combat.HitRadius, target.MapId, target.X, target.Y, null);
-                }
-
-                //Check that the npc has not been destroyed by the splash spell
-                //TODO: Actually implement this, since null check is wrong.
-                if (target == null)
-                {
-                    return;
-                }
-            }
-
-            if (targetPlayer == null && !(target is Npc) || target.IsDead())
-            {
-                return;
-            }
-
-            if (projectile.HomingBehavior || projectile.DirectShotBehavior)
-            {
-                // we need to get the direction based on the shooter's position and the target's position and angle between them
-                double angle = 0;
-                if (target.MapId == MapId)
-                {
-                    angle = Math.Atan2(target.Y - Y, target.X - X);
+                    PacketSender.SendActionMsg(
+                        target, Strings.Combat.ImmuneToEffect, CustomColors.Combat.Status
+                    );
                 }
                 else
                 {
-                    var grid = DbInterface.GetGrid(Map.MapGrid);
-                    bool angleFound = false;
-
-                    for (var y = Map.MapGridY - 1; y <= Map.MapGridY + 1; y++)
-                    {
-                        for (var x = Map.MapGridX - 1; x <= Map.MapGridX + 1; x++)
-                        {
-                            if (x < 0 || x >= grid.MapIdGrid.GetLength(0) || y < 0 || y >= grid.MapIdGrid.GetLength(1))
-                            {
-                                continue;
-                            }
-
-                            if (grid.MapIdGrid[x, y] == target.MapId)
-                            {
-                                int targetAbsoluteX = target.X + (x * Options.MapWidth);
-                                int targetAbsoluteY = target.Y + (y * Options.MapHeight);
-                                int playerAbsoluteX = X + (Map.MapGridX * Options.MapWidth);
-                                int playerAbsoluteY = Y + (Map.MapGridY * Options.MapHeight);
-
-                                angle = Math.Atan2(targetAbsoluteY - playerAbsoluteY, targetAbsoluteX - playerAbsoluteX);
-                                angleFound = true;
-                                break;
-                            }
-                        }
-
-                        if (angleFound) break;
-                    }
-                }
-
-                var angleDegrees = angle * (180 / Math.PI);
-                if (angleDegrees >= -30 && angleDegrees <= 30)
-                {
-                    projectileDir = Direction.Right;
-                }
-                else if (angleDegrees >= 30 && angleDegrees <= 60)
-                {
-                    projectileDir = Direction.DownRight;
-                }
-                else if (angleDegrees >= 60 && angleDegrees <= 120)
-                {
-                    projectileDir = Direction.Down;
-                }
-                else if (angleDegrees >= 120 && angleDegrees <= 150)
-                {
-                    projectileDir = Direction.DownLeft;
-                }
-                else if (angleDegrees >= 150 || angleDegrees <= -150)
-                {
-                    projectileDir = Direction.Left;
-                }
-                else if (angleDegrees >= -150 && angleDegrees <= -120)
-                {
-                    projectileDir = Direction.UpLeft;
-                }
-                else if (angleDegrees >= -120 && angleDegrees <= -60)
-                {
-                    projectileDir = Direction.Up;
-                }
-                else if (angleDegrees >= -60 && angleDegrees <= -30)
-                {
-                    projectileDir = Direction.UpRight;
-                }
-            }
-
-            // If there is knock-back: knock them backwards.
-            if (projectile.Knockback > 0 && ((int)projectileDir < Options.Instance.MapOpts.MovementDirections) && !target.Immunities.Contains(SpellEffect.Knockback))
-            {
-                var dash = new Dash(target, projectile.Knockback, projectileDir, false, false, false, false);
-            }
-        }
-
-        //Attacking with spell
-        public virtual void TryAttack(
-            Entity target,
-            SpellBase spellBase,
-            bool onHitTrigger = false,
-            bool trapTrigger = false
-        )
-        {
-            if (target is Resource || target is EventPageInstance)
-            {
-                return;
-            }
-
-            if (spellBase == null)
-            {
-                return;
-            }
-
-            var deadAnimations = new List<KeyValuePair<Guid, Direction>>();
-            var aliveAnimations = new List<KeyValuePair<Guid, Direction>>();
-
-            //Only count safe zones and friendly fire if its a dangerous spell! (If one has been used)
-            if (!spellBase.Combat.Friendly &&
-                (spellBase.Combat.TargetType != (int)SpellTargetType.Self || onHitTrigger))
-            {
-                //If about to hit self with an unfriendly spell (maybe aoe?) return
-                if (target == this && spellBase.Combat.Effect != SpellEffect.OnHit)
-                {
-                    return;
-                }
-
-                //Check for parties and safe zones, friendly fire off (unless its healing)
-                if (target is Npc && this is Npc npc)
-                {
-                    if (!npc.CanNpcCombat(target, spellBase.Combat.Friendly))
-                    {
-                        return;
-                    }
-                }
-
-                if (target is Player targetPlayer && this is Player player)
-                {
-                    if (player.IsAllyOf(targetPlayer))
-                    {
-                        return;
-                    }
-
-                    // Check if either the attacker or the defender is in a "safe zone" (Only apply if combat is PVP)
-                    if (MapController.Get(MapId).ZoneType == MapZone.Safe)
-                    {
-                        return;
-                    }
-
-                    if (MapController.Get(target.MapId).ZoneType == MapZone.Safe)
-                    {
-                        return;
-                    }
-                }
-
-                if (!CanAttack(target, spellBase))
-                {
-                    return;
-                }
-            }
-            else
-            {
-                // Friendly Spell! Do not attack other players/npcs around us.
-                switch (target)
-                {
-                    case Player targetPlayer
-                        when this is Player player && !IsAllyOf(targetPlayer) && this != target:
-                    case Npc _ when this is Npc npc && !npc.CanNpcCombat(target, spellBase.Combat.Friendly):
-                        return;
-                }
-
-                if (target?.GetType() != GetType())
-                {
-                    return; // Don't let players aoe heal npcs. Don't let npcs aoe heal players.
-                }
-            }
-
-            if (spellBase.HitAnimationId != Guid.Empty &&
-                (spellBase.Combat.Effect != SpellEffect.OnHit || onHitTrigger))
-            {
-                deadAnimations.Add(new KeyValuePair<Guid, Direction>(spellBase.HitAnimationId, Direction.Up));
-                aliveAnimations.Add(new KeyValuePair<Guid, Direction>(spellBase.HitAnimationId, Direction.Up));
-            }
-
-            var statBuffTime = -1;
-            var expireTime = Timing.Global.Milliseconds + spellBase.Combat.Duration;
-            for (var i = 0; i < Enum.GetValues<Stat>().Length; i++)
-            {
-                target.Stat[i]
-                    .AddBuff(
-                        new Buff(spellBase, spellBase.Combat.StatDiff[i], spellBase.Combat.PercentageStatDiff[i], expireTime)
+                    // Else, apply the status
+                    new Status(
+                        target, this, spellBase, spellBase.Combat.Effect, spellBase.Combat.Duration,
+                        spellBase.Combat.TransformSprite
                     );
 
-                if (spellBase.Combat.StatDiff[i] != 0 || spellBase.Combat.PercentageStatDiff[i] != 0)
-                {
-                    statBuffTime = spellBase.Combat.Duration;
-                }
-            }
-
-            if (statBuffTime == -1)
-            {
-                if (spellBase.Combat.HoTDoT && spellBase.Combat.HotDotInterval > 0)
-                {
-                    statBuffTime = spellBase.Combat.Duration;
-                }
-            }
-
-            var damageHealth = spellBase.Combat.VitalDiff[(int)Vital.Health];
-            var damageMana = spellBase.Combat.VitalDiff[(int)Vital.Mana];
-
-            if ((spellBase.Combat.Effect != SpellEffect.OnHit || onHitTrigger) &&
-                spellBase.Combat.Effect != SpellEffect.Shield)
-            {
-                Attack(
-                    target, damageHealth, damageMana, (DamageType)spellBase.Combat.DamageType,
-                    (Stat)spellBase.Combat.ScalingStat, spellBase.Combat.Scaling, spellBase.Combat.CritChance,
-                    spellBase.Combat.CritMultiplier, deadAnimations, aliveAnimations, false
-                );
-            }
-
-            if (spellBase.Combat.Effect > 0) //Handle status effects
-            {
-                //Check for onhit effect to avoid the onhit effect recycling.
-                if (!(onHitTrigger && spellBase.Combat.Effect == SpellEffect.OnHit))
-                {
-                    // If the entity is immune to some status, then just inform the client of such
-                    if (target.Immunities.Contains(spellBase.Combat.Effect))
+                    if (target is Npc npc)
                     {
-                        PacketSender.SendActionMsg(
-                            target, Strings.Combat.ImmuneToEffect, CustomColors.Combat.Status
-                        );
+                        npc.AssignTarget(this);
                     }
-                    else
+
+                    PacketSender.SendActionMsg(
+                        target, Strings.Combat.status[(int)spellBase.Combat.Effect], CustomColors.Combat.Status
+                    );
+
+                    //If an onhit or shield status bail out as we don't want to do any damage.
+                    if (spellBase.Combat.Effect == SpellEffect.OnHit || spellBase.Combat.Effect == SpellEffect.Shield)
                     {
-                        // Else, apply the status
-                        new Status(
-                            target, this, spellBase, spellBase.Combat.Effect, spellBase.Combat.Duration,
-                            spellBase.Combat.TransformSprite
-                        );
+                        Animate(target, aliveAnimations);
 
-                        if (target is Npc npc)
-                        {
-                            npc.AssignTarget(this);
-                        }
-
-                        PacketSender.SendActionMsg(
-                            target, Strings.Combat.status[(int)spellBase.Combat.Effect], CustomColors.Combat.Status
-                        );
-
-                        //If an onhit or shield status bail out as we don't want to do any damage.
-                        if (spellBase.Combat.Effect == SpellEffect.OnHit || spellBase.Combat.Effect == SpellEffect.Shield)
-                        {
-                            Animate(target, aliveAnimations);
-
-                            return;
-                        }
+                        return;
                     }
                 }
             }
-            else
+        }
+        else
+        {
+            if (statBuffTime > -1)
             {
-                if (statBuffTime > -1)
+                if (!target.Immunities.Contains(spellBase.Combat.Effect))
                 {
-                    if (!target.Immunities.Contains(spellBase.Combat.Effect))
-                    {
-                        new Status(target, this, spellBase, spellBase.Combat.Effect, statBuffTime, "");
+                    new Status(target, this, spellBase, spellBase.Combat.Effect, statBuffTime, "");
 
-                        if (target is Npc npc)
-                        {
-                            npc.AssignTarget(this);
-                        }
-                    }
-                    else
+                    if (target is Npc npc)
                     {
-                        PacketSender.SendActionMsg(target, Strings.Combat.ImmuneToEffect, CustomColors.Combat.Status);
+                        npc.AssignTarget(this);
                     }
                 }
-            }
-
-            //Handle DoT/HoT spells]
-            if (spellBase.Combat.HoTDoT)
-            {
-                foreach (var dot in target.CachedDots)
+                else
                 {
-                    if (dot.SpellBase.Id == spellBase.Id && dot.Attacker == this)
-                    {
-                        dot.Expire();
-                    }
+                    PacketSender.SendActionMsg(target, Strings.Combat.ImmuneToEffect, CustomColors.Combat.Status);
                 }
-
-                new DoT(this, spellBase.Id, target);
             }
         }
 
-        private void Animate(Entity target, List<KeyValuePair<Guid, Direction>> animations)
+        //Handle DoT/HoT spells]
+        if (spellBase.Combat.HoTDoT)
         {
-            foreach (var anim in animations)
+            foreach (var dot in target.CachedDots)
             {
-                PacketSender.SendAnimationToProximity(anim.Key, 1, target.Id, target.MapId, 0, 0, anim.Value, MapInstanceId);
+                if (dot.SpellBase.Id == spellBase.Id && dot.Attacker == this)
+                {
+                    dot.Expire();
+                }
             }
+
+            new DoT(this, spellBase.Id, target);
+        }
+    }
+
+    private void Animate(Entity target, List<KeyValuePair<Guid, Direction>> animations)
+    {
+        foreach (var anim in animations)
+        {
+            PacketSender.SendAnimationToProximity(anim.Key, 1, target.Id, target.MapId, 0, 0, anim.Value, MapInstanceId);
+        }
+    }
+
+    //Attacking with weapon or unarmed.
+    public virtual void TryAttack(Entity target)
+    {
+        //See player and npc override of this virtual void
+    }
+
+    //Attack using a weapon or unarmed
+    public virtual void TryAttack(Entity target,
+        int baseDamage,
+        DamageType damageType,
+        Stat scalingStat,
+        int scaling,
+        int critChance,
+        double critMultiplier,
+        List<KeyValuePair<Guid, Direction>> deadAnimations = null,
+        List<KeyValuePair<Guid, Direction>> aliveAnimations = null,
+        ItemBase weapon = null)
+    {
+        if (IsAttacking)
+        {
+            return;
         }
 
-        //Attacking with weapon or unarmed.
-        public virtual void TryAttack(Entity target)
+        //Check for parties and safe zones, friendly fire off (unless its healing)
+        if (target is Player targetPlayer && this is Player player)
         {
-            //See player and npc override of this virtual void
-        }
-
-        //Attack using a weapon or unarmed
-        public virtual void TryAttack(Entity target,
-            int baseDamage,
-            DamageType damageType,
-            Stat scalingStat,
-            int scaling,
-            int critChance,
-            double critMultiplier,
-            List<KeyValuePair<Guid, Direction>> deadAnimations = null,
-            List<KeyValuePair<Guid, Direction>> aliveAnimations = null,
-            ItemBase weapon = null)
-        {
-            if (IsAttacking)
+            if (player.InParty(targetPlayer))
             {
                 return;
             }
 
-            //Check for parties and safe zones, friendly fire off (unless its healing)
-            if (target is Player targetPlayer && this is Player player)
+            //Check if either the attacker or the defender is in a "safe zone" (Only apply if combat is PVP)
+            //Player interaction common events
+            targetPlayer.StartCommonEventsWithTrigger(CommonEventTrigger.PlayerInteract, "", this.Name);
+
+            if (MapController.Get(MapId)?.ZoneType == MapZone.Safe)
             {
-                if (player.InParty(targetPlayer))
-                {
-                    return;
-                }
+                return;
+            }
 
-                //Check if either the attacker or the defender is in a "safe zone" (Only apply if combat is PVP)
-                //Player interaction common events
-                targetPlayer.StartCommonEventsWithTrigger(CommonEventTrigger.PlayerInteract, "", this.Name);
+            if (MapController.Get(target.MapId)?.ZoneType == MapZone.Safe)
+            {
+                return;
+            }
+        }
 
-                if (MapController.Get(MapId)?.ZoneType == MapZone.Safe)
+        //Check for taunt status and trying to attack a target that has not taunted you.
+        foreach (var status in CachedStatuses)
+        {
+            if (status.Type == SpellEffect.Taunt)
+            {
+                if (Target != target)
                 {
-                    return;
-                }
+                    PacketSender.SendActionMsg(this, Strings.Combat.miss, CustomColors.Combat.Missed);
 
-                if (MapController.Get(target.MapId)?.ZoneType == MapZone.Safe)
-                {
                     return;
                 }
             }
+        }
 
-            //Check for taunt status and trying to attack a target that has not taunted you.
+        AttackTimer = Timing.Global.Milliseconds + CalculateAttackTime();
+
+        //Check if the attacker is blinded.
+        if (IsOneBlockAway(target))
+        {
             foreach (var status in CachedStatuses)
             {
-                if (status.Type == SpellEffect.Taunt)
+                if (status.Type == SpellEffect.Stun ||
+                    status.Type == SpellEffect.Blind ||
+                    status.Type == SpellEffect.Sleep)
                 {
-                    if (Target != target)
-                    {
-                        PacketSender.SendActionMsg(this, Strings.Combat.miss, CustomColors.Combat.Missed);
+                    PacketSender.SendActionMsg(this, Strings.Combat.miss, CustomColors.Combat.Missed);
+                    PacketSender.SendEntityAttack(this, CalculateAttackTime());
 
-                        return;
-                    }
+                    return;
                 }
             }
-
-            AttackTimer = Timing.Global.Milliseconds + CalculateAttackTime();
-
-            //Check if the attacker is blinded.
-            if (IsOneBlockAway(target))
-            {
-                foreach (var status in CachedStatuses)
-                {
-                    if (status.Type == SpellEffect.Stun ||
-                        status.Type == SpellEffect.Blind ||
-                        status.Type == SpellEffect.Sleep)
-                    {
-                        PacketSender.SendActionMsg(this, Strings.Combat.miss, CustomColors.Combat.Missed);
-                        PacketSender.SendEntityAttack(this, CalculateAttackTime());
-
-                        return;
-                    }
-                }
-            }
-
-            Attack(
-                target, baseDamage, 0, damageType, scalingStat, scaling, critChance, critMultiplier, deadAnimations,
-                aliveAnimations, true
-            );
         }
 
-        public void Attack(
-            Entity enemy,
-            long baseDamage,
-            long secondaryDamage,
-            DamageType damageType,
-            Stat scalingStat,
-            int scaling,
-            int critChance,
-            double critMultiplier,
-            List<KeyValuePair<Guid, Direction>> deadAnimations = null,
-            List<KeyValuePair<Guid, Direction>> aliveAnimations = null,
-            bool isAutoAttack = false
-        )
+        Attack(
+            target, baseDamage, 0, damageType, scalingStat, scaling, critChance, critMultiplier, deadAnimations,
+            aliveAnimations, true
+        );
+    }
+
+    public void Attack(
+        Entity enemy,
+        long baseDamage,
+        long secondaryDamage,
+        DamageType damageType,
+        Stat scalingStat,
+        int scaling,
+        int critChance,
+        double critMultiplier,
+        List<KeyValuePair<Guid, Direction>> deadAnimations = null,
+        List<KeyValuePair<Guid, Direction>> aliveAnimations = null,
+        bool isAutoAttack = false
+    )
+    {
+        var damagingAttack = baseDamage > 0;
+        var secondaryDamagingAttack = secondaryDamage > 0;
+
+        if (enemy == null)
         {
-            var damagingAttack = baseDamage > 0;
-            var secondaryDamagingAttack = secondaryDamage > 0;
+            return;
+        }
 
-            if (enemy == null)
-            {
-                return;
-            }
+        //Let's save the entity's vitals before they takes damage to use in lifesteal/manasteal
+        var enemyVitals = enemy.GetVitals();
+        var invulnerable = enemy.CachedStatuses.Any(status => status.Type == SpellEffect.Invulnerable);
 
-            //Let's save the entity's vitals before they takes damage to use in lifesteal/manasteal
-            var enemyVitals = enemy.GetVitals();
-            var invulnerable = enemy.CachedStatuses.Any(status => status.Type == SpellEffect.Invulnerable);
+        bool isCrit = false;
+        //Is this a critical hit?
+        if (Randomization.Next(1, 101) > critChance)
+        {
+            critMultiplier = 1;
+        }
+        else
+        {
+            isCrit = true;
+        }
 
-            bool isCrit = false;
-            //Is this a critical hit?
-            if (Randomization.Next(1, 101) > critChance)
-            {
-                critMultiplier = 1;
-            }
-            else
-            {
-                isCrit = true;
-            }
+        //If the enemy is a resource, the original base damage value will be used on "Calculate Damages", if not, we need change...
+        if (!(enemy is Resource))
+        {
+            baseDamage = Formulas.CalculateDamage(
+            baseDamage, damageType, scalingStat, scaling, critMultiplier, this, enemy
+        );
+        }
 
-            //If the enemy is a resource, the original base damage value will be used on "Calculate Damages", if not, we need change...
-            if (!(enemy is Resource))
+        //Check on each attack if the enemy is a player AND if they are blocking.
+        if (enemy is Player player && player.IsBlocking)
+        {
+            if (player.TryGetEquipmentSlot(Options.ShieldIndex, out var slot) && player.TryGetItemAt(slot, out var itm))
             {
-                baseDamage = Formulas.CalculateDamage(
-                baseDamage, damageType, scalingStat, scaling, critMultiplier, this, enemy
-            );
-            }
+                var item = itm.Descriptor;
+                var originalBaseDamage = baseDamage;
+                var blockChance = item.BlockChance;
+                var blockAmount = item.BlockAmount / 100.0;
+                var blockAbsorption = item.BlockAbsorption / 100.0;
 
-            //Check on each attack if the enemy is a player AND if they are blocking.
-            if (enemy is Player player && player.IsBlocking)
-            {
-                if (player.TryGetEquipmentSlot(Options.ShieldIndex, out var slot) && player.TryGetItemAt(slot, out var itm))
+                //Generate a new attempt to block
+                if (Randomization.Next(0, 101) < blockChance)
                 {
-                    var item = itm.Descriptor;
-                    var originalBaseDamage = baseDamage;
-                    var blockChance = item.BlockChance;
-                    var blockAmount = item.BlockAmount / 100.0;
-                    var blockAbsorption = item.BlockAbsorption / 100.0;
-
-                    //Generate a new attempt to block
-                    if (Randomization.Next(0, 101) < blockChance)
+                    if (item.BlockAmount < 100)
                     {
-                        if (item.BlockAmount < 100)
-                        {
-                            baseDamage -= (int)Math.Round(baseDamage * blockAmount);
-                        }
-                        else
-                        {
-                            baseDamage = 0;
-                        }
-
-                        var absorptionAmount = (int)Math.Round(baseDamage * blockAbsorption);
-
-                        if (absorptionAmount == 0)
-                        {
-                            absorptionAmount = (int)Math.Round(originalBaseDamage * blockAbsorption);
-                        }
-
-                        if (blockAbsorption > 0)
-                        {
-                            player.AddVital(Vital.Health, absorptionAmount);
-
-                            PacketSender.SendActionMsg(
-                            enemy, Strings.Combat.addsymbol + Math.Abs(absorptionAmount),
-                            CustomColors.Combat.Heal
-                            );
-                        }
-
-                        PacketSender.SendActionMsg(enemy, Strings.Combat.blocked, CustomColors.Combat.Blocked);
+                        baseDamage -= (int)Math.Round(baseDamage * blockAmount);
                     }
-                }
-            }
-
-            //Calculate Damages
-            if (baseDamage != 0)
-            {
-
-                if (baseDamage < 0 && damagingAttack)
-                {
-                    baseDamage = 0;
-                }
-
-                if (baseDamage > 0 && enemy.HasVital(Vital.Health) && !invulnerable)
-                {
-                    if (isCrit)
+                    else
                     {
-                        PacketSender.SendActionMsg(enemy, Strings.Combat.critical, CustomColors.Combat.Critical);
+                        baseDamage = 0;
                     }
 
-                    enemy.SubVital(Vital.Health, baseDamage);
-                    switch (damageType)
+                    var absorptionAmount = (int)Math.Round(baseDamage * blockAbsorption);
+
+                    if (absorptionAmount == 0)
                     {
-                        case DamageType.Physical:
-                            PacketSender.SendActionMsg(
-                                enemy, Strings.Combat.removesymbol + baseDamage,
-                                CustomColors.Combat.PhysicalDamage
-                            );
-
-                            break;
-                        case DamageType.Magic:
-                            PacketSender.SendActionMsg(
-                                enemy, Strings.Combat.removesymbol + baseDamage, CustomColors.Combat.MagicDamage
-                            );
-
-                            break;
-                        case DamageType.True:
-                            PacketSender.SendActionMsg(
-                                enemy, Strings.Combat.removesymbol + baseDamage, CustomColors.Combat.TrueDamage
-                            );
-
-                            break;
+                        absorptionAmount = (int)Math.Round(originalBaseDamage * blockAbsorption);
                     }
 
-                    var toRemove = new List<Status>();
-                    foreach (var status in enemy.CachedStatuses.ToArray())  // ToArray the Array since removing a status will.. you know, change the collection.
+                    if (blockAbsorption > 0)
                     {
-                        //Wake up any sleeping targets targets and take stealthed entities out of stealth
-                        if (status.Type == SpellEffect.Sleep || status.Type == SpellEffect.Stealth)
-                        {
-                            status.RemoveStatus();
-                        }
-                    }
+                        player.AddVital(Vital.Health, absorptionAmount);
 
-                    // Add the attacker to the Npcs threat and loot table.
-                    if (enemy is Npc enemyNpc)
-                    {
-                        var dmgMap = enemyNpc.DamageMap;
-                        dmgMap.TryGetValue(this, out var damage);
-                        dmgMap[this] = damage + baseDamage;
-
-                        enemyNpc.LootMap.TryAdd(Id, true);
-                        enemyNpc.LootMapCache = enemyNpc.LootMap.Keys.ToArray();
-                        enemyNpc.TryFindNewTarget(Timing.Global.Milliseconds, default, false, this);
-                    }
-
-                    enemy.NotifySwarm(this);
-                }
-                else if (baseDamage < 0 && !enemy.IsFullVital(Vital.Health))
-                {
-                    enemy.AddVital(Vital.Health, -baseDamage);
-                    PacketSender.SendActionMsg(
-                        enemy, Strings.Combat.addsymbol + Math.Abs(baseDamage), CustomColors.Combat.Heal
-                    );
-                }
-            }
-
-            if (secondaryDamage != 0)
-            {
-                secondaryDamage = Formulas.CalculateDamage(
-                    secondaryDamage, damageType, scalingStat, scaling, critMultiplier, this, enemy
-                );
-
-                if (secondaryDamage < 0 && secondaryDamagingAttack)
-                {
-                    secondaryDamage = 0;
-                }
-
-                if (secondaryDamage > 0 && enemy.HasVital(Vital.Mana) && !invulnerable)
-                {
-                    //If we took damage lets reset our combat timer
-                    enemy.SubVital(Vital.Mana, secondaryDamage);
-                    PacketSender.SendActionMsg(
-                        enemy, Strings.Combat.removesymbol + secondaryDamage, CustomColors.Combat.RemoveMana
-                    );
-
-                    //No Matter what, if we attack the entitiy, make them chase us
-                    if (enemy is Npc enemyNpc)
-                    {
-                        enemyNpc.TryFindNewTarget(Timing.Global.Milliseconds, default, false, this);
-                    }
-
-                    enemy.NotifySwarm(this);
-                }
-                else if (secondaryDamage < 0 && !enemy.IsFullVital(Vital.Mana))
-                {
-                    enemy.AddVital(Vital.Mana, -secondaryDamage);
-                    PacketSender.SendActionMsg(
-                        enemy, Strings.Combat.addsymbol + Math.Abs(secondaryDamage), CustomColors.Combat.AddMana
-                    );
-                }
-            }
-
-            // Set combat timers!
-            enemy.CombatTimer = Timing.Global.Milliseconds + Options.CombatTime;
-            CombatTimer = Timing.Global.Milliseconds + Options.CombatTime;
-
-            var thisPlayer = this as Player;
-
-            //Check for lifesteal/manasteal
-            if (this is Player && !(enemy is Resource))
-            {
-                var lifestealRate = thisPlayer.GetEquipmentBonusEffect(ItemEffect.Lifesteal) / 100f;
-                var idealHealthRecovered = lifestealRate * baseDamage;
-                var actualHealthRecovered = Math.Min(enemyVitals[(int)Vital.Health], idealHealthRecovered);
-
-                if (actualHealthRecovered > 0)
-                {
-                    // Don't send any +0 msg's.
-                    AddVital(Vital.Health, (int)actualHealthRecovered);
-                    PacketSender.SendActionMsg(
-                        this,
-                        Strings.Combat.addsymbol + (int)actualHealthRecovered,
+                        PacketSender.SendActionMsg(
+                        enemy, Strings.Combat.addsymbol + Math.Abs(absorptionAmount),
                         CustomColors.Combat.Heal
-                    );
-                }
-
-                var manastealRate = (thisPlayer.GetEquipmentBonusEffect(ItemEffect.Manasteal) / 100f);
-                var idealManaRecovered = manastealRate * baseDamage;
-                var actualManaRecovered = Math.Min(enemyVitals[(int)Vital.Mana], idealManaRecovered);
-
-                if (actualManaRecovered > 0)
-                {
-                    // Don't send any +0 msg's.
-                    AddVital(Vital.Mana, (int)actualManaRecovered);
-                    enemy.SubVital(Vital.Mana, (int)actualManaRecovered);
-                    PacketSender.SendActionMsg(
-                        this,
-                        Strings.Combat.addsymbol + (int)actualManaRecovered,
-                        CustomColors.Combat.AddMana
-                    );
-                }
-
-                var remainingManaRecovery = idealManaRecovered - actualManaRecovered;
-                if (remainingManaRecovery > 0)
-                {
-                    // If the mana recovered is less than it should be, deal the remainder as bonus damage
-                    enemy.SubVital(Vital.Health, (int)remainingManaRecovery);
-                    PacketSender.SendActionMsg(
-                        enemy,
-                        Strings.Combat.removesymbol + remainingManaRecovery,
-                        CustomColors.Combat.TrueDamage
-                    );
-                }
-            }
-
-            //Dead entity check
-            if (enemy.GetVital(Vital.Health) <= 0)
-            {
-                if (enemy is Npc || enemy is Resource)
-                {
-                    lock (enemy.EntityLock)
-                    {
-                        enemy.Die(true, this);
-                    }
-                }
-                else
-                {
-                    //PVP Kill common events
-                    if (!enemy.Dead && enemy is Player enemyPlayer && this is Player)
-                    {
-                        thisPlayer.StartCommonEventsWithTrigger(CommonEventTrigger.PVPKill, "", enemy.Name);
-                        enemyPlayer.StartCommonEventsWithTrigger(CommonEventTrigger.PVPDeath, "", this.Name);
-                    }
-
-                    lock (enemy.EntityLock)
-                    {
-                        enemy.Die(true, this);
-                    }
-                }
-
-                if (deadAnimations != null)
-                {
-                    foreach (var anim in deadAnimations)
-                    {
-                        PacketSender.SendAnimationToProximity(
-                            anim.Key, -1, Id, enemy.MapId, enemy.X, enemy.Y, anim.Value, MapInstanceId
                         );
                     }
-                }
-            }
-            else
-            {
-                //Hit him, make him mad and send the vital update.
-                if (aliveAnimations?.Count > 0)
-                {
-                    Animate(enemy, aliveAnimations);
-                }
-            }
 
-            //Check for any onhit damage bonus effects!
-            CheckForOnhitAttack(enemy, isAutoAttack);
-
-            // Add a timer before able to make the next move.
-            if (this is Npc thisNpc)
-            {
-                thisNpc.MoveTimer = Timing.Global.Milliseconds + (long)GetMovementTime();
+                    PacketSender.SendActionMsg(enemy, Strings.Combat.blocked, CustomColors.Combat.Blocked);
+                }
             }
         }
 
-        protected virtual void CheckForOnhitAttack(Entity enemy, bool isAutoAttack)
+        //Calculate Damages
+        if (baseDamage != 0)
         {
-            if (isAutoAttack && !enemy.IsDead()) //Ignore spell damage.
+
+            if (baseDamage < 0 && damagingAttack)
             {
-                foreach (var status in CachedStatuses)
+                baseDamage = 0;
+            }
+
+            if (baseDamage > 0 && enemy.HasVital(Vital.Health) && !invulnerable)
+            {
+                if (isCrit)
                 {
-                    if (status.Type == SpellEffect.OnHit)
+                    PacketSender.SendActionMsg(enemy, Strings.Combat.critical, CustomColors.Combat.Critical);
+                }
+
+                enemy.SubVital(Vital.Health, baseDamage);
+                switch (damageType)
+                {
+                    case DamageType.Physical:
+                        PacketSender.SendActionMsg(
+                            enemy, Strings.Combat.removesymbol + baseDamage,
+                            CustomColors.Combat.PhysicalDamage
+                        );
+
+                        break;
+                    case DamageType.Magic:
+                        PacketSender.SendActionMsg(
+                            enemy, Strings.Combat.removesymbol + baseDamage, CustomColors.Combat.MagicDamage
+                        );
+
+                        break;
+                    case DamageType.True:
+                        PacketSender.SendActionMsg(
+                            enemy, Strings.Combat.removesymbol + baseDamage, CustomColors.Combat.TrueDamage
+                        );
+
+                        break;
+                }
+
+                var toRemove = new List<Status>();
+                foreach (var status in enemy.CachedStatuses.ToArray())  // ToArray the Array since removing a status will.. you know, change the collection.
+                {
+                    //Wake up any sleeping targets targets and take stealthed entities out of stealth
+                    if (status.Type == SpellEffect.Sleep || status.Type == SpellEffect.Stealth)
                     {
-                        TryAttack(enemy, status.Spell, true);
                         status.RemoveStatus();
                     }
                 }
+
+                // Add the attacker to the Npcs threat and loot table.
+                if (enemy is Npc enemyNpc)
+                {
+                    var dmgMap = enemyNpc.DamageMap;
+                    dmgMap.TryGetValue(this, out var damage);
+                    dmgMap[this] = damage + baseDamage;
+
+                    enemyNpc.LootMap.TryAdd(Id, true);
+                    enemyNpc.LootMapCache = enemyNpc.LootMap.Keys.ToArray();
+                    enemyNpc.TryFindNewTarget(Timing.Global.Milliseconds, default, false, this);
+                }
+
+                enemy.NotifySwarm(this);
+            }
+            else if (baseDamage < 0 && !enemy.IsFullVital(Vital.Health))
+            {
+                enemy.AddVital(Vital.Health, -baseDamage);
+                PacketSender.SendActionMsg(
+                    enemy, Strings.Combat.addsymbol + Math.Abs(baseDamage), CustomColors.Combat.Heal
+                );
             }
         }
 
-        public virtual void KilledEntity(Entity entity)
+        if (secondaryDamage != 0)
         {
-        }
+            secondaryDamage = Formulas.CalculateDamage(
+                secondaryDamage, damageType, scalingStat, scaling, critMultiplier, this, enemy
+            );
 
-        public virtual bool CanCastSpell(SpellBase spell, Entity target, bool checkVitalReqs, out SpellCastFailureReason reason)
-        {
-            // Is this a valid spell?
-            if (spell == null)
+            if (secondaryDamage < 0 && secondaryDamagingAttack)
             {
-                reason = SpellCastFailureReason.InvalidSpell;
-                return false;
+                secondaryDamage = 0;
             }
 
-            // Is this spell on cooldown?
-            if (SpellCooldowns.TryGetValue(spell.Id, out var spellCooldown) &&
-                spellCooldown > Timing.Global.MillisecondsUtc)
+            if (secondaryDamage > 0 && enemy.HasVital(Vital.Mana) && !invulnerable)
             {
-                reason = SpellCastFailureReason.OnCooldown;
-                return false;
-            }
+                //If we took damage lets reset our combat timer
+                enemy.SubVital(Vital.Mana, secondaryDamage);
+                PacketSender.SendActionMsg(
+                    enemy, Strings.Combat.removesymbol + secondaryDamage, CustomColors.Combat.RemoveMana
+                );
 
-            // Do we meet the vital requirements?
-            if (checkVitalReqs)
-            {
-                if (spell.VitalCost[(int)Vital.Mana] > GetVital(Vital.Mana))
+                //No Matter what, if we attack the entitiy, make them chase us
+                if (enemy is Npc enemyNpc)
                 {
-                    reason = SpellCastFailureReason.InsufficientMP;
-                    return false;
+                    enemyNpc.TryFindNewTarget(Timing.Global.Milliseconds, default, false, this);
                 }
 
-                if (spell.VitalCost[(int)Vital.Health] >= GetVital(Vital.Health))
-                {
-                    reason = SpellCastFailureReason.InsufficientHP;
-                    return false;
-                }
+                enemy.NotifySwarm(this);
             }
-
-            // Check if the caster has any status effects that need to apply.
-            // Ignore if the current spell is a Cleanse, this will ignore any and all status effects.
-            if (spell.Combat.Effect != SpellEffect.Cleanse)
+            else if (secondaryDamage < 0 && !enemy.IsFullVital(Vital.Mana))
             {
-                foreach (var status in CachedStatuses)
-                {
-                    if (status.Type == SpellEffect.Silence)
-                    {
-                        reason = SpellCastFailureReason.Silenced;
-                        return false;
-                    }
-
-                    if (status.Type == SpellEffect.Stun)
-                    {
-                        reason = SpellCastFailureReason.Stunned;
-                        return false;
-                    }
-
-                    if (status.Type == SpellEffect.Sleep)
-                    {
-                        reason = SpellCastFailureReason.Asleep;
-                        return false;
-                    }
-
-                    if (status.Type == SpellEffect.Snare)
-                    {
-                        // If this spell is a Dash or Warp type ability, we can not use it while snared.
-                        if (spell.SpellType == SpellType.Dash || spell.SpellType == SpellType.Warp || spell.SpellType == SpellType.WarpTo)
-                        {
-                            reason = SpellCastFailureReason.Snared;
-                            return false;
-                        }
-                    }
-                }
-            }
-
-            // Check for target validity
-            var singleTargetSpell = (spell.SpellType == SpellType.CombatSpell && spell.Combat.TargetType == SpellTargetType.Single) || spell.SpellType == SpellType.WarpTo;
-            if (target == null && singleTargetSpell)
-            {
-                reason = SpellCastFailureReason.InvalidTarget;
-                return false;
-            }
-
-            if (target == this && spell.SpellType == SpellType.WarpTo)
-            {
-                reason = SpellCastFailureReason.InvalidTarget;
-                return false;
-            }
-
-            if (target != null && singleTargetSpell)
-            {
-                if (spell.Combat.Friendly != IsAllyOf(target) || !CanAttack(target, spell))
-                {
-                    reason = SpellCastFailureReason.InvalidTarget;
-                    return false;
-                }
-            }
-
-            //Check for range of a single target spell
-            if (singleTargetSpell && target != this)
-            {
-                if (!InRangeOf(target, spell.Combat.CastRange))
-                {
-                    reason = SpellCastFailureReason.OutOfRange;
-                    return false;
-                }
-            }
-
-            // We have no reason to stop the entity from casting!
-            reason = SpellCastFailureReason.None;
-            return true;
-        }
-
-        public virtual void CastSpell(Guid spellId, int spellSlot = -1)
-        {
-            if (!SpellBase.TryGet(spellId, out var spellBase))
-            {
-                return;
-            }
-
-            if (!CanCastSpell(spellBase, CastTarget, false, out _))
-            {
-                return;
-            }
-
-            if (spellBase.VitalCost[(int)Vital.Mana] > 0)
-            {
-                SubVital(Vital.Mana, spellBase.VitalCost[(int)Vital.Mana]);
-            }
-            else
-            {
-                AddVital(Vital.Mana, -spellBase.VitalCost[(int)Vital.Mana]);
-            }
-
-            if (spellBase.VitalCost[(int)Vital.Health] > 0)
-            {
-                SubVital(Vital.Health, spellBase.VitalCost[(int)Vital.Health]);
-            }
-            else
-            {
-                AddVital(Vital.Health, -spellBase.VitalCost[(int)Vital.Health]);
-            }
-
-            try
-            {
-                switch (spellBase.SpellType)
-                {
-                    case SpellType.CombatSpell:
-                    case SpellType.Event:
-
-                        switch (spellBase.Combat.TargetType)
-                        {
-                            case SpellTargetType.Self:
-                                if (spellBase.HitAnimationId != Guid.Empty &&
-                                    spellBase.Combat.Effect != SpellEffect.OnHit)
-                                {
-                                    PacketSender.SendAnimationToProximity(
-                                        spellBase.HitAnimationId,
-                                        1,
-                                        Id,
-                                        MapId,
-                                        0,
-                                        0,
-                                        Dir,
-                                        MapInstanceId
-                                    ); //Target Type 1 will be global entity
-                                }
-
-                                TryAttack(this, spellBase);
-
-                                break;
-                            case SpellTargetType.Single:
-                                if (CastTarget == null)
-                                {
-                                    return;
-                                }
-
-                                //If target has stealthed we cannot hit the spell.
-                                foreach (var status in CastTarget.CachedStatuses)
-                                {
-                                    if (status.Type == SpellEffect.Stealth)
-                                    {
-                                        return;
-                                    }
-                                }
-
-                                if (spellBase.Combat.HitRadius > 0) //Single target spells with AoE hit radius'
-                                {
-                                    HandleAoESpell(
-                                        spellId,
-                                        spellBase.Combat.HitRadius,
-                                        CastTarget.MapId,
-                                        CastTarget.X,
-                                        CastTarget.Y,
-                                        null
-                                    );
-                                }
-                                else
-                                {
-                                    TryAttack(CastTarget, spellBase);
-                                }
-
-                                break;
-                            case SpellTargetType.AoE:
-                                HandleAoESpell(spellId, spellBase.Combat.HitRadius, MapId, X, Y, null);
-
-                                break;
-                            case SpellTargetType.Projectile:
-                                var projectileBase = spellBase.Combat.Projectile;
-                                if (projectileBase != null)
-                                {
-                                    if (MapController.TryGetInstanceFromMap(MapId, MapInstanceId, out var mapInstance))
-                                    {
-                                        mapInstance.SpawnMapProjectile(
-                                            this,
-                                            projectileBase,
-                                            spellBase,
-                                            null,
-                                            MapId,
-                                            (byte)X,
-                                            (byte)Y,
-                                            (byte)Z,
-                                            Dir,
-                                            CastTarget
-                                        );
-                                    }
-                                }
-
-                                break;
-                            case SpellTargetType.OnHit:
-                                if (spellBase.Combat.Effect == SpellEffect.OnHit)
-                                {
-                                    new Status(
-                                        this,
-                                        this,
-                                        spellBase,
-                                        SpellEffect.OnHit,
-                                        spellBase.Combat.OnHitDuration,
-                                        spellBase.Combat.TransformSprite
-                                    );
-
-                                    PacketSender.SendActionMsg(
-                                        this,
-                                        Strings.Combat.status[(int)spellBase.Combat.Effect],
-                                        CustomColors.Combat.Status
-                                    );
-                                }
-
-                                break;
-                            case SpellTargetType.Trap:
-                                if (MapController.TryGetInstanceFromMap(MapId, MapInstanceId, out var instance))
-                                {
-                                    instance.SpawnTrap(this, spellBase, (byte)X, (byte)Y, (byte)Z);
-                                }
-
-                                break;
-                            default:
-                                break;
-                        }
-
-                        break;
-                    case SpellType.Warp:
-                        if (this is Player)
-                        {
-                            Warp(
-                                spellBase.Warp.MapId,
-                                spellBase.Warp.X,
-                                spellBase.Warp.Y,
-                                spellBase.Warp.Dir - 1 == -1 ? this.Dir : (Direction)(spellBase.Warp.Dir - 1)
-                            );
-                        }
-
-                        break;
-                    case SpellType.WarpTo:
-                        if (CastTarget != null)
-                        {
-                            HandleAoESpell(spellId, spellBase.Combat.CastRange, MapId, X, Y, CastTarget);
-                        }
-
-                        break;
-                    case SpellType.Dash:
-                        PacketSender.SendActionMsg(this, Strings.Combat.dash, CustomColors.Combat.Dash);
-                        var dash = new Dash(
-                            this,
-                            spellBase.Combat.CastRange,
-                            Dir,
-                            Convert.ToBoolean(spellBase.Dash.IgnoreMapBlocks),
-                            Convert.ToBoolean(spellBase.Dash.IgnoreActiveResources),
-                            Convert.ToBoolean(spellBase.Dash.IgnoreInactiveResources),
-                            Convert.ToBoolean(spellBase.Dash.IgnoreZDimensionAttributes)
-                        );
-
-                        break;
-                    default:
-                        break;
-                }
-
-                UpdateSpellCooldown(spellBase, spellSlot);
-            }
-            finally
-            {
-                if (GetVital(Vital.Health) < 1)
-                {
-                    Die(true, this);
-                }
+                enemy.AddVital(Vital.Mana, -secondaryDamage);
+                PacketSender.SendActionMsg(
+                    enemy, Strings.Combat.addsymbol + Math.Abs(secondaryDamage), CustomColors.Combat.AddMana
+                );
             }
         }
 
-        private void HandleAoESpell(
-            Guid spellId,
-            int range,
-            Guid startMapId,
-            int startX,
-            int startY,
-            Entity spellTarget
-        )
+        // Set combat timers!
+        enemy.CombatTimer = Timing.Global.Milliseconds + Options.CombatTime;
+        CombatTimer = Timing.Global.Milliseconds + Options.CombatTime;
+
+        var thisPlayer = this as Player;
+
+        //Check for lifesteal/manasteal
+        if (this is Player && !(enemy is Resource))
         {
-            var spellBase = SpellBase.Get(spellId);
-            if (spellBase != null)
+            var lifestealRate = thisPlayer.GetEquipmentBonusEffect(ItemEffect.Lifesteal) / 100f;
+            var idealHealthRecovered = lifestealRate * baseDamage;
+            var actualHealthRecovered = Math.Min(enemyVitals[(int)Vital.Health], idealHealthRecovered);
+
+            if (actualHealthRecovered > 0)
             {
-                var startMap = MapController.Get(startMapId);
-                foreach (var instance in MapController.GetSurroundingMapInstances(startMapId, MapInstanceId, true))
-                {
-                    foreach (var entity in instance.GetCachedEntities())
-                    {
-                        if (entity != null && (entity is Player || entity is Npc))
-                        {
-                            if (spellTarget == null || spellTarget == entity)
-                            {
-                                if (entity.GetDistanceTo(startMap, startX, startY) <= range)
-                                {
-                                    //Check to handle a warp to spell
-                                    if (spellBase.SpellType == SpellType.WarpTo)
-                                    {
-                                        if (spellTarget != null)
-                                        {
-                                            //Spelltarget used to be Target. I don't know if this is correct or not.
-                                            int[] position = GetPositionNearTarget(spellTarget.MapId, spellTarget.X, spellTarget.Y);
-                                            Warp(spellTarget.MapId, (byte)position[0], (byte)position[1], Dir);
-                                            ChangeDir(DirectionToTarget(spellTarget));
-                                        }
-                                    }
-
-                                    TryAttack(entity, spellBase); //Handle damage
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        private int[] GetPositionNearTarget(Guid mapId, int x, int y)
-        {
-            if (MapController.TryGetInstanceFromMap(mapId, MapInstanceId, out var instance))
-            {
-                List<int[]> validPosition = new List<int[]>();
-
-                // Start by north, west, est and south
-                for (int col = -1; col < 2; col++)
-                {
-                    for (int row = -1; row < 2; row++)
-                    {
-                        if (Math.Abs(col % 2) != Math.Abs(row % 2))
-                        {
-                            int newX = x + row;
-                            int newY = y + col;
-
-                            if (newX >= 0 && newX <= Options.MapWidth &&
-                                newY >= 0 && newY <= Options.MapHeight &&
-                                !instance.TileBlocked(newX, newY))
-                            {
-                                validPosition.Add(new int[] { newX, newY });
-                            }
-                        }
-                    }
-                }
-
-                if (validPosition.Count > 0)
-                {
-                    return validPosition[Randomization.Next(0, validPosition.Count)];
-                }
-
-                // If nothing found, diagonal direction
-                for (int col = -1; col < 2; col++)
-                {
-                    for (int row = -1; row < 2; row++)
-                    {
-                        if (Math.Abs(col % 2) == Math.Abs(row % 2))
-                        {
-                            int newX = x + row;
-                            int newY = y + col;
-
-                            // Tile must not be the target position
-                            if (newX >= 0 && newX <= Options.MapWidth &&
-                                newY >= 0 && newY <= Options.MapHeight &&
-                                !(x + row == x && y + col == y) &&
-                                !instance.TileBlocked(newX, newY))
-                            {
-                                validPosition.Add(new int[] { newX, newY });
-                            }
-                        }
-                    }
-                }
-
-                if (validPosition.Count > 0)
-                {
-                    return validPosition[Randomization.Next(0, validPosition.Count)];
-                }
-
-                // If nothing found, return target position
-                return new int[] { x, y };
-            }
-            else
-            {
-                return new int[] { x, y };
-            }
-        }
-
-        // Check if the target is one tile away and within the same Z dimension.
-        protected bool IsOneBlockAway(Entity target)
-        {
-            if (Z != target.Z)
-            {
-                return false;
-            }
-
-            var myTile = new TileHelper(MapId, X, Y);
-            var enemyTile = new TileHelper(target.MapId, target.X, target.Y);
-
-            myTile.Translate(0, -1); // Target Up
-            if (myTile.Matches(enemyTile))
-            {
-                return true;
-            }
-
-            myTile.Translate(0, 2); // Target Down
-            if (myTile.Matches(enemyTile))
-            {
-                return true;
-            }
-
-            myTile.Translate(-1, -1); // Target Left
-            if (myTile.Matches(enemyTile))
-            {
-                return true;
-            }
-
-            myTile.Translate(2, 0); // Target Right
-            if (myTile.Matches(enemyTile))
-            {
-                return true;
-            }
-
-            if (Options.Instance.MapOpts.EnableDiagonalMovement)
-            {
-                myTile.Translate(-2, -1); // Target UpLeft
-                if (myTile.Matches(enemyTile))
-                {
-                    return true;
-                }
-
-                myTile.Translate(2, 0); // Target UpRight
-                if (myTile.Matches(enemyTile))
-                {
-                    return true;
-                }
-
-                myTile.Translate(-2, 2); // Target DownLeft
-                if (myTile.Matches(enemyTile))
-                {
-                    return true;
-                }
-
-                myTile.Translate(2, 0); // Target DownRight
-                if (myTile.Matches(enemyTile))
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        //These functions only work when one block away.
-        protected bool IsFacingTarget(Entity target)
-        {
-            if (!IsOneBlockAway(target.MapId, target.X, target.Y))
-            {
-                return false;
-            }
-
-            if (!MapController.TryGet(MapId, out var originMapController) ||
-                !MapController.TryGet(target.MapId, out var targetMapController))
-            {
-                return false;
-            }
-
-            var originY = Y + originMapController.MapGridY * Options.MapHeight;
-            var originX = X + originMapController.MapGridX * Options.MapWidth;
-            var targetY = target.Y + targetMapController.MapGridY * Options.MapHeight;
-            var targetX = target.X + targetMapController.MapGridX * Options.MapWidth;
-
-            var xDiff = targetX - originX;
-            var yDiff = targetY - originY;
-            var diagonalMovement = Options.Instance.MapOpts.EnableDiagonalMovement;
-
-            switch (xDiff)
-            {
-                case 0 when yDiff == -1 && Dir == Direction.Up:
-                case 0 when yDiff == 1 && Dir == Direction.Down:
-                case 1 when yDiff == 0 && Dir == Direction.Right:
-                case -1 when yDiff == 0 && Dir == Direction.Left:
-                case 1 when diagonalMovement && yDiff == -1 && Dir == Direction.UpRight:
-                case -1 when diagonalMovement && yDiff == -1 && Dir == Direction.UpLeft:
-                case 1 when diagonalMovement && yDiff == 1 && Dir == Direction.DownRight:
-                case -1 when diagonalMovement && yDiff == 1 && Dir == Direction.DownLeft:
-                    return true;
-                default:
-                    return false;
-            }
-        }
-
-        public int GetDistanceTo(Entity target)
-        {
-            if (target != null)
-            {
-                return GetDistanceTo(target.Map, target.X, target.Y);
-            }
-            //Something is null.. return a value that is out of range :)
-            return 9999;
-        }
-
-        public int GetDistanceTo(MapController targetMap, int targetX, int targetY)
-        {
-            return GetDistanceBetween(Map, targetMap, X, targetX, Y, targetY);
-        }
-
-        public int GetDistanceBetween(MapController mapA, MapController mapB, int xTileA, int xTileB, int yTileA, int yTileB)
-        {
-            if (mapA != null && mapB != null && mapA.MapGrid == mapB.MapGrid
-            ) //Make sure both maps exist and that they are in the same dimension
-            {
-                //Calculate World Tile of Me
-                var x1 = xTileA + mapA.MapGridX * Options.MapWidth;
-                var y1 = yTileA + mapA.MapGridY * Options.MapHeight;
-
-                //Calculate world tile of target
-                var x2 = xTileB + mapB.MapGridX * Options.MapWidth;
-                var y2 = yTileB + mapB.MapGridY * Options.MapHeight;
-
-                return (int)Math.Sqrt(Math.Pow(x1 - x2, 2) + Math.Pow(y1 - y2, 2));
-            }
-
-            //Something is null.. return a value that is out of range :)
-            return 9999;
-        }
-
-        public bool InRangeOf(Entity target, int range)
-        {
-            var dist = GetDistanceTo(target);
-            if (dist == 9999)
-            {
-                return false;
-            }
-
-            if (dist <= range)
-            {
-                return true;
-            }
-
-            return false;
-        }
-
-        public virtual void NotifySwarm(Entity attacker)
-        {
-        }
-
-        protected Direction DirectionToTarget(Entity en)
-        {
-            if (en == null || IsTurnAroundWhileCastingDisabled)
-            {
-                return Dir;
-            }
-
-            if (!MapController.TryGet(MapId, out var originMapController) ||
-                !MapController.TryGet(en.MapId, out var targetMapController))
-            {
-                return Dir;
-            }
-
-            var originY = Y + originMapController.MapGridY * Options.MapHeight;
-            var originX = X + originMapController.MapGridX * Options.MapWidth;
-            var targetY = en.Y + targetMapController.MapGridY * Options.MapHeight;
-            var targetX = en.X + targetMapController.MapGridX * Options.MapWidth;
-
-            var yDiff = originY - targetY;
-            var xDiff = originX - targetX;
-
-            // If Y offset is 0, direction is determined by X offset.
-            if (yDiff == 0)
-            {
-                return xDiff > 0 ? Direction.Left : Direction.Right;
-            }
-
-            // If X offset is 0 or If diagonal movement is disabled, direction is determined by Y offset.
-            if (xDiff == 0 || !Options.Instance.MapOpts.EnableDiagonalMovement)
-            {
-                return yDiff > 0 ? Direction.Up : Direction.Down;
-            }
-
-            // If both X and Y offset are non-zero, direction is determined by both offsets.
-            var xPositive = xDiff > 0;
-            var yPositive = yDiff > 0;
-
-            if (xPositive)
-            {
-                return yPositive ? Direction.UpLeft : Direction.DownLeft;
-            }
-
-            return yPositive ? Direction.UpRight : Direction.DownRight;
-        }
-
-        protected bool IsOneBlockAway(Guid mapId, int x, int y, int z = 0)
-        {
-            if (z != Z)
-            {
-                return false;
-            }
-
-            if (!MapController.TryGet(MapId, out var originMapController) ||
-                !MapController.TryGet(mapId, out var targetMapController))
-            {
-                return false;
-            }
-
-            // Adjust coordinates based on map grid positions.
-            var originY = Y + originMapController.MapGridY * Options.MapHeight;
-            var originX = X + originMapController.MapGridX * Options.MapWidth;
-            var targetY = y + targetMapController.MapGridY * Options.MapHeight;
-            var targetX = x + targetMapController.MapGridX * Options.MapWidth;
-
-            // Calculate the absolute differences in coordinates.
-            var yDiff = Math.Abs(originY - targetY);
-            var xDiff = Math.Abs(originX - targetX);
-
-            // Check if entities are one block away.
-            return (xDiff == 1 && yDiff == 0) || (xDiff == 0 && yDiff == 1) ||
-                   (Options.Instance.MapOpts.EnableDiagonalMovement && xDiff == 1 && yDiff == 1);
-        }
-
-        //Spawning/Dying
-        public virtual void Die(bool dropItems = true, Entity killer = null)
-        {
-            if (IsDead() || Items == null)
-            {
-                return;
-            }
-
-            // Run events and other things.
-            killer?.KilledEntity(this);
-
-            if (dropItems)
-            {
-                var lootGenerated = new List<Player>();
-                // If this is an NPC, drop loot for every single player that participated in the fight.
-                if (this is Npc npc && npc.Base.IndividualizedLoot)
-                {
-                    // Generate loot for every player that has helped damage this monster, as well as their party members.
-                    // Keep track of who already got loot generated for them though, or this gets messy!
-                    foreach (var entityEntry in npc.LootMapCache)
-                    {
-                        var player = Player.FindOnline(entityEntry);
-                        if (player != null)
-                        {
-
-                            // Cache our value for further processing.
-                            var party = player.Party.ToArray();
-
-                            // is this player in a party?
-                            if (party.Length > 0 && Options.Instance.LootOpts.IndividualizedLootAutoIncludePartyMembers)
-                            {
-                                // They are, so check for all party members and drop if still eligible!
-                                foreach (var partyMember in party)
-                                {
-                                    if (!lootGenerated.Contains(partyMember))
-                                    {
-                                        DropItems(partyMember);
-                                        lootGenerated.Add(partyMember);
-                                    }
-                                }
-                            }
-                            else
-                            {
-                                // They're not in a party, so drop the item if still eligible!
-                                if (!lootGenerated.Contains(player))
-                                {
-                                    DropItems(player);
-                                    lootGenerated.Add(player);
-                                }
-                            }
-                        }
-                    }
-
-                    // Clear their loot table and threat table.
-                    npc.DamageMap.Clear();
-                    npc.LootMap.Clear();
-                    npc.LootMapCache = Array.Empty<Guid>();
-                }
-                else
-                {
-                    // Drop as normal.
-                    DropItems(killer);
-                }
-            }
-
-            foreach (var instance in MapController.GetSurroundingMapInstances(MapId, MapInstanceId, true))
-            {
-                instance.ClearEntityTargetsOf(this);
-            }
-
-            DoT?.Clear();
-            CachedDots = new DoT[0];
-            Statuses?.Clear();
-            CachedStatuses = new Status[0];
-            Stat?.ToList().ForEach(stat => stat?.Reset());
-
-            Dead = true;
-        }
-
-        protected virtual bool ShouldDropItem(Entity killer, ItemBase itemDescriptor, Item item, float dropRateModifier, out Guid lootOwner)
-        {
-            lootOwner = default;
-
-            var dropRate = item.DropChance * 1000 * dropRateModifier;
-            var dropResult = Randomization.Next(1, 100001);
-            if (dropResult >= dropRate)
-            {
-                return false;
-            }
-
-            // Set the attributes for this item.
-            item.Set(new Item(item.ItemId, item.Quantity, null));
-            return true;
-        }
-
-        protected virtual void OnDropItem(InventorySlot slot, Item drop) { }
-
-        protected virtual void DropItems(Entity killer, bool sendUpdate = true)
-        {
-            if (this is Player && Options.Instance.MapOpts.DisablePlayerDropsInArenaMaps && Map.ZoneType == MapZone.Arena)
-            {
-                return;
-            }
-
-            // Drop items
-            foreach (var slot in Items)
-            {
-                if (slot == default)
-                {
-                    continue;
-                }
-
-                // Don't mess with the actual object.
-                var drop = slot.Clone();
-
-                var itemDescriptor = ItemBase.Get(drop.ItemId);
-                if (itemDescriptor == default)
-                {
-                    continue;
-                }
-
-                var playerKiller = killer as Player;
-                var dropRateModifier = 1 + (playerKiller?.GetEquipmentBonusEffect(ItemEffect.Luck) / 100f ?? 0);
-                if (!ShouldDropItem(killer, itemDescriptor, drop, dropRateModifier, out Guid lootOwner))
-                {
-                    continue;
-                }
-
-                // Spawn the actual item!
-                if (MapController.TryGetInstanceFromMap(MapId, MapInstanceId, out var instance))
-                {
-                    instance.SpawnItem(X, Y, drop, drop.Quantity, lootOwner, sendUpdate);
-                }
-
-                // Process the drop (for players this would remove it from their inventory)
-                OnDropItem(slot, drop);
-            }
-        }
-
-        public bool IsDead()
-        {
-            return Dead;
-        }
-
-        public virtual void Reset()
-        {
-            for (var i = 0; i < Enum.GetValues<Vital>().Length; i++)
-            {
-                RestoreVital((Vital)i);
-            }
-
-            Dead = false;
-        }
-
-        //Empty virtual functions for players
-        public virtual void Warp(Guid newMapId, float newX, float newY, bool adminWarp = false)
-        {
-            Warp(newMapId, newX, newY, Dir, adminWarp);
-        }
-
-        public virtual void Warp(Guid newMapId,
-            float newX,
-            float newY,
-            Direction newDir,
-            bool adminWarp = false,
-            int zOverride = 0,
-            bool mapSave = false,
-            bool fromWarpEvent = false,
-            MapInstanceType? mapInstanceType = null,
-            bool fromLogin = false,
-            bool forceInstanceChange = false)
-        {
-        }
-
-        public virtual EntityPacket EntityPacket(EntityPacket packet = null, Player forPlayer = null)
-        {
-            if (packet == null)
-            {
-                throw new Exception("No packet to populate!");
-            }
-
-            packet.EntityId = Id;
-            packet.MapId = MapId;
-            packet.Name = Name;
-            packet.Sprite = Sprite;
-            packet.Color = Color;
-            packet.Face = Face;
-            packet.Level = Level;
-            packet.X = (byte)X;
-            packet.Y = (byte)Y;
-            packet.Z = (byte)Z;
-            packet.Dir = (byte)Dir;
-            packet.Passable = Passable;
-            packet.HideName = HideName;
-            packet.HideEntity = HideEntity;
-            packet.Animations = Animations.ToArray();
-            packet.Vital = GetVitals();
-            packet.MaxVital = GetMaxVitals();
-            packet.Stats = GetStatValues();
-            packet.StatusEffects = StatusPackets();
-            packet.NameColor = NameColor;
-            packet.HeaderLabel = new LabelPacket(HeaderLabel.Text, HeaderLabel.Color);
-            packet.FooterLabel = new LabelPacket(FooterLabel.Text, FooterLabel.Color);
-
-            return packet;
-        }
-
-        public StatusPacket[] StatusPackets()
-        {
-            var statuses = CachedStatuses;
-            var statusPackets = new StatusPacket[statuses.Length];
-            for (var i = 0; i < statuses.Length; i++)
-            {
-                var status = statuses[i];
-                long[] vitalShields = null;
-                if (status.Type == SpellEffect.Shield)
-                {
-                    vitalShields = new long[Enum.GetValues<Vital>().Length];
-                    for (var x = 0; x < Enum.GetValues<Vital>().Length; x++)
-                    {
-                        vitalShields[x] = status.Shield[x];
-                    }
-                }
-
-                statusPackets[i] = new StatusPacket(
-                    status.Spell.Id, status.Type, status.Data, (int)(status.Duration - Timing.Global.Milliseconds),
-                    (int)(status.Duration - status.StartTime), vitalShields
+                // Don't send any +0 msg's.
+                AddVital(Vital.Health, (int)actualHealthRecovered);
+                PacketSender.SendActionMsg(
+                    this,
+                    Strings.Combat.addsymbol + (int)actualHealthRecovered,
+                    CustomColors.Combat.Heal
                 );
             }
 
-            return statusPackets;
+            var manastealRate = (thisPlayer.GetEquipmentBonusEffect(ItemEffect.Manasteal) / 100f);
+            var idealManaRecovered = manastealRate * baseDamage;
+            var actualManaRecovered = Math.Min(enemyVitals[(int)Vital.Mana], idealManaRecovered);
+
+            if (actualManaRecovered > 0)
+            {
+                // Don't send any +0 msg's.
+                AddVital(Vital.Mana, (int)actualManaRecovered);
+                enemy.SubVital(Vital.Mana, (int)actualManaRecovered);
+                PacketSender.SendActionMsg(
+                    this,
+                    Strings.Combat.addsymbol + (int)actualManaRecovered,
+                    CustomColors.Combat.AddMana
+                );
+            }
+
+            var remainingManaRecovery = idealManaRecovered - actualManaRecovered;
+            if (remainingManaRecovery > 0)
+            {
+                // If the mana recovered is less than it should be, deal the remainder as bonus damage
+                enemy.SubVital(Vital.Health, (int)remainingManaRecovery);
+                PacketSender.SendActionMsg(
+                    enemy,
+                    Strings.Combat.removesymbol + remainingManaRecovery,
+                    CustomColors.Combat.TrueDamage
+                );
+            }
         }
 
-        #region Spell Cooldowns
-
-        [JsonIgnore, Column("SpellCooldowns")]
-        public string SpellCooldownsJson
+        //Dead entity check
+        if (enemy.GetVital(Vital.Health) <= 0)
         {
-            get => JsonConvert.SerializeObject(SpellCooldowns);
-            set => SpellCooldowns = JsonConvert.DeserializeObject<ConcurrentDictionary<Guid, long>>(value ?? "{}");
+            if (enemy is Npc || enemy is Resource)
+            {
+                lock (enemy.EntityLock)
+                {
+                    enemy.Die(true, this);
+                }
+            }
+            else
+            {
+                //PVP Kill common events
+                if (!enemy.Dead && enemy is Player enemyPlayer && this is Player)
+                {
+                    thisPlayer.StartCommonEventsWithTrigger(CommonEventTrigger.PVPKill, "", enemy.Name);
+                    enemyPlayer.StartCommonEventsWithTrigger(CommonEventTrigger.PVPDeath, "", this.Name);
+                }
+
+                lock (enemy.EntityLock)
+                {
+                    enemy.Die(true, this);
+                }
+            }
+
+            if (deadAnimations != null)
+            {
+                foreach (var anim in deadAnimations)
+                {
+                    PacketSender.SendAnimationToProximity(
+                        anim.Key, -1, Id, enemy.MapId, enemy.X, enemy.Y, anim.Value, MapInstanceId
+                    );
+                }
+            }
+        }
+        else
+        {
+            //Hit him, make him mad and send the vital update.
+            if (aliveAnimations?.Count > 0)
+            {
+                Animate(enemy, aliveAnimations);
+            }
         }
 
-        [NotMapped] public ConcurrentDictionary<Guid, long> SpellCooldowns = new ConcurrentDictionary<Guid, long>();
+        //Check for any onhit damage bonus effects!
+        CheckForOnhitAttack(enemy, isAutoAttack);
 
-        #endregion
-
+        // Add a timer before able to make the next move.
+        if (this is Npc thisNpc)
+        {
+            thisNpc.MoveTimer = Timing.Global.Milliseconds + (long)GetMovementTime();
+        }
     }
+
+    protected virtual void CheckForOnhitAttack(Entity enemy, bool isAutoAttack)
+    {
+        if (isAutoAttack && !enemy.IsDead()) //Ignore spell damage.
+        {
+            foreach (var status in CachedStatuses)
+            {
+                if (status.Type == SpellEffect.OnHit)
+                {
+                    TryAttack(enemy, status.Spell, true);
+                    status.RemoveStatus();
+                }
+            }
+        }
+    }
+
+    public virtual void KilledEntity(Entity entity)
+    {
+    }
+
+    public virtual bool CanCastSpell(SpellBase spell, Entity target, bool checkVitalReqs, out SpellCastFailureReason reason)
+    {
+        // Is this a valid spell?
+        if (spell == null)
+        {
+            reason = SpellCastFailureReason.InvalidSpell;
+            return false;
+        }
+
+        // Is this spell on cooldown?
+        if (SpellCooldowns.TryGetValue(spell.Id, out var spellCooldown) &&
+            spellCooldown > Timing.Global.MillisecondsUtc)
+        {
+            reason = SpellCastFailureReason.OnCooldown;
+            return false;
+        }
+
+        // Do we meet the vital requirements?
+        if (checkVitalReqs)
+        {
+            if (spell.VitalCost[(int)Vital.Mana] > GetVital(Vital.Mana))
+            {
+                reason = SpellCastFailureReason.InsufficientMP;
+                return false;
+            }
+
+            if (spell.VitalCost[(int)Vital.Health] >= GetVital(Vital.Health))
+            {
+                reason = SpellCastFailureReason.InsufficientHP;
+                return false;
+            }
+        }
+
+        // Check if the caster has any status effects that need to apply.
+        // Ignore if the current spell is a Cleanse, this will ignore any and all status effects.
+        if (spell.Combat.Effect != SpellEffect.Cleanse)
+        {
+            foreach (var status in CachedStatuses)
+            {
+                if (status.Type == SpellEffect.Silence)
+                {
+                    reason = SpellCastFailureReason.Silenced;
+                    return false;
+                }
+
+                if (status.Type == SpellEffect.Stun)
+                {
+                    reason = SpellCastFailureReason.Stunned;
+                    return false;
+                }
+
+                if (status.Type == SpellEffect.Sleep)
+                {
+                    reason = SpellCastFailureReason.Asleep;
+                    return false;
+                }
+
+                if (status.Type == SpellEffect.Snare)
+                {
+                    // If this spell is a Dash or Warp type ability, we can not use it while snared.
+                    if (spell.SpellType == SpellType.Dash || spell.SpellType == SpellType.Warp || spell.SpellType == SpellType.WarpTo)
+                    {
+                        reason = SpellCastFailureReason.Snared;
+                        return false;
+                    }
+                }
+            }
+        }
+
+        // Check for target validity
+        var singleTargetSpell = (spell.SpellType == SpellType.CombatSpell && spell.Combat.TargetType == SpellTargetType.Single) || spell.SpellType == SpellType.WarpTo;
+        if (target == null && singleTargetSpell)
+        {
+            reason = SpellCastFailureReason.InvalidTarget;
+            return false;
+        }
+
+        if (target == this && spell.SpellType == SpellType.WarpTo)
+        {
+            reason = SpellCastFailureReason.InvalidTarget;
+            return false;
+        }
+
+        if (target != null && singleTargetSpell)
+        {
+            if (spell.Combat.Friendly != IsAllyOf(target) || !CanAttack(target, spell))
+            {
+                reason = SpellCastFailureReason.InvalidTarget;
+                return false;
+            }
+        }
+
+        //Check for range of a single target spell
+        if (singleTargetSpell && target != this)
+        {
+            if (!InRangeOf(target, spell.Combat.CastRange))
+            {
+                reason = SpellCastFailureReason.OutOfRange;
+                return false;
+            }
+        }
+
+        // We have no reason to stop the entity from casting!
+        reason = SpellCastFailureReason.None;
+        return true;
+    }
+
+    public virtual void CastSpell(Guid spellId, int spellSlot = -1)
+    {
+        if (!SpellBase.TryGet(spellId, out var spellBase))
+        {
+            return;
+        }
+
+        if (!CanCastSpell(spellBase, CastTarget, false, out _))
+        {
+            return;
+        }
+
+        if (spellBase.VitalCost[(int)Vital.Mana] > 0)
+        {
+            SubVital(Vital.Mana, spellBase.VitalCost[(int)Vital.Mana]);
+        }
+        else
+        {
+            AddVital(Vital.Mana, -spellBase.VitalCost[(int)Vital.Mana]);
+        }
+
+        if (spellBase.VitalCost[(int)Vital.Health] > 0)
+        {
+            SubVital(Vital.Health, spellBase.VitalCost[(int)Vital.Health]);
+        }
+        else
+        {
+            AddVital(Vital.Health, -spellBase.VitalCost[(int)Vital.Health]);
+        }
+
+        try
+        {
+            switch (spellBase.SpellType)
+            {
+                case SpellType.CombatSpell:
+                case SpellType.Event:
+
+                    switch (spellBase.Combat.TargetType)
+                    {
+                        case SpellTargetType.Self:
+                            if (spellBase.HitAnimationId != Guid.Empty &&
+                                spellBase.Combat.Effect != SpellEffect.OnHit)
+                            {
+                                PacketSender.SendAnimationToProximity(
+                                    spellBase.HitAnimationId,
+                                    1,
+                                    Id,
+                                    MapId,
+                                    0,
+                                    0,
+                                    Dir,
+                                    MapInstanceId
+                                ); //Target Type 1 will be global entity
+                            }
+
+                            TryAttack(this, spellBase);
+
+                            break;
+                        case SpellTargetType.Single:
+                            if (CastTarget == null)
+                            {
+                                return;
+                            }
+
+                            //If target has stealthed we cannot hit the spell.
+                            foreach (var status in CastTarget.CachedStatuses)
+                            {
+                                if (status.Type == SpellEffect.Stealth)
+                                {
+                                    return;
+                                }
+                            }
+
+                            if (spellBase.Combat.HitRadius > 0) //Single target spells with AoE hit radius'
+                            {
+                                HandleAoESpell(
+                                    spellId,
+                                    spellBase.Combat.HitRadius,
+                                    CastTarget.MapId,
+                                    CastTarget.X,
+                                    CastTarget.Y,
+                                    null
+                                );
+                            }
+                            else
+                            {
+                                TryAttack(CastTarget, spellBase);
+                            }
+
+                            break;
+                        case SpellTargetType.AoE:
+                            HandleAoESpell(spellId, spellBase.Combat.HitRadius, MapId, X, Y, null);
+
+                            break;
+                        case SpellTargetType.Projectile:
+                            var projectileBase = spellBase.Combat.Projectile;
+                            if (projectileBase != null)
+                            {
+                                if (MapController.TryGetInstanceFromMap(MapId, MapInstanceId, out var mapInstance))
+                                {
+                                    mapInstance.SpawnMapProjectile(
+                                        this,
+                                        projectileBase,
+                                        spellBase,
+                                        null,
+                                        MapId,
+                                        (byte)X,
+                                        (byte)Y,
+                                        (byte)Z,
+                                        Dir,
+                                        CastTarget
+                                    );
+                                }
+                            }
+
+                            break;
+                        case SpellTargetType.OnHit:
+                            if (spellBase.Combat.Effect == SpellEffect.OnHit)
+                            {
+                                new Status(
+                                    this,
+                                    this,
+                                    spellBase,
+                                    SpellEffect.OnHit,
+                                    spellBase.Combat.OnHitDuration,
+                                    spellBase.Combat.TransformSprite
+                                );
+
+                                PacketSender.SendActionMsg(
+                                    this,
+                                    Strings.Combat.status[(int)spellBase.Combat.Effect],
+                                    CustomColors.Combat.Status
+                                );
+                            }
+
+                            break;
+                        case SpellTargetType.Trap:
+                            if (MapController.TryGetInstanceFromMap(MapId, MapInstanceId, out var instance))
+                            {
+                                instance.SpawnTrap(this, spellBase, (byte)X, (byte)Y, (byte)Z);
+                            }
+
+                            break;
+                        default:
+                            break;
+                    }
+
+                    break;
+                case SpellType.Warp:
+                    if (this is Player)
+                    {
+                        Warp(
+                            spellBase.Warp.MapId,
+                            spellBase.Warp.X,
+                            spellBase.Warp.Y,
+                            spellBase.Warp.Dir - 1 == -1 ? this.Dir : (Direction)(spellBase.Warp.Dir - 1)
+                        );
+                    }
+
+                    break;
+                case SpellType.WarpTo:
+                    if (CastTarget != null)
+                    {
+                        HandleAoESpell(spellId, spellBase.Combat.CastRange, MapId, X, Y, CastTarget);
+                    }
+
+                    break;
+                case SpellType.Dash:
+                    PacketSender.SendActionMsg(this, Strings.Combat.dash, CustomColors.Combat.Dash);
+                    var dash = new Dash(
+                        this,
+                        spellBase.Combat.CastRange,
+                        Dir,
+                        Convert.ToBoolean(spellBase.Dash.IgnoreMapBlocks),
+                        Convert.ToBoolean(spellBase.Dash.IgnoreActiveResources),
+                        Convert.ToBoolean(spellBase.Dash.IgnoreInactiveResources),
+                        Convert.ToBoolean(spellBase.Dash.IgnoreZDimensionAttributes)
+                    );
+
+                    break;
+                default:
+                    break;
+            }
+
+            UpdateSpellCooldown(spellBase, spellSlot);
+        }
+        finally
+        {
+            if (GetVital(Vital.Health) < 1)
+            {
+                Die(true, this);
+            }
+        }
+    }
+
+    private void HandleAoESpell(
+        Guid spellId,
+        int range,
+        Guid startMapId,
+        int startX,
+        int startY,
+        Entity spellTarget
+    )
+    {
+        var spellBase = SpellBase.Get(spellId);
+        if (spellBase != null)
+        {
+            var startMap = MapController.Get(startMapId);
+            foreach (var instance in MapController.GetSurroundingMapInstances(startMapId, MapInstanceId, true))
+            {
+                foreach (var entity in instance.GetCachedEntities())
+                {
+                    if (entity != null && (entity is Player || entity is Npc))
+                    {
+                        if (spellTarget == null || spellTarget == entity)
+                        {
+                            if (entity.GetDistanceTo(startMap, startX, startY) <= range)
+                            {
+                                //Check to handle a warp to spell
+                                if (spellBase.SpellType == SpellType.WarpTo)
+                                {
+                                    if (spellTarget != null)
+                                    {
+                                        //Spelltarget used to be Target. I don't know if this is correct or not.
+                                        int[] position = GetPositionNearTarget(spellTarget.MapId, spellTarget.X, spellTarget.Y);
+                                        Warp(spellTarget.MapId, (byte)position[0], (byte)position[1], Dir);
+                                        ChangeDir(DirectionToTarget(spellTarget));
+                                    }
+                                }
+
+                                TryAttack(entity, spellBase); //Handle damage
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private int[] GetPositionNearTarget(Guid mapId, int x, int y)
+    {
+        if (MapController.TryGetInstanceFromMap(mapId, MapInstanceId, out var instance))
+        {
+            List<int[]> validPosition = new List<int[]>();
+
+            // Start by north, west, est and south
+            for (int col = -1; col < 2; col++)
+            {
+                for (int row = -1; row < 2; row++)
+                {
+                    if (Math.Abs(col % 2) != Math.Abs(row % 2))
+                    {
+                        int newX = x + row;
+                        int newY = y + col;
+
+                        if (newX >= 0 && newX <= Options.MapWidth &&
+                            newY >= 0 && newY <= Options.MapHeight &&
+                            !instance.TileBlocked(newX, newY))
+                        {
+                            validPosition.Add(new int[] { newX, newY });
+                        }
+                    }
+                }
+            }
+
+            if (validPosition.Count > 0)
+            {
+                return validPosition[Randomization.Next(0, validPosition.Count)];
+            }
+
+            // If nothing found, diagonal direction
+            for (int col = -1; col < 2; col++)
+            {
+                for (int row = -1; row < 2; row++)
+                {
+                    if (Math.Abs(col % 2) == Math.Abs(row % 2))
+                    {
+                        int newX = x + row;
+                        int newY = y + col;
+
+                        // Tile must not be the target position
+                        if (newX >= 0 && newX <= Options.MapWidth &&
+                            newY >= 0 && newY <= Options.MapHeight &&
+                            !(x + row == x && y + col == y) &&
+                            !instance.TileBlocked(newX, newY))
+                        {
+                            validPosition.Add(new int[] { newX, newY });
+                        }
+                    }
+                }
+            }
+
+            if (validPosition.Count > 0)
+            {
+                return validPosition[Randomization.Next(0, validPosition.Count)];
+            }
+
+            // If nothing found, return target position
+            return new int[] { x, y };
+        }
+        else
+        {
+            return new int[] { x, y };
+        }
+    }
+
+    // Check if the target is one tile away and within the same Z dimension.
+    protected bool IsOneBlockAway(Entity target)
+    {
+        if (Z != target.Z)
+        {
+            return false;
+        }
+
+        var myTile = new TileHelper(MapId, X, Y);
+        var enemyTile = new TileHelper(target.MapId, target.X, target.Y);
+
+        myTile.Translate(0, -1); // Target Up
+        if (myTile.Matches(enemyTile))
+        {
+            return true;
+        }
+
+        myTile.Translate(0, 2); // Target Down
+        if (myTile.Matches(enemyTile))
+        {
+            return true;
+        }
+
+        myTile.Translate(-1, -1); // Target Left
+        if (myTile.Matches(enemyTile))
+        {
+            return true;
+        }
+
+        myTile.Translate(2, 0); // Target Right
+        if (myTile.Matches(enemyTile))
+        {
+            return true;
+        }
+
+        if (Options.Instance.MapOpts.EnableDiagonalMovement)
+        {
+            myTile.Translate(-2, -1); // Target UpLeft
+            if (myTile.Matches(enemyTile))
+            {
+                return true;
+            }
+
+            myTile.Translate(2, 0); // Target UpRight
+            if (myTile.Matches(enemyTile))
+            {
+                return true;
+            }
+
+            myTile.Translate(-2, 2); // Target DownLeft
+            if (myTile.Matches(enemyTile))
+            {
+                return true;
+            }
+
+            myTile.Translate(2, 0); // Target DownRight
+            if (myTile.Matches(enemyTile))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    //These functions only work when one block away.
+    protected bool IsFacingTarget(Entity target)
+    {
+        if (!IsOneBlockAway(target.MapId, target.X, target.Y))
+        {
+            return false;
+        }
+
+        if (!MapController.TryGet(MapId, out var originMapController) ||
+            !MapController.TryGet(target.MapId, out var targetMapController))
+        {
+            return false;
+        }
+
+        var originY = Y + originMapController.MapGridY * Options.MapHeight;
+        var originX = X + originMapController.MapGridX * Options.MapWidth;
+        var targetY = target.Y + targetMapController.MapGridY * Options.MapHeight;
+        var targetX = target.X + targetMapController.MapGridX * Options.MapWidth;
+
+        var xDiff = targetX - originX;
+        var yDiff = targetY - originY;
+        var diagonalMovement = Options.Instance.MapOpts.EnableDiagonalMovement;
+
+        switch (xDiff)
+        {
+            case 0 when yDiff == -1 && Dir == Direction.Up:
+            case 0 when yDiff == 1 && Dir == Direction.Down:
+            case 1 when yDiff == 0 && Dir == Direction.Right:
+            case -1 when yDiff == 0 && Dir == Direction.Left:
+            case 1 when diagonalMovement && yDiff == -1 && Dir == Direction.UpRight:
+            case -1 when diagonalMovement && yDiff == -1 && Dir == Direction.UpLeft:
+            case 1 when diagonalMovement && yDiff == 1 && Dir == Direction.DownRight:
+            case -1 when diagonalMovement && yDiff == 1 && Dir == Direction.DownLeft:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    public int GetDistanceTo(Entity target)
+    {
+        if (target != null)
+        {
+            return GetDistanceTo(target.Map, target.X, target.Y);
+        }
+        //Something is null.. return a value that is out of range :)
+        return 9999;
+    }
+
+    public int GetDistanceTo(MapController targetMap, int targetX, int targetY)
+    {
+        return GetDistanceBetween(Map, targetMap, X, targetX, Y, targetY);
+    }
+
+    public int GetDistanceBetween(MapController mapA, MapController mapB, int xTileA, int xTileB, int yTileA, int yTileB)
+    {
+        if (mapA != null && mapB != null && mapA.MapGrid == mapB.MapGrid
+        ) //Make sure both maps exist and that they are in the same dimension
+        {
+            //Calculate World Tile of Me
+            var x1 = xTileA + mapA.MapGridX * Options.MapWidth;
+            var y1 = yTileA + mapA.MapGridY * Options.MapHeight;
+
+            //Calculate world tile of target
+            var x2 = xTileB + mapB.MapGridX * Options.MapWidth;
+            var y2 = yTileB + mapB.MapGridY * Options.MapHeight;
+
+            return (int)Math.Sqrt(Math.Pow(x1 - x2, 2) + Math.Pow(y1 - y2, 2));
+        }
+
+        //Something is null.. return a value that is out of range :)
+        return 9999;
+    }
+
+    public bool InRangeOf(Entity target, int range)
+    {
+        var dist = GetDistanceTo(target);
+        if (dist == 9999)
+        {
+            return false;
+        }
+
+        if (dist <= range)
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    public virtual void NotifySwarm(Entity attacker)
+    {
+    }
+
+    protected Direction DirectionToTarget(Entity en)
+    {
+        if (en == null || IsTurnAroundWhileCastingDisabled)
+        {
+            return Dir;
+        }
+
+        if (!MapController.TryGet(MapId, out var originMapController) ||
+            !MapController.TryGet(en.MapId, out var targetMapController))
+        {
+            return Dir;
+        }
+
+        var originY = Y + originMapController.MapGridY * Options.MapHeight;
+        var originX = X + originMapController.MapGridX * Options.MapWidth;
+        var targetY = en.Y + targetMapController.MapGridY * Options.MapHeight;
+        var targetX = en.X + targetMapController.MapGridX * Options.MapWidth;
+
+        var yDiff = originY - targetY;
+        var xDiff = originX - targetX;
+
+        // If Y offset is 0, direction is determined by X offset.
+        if (yDiff == 0)
+        {
+            return xDiff > 0 ? Direction.Left : Direction.Right;
+        }
+
+        // If X offset is 0 or If diagonal movement is disabled, direction is determined by Y offset.
+        if (xDiff == 0 || !Options.Instance.MapOpts.EnableDiagonalMovement)
+        {
+            return yDiff > 0 ? Direction.Up : Direction.Down;
+        }
+
+        // If both X and Y offset are non-zero, direction is determined by both offsets.
+        var xPositive = xDiff > 0;
+        var yPositive = yDiff > 0;
+
+        if (xPositive)
+        {
+            return yPositive ? Direction.UpLeft : Direction.DownLeft;
+        }
+
+        return yPositive ? Direction.UpRight : Direction.DownRight;
+    }
+
+    protected bool IsOneBlockAway(Guid mapId, int x, int y, int z = 0)
+    {
+        if (z != Z)
+        {
+            return false;
+        }
+
+        if (!MapController.TryGet(MapId, out var originMapController) ||
+            !MapController.TryGet(mapId, out var targetMapController))
+        {
+            return false;
+        }
+
+        // Adjust coordinates based on map grid positions.
+        var originY = Y + originMapController.MapGridY * Options.MapHeight;
+        var originX = X + originMapController.MapGridX * Options.MapWidth;
+        var targetY = y + targetMapController.MapGridY * Options.MapHeight;
+        var targetX = x + targetMapController.MapGridX * Options.MapWidth;
+
+        // Calculate the absolute differences in coordinates.
+        var yDiff = Math.Abs(originY - targetY);
+        var xDiff = Math.Abs(originX - targetX);
+
+        // Check if entities are one block away.
+        return (xDiff == 1 && yDiff == 0) || (xDiff == 0 && yDiff == 1) ||
+               (Options.Instance.MapOpts.EnableDiagonalMovement && xDiff == 1 && yDiff == 1);
+    }
+
+    //Spawning/Dying
+    public virtual void Die(bool dropItems = true, Entity killer = null)
+    {
+        if (IsDead() || Items == null)
+        {
+            return;
+        }
+
+        // Run events and other things.
+        killer?.KilledEntity(this);
+
+        if (dropItems)
+        {
+            var lootGenerated = new List<Player>();
+            // If this is an NPC, drop loot for every single player that participated in the fight.
+            if (this is Npc npc && npc.Base.IndividualizedLoot)
+            {
+                // Generate loot for every player that has helped damage this monster, as well as their party members.
+                // Keep track of who already got loot generated for them though, or this gets messy!
+                foreach (var entityEntry in npc.LootMapCache)
+                {
+                    var player = Player.FindOnline(entityEntry);
+                    if (player != null)
+                    {
+
+                        // Cache our value for further processing.
+                        var party = player.Party.ToArray();
+
+                        // is this player in a party?
+                        if (party.Length > 0 && Options.Instance.LootOpts.IndividualizedLootAutoIncludePartyMembers)
+                        {
+                            // They are, so check for all party members and drop if still eligible!
+                            foreach (var partyMember in party)
+                            {
+                                if (!lootGenerated.Contains(partyMember))
+                                {
+                                    DropItems(partyMember);
+                                    lootGenerated.Add(partyMember);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            // They're not in a party, so drop the item if still eligible!
+                            if (!lootGenerated.Contains(player))
+                            {
+                                DropItems(player);
+                                lootGenerated.Add(player);
+                            }
+                        }
+                    }
+                }
+
+                // Clear their loot table and threat table.
+                npc.DamageMap.Clear();
+                npc.LootMap.Clear();
+                npc.LootMapCache = Array.Empty<Guid>();
+            }
+            else
+            {
+                // Drop as normal.
+                DropItems(killer);
+            }
+        }
+
+        foreach (var instance in MapController.GetSurroundingMapInstances(MapId, MapInstanceId, true))
+        {
+            instance.ClearEntityTargetsOf(this);
+        }
+
+        DoT?.Clear();
+        CachedDots = new DoT[0];
+        Statuses?.Clear();
+        CachedStatuses = new Status[0];
+        Stat?.ToList().ForEach(stat => stat?.Reset());
+
+        Dead = true;
+    }
+
+    protected virtual bool ShouldDropItem(Entity killer, ItemBase itemDescriptor, Item item, float dropRateModifier, out Guid lootOwner)
+    {
+        lootOwner = default;
+
+        var dropRate = item.DropChance * 1000 * dropRateModifier;
+        var dropResult = Randomization.Next(1, 100001);
+        if (dropResult >= dropRate)
+        {
+            return false;
+        }
+
+        // Set the attributes for this item.
+        item.Set(new Item(item.ItemId, item.Quantity, null));
+        return true;
+    }
+
+    protected virtual void OnDropItem(InventorySlot slot, Item drop) { }
+
+    protected virtual void DropItems(Entity killer, bool sendUpdate = true)
+    {
+        if (this is Player && Options.Instance.MapOpts.DisablePlayerDropsInArenaMaps && Map.ZoneType == MapZone.Arena)
+        {
+            return;
+        }
+
+        // Drop items
+        foreach (var slot in Items)
+        {
+            if (slot == default)
+            {
+                continue;
+            }
+
+            // Don't mess with the actual object.
+            var drop = slot.Clone();
+
+            var itemDescriptor = ItemBase.Get(drop.ItemId);
+            if (itemDescriptor == default)
+            {
+                continue;
+            }
+
+            var playerKiller = killer as Player;
+            var dropRateModifier = 1 + (playerKiller?.GetEquipmentBonusEffect(ItemEffect.Luck) / 100f ?? 0);
+            if (!ShouldDropItem(killer, itemDescriptor, drop, dropRateModifier, out Guid lootOwner))
+            {
+                continue;
+            }
+
+            // Spawn the actual item!
+            if (MapController.TryGetInstanceFromMap(MapId, MapInstanceId, out var instance))
+            {
+                instance.SpawnItem(X, Y, drop, drop.Quantity, lootOwner, sendUpdate);
+            }
+
+            // Process the drop (for players this would remove it from their inventory)
+            OnDropItem(slot, drop);
+        }
+    }
+
+    public bool IsDead()
+    {
+        return Dead;
+    }
+
+    public virtual void Reset()
+    {
+        for (var i = 0; i < Enum.GetValues<Vital>().Length; i++)
+        {
+            RestoreVital((Vital)i);
+        }
+
+        Dead = false;
+    }
+
+    //Empty virtual functions for players
+    public virtual void Warp(Guid newMapId, float newX, float newY, bool adminWarp = false)
+    {
+        Warp(newMapId, newX, newY, Dir, adminWarp);
+    }
+
+    public virtual void Warp(Guid newMapId,
+        float newX,
+        float newY,
+        Direction newDir,
+        bool adminWarp = false,
+        int zOverride = 0,
+        bool mapSave = false,
+        bool fromWarpEvent = false,
+        MapInstanceType? mapInstanceType = null,
+        bool fromLogin = false,
+        bool forceInstanceChange = false)
+    {
+    }
+
+    public virtual EntityPacket EntityPacket(EntityPacket packet = null, Player forPlayer = null)
+    {
+        if (packet == null)
+        {
+            throw new Exception("No packet to populate!");
+        }
+
+        packet.EntityId = Id;
+        packet.MapId = MapId;
+        packet.Name = Name;
+        packet.Sprite = Sprite;
+        packet.Color = Color;
+        packet.Face = Face;
+        packet.Level = Level;
+        packet.X = (byte)X;
+        packet.Y = (byte)Y;
+        packet.Z = (byte)Z;
+        packet.Dir = (byte)Dir;
+        packet.Passable = Passable;
+        packet.HideName = HideName;
+        packet.HideEntity = HideEntity;
+        packet.Animations = Animations.ToArray();
+        packet.Vital = GetVitals();
+        packet.MaxVital = GetMaxVitals();
+        packet.Stats = GetStatValues();
+        packet.StatusEffects = StatusPackets();
+        packet.NameColor = NameColor;
+        packet.HeaderLabel = new LabelPacket(HeaderLabel.Text, HeaderLabel.Color);
+        packet.FooterLabel = new LabelPacket(FooterLabel.Text, FooterLabel.Color);
+
+        return packet;
+    }
+
+    public StatusPacket[] StatusPackets()
+    {
+        var statuses = CachedStatuses;
+        var statusPackets = new StatusPacket[statuses.Length];
+        for (var i = 0; i < statuses.Length; i++)
+        {
+            var status = statuses[i];
+            long[] vitalShields = null;
+            if (status.Type == SpellEffect.Shield)
+            {
+                vitalShields = new long[Enum.GetValues<Vital>().Length];
+                for (var x = 0; x < Enum.GetValues<Vital>().Length; x++)
+                {
+                    vitalShields[x] = status.Shield[x];
+                }
+            }
+
+            statusPackets[i] = new StatusPacket(
+                status.Spell.Id, status.Type, status.Data, (int)(status.Duration - Timing.Global.Milliseconds),
+                (int)(status.Duration - status.StartTime), vitalShields
+            );
+        }
+
+        return statusPackets;
+    }
+
+    #region Spell Cooldowns
+
+    [JsonIgnore, Column("SpellCooldowns")]
+    public string SpellCooldownsJson
+    {
+        get => JsonConvert.SerializeObject(SpellCooldowns);
+        set => SpellCooldowns = JsonConvert.DeserializeObject<ConcurrentDictionary<Guid, long>>(value ?? "{}");
+    }
+
+    [NotMapped] public ConcurrentDictionary<Guid, long> SpellCooldowns = new ConcurrentDictionary<Guid, long>();
+
+    #endregion
 
 }

--- a/Intersect.Server.Core/Entities/Events/CommandInstance.cs
+++ b/Intersect.Server.Core/Entities/Events/CommandInstance.cs
@@ -1,86 +1,84 @@
 using Intersect.GameObjects.Events.Commands;
 
-namespace Intersect.Server.Entities.Events
+namespace Intersect.Server.Entities.Events;
+
+
+public partial class CommandInstance
 {
 
-    public partial class CommandInstance
+    public enum EventResponse
     {
 
-        public enum EventResponse
+        None = 0,
+
+        Dialogue,
+
+        Shop,
+
+        Bank,
+
+        Crafting,
+
+        Quest,
+
+        Timer,
+
+        Picture,
+
+        Fade
+
+    }
+
+    public Guid[]
+        BranchIds = null; //Potential Branches for Commands that require responses such as ShowingOptions or Offering a Quest
+
+    public EventCommand Command;
+
+    private int commandIndex;
+
+    public List<EventCommand> CommandList;
+
+    public Guid CommandListId;
+
+    public GameObjects.Events.EventPage Page;
+
+    public EventResponse WaitingForResponse = EventResponse.None;
+
+    public Guid WaitingForRoute;
+
+    public Guid WaitingForRouteMap;
+
+    public EventCommand WaitingOnCommand = null;
+
+    public CommandInstance(GameObjects.Events.EventPage page, int listIndex = 0)
+    {
+        Page = page;
+        CommandList = page.CommandLists.Values.First();
+        CommandIndex = listIndex;
+    }
+
+    public CommandInstance(GameObjects.Events.EventPage page, List<EventCommand> commandList, int listIndex = 0)
+    {
+        Page = page;
+        CommandList = commandList;
+        CommandIndex = listIndex;
+    }
+
+    public CommandInstance(GameObjects.Events.EventPage page, Guid commandListId, int listIndex = 0)
+    {
+        Page = page;
+        CommandList = page.CommandLists[commandListId];
+        CommandIndex = listIndex;
+    }
+
+    public int CommandIndex
+    {
+        get => commandIndex;
+        set
         {
-
-            None = 0,
-
-            Dialogue,
-
-            Shop,
-
-            Bank,
-
-            Crafting,
-
-            Quest,
-
-            Timer,
-
-            Picture,
-
-            Fade
-
+            commandIndex = value;
+            Command = commandIndex >= 0 && commandIndex < CommandList.Count ? CommandList[commandIndex] : null;
         }
-
-        public Guid[]
-            BranchIds = null; //Potential Branches for Commands that require responses such as ShowingOptions or Offering a Quest
-
-        public EventCommand Command;
-
-        private int commandIndex;
-
-        public List<EventCommand> CommandList;
-
-        public Guid CommandListId;
-
-        public GameObjects.Events.EventPage Page;
-
-        public EventResponse WaitingForResponse = EventResponse.None;
-
-        public Guid WaitingForRoute;
-
-        public Guid WaitingForRouteMap;
-
-        public EventCommand WaitingOnCommand = null;
-
-        public CommandInstance(GameObjects.Events.EventPage page, int listIndex = 0)
-        {
-            Page = page;
-            CommandList = page.CommandLists.Values.First();
-            CommandIndex = listIndex;
-        }
-
-        public CommandInstance(GameObjects.Events.EventPage page, List<EventCommand> commandList, int listIndex = 0)
-        {
-            Page = page;
-            CommandList = commandList;
-            CommandIndex = listIndex;
-        }
-
-        public CommandInstance(GameObjects.Events.EventPage page, Guid commandListId, int listIndex = 0)
-        {
-            Page = page;
-            CommandList = page.CommandLists[commandListId];
-            CommandIndex = listIndex;
-        }
-
-        public int CommandIndex
-        {
-            get => commandIndex;
-            set
-            {
-                commandIndex = value;
-                Command = commandIndex >= 0 && commandIndex < CommandList.Count ? CommandList[commandIndex] : null;
-            }
-        }
-
     }
 
 }

--- a/Intersect.Server.Core/Entities/Events/CommandProcessing.cs
+++ b/Intersect.Server.Core/Entities/Events/CommandProcessing.cs
@@ -15,1378 +15,230 @@ using Intersect.Server.Networking;
 using Intersect.Utilities;
 using VariableMod = Intersect.Enums.VariableMod;
 
-namespace Intersect.Server.Entities.Events
+namespace Intersect.Server.Entities.Events;
+
+
+public static partial class CommandProcessing
 {
 
-    public static partial class CommandProcessing
+    public static void ProcessCommand(EventCommand command, Player player, Event instance)
     {
+        var stackInfo = instance.CallStack.Peek();
+        stackInfo.WaitingForResponse = CommandInstance.EventResponse.None;
+        stackInfo.WaitingOnCommand = null;
+        stackInfo.BranchIds = null;
 
-        public static void ProcessCommand(EventCommand command, Player player, Event instance)
+        ProcessCommand((dynamic)command, player, instance, instance.CallStack.Peek(), instance.CallStack);
+
+        stackInfo.CommandIndex++;
+    }
+
+    //Show Text Command
+    private static void ProcessCommand(
+        ShowTextCommand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        PacketSender.SendEventDialog(
+            player, ParseEventText(command.Text, player, instance), command.Face, instance.PageInstance.Id
+        );
+
+        stackInfo.WaitingForResponse = CommandInstance.EventResponse.Dialogue;
+    }
+
+    //Show Options Command
+    private static void ProcessCommand(
+        ShowOptionsCommand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        var txt = ParseEventText(command.Text, player, instance);
+        var opt1 = ParseEventText(command.Options[0], player, instance);
+        var opt2 = ParseEventText(command.Options[1], player, instance);
+        var opt3 = ParseEventText(command.Options[2], player, instance);
+        var opt4 = ParseEventText(command.Options[3], player, instance);
+        PacketSender.SendEventDialog(player, txt, opt1, opt2, opt3, opt4, command.Face, instance.PageInstance.Id);
+        stackInfo.WaitingForResponse = CommandInstance.EventResponse.Dialogue;
+        stackInfo.WaitingOnCommand = command;
+        stackInfo.BranchIds = command.BranchIds;
+    }
+
+    //Input Variable Command
+    private static void ProcessCommand(
+        InputVariableCommand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        var title = ParseEventText(command.Title, player, instance);
+        var txt = ParseEventText(command.Text, player, instance);
+        var type = -1;
+
+        if (command.VariableType == VariableType.PlayerVariable)
         {
-            var stackInfo = instance.CallStack.Peek();
-            stackInfo.WaitingForResponse = CommandInstance.EventResponse.None;
-            stackInfo.WaitingOnCommand = null;
-            stackInfo.BranchIds = null;
-
-            ProcessCommand((dynamic)command, player, instance, instance.CallStack.Peek(), instance.CallStack);
-
-            stackInfo.CommandIndex++;
-        }
-
-        //Show Text Command
-        private static void ProcessCommand(
-            ShowTextCommand command,
-            Player player,
-            Event instance,
-            CommandInstance stackInfo,
-            Stack<CommandInstance> callStack
-        )
-        {
-            PacketSender.SendEventDialog(
-                player, ParseEventText(command.Text, player, instance), command.Face, instance.PageInstance.Id
-            );
-
-            stackInfo.WaitingForResponse = CommandInstance.EventResponse.Dialogue;
-        }
-
-        //Show Options Command
-        private static void ProcessCommand(
-            ShowOptionsCommand command,
-            Player player,
-            Event instance,
-            CommandInstance stackInfo,
-            Stack<CommandInstance> callStack
-        )
-        {
-            var txt = ParseEventText(command.Text, player, instance);
-            var opt1 = ParseEventText(command.Options[0], player, instance);
-            var opt2 = ParseEventText(command.Options[1], player, instance);
-            var opt3 = ParseEventText(command.Options[2], player, instance);
-            var opt4 = ParseEventText(command.Options[3], player, instance);
-            PacketSender.SendEventDialog(player, txt, opt1, opt2, opt3, opt4, command.Face, instance.PageInstance.Id);
-            stackInfo.WaitingForResponse = CommandInstance.EventResponse.Dialogue;
-            stackInfo.WaitingOnCommand = command;
-            stackInfo.BranchIds = command.BranchIds;
-        }
-
-        //Input Variable Command
-        private static void ProcessCommand(
-            InputVariableCommand command,
-            Player player,
-            Event instance,
-            CommandInstance stackInfo,
-            Stack<CommandInstance> callStack
-        )
-        {
-            var title = ParseEventText(command.Title, player, instance);
-            var txt = ParseEventText(command.Text, player, instance);
-            var type = -1;
-
-            if (command.VariableType == VariableType.PlayerVariable)
-            {
-                var variable = PlayerVariableBase.Get(command.VariableId);
-                if (variable != null)
-                {
-                    type = (int)variable.Type;
-                }
-            }
-            else if (command.VariableType == VariableType.ServerVariable)
-            {
-                var variable = ServerVariableBase.Get(command.VariableId);
-                if (variable != null)
-                {
-                    type = (int)variable.Type;
-                }
-            }
-            else if (command.VariableType == VariableType.GuildVariable)
-            {
-                var variable = GuildVariableBase.Get(command.VariableId);
-                type = (int)variable.Type;
-            }
-            else if (command.VariableType == VariableType.UserVariable)
-            {
-                var variable = UserVariableBase.Get(command.VariableId);
-                type = (int)variable.Type;
-            }
-            else if (type == -1)
-            {
-                var tmpStack = new CommandInstance(stackInfo.Page, command.BranchIds[1]);
-                callStack.Push(tmpStack);
-                return;
-            }
-
-            PacketSender.SendInputVariableDialog(player, title, txt, (VariableDataType)type, instance.PageInstance.Id);
-            stackInfo.WaitingForResponse = CommandInstance.EventResponse.Dialogue;
-            stackInfo.WaitingOnCommand = command;
-            stackInfo.BranchIds = command.BranchIds;
-        }
-
-        //Show Add Chatbox Text Command
-        private static void ProcessCommand(
-            AddChatboxTextCommand command,
-            Player player,
-            Event instance,
-            CommandInstance stackInfo,
-            Stack<CommandInstance> callStack
-        )
-        {
-            var txt = ParseEventText(command.Text, player, instance);
-            var color = Color.FromName(command.Color, Strings.Colors.presets);
-            switch (command.Channel)
-            {
-                case ChatboxChannel.Player:
-                    PacketSender.SendChatMsg(player, txt, command.MessageType, color);
-
-                    break;
-                case ChatboxChannel.Local:
-                    PacketSender.SendProximityMsg(txt, ChatMessageType.Local, player.MapId, color);
-
-                    break;
-                case ChatboxChannel.Global:
-                    PacketSender.SendGlobalMsg(txt, color, string.Empty, ChatMessageType.Global);
-
-                    break;
-                case ChatboxChannel.Party:
-                    if (player.Party?.Count > 0)
-                    {
-                        PacketSender.SendPartyMsg(player, txt, color, player.Name);
-                    }
-
-                    break;
-                case ChatboxChannel.Guild:
-                    if (player.Guild != null)
-                    {
-                        PacketSender.SendGuildMsg(player, txt, color, player.Name);
-                    }
-                    break;
-            }
-
-            if (command.ShowChatBubble)
-            {
-                PacketSender.SendChatBubbleToPlayer(
-                    player,
-                    instance.PageInstance.Id,
-                    instance.PageInstance.GetEntityType(),
-                    txt,
-                    instance.PageInstance.MapId
-                );
-            }
-        }
-
-        //Set Variable Commands
-        private static void ProcessCommand(
-            SetVariableCommand command,
-            Player player,
-            Event instance,
-            CommandInstance stackInfo,
-            Stack<CommandInstance> callStack
-        )
-        {
-            ProcessVariableModification(command, (dynamic)command.Modification, player, instance);
-            player.UnequipInvalidItems();
-        }
-
-        //Set Self Switch Command
-        private static void ProcessCommand(
-            SetSelfSwitchCommand command,
-            Player player,
-            Event eventInstance,
-            CommandInstance stackInfo,
-            Stack<CommandInstance> callStack
-        )
-        {
-            if (eventInstance.Global)
-            {
-                if (MapController.TryGetInstanceFromMap(eventInstance.MapId, player.MapInstanceId, out var instance))
-                {
-                    var evts = instance.GlobalEventInstances.Values.ToList();
-                    for (var i = 0; i < evts.Count; i++)
-                    {
-                        if (evts[i] != null && evts[i].BaseEvent == eventInstance.BaseEvent)
-                        {
-                            evts[i].SelfSwitch[command.SwitchId] = command.Value;
-                        }
-                    }
-                }
-            }
-            else
-            {
-                eventInstance.SelfSwitch[command.SwitchId] = command.Value;
-            }
-        }
-
-        //Conditional Branch Command
-        private static void ProcessCommand(
-            ConditionalBranchCommand command,
-            Player player,
-            Event instance,
-            CommandInstance stackInfo,
-            Stack<CommandInstance> callStack
-        )
-        {
-            var success = Conditions.MeetsCondition(command.Condition, player, instance, null);
-
-            List<EventCommand> newCommandList = null;
-            if (success && stackInfo.Page.CommandLists.ContainsKey(command.BranchIds[0]))
-            {
-                newCommandList = stackInfo.Page.CommandLists[command.BranchIds[0]];
-            }
-
-            if (!success && command.Condition.ElseEnabled && stackInfo.Page.CommandLists.ContainsKey(command.BranchIds[1]))
-            {
-                newCommandList = stackInfo.Page.CommandLists[command.BranchIds[1]];
-            }
-
-            if (newCommandList != null)
-            {
-                var tmpStack = new CommandInstance(stackInfo.Page)
-                {
-                    CommandList = newCommandList,
-                    CommandIndex = 0,
-                };
-
-                callStack.Push(tmpStack);
-            }
-        }
-
-        //Exit Event Process Command
-        private static void ProcessCommand(
-            ExitEventProcessingCommand command,
-            Player player,
-            Event instance,
-            CommandInstance stackInfo,
-            Stack<CommandInstance> callStack
-        )
-        {
-            callStack.Clear();
-        }
-
-        //Label Command
-        private static void ProcessCommand(
-            LabelCommand command,
-            Player player,
-            Event instance,
-            CommandInstance stackInfo,
-            Stack<CommandInstance> callStack
-        )
-        {
-            return; //Do Nothing.. just a label
-        }
-
-        //Go To Label Command
-        private static void ProcessCommand(
-            GoToLabelCommand command,
-            Player player,
-            Event instance,
-            CommandInstance stackInfo,
-            Stack<CommandInstance> callStack
-        )
-        {
-            //Recursively search through commands for the label, and create a brand new call stack based on where that label is located.
-            var newCallStack = LoadLabelCallstack(command.Label, stackInfo.Page);
-            if (newCallStack != null)
-            {
-                newCallStack.Reverse();
-                while (callStack.Peek().CommandListId != Guid.Empty)
-                {
-                    callStack.Pop();
-                }
-
-                //also pop the current event
-                callStack.Pop();
-                foreach (var itm in newCallStack)
-                {
-                    callStack.Push(itm);
-                }
-            }
-        }
-
-        //Start Common Event Command
-        private static void ProcessCommand(
-            StartCommmonEventCommand command,
-            Player player,
-            Event instance,
-            CommandInstance stackInfo,
-            Stack<CommandInstance> callStack
-        )
-        {
-            if (!EventBase.TryGet(command.EventId, out var commonEvent))
-            {
-                return;
-            }
-
-            foreach (var page in commonEvent.Pages)
-            {
-                if (Conditions.CanSpawnPage(page, player, instance))
-                {
-                    var commonEventStack = new CommandInstance(page);
-                    callStack.Push(commonEventStack);
-                }
-            }
-
-            if (player.MapInstanceId == Guid.Empty && !command.AllowInOverworld)
-            {
-                return;
-            }
-
-            if (command.AllInInstance && InstanceProcessor.TryGetInstanceController(player.MapInstanceId, out var instanceController))
-            {
-                foreach (var instanceMember in instanceController.Players.ToArray())
-                {
-                    if (instanceMember.Id == player.Id || !instanceMember.Online)
-                    {
-                        continue;
-                    }
-
-                    instanceMember.EnqueueStartCommonEvent(commonEvent);
-                }
-            }
-        }
-
-        //Restore Hp Command
-        private static void ProcessCommand(
-            RestoreHpCommand command,
-            Player player,
-            Event instance,
-            CommandInstance stackInfo,
-            Stack<CommandInstance> callStack
-        )
-        {
-            if (command.Amount > 0)
-            {
-                player.AddVital(Vital.Health, command.Amount);
-            }
-            else if (command.Amount < 0)
-            {
-                player.SubVital(Vital.Health, -command.Amount);
-                player.CombatTimer = Timing.Global.Milliseconds + Options.CombatTime;
-                if (player.GetVital(Vital.Health) <= 0)
-                {
-                    lock (player.EntityLock)
-                    {
-                        player.Die();
-                    }
-                }
-            }
-            else
-            {
-                player.RestoreVital(Vital.Health);
-            }
-        }
-
-        //Restore Mp Command
-        private static void ProcessCommand(
-            RestoreMpCommand command,
-            Player player,
-            Event instance,
-            CommandInstance stackInfo,
-            Stack<CommandInstance> callStack
-        )
-        {
-            if (command.Amount > 0)
-            {
-                player.AddVital(Vital.Mana, command.Amount);
-            }
-            else if (command.Amount < 0)
-            {
-                player.SubVital(Vital.Mana, -command.Amount);
-                player.CombatTimer = Timing.Global.Milliseconds + Options.CombatTime;
-            }
-            else
-            {
-                player.RestoreVital(Vital.Mana);
-            }
-        }
-
-        //Level Up Command
-        private static void ProcessCommand(
-            LevelUpCommand command,
-            Player player,
-            Event instance,
-            CommandInstance stackInfo,
-            Stack<CommandInstance> callStack
-        )
-        {
-            player.LevelUp();
-        }
-
-        //Give Experience Command
-        private static void ProcessCommand(
-            GiveExperienceCommand command,
-            Player player,
-            Event instance,
-            CommandInstance stackInfo,
-            Stack<CommandInstance> callStack
-        )
-        {
-            var quantity = command.Exp;
-            if (command.UseVariable)
-            {
-                switch (command.VariableType)
-                {
-                    case VariableType.PlayerVariable:
-                        quantity = (int)player.GetVariableValue(command.VariableId).Integer;
-
-                        break;
-                    case VariableType.ServerVariable:
-                        quantity = (int)ServerVariableBase.Get(command.VariableId)?.Value.Integer;
-
-                        break;
-
-                    case VariableType.GuildVariable:
-                        quantity = (int)player.Guild?.GetVariableValue(command.VariableId)?.Integer;
-
-                        break;
-                }
-            }
-
-            player.GiveExperience(quantity);
-        }
-
-        //Change Level Command
-        private static void ProcessCommand(
-            ChangeLevelCommand command,
-            Player player,
-            Event instance,
-            CommandInstance stackInfo,
-            Stack<CommandInstance> callStack
-        )
-        {
-            player.SetLevel(command.Level, true);
-        }
-
-        //Change Spells Command
-        private static void ProcessCommand(
-            ChangeSpellsCommand command,
-            Player player,
-            Event instance,
-            CommandInstance stackInfo,
-            Stack<CommandInstance> callStack
-        )
-        {
-            //0 is add, 1 is remove
-            var success = false;
-            if (command.Add) //Try to add a spell
-            {
-                success = player.TryTeachSpell(new Spell(command.SpellId));
-            }
-            else
-            {
-                if (player.FindSpell(command.SpellId) > -1 && command.SpellId != Guid.Empty)
-                {
-                    player.ForgetSpell(player.FindSpell(command.SpellId), command.RemoveBoundSpell);
-                    success = true;
-                }
-            }
-
-            List<EventCommand> newCommandList = null;
-            if (success && stackInfo.Page.CommandLists.ContainsKey(command.BranchIds[0]))
-            {
-                newCommandList = stackInfo.Page.CommandLists[command.BranchIds[0]];
-            }
-
-            if (!success && stackInfo.Page.CommandLists.ContainsKey(command.BranchIds[1]))
-            {
-                newCommandList = stackInfo.Page.CommandLists[command.BranchIds[1]];
-            }
-
-            var tmpStack = new CommandInstance(stackInfo.Page)
-            {
-                CommandList = newCommandList,
-                CommandIndex = 0,
-            };
-
-            callStack.Push(tmpStack);
-        }
-
-        //Change Items Command
-        private static void ProcessCommand(
-            ChangeItemsCommand command,
-            Player player,
-            Event instance,
-            CommandInstance stackInfo,
-            Stack<CommandInstance> callStack
-        )
-        {
-            var success = false;
-            var skip = false;
-
-            // Use the command quantity, unless we're using a variable for input!
-            var quantity = command.Quantity;
-            if (command.UseVariable)
-            {
-                switch (command.VariableType)
-                {
-                    case VariableType.PlayerVariable:
-                        quantity = (int)player.GetVariableValue(command.VariableId).Integer;
-
-                        break;
-                    case VariableType.ServerVariable:
-                        quantity = (int)ServerVariableBase.Get(command.VariableId)?.Value.Integer;
-
-                        break;
-                    case VariableType.GuildVariable:
-                        quantity = (int)player.Guild?.GetVariableValue(command.VariableId)?.Integer;
-
-                        break;
-                }
-
-                // The code further ahead converts 0 to quantity 1, due to some legacy junk where some editors would (maybe still do?) set quantity to 0 for non-stackable items.
-                // but if we want to give a player no items through an event we should listen to that.
-                if (quantity <= 0)
-                {
-                    skip = true;
-                }
-            }
-
-            if (!skip)
-            {
-                if (command.Add)
-                {
-                    success = player.TryGiveItem(command.ItemId, quantity, command.ItemHandling);
-                }
-                else
-                {
-                    success = player.TryTakeItem(command.ItemId, quantity, command.ItemHandling);
-                }
-            }
-            else
-            {
-                // If we're skipping, this always succeeds.
-                success = true;
-            }
-
-            List<EventCommand> newCommandList = null;
-            if (success && stackInfo.Page.CommandLists.ContainsKey(command.BranchIds[0]))
-            {
-                newCommandList = stackInfo.Page.CommandLists[command.BranchIds[0]];
-            }
-
-            if (!success && stackInfo.Page.CommandLists.ContainsKey(command.BranchIds[1]))
-            {
-                newCommandList = stackInfo.Page.CommandLists[command.BranchIds[1]];
-            }
-
-            var tmpStack = new CommandInstance(stackInfo.Page)
-            {
-                CommandList = newCommandList,
-                CommandIndex = 0,
-            };
-
-            callStack.Push(tmpStack);
-        }
-
-        //Equip Items Command
-        private static void ProcessCommand(
-            EquipItemCommand command,
-            Player player,
-            Event instance,
-            CommandInstance stackInfo,
-            Stack<CommandInstance> callStack
-        )
-        {
-            var itm = ItemBase.Get(command.ItemId);
-
-            if (command.Unequip)
-            {
-                if (command.IsItem && itm != default)
-                {
-                    player.UnequipItem(command.ItemId);
-                }
-                else if(!command.IsItem && command.Slot > -1 && player.TryGetEquippedItem(command.Slot, out var equippedItem))
-                {
-                     player.UnequipItem(equippedItem.ItemId);
-                }
-            }
-            else
-            {
-                if (itm == null) return;
-                player.EquipItem(ItemBase.Get(command.ItemId), updateCooldown: command.TriggerCooldown);
-            }
-        }
-
-        //Change Sprite Command
-        private static void ProcessCommand(
-            ChangeSpriteCommand command,
-            Player player,
-            Event instance,
-            CommandInstance stackInfo,
-            Stack<CommandInstance> callStack
-        )
-        {
-            player.Sprite = command.Sprite;
-            PacketSender.SendEntityDataToProximity(player);
-        }
-
-        //Change Face Command
-        private static void ProcessCommand(
-            ChangeFaceCommand command,
-            Player player,
-            Event instance,
-            CommandInstance stackInfo,
-            Stack<CommandInstance> callStack
-        )
-        {
-            player.Face = command.Face;
-            PacketSender.SendEntityDataToProximity(player);
-        }
-
-        //Change Gender Command
-        private static void ProcessCommand(
-            ChangeGenderCommand command,
-            Player player,
-            Event instance,
-            CommandInstance stackInfo,
-            Stack<CommandInstance> callStack
-        )
-        {
-            player.Gender = command.Gender;
-            PacketSender.SendEntityDataToProximity(player);
-            player.UnequipInvalidItems();
-        }
-
-        //Change Name Color Command
-        private static void ProcessCommand(
-            ChangeNameColorCommand command,
-            Player player,
-            Event instance,
-            CommandInstance stackInfo,
-            Stack<CommandInstance> callStack
-        )
-        {
-            if (command.Remove)
-            {
-                player.NameColor = null;
-                PacketSender.SendEntityDataToProximity(player);
-
-                return;
-            }
-
-            //Don't set the name color if it doesn't override admin name colors.
-            if (player.Power != UserRights.None && !command.Override)
-            {
-                return;
-            }
-
-            player.NameColor = command.Color;
-            PacketSender.SendEntityDataToProximity(player);
-        }
-
-        //Change Player Label Command
-        private static void ProcessCommand(
-            ChangePlayerLabelCommand command,
-            Player player,
-            Event instance,
-            CommandInstance stackInfo,
-            Stack<CommandInstance> callStack
-        )
-        {
-            var label = ParseEventText(command.Value, player, instance);
-
-            var color = command.Color;
-            if (command.MatchNameColor)
-            {
-                color = Color.Transparent;
-            }
-
-            if (command.Position == 0) // Header
-            {
-                player.HeaderLabel = new Label(label, color);
-            }
-            else if (command.Position == 1) // Footer
-            {
-                player.FooterLabel = new Label(label, color);
-            }
-
-            PacketSender.SendEntityDataToProximity(player);
-        }
-
-        //Set Access Command (wtf why would we even allow this? lol)
-        private static void ProcessCommand(
-            SetAccessCommand command,
-            Player player,
-            Event instance,
-            CommandInstance stackInfo,
-            Stack<CommandInstance> callStack
-        )
-        {
-            if (player.Client == null)
-            {
-                return;
-            }
-
-            switch (command.Access)
-            {
-                case Access.Moderator:
-                    player.Client.Power = UserRights.Moderation;
-
-                    break;
-                case Access.Admin:
-                    player.Client.Power = UserRights.Admin;
-
-                    break;
-                default:
-                    player.Client.Power = UserRights.None;
-
-                    break;
-            }
-
-            PacketSender.SendEntityDataToProximity(player);
-            PacketSender.SendChatMsg(player, Strings.Player.powerchanged, ChatMessageType.Notice, Color.Red);
-            player.UnequipInvalidItems();
-        }
-
-        //Warp Player Command
-        private static void ProcessCommand(
-            WarpCommand command,
-            Player player,
-            Event instance,
-            CommandInstance stackInfo,
-            Stack<CommandInstance> callStack
-        )
-        {
-            MapInstanceType? instanceType = null;
-            if (command.ChangeInstance)
-            {
-                instanceType = command.InstanceType;
-            }
-
-            player.Warp(
-                command.MapId, command.X, command.Y,
-                command.Direction == WarpDirection.Retain ? player.Dir : (Direction)(command.Direction - 1),
-                mapInstanceType: instanceType
-            );
-        }
-
-        //Set Move Route Command
-        private static void ProcessCommand(
-            SetMoveRouteCommand command,
-            Player player,
-            Event instance,
-            CommandInstance stackInfo,
-            Stack<CommandInstance> callStack
-        )
-        {
-            if (command.Route.Target == Guid.Empty)
-            {
-                player.MoveRoute = new EventMoveRoute();
-                player.MoveRouteSetter = instance.PageInstance;
-                player.MoveRoute.CopyFrom(command.Route);
-                PacketSender.SendMoveRouteToggle(player, true);
-            }
-            else
-            {
-                foreach (var evt in player.EventLookup)
-                {
-                    if (evt.Value.BaseEvent.Id == command.Route.Target)
-                    {
-                        if (evt.Value.PageInstance != null)
-                        {
-                            evt.Value.PageInstance.MoveRoute.CopyFrom(command.Route);
-                            evt.Value.PageInstance.MovementType = EventMovementType.MoveRoute;
-                            if (evt.Value.PageInstance.GlobalClone != null)
-                            {
-                                evt.Value.PageInstance.GlobalClone.MovementType = EventMovementType.MoveRoute;
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        //Wait for Route Completion Command
-        private static void ProcessCommand(
-            WaitForRouteCommand command,
-            Player player,
-            Event instance,
-            CommandInstance stackInfo,
-            Stack<CommandInstance> callStack
-        )
-        {
-            if (command.TargetId == Guid.Empty)
-            {
-                stackInfo.WaitingForRoute = player.Id;
-                stackInfo.WaitingForRouteMap = player.MapId;
-            }
-            else
-            {
-                foreach (var evt in player.EventLookup)
-                {
-                    if (evt.Value.BaseEvent.Id == command.TargetId)
-                    {
-                        stackInfo.WaitingForRoute = evt.Value.BaseEvent.Id;
-                        stackInfo.WaitingForRouteMap = evt.Value.MapId;
-
-                        break;
-                    }
-                }
-            }
-        }
-
-        //Spawn Npc Command
-        private static void ProcessCommand(
-            SpawnNpcCommand command,
-            Player player,
-            Event eventInstance,
-            CommandInstance stackInfo,
-            Stack<CommandInstance> callStack
-        )
-        {
-            var npcId = command.NpcId;
-            var mapId = command.MapId;
-            var tileX = 0;
-            var tileY = 0;
-            Direction direction = (byte)Direction.Up;
-            var targetEntity = (Entity)player;
-            if (mapId != Guid.Empty)
-            {
-                tileX = command.X;
-                tileY = command.Y;
-                direction = command.Dir;
-            }
-            else
-            {
-                if (command.EntityId != Guid.Empty)
-                {
-                    foreach (var evt in player.EventLookup)
-                    {
-                        if (evt.Value.MapId != eventInstance.MapId)
-                        {
-                            continue;
-                        }
-
-                        if (evt.Value.BaseEvent.Id == command.EntityId)
-                        {
-                            targetEntity = evt.Value.PageInstance;
-
-                            break;
-                        }
-                    }
-                }
-
-                if (targetEntity != null)
-                {
-                    int xDiff = command.X;
-                    int yDiff = command.Y;
-                    if (command.Dir == Direction.Down)
-                    {
-                        var tmp = 0;
-                        switch (targetEntity.Dir)
-                        {
-                            case Direction.Down:
-                                yDiff *= -1;
-                                xDiff *= -1;
-
-                                break;
-                            case Direction.Left:
-                                tmp = yDiff;
-                                yDiff = xDiff;
-                                xDiff = tmp;
-
-                                break;
-                            case Direction.Right:
-                                tmp = yDiff;
-                                yDiff = xDiff;
-                                xDiff = -tmp;
-
-                                break;
-                        }
-
-                        direction = targetEntity.Dir;
-                    }
-
-                    mapId = targetEntity.MapId;
-                    tileX = (byte)(targetEntity.X + xDiff);
-                    tileY = (byte)(targetEntity.Y + yDiff);
-                }
-                else
-                {
-                    return;
-                }
-            }
-
-            var tile = new TileHelper(mapId, tileX, tileY);
-            if (tile.TryFix() && MapController.TryGetInstanceFromMap(mapId, player.MapInstanceId, out var instance))
-            {
-                var npc = instance.SpawnNpc((byte)tileX, (byte)tileY, direction, npcId, true);
-                player.SpawnedNpcs.Add(npc);
-            }
-        }
-
-        //Despawn Npcs Command
-        private static void ProcessCommand(
-            DespawnNpcCommand command,
-            Player player,
-            Event instance,
-            CommandInstance stackInfo,
-            Stack<CommandInstance> callStack
-        )
-        {
-            foreach (var entity in player.SpawnedNpcs.ToArray())
-            {
-                if (entity is Npc npc && npc.Despawnable == true)
-                {
-                    lock (player.EntityLock)
-                    {
-                        npc.Die();
-                    }
-                }
-            }
-
-            player.SpawnedNpcs.Clear();
-        }
-
-        //Play Animation Command
-        private static void ProcessCommand(
-            PlayAnimationCommand command,
-            Player player,
-            Event instance,
-            CommandInstance stackInfo,
-            Stack<CommandInstance> callStack
-        )
-        {
-            //Playing an animations requires a target type/target or just a tile.
-            //We need an animation number and whether or not it should rotate (and the direction I guess)
-            var animId = command.AnimationId;
-            var mapId = command.MapId;
-            var tileX = 0;
-            var tileY = 0;
-            var direction = Direction.Up;
-            var targetEntity = (Entity)player;
-            if (mapId != Guid.Empty)
-            {
-                tileX = command.X;
-                tileY = command.Y;
-                direction = (Direction)command.Dir;
-            }
-            else
-            {
-                if (command.EntityId != Guid.Empty)
-                {
-                    foreach (var evt in player.EventLookup)
-                    {
-                        if (evt.Value.MapId != instance.MapId)
-                        {
-                            continue;
-                        }
-
-                        if (evt.Value.BaseEvent.Id == command.EntityId)
-                        {
-                            targetEntity = evt.Value.PageInstance;
-
-                            break;
-                        }
-                    }
-                }
-
-                if (targetEntity != null)
-                {
-                    if (command.X == 0 && command.Y == 0 && command.Dir == 0)
-                    {
-                        var targetType = targetEntity.GetEntityType() == EntityType.Event ? 2 : 1;
-                        //Attach to entity instead of playing on tile
-                        if (command.InstanceToPlayer)
-                        {
-                            PacketSender.SendAnimationTo(
-                                animId, targetType, targetEntity.Id, targetEntity.MapId, 0, 0, 0, player
-                            );
-                        }
-                        else
-                        {
-                            PacketSender.SendAnimationToProximity(
-                                animId, targetType, targetEntity.Id,
-                                targetEntity.MapId, 0, 0, 0, targetEntity.MapInstanceId
-                            );
-                        }
-
-                        return;
-                    }
-
-                    int xDiff = command.X;
-                    int yDiff = command.Y;
-                    if (command.Dir == 1)
-                    {
-                        var tmp = 0;
-                        switch (targetEntity.Dir)
-                        {
-                            case Direction.Down:
-                                yDiff *= -1;
-                                xDiff *= -1;
-
-                                break;
-                            case Direction.Left:
-                                tmp = yDiff;
-                                yDiff = xDiff;
-                                xDiff = tmp;
-
-                                break;
-                            case Direction.Right:
-                                tmp = yDiff;
-                                yDiff = xDiff;
-                                xDiff = -tmp;
-
-                                break;
-                        }
-
-                        direction = targetEntity.Dir;
-                    }
-
-                    mapId = targetEntity.MapId;
-                    tileX = targetEntity.X + xDiff;
-                    tileY = targetEntity.Y + yDiff;
-                }
-                else
-                {
-                    return;
-                }
-            }
-
-            var tile = new TileHelper(mapId, tileX, tileY);
-            if (tile.TryFix())
-            {
-                if (command.InstanceToPlayer)
-                {
-                    PacketSender.SendAnimationTo(
-                        animId, -1, Guid.Empty, tile.GetMapId(), tile.GetX(), tile.GetY(), direction, player
-                    );
-                }
-                else
-                {
-                    PacketSender.SendAnimationToProximity(
-                        animId, -1, Guid.Empty, tile.GetMapId(), tile.GetX(), tile.GetY(), direction, player.MapInstanceId
-                    );
-                }
-            }
-        }
-
-        //Hold Player Command
-        private static void ProcessCommand(
-            HoldPlayerCommand command,
-            Player player,
-            Event instance,
-            CommandInstance stackInfo,
-            Stack<CommandInstance> callStack
-        )
-        {
-            instance.HoldingPlayer = true;
-            PacketSender.SendHoldPlayer(player, instance.BaseEvent.Id, instance.BaseEvent.MapId);
-        }
-
-        //Release Player Command
-        private static void ProcessCommand(
-            ReleasePlayerCommand command,
-            Player player,
-            Event instance,
-            CommandInstance stackInfo,
-            Stack<CommandInstance> callStack
-        )
-        {
-            instance.HoldingPlayer = false;
-            PacketSender.SendReleasePlayer(player, instance.BaseEvent.Id);
-        }
-
-        //Hide Player Command
-        private static void ProcessCommand(
-            HidePlayerCommand command,
-            Player player,
-            Event instance,
-            CommandInstance stackInfo,
-            Stack<CommandInstance> callStack
-        )
-        {
-            player.HideEntity = true;
-            player.HideName = true;
-            PacketSender.SendEntityDataToProximity(player);
-        }
-
-        //Show Player Command
-        private static void ProcessCommand(
-            ShowPlayerCommand command,
-            Player player,
-            Event instance,
-            CommandInstance stackInfo,
-            Stack<CommandInstance> callStack
-        )
-        {
-            player.HideEntity = false;
-            player.HideName = false;
-            PacketSender.SendEntityDataToProximity(player);
-        }
-
-        //Play Bgm Command
-        private static void ProcessCommand(
-            PlayBgmCommand command,
-            Player player,
-            Event instance,
-            CommandInstance stackInfo,
-            Stack<CommandInstance> callStack
-        )
-        {
-            PacketSender.SendPlayMusic(player, command.File);
-        }
-
-        //Fadeout Bgm Command
-        private static void ProcessCommand(
-            FadeoutBgmCommand command,
-            Player player,
-            Event instance,
-            CommandInstance stackInfo,
-            Stack<CommandInstance> callStack
-        )
-        {
-            PacketSender.SendFadeMusic(player);
-        }
-
-        //Play Sound Command
-        private static void ProcessCommand(
-            PlaySoundCommand command,
-            Player player,
-            Event instance,
-            CommandInstance stackInfo,
-            Stack<CommandInstance> callStack
-        )
-        {
-            PacketSender.SendPlaySound(player, command.File);
-        }
-
-        //Stop Sounds Command
-        private static void ProcessCommand(
-            StopSoundsCommand command,
-            Player player,
-            Event instance,
-            CommandInstance stackInfo,
-            Stack<CommandInstance> callStack
-        )
-        {
-            PacketSender.SendStopSounds(player);
-        }
-
-        //Show Picture Command
-        private static void ProcessCommand(
-            ShowPictureCommand command,
-            Player player,
-            Event instance,
-            CommandInstance stackInfo,
-            Stack<CommandInstance> callStack
-        )
-        {
-            var id = Guid.Empty;
-            var shouldWait = command.WaitUntilClosed && (command.Clickable || command.HideTime > 0);
-            if (shouldWait)
-            {
-                id = instance.PageInstance.Id;
-                stackInfo.WaitingForResponse = CommandInstance.EventResponse.Picture;
-            }
-
-            PacketSender.SendShowPicture(player, command.File, command.Size, command.Clickable, command.HideTime, id);
-        }
-
-        //Hide Picture Command
-        private static void ProcessCommand(
-            HidePictureCommmand command,
-            Player player,
-            Event instance,
-            CommandInstance stackInfo,
-            Stack<CommandInstance> callStack
-        )
-        {
-            PacketSender.SendHidePicture(player);
-        }
-
-        //Wait Command
-        private static void ProcessCommand(
-            WaitCommand command,
-            Player player,
-            Event instance,
-            CommandInstance stackInfo,
-            Stack<CommandInstance> callStack
-        )
-        {
-            instance.WaitTimer = Timing.Global.Milliseconds + command.Time;
-            callStack.Peek().WaitingForResponse = CommandInstance.EventResponse.Timer;
-        }
-
-        //Open Bank Command
-        private static void ProcessCommand(
-            OpenBankCommand command,
-            Player player,
-            Event instance,
-            CommandInstance stackInfo,
-            Stack<CommandInstance> callStack
-        )
-        {
-            player.OpenBank();
-            callStack.Peek().WaitingForResponse = CommandInstance.EventResponse.Bank;
-        }
-
-        //Open Shop Command
-        private static void ProcessCommand(
-            OpenShopCommand command,
-            Player player,
-            Event instance,
-            CommandInstance stackInfo,
-            Stack<CommandInstance> callStack
-        )
-        {
-            player.OpenShop(ShopBase.Get(command.ShopId));
-            callStack.Peek().WaitingForResponse = CommandInstance.EventResponse.Shop;
-        }
-
-        //Open Crafting Table Command
-        private static void ProcessCommand(
-            OpenCraftingTableCommand command,
-            Player player,
-            Event instance,
-            CommandInstance stackInfo,
-            Stack<CommandInstance> callStack
-        )
-        {
-            player.OpenCraftingTable(CraftingTableBase.Get(command.CraftingTableId), command.JournalMode);
-            callStack.Peek().WaitingForResponse = CommandInstance.EventResponse.Crafting;
-        }
-
-        //Set Class Command
-        private static void ProcessCommand(
-            SetClassCommand command,
-            Player player,
-            Event instance,
-            CommandInstance stackInfo,
-            Stack<CommandInstance> callStack
-        )
-        {
-            if (ClassBase.Get(command.ClassId) != null)
-            {
-                player.ClassId = command.ClassId;
-                player.RecalculateStatsAndPoints();
-                player.UnequipInvalidItems();
-            }
-
-            PacketSender.SendEntityDataToProximity(player);
-        }
-
-        //Start Quest Command
-        private static void ProcessCommand(
-            StartQuestCommand command,
-            Player player,
-            Event instance,
-            CommandInstance stackInfo,
-            Stack<CommandInstance> callStack
-        )
-        {
-            var success = false;
-            var quest = QuestBase.Get(command.QuestId);
-            if (quest != null)
-            {
-                if (player.CanStartQuest(quest))
-                {
-                    if (command.Offer)
-                    {
-                        player.OfferQuest(quest);
-                        stackInfo.WaitingForResponse = CommandInstance.EventResponse.Quest;
-                        stackInfo.BranchIds = command.BranchIds;
-                        stackInfo.WaitingOnCommand = command;
-
-                        return;
-                    }
-                    else
-                    {
-                        player.StartQuest(quest);
-                        success = true;
-                    }
-                }
-            }
-
-            List<EventCommand> newCommandList = null;
-            if (success && stackInfo.Page.CommandLists.ContainsKey(command.BranchIds[0]))
-            {
-                newCommandList = stackInfo.Page.CommandLists[command.BranchIds[0]];
-            }
-
-            if (!success && stackInfo.Page.CommandLists.ContainsKey(command.BranchIds[1]))
-            {
-                newCommandList = stackInfo.Page.CommandLists[command.BranchIds[1]];
-            }
-
-            var tmpStack = new CommandInstance(stackInfo.Page)
-            {
-                CommandList = newCommandList,
-                CommandIndex = 0,
-            };
-
-            callStack.Push(tmpStack);
-        }
-
-        //Complete Quest Task Command
-        private static void ProcessCommand(
-            CompleteQuestTaskCommand command,
-            Player player,
-            Event instance,
-            CommandInstance stackInfo,
-            Stack<CommandInstance> callStack
-        )
-        {
-            player.CompleteQuestTask(command.QuestId, command.TaskId);
-        }
-
-        //End Quest Command
-        private static void ProcessCommand(
-            EndQuestCommand command,
-            Player player,
-            Event instance,
-            CommandInstance stackInfo,
-            Stack<CommandInstance> callStack
-        )
-        {
-            player.CompleteQuest(command.QuestId, command.SkipCompletionEvent);
-        }
-
-        // Change Player Color Command
-        private static void ProcessCommand(
-            ChangePlayerColorCommand command,
-            Player player,
-            Event instance,
-            CommandInstance stackInfo,
-            Stack<CommandInstance> callStack
-        )
-        {
-            player.Color = command.Color;
-            PacketSender.SendEntityDataToProximity(player);
-        }
-
-        private static void ProcessCommand(
-            ChangeNameCommand command,
-            Player player,
-            Event instance,
-            CommandInstance stackInfo,
-            Stack<CommandInstance> callStack
-        )
-        {
-            var success = false;
-
             var variable = PlayerVariableBase.Get(command.VariableId);
             if (variable != null)
             {
-                if (variable.Type == VariableDataType.String)
+                type = (int)variable.Type;
+            }
+        }
+        else if (command.VariableType == VariableType.ServerVariable)
+        {
+            var variable = ServerVariableBase.Get(command.VariableId);
+            if (variable != null)
+            {
+                type = (int)variable.Type;
+            }
+        }
+        else if (command.VariableType == VariableType.GuildVariable)
+        {
+            var variable = GuildVariableBase.Get(command.VariableId);
+            type = (int)variable.Type;
+        }
+        else if (command.VariableType == VariableType.UserVariable)
+        {
+            var variable = UserVariableBase.Get(command.VariableId);
+            type = (int)variable.Type;
+        }
+        else if (type == -1)
+        {
+            var tmpStack = new CommandInstance(stackInfo.Page, command.BranchIds[1]);
+            callStack.Push(tmpStack);
+            return;
+        }
+
+        PacketSender.SendInputVariableDialog(player, title, txt, (VariableDataType)type, instance.PageInstance.Id);
+        stackInfo.WaitingForResponse = CommandInstance.EventResponse.Dialogue;
+        stackInfo.WaitingOnCommand = command;
+        stackInfo.BranchIds = command.BranchIds;
+    }
+
+    //Show Add Chatbox Text Command
+    private static void ProcessCommand(
+        AddChatboxTextCommand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        var txt = ParseEventText(command.Text, player, instance);
+        var color = Color.FromName(command.Color, Strings.Colors.presets);
+        switch (command.Channel)
+        {
+            case ChatboxChannel.Player:
+                PacketSender.SendChatMsg(player, txt, command.MessageType, color);
+
+                break;
+            case ChatboxChannel.Local:
+                PacketSender.SendProximityMsg(txt, ChatMessageType.Local, player.MapId, color);
+
+                break;
+            case ChatboxChannel.Global:
+                PacketSender.SendGlobalMsg(txt, color, string.Empty, ChatMessageType.Global);
+
+                break;
+            case ChatboxChannel.Party:
+                if (player.Party?.Count > 0)
                 {
-                    var data = player.GetVariable(variable.Id)?.Value;
-                    if (data != null)
+                    PacketSender.SendPartyMsg(player, txt, color, player.Name);
+                }
+
+                break;
+            case ChatboxChannel.Guild:
+                if (player.Guild != null)
+                {
+                    PacketSender.SendGuildMsg(player, txt, color, player.Name);
+                }
+                break;
+        }
+
+        if (command.ShowChatBubble)
+        {
+            PacketSender.SendChatBubbleToPlayer(
+                player,
+                instance.PageInstance.Id,
+                instance.PageInstance.GetEntityType(),
+                txt,
+                instance.PageInstance.MapId
+            );
+        }
+    }
+
+    //Set Variable Commands
+    private static void ProcessCommand(
+        SetVariableCommand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        ProcessVariableModification(command, (dynamic)command.Modification, player, instance);
+        player.UnequipInvalidItems();
+    }
+
+    //Set Self Switch Command
+    private static void ProcessCommand(
+        SetSelfSwitchCommand command,
+        Player player,
+        Event eventInstance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        if (eventInstance.Global)
+        {
+            if (MapController.TryGetInstanceFromMap(eventInstance.MapId, player.MapInstanceId, out var instance))
+            {
+                var evts = instance.GlobalEventInstances.Values.ToList();
+                for (var i = 0; i < evts.Count; i++)
+                {
+                    if (evts[i] != null && evts[i].BaseEvent == eventInstance.BaseEvent)
                     {
-                        success = player.TryChangeName(data.String);
+                        evts[i].SelfSwitch[command.SwitchId] = command.Value;
                     }
                 }
             }
+        }
+        else
+        {
+            eventInstance.SelfSwitch[command.SwitchId] = command.Value;
+        }
+    }
 
-            List<EventCommand> newCommandList = null;
-            if (success && stackInfo.Page.CommandLists.ContainsKey(command.BranchIds[0]))
-            {
-                newCommandList = stackInfo.Page.CommandLists[command.BranchIds[0]];
-            }
+    //Conditional Branch Command
+    private static void ProcessCommand(
+        ConditionalBranchCommand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        var success = Conditions.MeetsCondition(command.Condition, player, instance, null);
 
-            if (!success && stackInfo.Page.CommandLists.ContainsKey(command.BranchIds[1]))
-            {
-                newCommandList = stackInfo.Page.CommandLists[command.BranchIds[1]];
-            }
+        List<EventCommand> newCommandList = null;
+        if (success && stackInfo.Page.CommandLists.ContainsKey(command.BranchIds[0]))
+        {
+            newCommandList = stackInfo.Page.CommandLists[command.BranchIds[0]];
+        }
 
+        if (!success && command.Condition.ElseEnabled && stackInfo.Page.CommandLists.ContainsKey(command.BranchIds[1]))
+        {
+            newCommandList = stackInfo.Page.CommandLists[command.BranchIds[1]];
+        }
+
+        if (newCommandList != null)
+        {
             var tmpStack = new CommandInstance(stackInfo.Page)
             {
                 CommandList = newCommandList,
@@ -1395,160 +247,274 @@ namespace Intersect.Server.Entities.Events
 
             callStack.Push(tmpStack);
         }
+    }
 
-        //Create Guild Command
-        private static void ProcessCommand(
-            CreateGuildCommand command,
-            Player player,
-            Event instance,
-            CommandInstance stackInfo,
-            Stack<CommandInstance> callStack
-        )
+    //Exit Event Process Command
+    private static void ProcessCommand(
+        ExitEventProcessingCommand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        callStack.Clear();
+    }
+
+    //Label Command
+    private static void ProcessCommand(
+        LabelCommand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        return; //Do Nothing.. just a label
+    }
+
+    //Go To Label Command
+    private static void ProcessCommand(
+        GoToLabelCommand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        //Recursively search through commands for the label, and create a brand new call stack based on where that label is located.
+        var newCallStack = LoadLabelCallstack(command.Label, stackInfo.Page);
+        if (newCallStack != null)
         {
-            var success = false;
-            var playerVariable = PlayerVariableBase.Get(command.VariableId);
-
-            // We only accept Strings as our Guild Names!
-            if (playerVariable.Type == VariableDataType.String)
+            newCallStack.Reverse();
+            while (callStack.Peek().CommandListId != Guid.Empty)
             {
-                // Get our intended guild name
-                var gname = player.GetVariable(playerVariable.Id)?.Value.String?.Trim();
-
-                // Can we use this name according to our configuration?
-                if (gname != null && FieldChecking.IsValidGuildName(gname, Strings.Regex.guildname))
-                {
-                    // Is the name already in use?
-                    if (Guild.GetGuild(gname) == null)
-                    {
-                        // Is the player already in a guild?
-                        if (player.Guild == null)
-                        {
-                            // Finally, we can actually MAKE this guild happen!
-                            var guild = Guild.CreateGuild(player, gname);
-                            if (guild != null)
-                            {
-                                // Send them a welcome message!
-                                PacketSender.SendChatMsg(player, Strings.Guilds.Welcome.ToString(gname), ChatMessageType.Guild, CustomColors.Alerts.Success);
-
-                                // Denote that we were successful.
-                                success = true;
-                            }
-                        }
-                        else
-                        {
-                            // This cheeky bugger is already in a guild, tell him so!
-                            PacketSender.SendChatMsg(player, Strings.Guilds.AlreadyInGuild, ChatMessageType.Guild, CustomColors.Alerts.Error);
-                        }
-                    }
-                    else
-                    {
-                        // This name already exists, oh dear!
-                        PacketSender.SendChatMsg(player, Strings.Guilds.GuildNameInUse, ChatMessageType.Guild, CustomColors.Alerts.Error);
-                    }
-                }
-                else
-                {
-                    // Let our player know they need to adjust their name.
-                    PacketSender.SendChatMsg(player, Strings.Guilds.VariableInvalid, ChatMessageType.Guild, CustomColors.Alerts.Error);
-                }
-            }
-            else
-            {
-                // Notify the user that something went wrong, the user really shouldn't see this.. Assuming the creator set up his events properly.
-                PacketSender.SendChatMsg(player, Strings.Guilds.VariableNotString, ChatMessageType.Guild, CustomColors.Alerts.Error);
+                callStack.Pop();
             }
 
-            List<EventCommand> newCommandList = null;
-            if (success && stackInfo.Page.CommandLists.ContainsKey(command.BranchIds[0]))
+            //also pop the current event
+            callStack.Pop();
+            foreach (var itm in newCallStack)
             {
-                newCommandList = stackInfo.Page.CommandLists[command.BranchIds[0]];
+                callStack.Push(itm);
             }
+        }
+    }
 
-            if (!success && stackInfo.Page.CommandLists.ContainsKey(command.BranchIds[1]))
-            {
-                newCommandList = stackInfo.Page.CommandLists[command.BranchIds[1]];
-            }
-
-            var tmpStack = new CommandInstance(stackInfo.Page)
-            {
-                CommandList = newCommandList,
-                CommandIndex = 0,
-            };
-
-            callStack.Push(tmpStack);
+    //Start Common Event Command
+    private static void ProcessCommand(
+        StartCommmonEventCommand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        if (!EventBase.TryGet(command.EventId, out var commonEvent))
+        {
+            return;
         }
 
-        private static void ProcessCommand(
-            DisbandGuildCommand command,
-            Player player,
-            Event instance,
-            CommandInstance stackInfo,
-            Stack<CommandInstance> callStack
-        )
+        foreach (var page in commonEvent.Pages)
         {
-            var success = false;
-
-            // Is this player in a guild?
-            if (player.Guild != null)
+            if (Conditions.CanSpawnPage(page, player, instance))
             {
-                // Send the members a notification, then start wiping the guild from existence through sheer willpower!
-                PacketSender.SendGuildMsg(player, Strings.Guilds.DisbandGuild.ToString(player.Guild.Name), CustomColors.Alerts.Info);
-                Guild.DeleteGuild(player.Guild, player);
-                player.UnequipInvalidItems();
+                var commonEventStack = new CommandInstance(page);
+                callStack.Push(commonEventStack);
+            }
+        }
 
-                // :(
+        if (player.MapInstanceId == Guid.Empty && !command.AllowInOverworld)
+        {
+            return;
+        }
+
+        if (command.AllInInstance && InstanceProcessor.TryGetInstanceController(player.MapInstanceId, out var instanceController))
+        {
+            foreach (var instanceMember in instanceController.Players.ToArray())
+            {
+                if (instanceMember.Id == player.Id || !instanceMember.Online)
+                {
+                    continue;
+                }
+
+                instanceMember.EnqueueStartCommonEvent(commonEvent);
+            }
+        }
+    }
+
+    //Restore Hp Command
+    private static void ProcessCommand(
+        RestoreHpCommand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        if (command.Amount > 0)
+        {
+            player.AddVital(Vital.Health, command.Amount);
+        }
+        else if (command.Amount < 0)
+        {
+            player.SubVital(Vital.Health, -command.Amount);
+            player.CombatTimer = Timing.Global.Milliseconds + Options.CombatTime;
+            if (player.GetVital(Vital.Health) <= 0)
+            {
+                lock (player.EntityLock)
+                {
+                    player.Die();
+                }
+            }
+        }
+        else
+        {
+            player.RestoreVital(Vital.Health);
+        }
+    }
+
+    //Restore Mp Command
+    private static void ProcessCommand(
+        RestoreMpCommand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        if (command.Amount > 0)
+        {
+            player.AddVital(Vital.Mana, command.Amount);
+        }
+        else if (command.Amount < 0)
+        {
+            player.SubVital(Vital.Mana, -command.Amount);
+            player.CombatTimer = Timing.Global.Milliseconds + Options.CombatTime;
+        }
+        else
+        {
+            player.RestoreVital(Vital.Mana);
+        }
+    }
+
+    //Level Up Command
+    private static void ProcessCommand(
+        LevelUpCommand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        player.LevelUp();
+    }
+
+    //Give Experience Command
+    private static void ProcessCommand(
+        GiveExperienceCommand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        var quantity = command.Exp;
+        if (command.UseVariable)
+        {
+            switch (command.VariableType)
+            {
+                case VariableType.PlayerVariable:
+                    quantity = (int)player.GetVariableValue(command.VariableId).Integer;
+
+                    break;
+                case VariableType.ServerVariable:
+                    quantity = (int)ServerVariableBase.Get(command.VariableId)?.Value.Integer;
+
+                    break;
+
+                case VariableType.GuildVariable:
+                    quantity = (int)player.Guild?.GetVariableValue(command.VariableId)?.Integer;
+
+                    break;
+            }
+        }
+
+        player.GiveExperience(quantity);
+    }
+
+    //Change Level Command
+    private static void ProcessCommand(
+        ChangeLevelCommand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        player.SetLevel(command.Level, true);
+    }
+
+    //Change Spells Command
+    private static void ProcessCommand(
+        ChangeSpellsCommand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        //0 is add, 1 is remove
+        var success = false;
+        if (command.Add) //Try to add a spell
+        {
+            success = player.TryTeachSpell(new Spell(command.SpellId));
+        }
+        else
+        {
+            if (player.FindSpell(command.SpellId) > -1 && command.SpellId != Guid.Empty)
+            {
+                player.ForgetSpell(player.FindSpell(command.SpellId), command.RemoveBoundSpell);
                 success = true;
             }
-            else
-            {
-                // They're not in a guild.. tell them?
-                PacketSender.SendChatMsg(player, Strings.Guilds.NotInGuild, ChatMessageType.Guild, CustomColors.Alerts.Error);
-            }
-
-            List<EventCommand> newCommandList = null;
-            if (success && stackInfo.Page.CommandLists.ContainsKey(command.BranchIds[0]))
-            {
-                newCommandList = stackInfo.Page.CommandLists[command.BranchIds[0]];
-            }
-
-            if (!success && stackInfo.Page.CommandLists.ContainsKey(command.BranchIds[1]))
-            {
-                newCommandList = stackInfo.Page.CommandLists[command.BranchIds[1]];
-            }
-
-            var tmpStack = new CommandInstance(stackInfo.Page)
-            {
-                CommandList = newCommandList,
-                CommandIndex = 0,
-            };
-
-            callStack.Push(tmpStack);
         }
 
-        //Open Guild Bank Command
-        private static void ProcessCommand(
-            OpenGuildBankCommand command,
-            Player player,
-            Event instance,
-            CommandInstance stackInfo,
-            Stack<CommandInstance> callStack
-        )
+        List<EventCommand> newCommandList = null;
+        if (success && stackInfo.Page.CommandLists.ContainsKey(command.BranchIds[0]))
         {
-            player.OpenBank(true);
-            callStack.Peek().WaitingForResponse = CommandInstance.EventResponse.Bank;
+            newCommandList = stackInfo.Page.CommandLists[command.BranchIds[0]];
         }
 
-
-        //Open Guild Bank Slots Count Command
-        private static void ProcessCommand(
-            SetGuildBankSlotsCommand command,
-            Player player,
-            Event instance,
-            CommandInstance stackInfo,
-            Stack<CommandInstance> callStack
-        )
+        if (!success && stackInfo.Page.CommandLists.ContainsKey(command.BranchIds[1]))
         {
-            var quantity = 0;
+            newCommandList = stackInfo.Page.CommandLists[command.BranchIds[1]];
+        }
+
+        var tmpStack = new CommandInstance(stackInfo.Page)
+        {
+            CommandList = newCommandList,
+            CommandIndex = 0,
+        };
+
+        callStack.Push(tmpStack);
+    }
+
+    //Change Items Command
+    private static void ProcessCommand(
+        ChangeItemsCommand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        var success = false;
+        var skip = false;
+
+        // Use the command quantity, unless we're using a variable for input!
+        var quantity = command.Quantity;
+        if (command.UseVariable)
+        {
             switch (command.VariableType)
             {
                 case VariableType.PlayerVariable:
@@ -1564,716 +530,1748 @@ namespace Intersect.Server.Entities.Events
 
                     break;
             }
-            var guild = player.Guild;
-            if (quantity > 0 && guild != null && guild.BankSlotsCount != quantity)
+
+            // The code further ahead converts 0 to quantity 1, due to some legacy junk where some editors would (maybe still do?) set quantity to 0 for non-stackable items.
+            // but if we want to give a player no items through an event we should listen to that.
+            if (quantity <= 0)
             {
-                guild.ExpandBankSlots(quantity);
+                skip = true;
             }
         }
 
-        //Reset Stat Point Allocations Command
-        private static void ProcessCommand(
-            ResetStatPointAllocationsCommand command,
-            Player player,
-            Event instance,
-            CommandInstance stackInfo,
-            Stack<CommandInstance> callStack
-        )
+        if (!skip)
         {
-            for (var i = 0; i < Enum.GetValues<Stat>().Length; i++)
+            if (command.Add)
             {
-                player.StatPointAllocations[i] = 0;
+                success = player.TryGiveItem(command.ItemId, quantity, command.ItemHandling);
             }
-            player.RecalculateStatsAndPoints();
-            player.UnequipInvalidItems();
+            else
+            {
+                success = player.TryTakeItem(command.ItemId, quantity, command.ItemHandling);
+            }
+        }
+        else
+        {
+            // If we're skipping, this always succeeds.
+            success = true;
+        }
+
+        List<EventCommand> newCommandList = null;
+        if (success && stackInfo.Page.CommandLists.ContainsKey(command.BranchIds[0]))
+        {
+            newCommandList = stackInfo.Page.CommandLists[command.BranchIds[0]];
+        }
+
+        if (!success && stackInfo.Page.CommandLists.ContainsKey(command.BranchIds[1]))
+        {
+            newCommandList = stackInfo.Page.CommandLists[command.BranchIds[1]];
+        }
+
+        var tmpStack = new CommandInstance(stackInfo.Page)
+        {
+            CommandList = newCommandList,
+            CommandIndex = 0,
+        };
+
+        callStack.Push(tmpStack);
+    }
+
+    //Equip Items Command
+    private static void ProcessCommand(
+        EquipItemCommand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        var itm = ItemBase.Get(command.ItemId);
+
+        if (command.Unequip)
+        {
+            if (command.IsItem && itm != default)
+            {
+                player.UnequipItem(command.ItemId);
+            }
+            else if(!command.IsItem && command.Slot > -1 && player.TryGetEquippedItem(command.Slot, out var equippedItem))
+            {
+                 player.UnequipItem(equippedItem.ItemId);
+            }
+        }
+        else
+        {
+            if (itm == null) return;
+            player.EquipItem(ItemBase.Get(command.ItemId), updateCooldown: command.TriggerCooldown);
+        }
+    }
+
+    //Change Sprite Command
+    private static void ProcessCommand(
+        ChangeSpriteCommand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        player.Sprite = command.Sprite;
+        PacketSender.SendEntityDataToProximity(player);
+    }
+
+    //Change Face Command
+    private static void ProcessCommand(
+        ChangeFaceCommand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        player.Face = command.Face;
+        PacketSender.SendEntityDataToProximity(player);
+    }
+
+    //Change Gender Command
+    private static void ProcessCommand(
+        ChangeGenderCommand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        player.Gender = command.Gender;
+        PacketSender.SendEntityDataToProximity(player);
+        player.UnequipInvalidItems();
+    }
+
+    //Change Name Color Command
+    private static void ProcessCommand(
+        ChangeNameColorCommand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        if (command.Remove)
+        {
+            player.NameColor = null;
             PacketSender.SendEntityDataToProximity(player);
+
+            return;
         }
 
-        // Cast Spell On command
-        private static void ProcessCommand(
-           CastSpellOn command,
-           Player player,
-           Event instance,
-           CommandInstance stackInfo,
-           Stack<CommandInstance> callStack
-       )
+        //Don't set the name color if it doesn't override admin name colors.
+        if (player.Power != UserRights.None && !command.Override)
         {
-            if (player == null || !player.Online)
-            {
-                return;
-            }
+            return;
+        }
 
-            List<Player> affectedPlayers = new List<Player>();
+        player.NameColor = command.Color;
+        PacketSender.SendEntityDataToProximity(player);
+    }
 
-            if (command.Self)
-            {
-                affectedPlayers.Add(player);
-            }
+    //Change Player Label Command
+    private static void ProcessCommand(
+        ChangePlayerLabelCommand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        var label = ParseEventText(command.Value, player, instance);
 
-            if (command.PartyMembers && player.IsInParty)
-            {
-                affectedPlayers.AddRange(player.Party.Where(pl => pl.Id != player.Id));
-            }
+        var color = command.Color;
+        if (command.MatchNameColor)
+        {
+            color = Color.Transparent;
+        }
 
-            if (command.GuildMembers && player.IsInGuild)
-            {
-                affectedPlayers.AddRange(player.Guild.FindOnlineMembers().Where(pl => pl.Id != player.Id));
-            }
+        if (command.Position == 0) // Header
+        {
+            player.HeaderLabel = new Label(label, color);
+        }
+        else if (command.Position == 1) // Footer
+        {
+            player.FooterLabel = new Label(label, color);
+        }
 
-            foreach (var affectedPlayer in affectedPlayers.DistinctBy(pl => pl.Id))
+        PacketSender.SendEntityDataToProximity(player);
+    }
+
+    //Set Access Command (wtf why would we even allow this? lol)
+    private static void ProcessCommand(
+        SetAccessCommand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        if (player.Client == null)
+        {
+            return;
+        }
+
+        switch (command.Access)
+        {
+            case Access.Moderator:
+                player.Client.Power = UserRights.Moderation;
+
+                break;
+            case Access.Admin:
+                player.Client.Power = UserRights.Admin;
+
+                break;
+            default:
+                player.Client.Power = UserRights.None;
+
+                break;
+        }
+
+        PacketSender.SendEntityDataToProximity(player);
+        PacketSender.SendChatMsg(player, Strings.Player.powerchanged, ChatMessageType.Notice, Color.Red);
+        player.UnequipInvalidItems();
+    }
+
+    //Warp Player Command
+    private static void ProcessCommand(
+        WarpCommand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        MapInstanceType? instanceType = null;
+        if (command.ChangeInstance)
+        {
+            instanceType = command.InstanceType;
+        }
+
+        player.Warp(
+            command.MapId, command.X, command.Y,
+            command.Direction == WarpDirection.Retain ? player.Dir : (Direction)(command.Direction - 1),
+            mapInstanceType: instanceType
+        );
+    }
+
+    //Set Move Route Command
+    private static void ProcessCommand(
+        SetMoveRouteCommand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        if (command.Route.Target == Guid.Empty)
+        {
+            player.MoveRoute = new EventMoveRoute();
+            player.MoveRouteSetter = instance.PageInstance;
+            player.MoveRoute.CopyFrom(command.Route);
+            PacketSender.SendMoveRouteToggle(player, true);
+        }
+        else
+        {
+            foreach (var evt in player.EventLookup)
             {
-                if (!affectedPlayer.Online)
+                if (evt.Value.BaseEvent.Id == command.Route.Target)
                 {
-                    continue;
-                }
-
-                affectedPlayer?.CastSpell(command.SpellId);
-            }
-        }
-
-        private static void ProcessCommand(
-           ScreenFadeCommand command,
-           Player player,
-           Event instance,
-           CommandInstance stackInfo,
-           Stack<CommandInstance> callStack
-        )
-        {
-            if (player == null || !player.Online)
-            {
-                return;
-            }
-
-            player.IsFading = command.WaitForCompletion;
-            PacketSender.SendFade(player, command.FadeType, command.WaitForCompletion, command.DurationMs);
-
-            if (command.WaitForCompletion)
-            {
-                callStack.Peek().WaitingForResponse = CommandInstance.EventResponse.Fade;
-            }
-        }
-
-        private static Stack<CommandInstance> LoadLabelCallstack(string label, EventPage currentPage)
-        {
-            var newStack = new Stack<CommandInstance>();
-            newStack.Push(new CommandInstance(currentPage)); //Start from the top
-            if (FindLabelResursive(newStack, currentPage, newStack.Peek().CommandList, label))
-            {
-                return newStack;
-            }
-
-            return null;
-        }
-
-        private static bool FindLabelResursive(
-            Stack<CommandInstance> stack,
-            EventPage page,
-            List<EventCommand> commandList,
-            string label
-        )
-        {
-            if (page.CommandLists.ContainsValue(commandList))
-            {
-                while (stack.Peek().CommandIndex < commandList.Count)
-                {
-                    var command = commandList[stack.Peek().CommandIndex];
-                    var branchIds = new List<Guid>();
-                    switch (command.Type)
+                    if (evt.Value.PageInstance != null)
                     {
-                        case EventCommandType.ShowOptions:
-                            branchIds.AddRange(((ShowOptionsCommand)command).BranchIds);
-
-                            break;
-                        case EventCommandType.InputVariable:
-                            branchIds.AddRange(((InputVariableCommand)command).BranchIds);
-
-                            break;
-                        case EventCommandType.ConditionalBranch:
-                            branchIds.AddRange(((ConditionalBranchCommand)command).BranchIds);
-
-                            break;
-                        case EventCommandType.ChangeSpells:
-                            branchIds.AddRange(((ChangeSpellsCommand)command).BranchIds);
-
-                            break;
-                        case EventCommandType.ChangeItems:
-                            branchIds.AddRange(((ChangeItemsCommand)command).BranchIds);
-
-                            break;
-                        case EventCommandType.StartQuest:
-                            branchIds.AddRange(((StartQuestCommand)command).BranchIds);
-
-                            break;
-                        case EventCommandType.Label:
-                            //See if we found the label!
-                            if (((LabelCommand)command).Label == label)
-                            {
-                                return true;
-                            }
-
-                            break;
-                    }
-
-                    //Test each branch
-                    foreach (var branch in branchIds)
-                    {
-                        if (page.CommandLists.ContainsKey(branch))
+                        evt.Value.PageInstance.MoveRoute.CopyFrom(command.Route);
+                        evt.Value.PageInstance.MovementType = EventMovementType.MoveRoute;
+                        if (evt.Value.PageInstance.GlobalClone != null)
                         {
-                            var tmpStack = new CommandInstance(page)
-                            {
-                                CommandList = page.CommandLists[branch],
-                                CommandIndex = 0,
-                            };
-
-                            stack.Peek().CommandIndex++;
-                            stack.Push(tmpStack);
-                            if (FindLabelResursive(stack, page, tmpStack.CommandList, label))
-                            {
-                                return true;
-                            }
-
-                            stack.Peek().CommandIndex--;
+                            evt.Value.PageInstance.GlobalClone.MovementType = EventMovementType.MoveRoute;
                         }
                     }
-
-                    stack.Peek().CommandIndex++;
                 }
-
-                stack.Pop(); //We made it through a list
             }
-
-            return false;
         }
+    }
 
-        public static string ParseEventText(string input, Player player, Event instance)
+    //Wait for Route Completion Command
+    private static void ProcessCommand(
+        WaitForRouteCommand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        if (command.TargetId == Guid.Empty)
         {
-            if (input == null)
+            stackInfo.WaitingForRoute = player.Id;
+            stackInfo.WaitingForRouteMap = player.MapId;
+        }
+        else
+        {
+            foreach (var evt in player.EventLookup)
             {
-                input = "";
+                if (evt.Value.BaseEvent.Id == command.TargetId)
+                {
+                    stackInfo.WaitingForRoute = evt.Value.BaseEvent.Id;
+                    stackInfo.WaitingForRouteMap = evt.Value.MapId;
+
+                    break;
+                }
             }
+        }
+    }
 
-            if (player != null && input.Contains("\\"))
+    //Spawn Npc Command
+    private static void ProcessCommand(
+        SpawnNpcCommand command,
+        Player player,
+        Event eventInstance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        var npcId = command.NpcId;
+        var mapId = command.MapId;
+        var tileX = 0;
+        var tileY = 0;
+        Direction direction = (byte)Direction.Up;
+        var targetEntity = (Entity)player;
+        if (mapId != Guid.Empty)
+        {
+            tileX = command.X;
+            tileY = command.Y;
+            direction = command.Dir;
+        }
+        else
+        {
+            if (command.EntityId != Guid.Empty)
             {
-                var sb = new StringBuilder(input);
-                var time = Time.GetTime();
-                var replacements = new Dictionary<string, string>()
+                foreach (var evt in player.EventLookup)
                 {
-                    { Strings.Events.playernamecommand, player.Name },
-                    { Strings.Events.playerguildcommand, player.Guild?.Name ?? "" },
-                    { Strings.Events.timehour, Time.Hour },
-                    { Strings.Events.militaryhour, Time.MilitaryHour },
-                    { Strings.Events.timeminute, Time.Minute },
-                    { Strings.Events.timesecond, Time.Second },
-                    { Strings.Events.timeperiod, time.Hour >= 12 ? Strings.Events.periodevening : Strings.Events.periodmorning },
-                    { Strings.Events.onlinecountcommand, Player.OnlineCount.ToString() },
-                    { Strings.Events.onlinelistcommand, input.Contains(Strings.Events.onlinelistcommand) ? string.Join(", ", Player.OnlineList.Select(p => p.Name).ToList()) : "" },
-                    { Strings.Events.eventnamecommand, instance?.PageInstance?.Name ?? "" },
-                    { Strings.Events.commandparameter, instance?.PageInstance?.Param ?? "" },
-                    { Strings.Events.eventparams, (instance != null && input.Contains(Strings.Events.eventparams)) ? instance.FormatParameters(player) : "" },
-
-                };
-
-                foreach (var val in replacements)
-                {
-                    if (input.Contains(val.Key))
-                        sb.Replace(val.Key, val.Value);
-                }
-
-                foreach (var val in DbInterface.ServerVariableEventTextLookup)
-                {
-                    if (input.Contains(val.Key))
-                        sb.Replace(val.Key, (val.Value).Value.ToString((val.Value).Type));
-                }
-
-                foreach (var val in DbInterface.PlayerVariableEventTextLookup)
-                {
-                    if (input.Contains(val.Key))
-                        sb.Replace(val.Key, player.GetVariableValue(val.Value.Id).ToString((val.Value).Type));
-                }
-
-                foreach (var val in DbInterface.GuildVariableEventTextLookup)
-                {
-                    if (input.Contains(val.Key))
-                        sb.Replace(val.Key, (player.Guild?.GetVariableValue(val.Value.Id) ?? new VariableValue()).ToString((val.Value).Type));
-                }
-
-                foreach (var val in DbInterface.UserVariableEventTextLookup)
-                {
-                    if (input.Contains(val.Key))
-                        sb.Replace(val.Key, (player.User.GetVariableValue(val.Value.Id) ?? new VariableValue()).ToString((val.Value).Type));
-                }
-
-                if (instance != null)
-                {
-                    var parms = instance.GetParams(player);
-                    foreach (var val in parms)
+                    if (evt.Value.MapId != eventInstance.MapId)
                     {
-                        sb.Replace(Strings.Events.eventparam + "{" + val.Key + "}", val.Value);
+                        continue;
+                    }
+
+                    if (evt.Value.BaseEvent.Id == command.EntityId)
+                    {
+                        targetEntity = evt.Value.PageInstance;
+
+                        break;
                     }
                 }
-
-                return sb.ToString();
             }
 
-            return input;
-        }
-
-        private static void ProcessVariableModification(
-            SetVariableCommand command,
-            GameObjects.Events.VariableMod mod,
-            Player player,
-            Event instance
-        )
-        {
-        }
-
-        private static void ProcessVariableModification(
-            SetVariableCommand command,
-            BooleanVariableMod mod,
-            Player player,
-            Event instance
-        )
-        {
-            VariableValue value = null;
-            Guild guild = null;
-
-            if (command.VariableType == VariableType.PlayerVariable)
+            if (targetEntity != null)
             {
-                value = player.GetVariableValue(command.VariableId);
-            }
-            else if (command.VariableType == VariableType.ServerVariable)
-            {
-                value = ServerVariableBase.Get(command.VariableId)?.Value;
-            }
-            else if (command.VariableType == VariableType.GuildVariable)
-            {
-                guild = player.Guild;
-                if (guild == null)
+                int xDiff = command.X;
+                int yDiff = command.Y;
+                if (command.Dir == Direction.Down)
                 {
+                    var tmp = 0;
+                    switch (targetEntity.Dir)
+                    {
+                        case Direction.Down:
+                            yDiff *= -1;
+                            xDiff *= -1;
+
+                            break;
+                        case Direction.Left:
+                            tmp = yDiff;
+                            yDiff = xDiff;
+                            xDiff = tmp;
+
+                            break;
+                        case Direction.Right:
+                            tmp = yDiff;
+                            yDiff = xDiff;
+                            xDiff = -tmp;
+
+                            break;
+                    }
+
+                    direction = targetEntity.Dir;
+                }
+
+                mapId = targetEntity.MapId;
+                tileX = (byte)(targetEntity.X + xDiff);
+                tileY = (byte)(targetEntity.Y + yDiff);
+            }
+            else
+            {
+                return;
+            }
+        }
+
+        var tile = new TileHelper(mapId, tileX, tileY);
+        if (tile.TryFix() && MapController.TryGetInstanceFromMap(mapId, player.MapInstanceId, out var instance))
+        {
+            var npc = instance.SpawnNpc((byte)tileX, (byte)tileY, direction, npcId, true);
+            player.SpawnedNpcs.Add(npc);
+        }
+    }
+
+    //Despawn Npcs Command
+    private static void ProcessCommand(
+        DespawnNpcCommand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        foreach (var entity in player.SpawnedNpcs.ToArray())
+        {
+            if (entity is Npc npc && npc.Despawnable == true)
+            {
+                lock (player.EntityLock)
+                {
+                    npc.Die();
+                }
+            }
+        }
+
+        player.SpawnedNpcs.Clear();
+    }
+
+    //Play Animation Command
+    private static void ProcessCommand(
+        PlayAnimationCommand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        //Playing an animations requires a target type/target or just a tile.
+        //We need an animation number and whether or not it should rotate (and the direction I guess)
+        var animId = command.AnimationId;
+        var mapId = command.MapId;
+        var tileX = 0;
+        var tileY = 0;
+        var direction = Direction.Up;
+        var targetEntity = (Entity)player;
+        if (mapId != Guid.Empty)
+        {
+            tileX = command.X;
+            tileY = command.Y;
+            direction = (Direction)command.Dir;
+        }
+        else
+        {
+            if (command.EntityId != Guid.Empty)
+            {
+                foreach (var evt in player.EventLookup)
+                {
+                    if (evt.Value.MapId != instance.MapId)
+                    {
+                        continue;
+                    }
+
+                    if (evt.Value.BaseEvent.Id == command.EntityId)
+                    {
+                        targetEntity = evt.Value.PageInstance;
+
+                        break;
+                    }
+                }
+            }
+
+            if (targetEntity != null)
+            {
+                if (command.X == 0 && command.Y == 0 && command.Dir == 0)
+                {
+                    var targetType = targetEntity.GetEntityType() == EntityType.Event ? 2 : 1;
+                    //Attach to entity instead of playing on tile
+                    if (command.InstanceToPlayer)
+                    {
+                        PacketSender.SendAnimationTo(
+                            animId, targetType, targetEntity.Id, targetEntity.MapId, 0, 0, 0, player
+                        );
+                    }
+                    else
+                    {
+                        PacketSender.SendAnimationToProximity(
+                            animId, targetType, targetEntity.Id,
+                            targetEntity.MapId, 0, 0, 0, targetEntity.MapInstanceId
+                        );
+                    }
+
                     return;
                 }
-                value = guild.GetVariableValue(command.VariableId) ?? new VariableValue();
-            }
-            else if (command.VariableType == VariableType.UserVariable)
-            {
-                value = player.User.GetVariableValue(command.VariableId);
-            }
 
-            if (value == null)
-            {
-                value = new VariableValue();
-            }
-
-            var originalValue = value.Boolean;
-
-            if (mod.DuplicateVariableId != Guid.Empty)
-            {
-                if (mod.DupVariableType == VariableType.PlayerVariable)
+                int xDiff = command.X;
+                int yDiff = command.Y;
+                if (command.Dir == 1)
                 {
-                    value.Boolean = player.GetVariableValue(mod.DuplicateVariableId).Boolean;
-                }
-                else if (mod.DupVariableType == VariableType.ServerVariable)
-                {
-                    var variable = ServerVariableBase.Get(mod.DuplicateVariableId);
-                    if (variable != null)
+                    var tmp = 0;
+                    switch (targetEntity.Dir)
                     {
-                        value.Boolean = ServerVariableBase.Get(mod.DuplicateVariableId).Value.Boolean;
+                        case Direction.Down:
+                            yDiff *= -1;
+                            xDiff *= -1;
+
+                            break;
+                        case Direction.Left:
+                            tmp = yDiff;
+                            yDiff = xDiff;
+                            xDiff = tmp;
+
+                            break;
+                        case Direction.Right:
+                            tmp = yDiff;
+                            yDiff = xDiff;
+                            xDiff = -tmp;
+
+                            break;
+                    }
+
+                    direction = targetEntity.Dir;
+                }
+
+                mapId = targetEntity.MapId;
+                tileX = targetEntity.X + xDiff;
+                tileY = targetEntity.Y + yDiff;
+            }
+            else
+            {
+                return;
+            }
+        }
+
+        var tile = new TileHelper(mapId, tileX, tileY);
+        if (tile.TryFix())
+        {
+            if (command.InstanceToPlayer)
+            {
+                PacketSender.SendAnimationTo(
+                    animId, -1, Guid.Empty, tile.GetMapId(), tile.GetX(), tile.GetY(), direction, player
+                );
+            }
+            else
+            {
+                PacketSender.SendAnimationToProximity(
+                    animId, -1, Guid.Empty, tile.GetMapId(), tile.GetX(), tile.GetY(), direction, player.MapInstanceId
+                );
+            }
+        }
+    }
+
+    //Hold Player Command
+    private static void ProcessCommand(
+        HoldPlayerCommand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        instance.HoldingPlayer = true;
+        PacketSender.SendHoldPlayer(player, instance.BaseEvent.Id, instance.BaseEvent.MapId);
+    }
+
+    //Release Player Command
+    private static void ProcessCommand(
+        ReleasePlayerCommand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        instance.HoldingPlayer = false;
+        PacketSender.SendReleasePlayer(player, instance.BaseEvent.Id);
+    }
+
+    //Hide Player Command
+    private static void ProcessCommand(
+        HidePlayerCommand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        player.HideEntity = true;
+        player.HideName = true;
+        PacketSender.SendEntityDataToProximity(player);
+    }
+
+    //Show Player Command
+    private static void ProcessCommand(
+        ShowPlayerCommand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        player.HideEntity = false;
+        player.HideName = false;
+        PacketSender.SendEntityDataToProximity(player);
+    }
+
+    //Play Bgm Command
+    private static void ProcessCommand(
+        PlayBgmCommand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        PacketSender.SendPlayMusic(player, command.File);
+    }
+
+    //Fadeout Bgm Command
+    private static void ProcessCommand(
+        FadeoutBgmCommand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        PacketSender.SendFadeMusic(player);
+    }
+
+    //Play Sound Command
+    private static void ProcessCommand(
+        PlaySoundCommand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        PacketSender.SendPlaySound(player, command.File);
+    }
+
+    //Stop Sounds Command
+    private static void ProcessCommand(
+        StopSoundsCommand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        PacketSender.SendStopSounds(player);
+    }
+
+    //Show Picture Command
+    private static void ProcessCommand(
+        ShowPictureCommand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        var id = Guid.Empty;
+        var shouldWait = command.WaitUntilClosed && (command.Clickable || command.HideTime > 0);
+        if (shouldWait)
+        {
+            id = instance.PageInstance.Id;
+            stackInfo.WaitingForResponse = CommandInstance.EventResponse.Picture;
+        }
+
+        PacketSender.SendShowPicture(player, command.File, command.Size, command.Clickable, command.HideTime, id);
+    }
+
+    //Hide Picture Command
+    private static void ProcessCommand(
+        HidePictureCommmand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        PacketSender.SendHidePicture(player);
+    }
+
+    //Wait Command
+    private static void ProcessCommand(
+        WaitCommand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        instance.WaitTimer = Timing.Global.Milliseconds + command.Time;
+        callStack.Peek().WaitingForResponse = CommandInstance.EventResponse.Timer;
+    }
+
+    //Open Bank Command
+    private static void ProcessCommand(
+        OpenBankCommand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        player.OpenBank();
+        callStack.Peek().WaitingForResponse = CommandInstance.EventResponse.Bank;
+    }
+
+    //Open Shop Command
+    private static void ProcessCommand(
+        OpenShopCommand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        player.OpenShop(ShopBase.Get(command.ShopId));
+        callStack.Peek().WaitingForResponse = CommandInstance.EventResponse.Shop;
+    }
+
+    //Open Crafting Table Command
+    private static void ProcessCommand(
+        OpenCraftingTableCommand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        player.OpenCraftingTable(CraftingTableBase.Get(command.CraftingTableId), command.JournalMode);
+        callStack.Peek().WaitingForResponse = CommandInstance.EventResponse.Crafting;
+    }
+
+    //Set Class Command
+    private static void ProcessCommand(
+        SetClassCommand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        if (ClassBase.Get(command.ClassId) != null)
+        {
+            player.ClassId = command.ClassId;
+            player.RecalculateStatsAndPoints();
+            player.UnequipInvalidItems();
+        }
+
+        PacketSender.SendEntityDataToProximity(player);
+    }
+
+    //Start Quest Command
+    private static void ProcessCommand(
+        StartQuestCommand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        var success = false;
+        var quest = QuestBase.Get(command.QuestId);
+        if (quest != null)
+        {
+            if (player.CanStartQuest(quest))
+            {
+                if (command.Offer)
+                {
+                    player.OfferQuest(quest);
+                    stackInfo.WaitingForResponse = CommandInstance.EventResponse.Quest;
+                    stackInfo.BranchIds = command.BranchIds;
+                    stackInfo.WaitingOnCommand = command;
+
+                    return;
+                }
+                else
+                {
+                    player.StartQuest(quest);
+                    success = true;
+                }
+            }
+        }
+
+        List<EventCommand> newCommandList = null;
+        if (success && stackInfo.Page.CommandLists.ContainsKey(command.BranchIds[0]))
+        {
+            newCommandList = stackInfo.Page.CommandLists[command.BranchIds[0]];
+        }
+
+        if (!success && stackInfo.Page.CommandLists.ContainsKey(command.BranchIds[1]))
+        {
+            newCommandList = stackInfo.Page.CommandLists[command.BranchIds[1]];
+        }
+
+        var tmpStack = new CommandInstance(stackInfo.Page)
+        {
+            CommandList = newCommandList,
+            CommandIndex = 0,
+        };
+
+        callStack.Push(tmpStack);
+    }
+
+    //Complete Quest Task Command
+    private static void ProcessCommand(
+        CompleteQuestTaskCommand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        player.CompleteQuestTask(command.QuestId, command.TaskId);
+    }
+
+    //End Quest Command
+    private static void ProcessCommand(
+        EndQuestCommand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        player.CompleteQuest(command.QuestId, command.SkipCompletionEvent);
+    }
+
+    // Change Player Color Command
+    private static void ProcessCommand(
+        ChangePlayerColorCommand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        player.Color = command.Color;
+        PacketSender.SendEntityDataToProximity(player);
+    }
+
+    private static void ProcessCommand(
+        ChangeNameCommand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        var success = false;
+
+        var variable = PlayerVariableBase.Get(command.VariableId);
+        if (variable != null)
+        {
+            if (variable.Type == VariableDataType.String)
+            {
+                var data = player.GetVariable(variable.Id)?.Value;
+                if (data != null)
+                {
+                    success = player.TryChangeName(data.String);
+                }
+            }
+        }
+
+        List<EventCommand> newCommandList = null;
+        if (success && stackInfo.Page.CommandLists.ContainsKey(command.BranchIds[0]))
+        {
+            newCommandList = stackInfo.Page.CommandLists[command.BranchIds[0]];
+        }
+
+        if (!success && stackInfo.Page.CommandLists.ContainsKey(command.BranchIds[1]))
+        {
+            newCommandList = stackInfo.Page.CommandLists[command.BranchIds[1]];
+        }
+
+        var tmpStack = new CommandInstance(stackInfo.Page)
+        {
+            CommandList = newCommandList,
+            CommandIndex = 0,
+        };
+
+        callStack.Push(tmpStack);
+    }
+
+    //Create Guild Command
+    private static void ProcessCommand(
+        CreateGuildCommand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        var success = false;
+        var playerVariable = PlayerVariableBase.Get(command.VariableId);
+
+        // We only accept Strings as our Guild Names!
+        if (playerVariable.Type == VariableDataType.String)
+        {
+            // Get our intended guild name
+            var gname = player.GetVariable(playerVariable.Id)?.Value.String?.Trim();
+
+            // Can we use this name according to our configuration?
+            if (gname != null && FieldChecking.IsValidGuildName(gname, Strings.Regex.guildname))
+            {
+                // Is the name already in use?
+                if (Guild.GetGuild(gname) == null)
+                {
+                    // Is the player already in a guild?
+                    if (player.Guild == null)
+                    {
+                        // Finally, we can actually MAKE this guild happen!
+                        var guild = Guild.CreateGuild(player, gname);
+                        if (guild != null)
+                        {
+                            // Send them a welcome message!
+                            PacketSender.SendChatMsg(player, Strings.Guilds.Welcome.ToString(gname), ChatMessageType.Guild, CustomColors.Alerts.Success);
+
+                            // Denote that we were successful.
+                            success = true;
+                        }
+                    }
+                    else
+                    {
+                        // This cheeky bugger is already in a guild, tell him so!
+                        PacketSender.SendChatMsg(player, Strings.Guilds.AlreadyInGuild, ChatMessageType.Guild, CustomColors.Alerts.Error);
                     }
                 }
-                else if (mod.DupVariableType == VariableType.GuildVariable)
+                else
                 {
-                    if (player.Guild != null)
-                    {
-                        value.Boolean = player.Guild.GetVariableValue(mod.DuplicateVariableId).Boolean;
-                    }
-                }
-                else if (mod.DupVariableType == VariableType.UserVariable)
-                {
-                    var variable = UserVariableBase.Get(mod.DuplicateVariableId);
-                    if (variable != null)
-                    {
-                        value.Boolean = player.User.GetVariableValue(mod.DuplicateVariableId).Value.Boolean;
-                    }
+                    // This name already exists, oh dear!
+                    PacketSender.SendChatMsg(player, Strings.Guilds.GuildNameInUse, ChatMessageType.Guild, CustomColors.Alerts.Error);
                 }
             }
             else
             {
-                value.Boolean = mod.Value;
+                // Let our player know they need to adjust their name.
+                PacketSender.SendChatMsg(player, Strings.Guilds.VariableInvalid, ChatMessageType.Guild, CustomColors.Alerts.Error);
+            }
+        }
+        else
+        {
+            // Notify the user that something went wrong, the user really shouldn't see this.. Assuming the creator set up his events properly.
+            PacketSender.SendChatMsg(player, Strings.Guilds.VariableNotString, ChatMessageType.Guild, CustomColors.Alerts.Error);
+        }
+
+        List<EventCommand> newCommandList = null;
+        if (success && stackInfo.Page.CommandLists.ContainsKey(command.BranchIds[0]))
+        {
+            newCommandList = stackInfo.Page.CommandLists[command.BranchIds[0]];
+        }
+
+        if (!success && stackInfo.Page.CommandLists.ContainsKey(command.BranchIds[1]))
+        {
+            newCommandList = stackInfo.Page.CommandLists[command.BranchIds[1]];
+        }
+
+        var tmpStack = new CommandInstance(stackInfo.Page)
+        {
+            CommandList = newCommandList,
+            CommandIndex = 0,
+        };
+
+        callStack.Push(tmpStack);
+    }
+
+    private static void ProcessCommand(
+        DisbandGuildCommand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        var success = false;
+
+        // Is this player in a guild?
+        if (player.Guild != null)
+        {
+            // Send the members a notification, then start wiping the guild from existence through sheer willpower!
+            PacketSender.SendGuildMsg(player, Strings.Guilds.DisbandGuild.ToString(player.Guild.Name), CustomColors.Alerts.Info);
+            Guild.DeleteGuild(player.Guild, player);
+            player.UnequipInvalidItems();
+
+            // :(
+            success = true;
+        }
+        else
+        {
+            // They're not in a guild.. tell them?
+            PacketSender.SendChatMsg(player, Strings.Guilds.NotInGuild, ChatMessageType.Guild, CustomColors.Alerts.Error);
+        }
+
+        List<EventCommand> newCommandList = null;
+        if (success && stackInfo.Page.CommandLists.ContainsKey(command.BranchIds[0]))
+        {
+            newCommandList = stackInfo.Page.CommandLists[command.BranchIds[0]];
+        }
+
+        if (!success && stackInfo.Page.CommandLists.ContainsKey(command.BranchIds[1]))
+        {
+            newCommandList = stackInfo.Page.CommandLists[command.BranchIds[1]];
+        }
+
+        var tmpStack = new CommandInstance(stackInfo.Page)
+        {
+            CommandList = newCommandList,
+            CommandIndex = 0,
+        };
+
+        callStack.Push(tmpStack);
+    }
+
+    //Open Guild Bank Command
+    private static void ProcessCommand(
+        OpenGuildBankCommand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        player.OpenBank(true);
+        callStack.Peek().WaitingForResponse = CommandInstance.EventResponse.Bank;
+    }
+
+
+    //Open Guild Bank Slots Count Command
+    private static void ProcessCommand(
+        SetGuildBankSlotsCommand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        var quantity = 0;
+        switch (command.VariableType)
+        {
+            case VariableType.PlayerVariable:
+                quantity = (int)player.GetVariableValue(command.VariableId).Integer;
+
+                break;
+            case VariableType.ServerVariable:
+                quantity = (int)ServerVariableBase.Get(command.VariableId)?.Value.Integer;
+
+                break;
+            case VariableType.GuildVariable:
+                quantity = (int)player.Guild?.GetVariableValue(command.VariableId)?.Integer;
+
+                break;
+        }
+        var guild = player.Guild;
+        if (quantity > 0 && guild != null && guild.BankSlotsCount != quantity)
+        {
+            guild.ExpandBankSlots(quantity);
+        }
+    }
+
+    //Reset Stat Point Allocations Command
+    private static void ProcessCommand(
+        ResetStatPointAllocationsCommand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        for (var i = 0; i < Enum.GetValues<Stat>().Length; i++)
+        {
+            player.StatPointAllocations[i] = 0;
+        }
+        player.RecalculateStatsAndPoints();
+        player.UnequipInvalidItems();
+        PacketSender.SendEntityDataToProximity(player);
+    }
+
+    // Cast Spell On command
+    private static void ProcessCommand(
+       CastSpellOn command,
+       Player player,
+       Event instance,
+       CommandInstance stackInfo,
+       Stack<CommandInstance> callStack
+   )
+    {
+        if (player == null || !player.Online)
+        {
+            return;
+        }
+
+        List<Player> affectedPlayers = new List<Player>();
+
+        if (command.Self)
+        {
+            affectedPlayers.Add(player);
+        }
+
+        if (command.PartyMembers && player.IsInParty)
+        {
+            affectedPlayers.AddRange(player.Party.Where(pl => pl.Id != player.Id));
+        }
+
+        if (command.GuildMembers && player.IsInGuild)
+        {
+            affectedPlayers.AddRange(player.Guild.FindOnlineMembers().Where(pl => pl.Id != player.Id));
+        }
+
+        foreach (var affectedPlayer in affectedPlayers.DistinctBy(pl => pl.Id))
+        {
+            if (!affectedPlayer.Online)
+            {
+                continue;
             }
 
-            var changed = value.Boolean != originalValue;
+            affectedPlayer?.CastSpell(command.SpellId);
+        }
+    }
 
-            if (command.VariableType == VariableType.PlayerVariable)
+    private static void ProcessCommand(
+       ScreenFadeCommand command,
+       Player player,
+       Event instance,
+       CommandInstance stackInfo,
+       Stack<CommandInstance> callStack
+    )
+    {
+        if (player == null || !player.Online)
+        {
+            return;
+        }
+
+        player.IsFading = command.WaitForCompletion;
+        PacketSender.SendFade(player, command.FadeType, command.WaitForCompletion, command.DurationMs);
+
+        if (command.WaitForCompletion)
+        {
+            callStack.Peek().WaitingForResponse = CommandInstance.EventResponse.Fade;
+        }
+    }
+
+    private static Stack<CommandInstance> LoadLabelCallstack(string label, EventPage currentPage)
+    {
+        var newStack = new Stack<CommandInstance>();
+        newStack.Push(new CommandInstance(currentPage)); //Start from the top
+        if (FindLabelResursive(newStack, currentPage, newStack.Peek().CommandList, label))
+        {
+            return newStack;
+        }
+
+        return null;
+    }
+
+    private static bool FindLabelResursive(
+        Stack<CommandInstance> stack,
+        EventPage page,
+        List<EventCommand> commandList,
+        string label
+    )
+    {
+        if (page.CommandLists.ContainsValue(commandList))
+        {
+            while (stack.Peek().CommandIndex < commandList.Count)
             {
-                if (changed)
+                var command = commandList[stack.Peek().CommandIndex];
+                var branchIds = new List<Guid>();
+                switch (command.Type)
                 {
+                    case EventCommandType.ShowOptions:
+                        branchIds.AddRange(((ShowOptionsCommand)command).BranchIds);
 
-                }
+                        break;
+                    case EventCommandType.InputVariable:
+                        branchIds.AddRange(((InputVariableCommand)command).BranchIds);
 
-                // Set the party member switches too if Sync Party enabled!
-                if (command.SyncParty)
-                {
-                    if (changed)
-                    {
-                        player.StartCommonEventsWithTrigger(CommonEventTrigger.PlayerVariableChange, "", command.VariableId.ToString());
-                    }
+                        break;
+                    case EventCommandType.ConditionalBranch:
+                        branchIds.AddRange(((ConditionalBranchCommand)command).BranchIds);
 
-                    foreach (var partyMember in player.Party)
-                    {
-                        if (partyMember != player)
+                        break;
+                    case EventCommandType.ChangeSpells:
+                        branchIds.AddRange(((ChangeSpellsCommand)command).BranchIds);
+
+                        break;
+                    case EventCommandType.ChangeItems:
+                        branchIds.AddRange(((ChangeItemsCommand)command).BranchIds);
+
+                        break;
+                    case EventCommandType.StartQuest:
+                        branchIds.AddRange(((StartQuestCommand)command).BranchIds);
+
+                        break;
+                    case EventCommandType.Label:
+                        //See if we found the label!
+                        if (((LabelCommand)command).Label == label)
                         {
-                            partyMember.SetSwitchValue(command.VariableId, mod.Value);
+                            return true;
                         }
+
+                        break;
+                }
+
+                //Test each branch
+                foreach (var branch in branchIds)
+                {
+                    if (page.CommandLists.ContainsKey(branch))
+                    {
+                        var tmpStack = new CommandInstance(page)
+                        {
+                            CommandList = page.CommandLists[branch],
+                            CommandIndex = 0,
+                        };
+
+                        stack.Peek().CommandIndex++;
+                        stack.Push(tmpStack);
+                        if (FindLabelResursive(stack, page, tmpStack.CommandList, label))
+                        {
+                            return true;
+                        }
+
+                        stack.Peek().CommandIndex--;
                     }
                 }
+
+                stack.Peek().CommandIndex++;
             }
-            else if (command.VariableType == VariableType.ServerVariable)
+
+            stack.Pop(); //We made it through a list
+        }
+
+        return false;
+    }
+
+    public static string ParseEventText(string input, Player player, Event instance)
+    {
+        if (input == null)
+        {
+            input = "";
+        }
+
+        if (player != null && input.Contains("\\"))
+        {
+            var sb = new StringBuilder(input);
+            var time = Time.GetTime();
+            var replacements = new Dictionary<string, string>()
             {
-                if (changed)
+                { Strings.Events.playernamecommand, player.Name },
+                { Strings.Events.playerguildcommand, player.Guild?.Name ?? "" },
+                { Strings.Events.timehour, Time.Hour },
+                { Strings.Events.militaryhour, Time.MilitaryHour },
+                { Strings.Events.timeminute, Time.Minute },
+                { Strings.Events.timesecond, Time.Second },
+                { Strings.Events.timeperiod, time.Hour >= 12 ? Strings.Events.periodevening : Strings.Events.periodmorning },
+                { Strings.Events.onlinecountcommand, Player.OnlineCount.ToString() },
+                { Strings.Events.onlinelistcommand, input.Contains(Strings.Events.onlinelistcommand) ? string.Join(", ", Player.OnlineList.Select(p => p.Name).ToList()) : "" },
+                { Strings.Events.eventnamecommand, instance?.PageInstance?.Name ?? "" },
+                { Strings.Events.commandparameter, instance?.PageInstance?.Param ?? "" },
+                { Strings.Events.eventparams, (instance != null && input.Contains(Strings.Events.eventparams)) ? instance.FormatParameters(player) : "" },
+
+            };
+
+            foreach (var val in replacements)
+            {
+                if (input.Contains(val.Key))
+                    sb.Replace(val.Key, val.Value);
+            }
+
+            foreach (var val in DbInterface.ServerVariableEventTextLookup)
+            {
+                if (input.Contains(val.Key))
+                    sb.Replace(val.Key, (val.Value).Value.ToString((val.Value).Type));
+            }
+
+            foreach (var val in DbInterface.PlayerVariableEventTextLookup)
+            {
+                if (input.Contains(val.Key))
+                    sb.Replace(val.Key, player.GetVariableValue(val.Value.Id).ToString((val.Value).Type));
+            }
+
+            foreach (var val in DbInterface.GuildVariableEventTextLookup)
+            {
+                if (input.Contains(val.Key))
+                    sb.Replace(val.Key, (player.Guild?.GetVariableValue(val.Value.Id) ?? new VariableValue()).ToString((val.Value).Type));
+            }
+
+            foreach (var val in DbInterface.UserVariableEventTextLookup)
+            {
+                if (input.Contains(val.Key))
+                    sb.Replace(val.Key, (player.User.GetVariableValue(val.Value.Id) ?? new VariableValue()).ToString((val.Value).Type));
+            }
+
+            if (instance != null)
+            {
+                var parms = instance.GetParams(player);
+                foreach (var val in parms)
                 {
-                    Player.StartCommonEventsWithTriggerForAll(CommonEventTrigger.ServerVariableChange, "", command.VariableId.ToString());
-                    DbInterface.UpdatedServerVariables.AddOrUpdate(command.VariableId, ServerVariableBase.Get(command.VariableId), (key, oldValue) => ServerVariableBase.Get(command.VariableId));
+                    sb.Replace(Strings.Events.eventparam + "{" + val.Key + "}", val.Value);
                 }
             }
-            else if (command.VariableType == VariableType.GuildVariable)
+
+            return sb.ToString();
+        }
+
+        return input;
+    }
+
+    private static void ProcessVariableModification(
+        SetVariableCommand command,
+        GameObjects.Events.VariableMod mod,
+        Player player,
+        Event instance
+    )
+    {
+    }
+
+    private static void ProcessVariableModification(
+        SetVariableCommand command,
+        BooleanVariableMod mod,
+        Player player,
+        Event instance
+    )
+    {
+        VariableValue value = null;
+        Guild guild = null;
+
+        if (command.VariableType == VariableType.PlayerVariable)
+        {
+            value = player.GetVariableValue(command.VariableId);
+        }
+        else if (command.VariableType == VariableType.ServerVariable)
+        {
+            value = ServerVariableBase.Get(command.VariableId)?.Value;
+        }
+        else if (command.VariableType == VariableType.GuildVariable)
+        {
+            guild = player.Guild;
+            if (guild == null)
             {
-                if (changed)
+                return;
+            }
+            value = guild.GetVariableValue(command.VariableId) ?? new VariableValue();
+        }
+        else if (command.VariableType == VariableType.UserVariable)
+        {
+            value = player.User.GetVariableValue(command.VariableId);
+        }
+
+        if (value == null)
+        {
+            value = new VariableValue();
+        }
+
+        var originalValue = value.Boolean;
+
+        if (mod.DuplicateVariableId != Guid.Empty)
+        {
+            if (mod.DupVariableType == VariableType.PlayerVariable)
+            {
+                value.Boolean = player.GetVariableValue(mod.DuplicateVariableId).Boolean;
+            }
+            else if (mod.DupVariableType == VariableType.ServerVariable)
+            {
+                var variable = ServerVariableBase.Get(mod.DuplicateVariableId);
+                if (variable != null)
                 {
-                    guild.StartCommonEventsWithTriggerForAll(CommonEventTrigger.GuildVariableChange, "", command.VariableId.ToString());
-                    guild.UpdatedVariables.AddOrUpdate(command.VariableId, GuildVariableBase.Get(command.VariableId), (key, oldValue) => GuildVariableBase.Get(command.VariableId));
+                    value.Boolean = ServerVariableBase.Get(mod.DuplicateVariableId).Value.Boolean;
                 }
             }
-            else if (command.VariableType == VariableType.UserVariable)
+            else if (mod.DupVariableType == VariableType.GuildVariable)
             {
-                if (changed)
+                if (player.Guild != null)
                 {
-                    player.User.StartCommonEventsWithTriggerForAll(CommonEventTrigger.UserVariableChange, "", command.VariableId.ToString());
-                    player.User.UpdatedVariables.AddOrUpdate(command.VariableId, UserVariableBase.Get(command.VariableId), (key, oldValue) => UserVariableBase.Get(command.VariableId));
+                    value.Boolean = player.Guild.GetVariableValue(mod.DuplicateVariableId).Boolean;
+                }
+            }
+            else if (mod.DupVariableType == VariableType.UserVariable)
+            {
+                var variable = UserVariableBase.Get(mod.DuplicateVariableId);
+                if (variable != null)
+                {
+                    value.Boolean = player.User.GetVariableValue(mod.DuplicateVariableId).Value.Boolean;
                 }
             }
         }
-
-        private static void ProcessVariableModification(
-            SetVariableCommand command,
-            IntegerVariableMod mod,
-            Player player,
-            Event instance
-        )
+        else
         {
-            VariableValue value = null;
-            Guild guild = null;
+            value.Boolean = mod.Value;
+        }
 
-            if (command.VariableType == VariableType.PlayerVariable)
+        var changed = value.Boolean != originalValue;
+
+        if (command.VariableType == VariableType.PlayerVariable)
+        {
+            if (changed)
             {
-                value = player.GetVariableValue(command.VariableId);
-            }
-            else if (command.VariableType == VariableType.ServerVariable)
-            {
-                value = ServerVariableBase.Get(command.VariableId)?.Value;
-            }
-            else if (command.VariableType == VariableType.GuildVariable)
-            {
-                guild = player.Guild;
-                if (guild == null)
-                {
-                    return;
-                }
-                value = guild.GetVariableValue(command.VariableId);
-            }
-            else if (command.VariableType == VariableType.UserVariable)
-            {
-                value = player.User.GetVariableValue(command.VariableId);
+
             }
 
-            if (value == null)
-            {
-                value = new VariableValue();
-            }
-
-            var originalValue = value.Integer;
-
-            switch (mod.ModType)
-            {
-                case VariableMod.Set:
-                    value.Integer = mod.Value;
-
-                    break;
-                case VariableMod.Add:
-                    value.Integer += mod.Value;
-
-                    break;
-                case VariableMod.Subtract:
-                    value.Integer -= mod.Value;
-
-                    break;
-                case VariableMod.Multiply:
-                    value.Integer *= mod.Value;
-
-                    break;
-                case VariableMod.Divide:
-                    if (mod.Value != 0)  //Idiot proofing divide by 0 LOL
-                    {
-                        value.Integer /= mod.Value;
-                    }
-
-                    break;
-                case VariableMod.LeftShift:
-                    value.Integer = value.Integer << (int)mod.Value;
-
-                    break;
-                case VariableMod.RightShift:
-                    value.Integer = value.Integer >> (int)mod.Value;
-
-                    break;
-                case VariableMod.Random:
-                    //TODO: Fix - Random doesnt work with longs lolz
-                    value.Integer = Randomization.Next((int)mod.Value, (int)mod.HighValue + 1);
-
-                    break;
-                case VariableMod.SystemTime:
-                    value.Integer = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
-
-                    break;
-                case VariableMod.DupPlayerVar:
-                    value.Integer = player.GetVariableValue(mod.DuplicateVariableId).Integer;
-
-                    break;
-                case VariableMod.DupGlobalVar:
-                    var dupServerVariable = ServerVariableBase.Get(mod.DuplicateVariableId);
-                    if (dupServerVariable != null)
-                    {
-                        value.Integer = dupServerVariable.Value.Integer;
-                    }
-
-                    break;
-                case VariableMod.AddPlayerVar:
-                    value.Integer += player.GetVariableValue(mod.DuplicateVariableId).Integer;
-
-                    break;
-                case VariableMod.AddGlobalVar:
-                    var asv = ServerVariableBase.Get(mod.DuplicateVariableId);
-                    if (asv != null)
-                    {
-                        value.Integer += asv.Value.Integer;
-                    }
-
-                    break;
-                case VariableMod.SubtractPlayerVar:
-                    value.Integer -= player.GetVariableValue(mod.DuplicateVariableId).Integer;
-
-                    break;
-                case VariableMod.SubtractGlobalVar:
-                    var ssv = ServerVariableBase.Get(mod.DuplicateVariableId);
-                    if (ssv != null)
-                    {
-                        value.Integer -= ssv.Value.Integer;
-                    }
-
-                    break;
-                case VariableMod.MultiplyPlayerVar:
-                    value.Integer *= player.GetVariableValue(mod.DuplicateVariableId).Integer;
-
-                    break;
-                case VariableMod.MultiplyGlobalVar:
-                    var msv = ServerVariableBase.Get(mod.DuplicateVariableId);
-                    if (msv != null)
-                    {
-                        value.Integer *= msv.Value.Integer;
-                    }
-
-                    break;
-                case VariableMod.DividePlayerVar:
-                    if (player.GetVariableValue(mod.DuplicateVariableId).Integer != 0) //Idiot proofing divide by 0 LOL
-                    {
-                        value.Integer /= player.GetVariableValue(mod.DuplicateVariableId).Integer;
-                    }
-
-                    break;
-                case VariableMod.DivideGlobalVar:
-                    var dsv = ServerVariableBase.Get(mod.DuplicateVariableId);
-                    if (dsv != null)
-                    {
-                        if (dsv.Value != 0) //Idiot proofing divide by 0 LOL
-                        {
-                            value.Integer /= dsv.Value.Integer;
-                        }
-                    }
-
-                    break;
-                case VariableMod.LeftShiftPlayerVar:
-                    value.Integer = value.Integer << (int)player.GetVariableValue(mod.DuplicateVariableId).Integer;
-
-                    break;
-                case VariableMod.LeftShiftGlobalVar:
-                    var lhsv = ServerVariableBase.Get(mod.DuplicateVariableId);
-                    if (lhsv != null)
-                    {
-                        value.Integer = value.Integer << (int)lhsv.Value.Integer;
-                    }
-
-                    break;
-                case VariableMod.RightShiftPlayerVar:
-                    value.Integer = value.Integer >> (int)player.GetVariableValue(mod.DuplicateVariableId).Integer;
-
-                    break;
-                case VariableMod.RightShiftGlobalVar:
-                    var rhsv = ServerVariableBase.Get(mod.DuplicateVariableId);
-                    if (rhsv != null)
-                    {
-                        value.Integer = value.Integer >> (int)rhsv.Value.Integer;
-                    }
-
-                    break;
-            }
-
-            var changed = value.Integer != originalValue;
-
-            if (command.VariableType == VariableType.PlayerVariable)
+            // Set the party member switches too if Sync Party enabled!
+            if (command.SyncParty)
             {
                 if (changed)
                 {
                     player.StartCommonEventsWithTrigger(CommonEventTrigger.PlayerVariableChange, "", command.VariableId.ToString());
                 }
 
-                // Set the party member switches too if Sync Party enabled!
-                if (command.SyncParty)
+                foreach (var partyMember in player.Party)
                 {
-                    foreach (var partyMember in player.Party)
+                    if (partyMember != player)
                     {
-                        if (partyMember != player)
-                        {
-                            partyMember.SetVariableValue(command.VariableId, value.Integer);
-                            partyMember.StartCommonEventsWithTrigger(CommonEventTrigger.PlayerVariableChange, string.Empty, command.VariableId.ToString());
-                        }
+                        partyMember.SetSwitchValue(command.VariableId, mod.Value);
                     }
                 }
             }
-            else if (command.VariableType == VariableType.ServerVariable)
-            {
-                if (changed)
-                {
-                    Player.StartCommonEventsWithTriggerForAll(CommonEventTrigger.ServerVariableChange, "", command.VariableId.ToString());
-                    DbInterface.UpdatedServerVariables.AddOrUpdate(command.VariableId, ServerVariableBase.Get(command.VariableId), (key, oldValue) => ServerVariableBase.Get(command.VariableId));
-                }
-            }
-            else if (command.VariableType == VariableType.GuildVariable)
-            {
-                if (changed)
-                {
-                    guild.StartCommonEventsWithTriggerForAll(CommonEventTrigger.GuildVariableChange, "", command.VariableId.ToString());
-                    guild.UpdatedVariables.AddOrUpdate(command.VariableId, GuildVariableBase.Get(command.VariableId), (key, oldValue) => GuildVariableBase.Get(command.VariableId));
-                }
-            }
-            else if (command.VariableType == VariableType.UserVariable)
-            {
-                if (changed)
-                {
-                    player.User.StartCommonEventsWithTriggerForAll(CommonEventTrigger.UserVariableChange, "", command.VariableId.ToString());
-                    player.User.UpdatedVariables.AddOrUpdate(command.VariableId, UserVariableBase.Get(command.VariableId), (key, oldValue) => UserVariableBase.Get(command.VariableId));
-                }
-            }
         }
-
-        private static void ProcessVariableModification(
-            SetVariableCommand command,
-            StringVariableMod mod,
-            Player player,
-            Event instance
-        )
+        else if (command.VariableType == VariableType.ServerVariable)
         {
-            VariableValue value = null;
-            Guild guild = null;
+            if (changed)
+            {
+                Player.StartCommonEventsWithTriggerForAll(CommonEventTrigger.ServerVariableChange, "", command.VariableId.ToString());
+                DbInterface.UpdatedServerVariables.AddOrUpdate(command.VariableId, ServerVariableBase.Get(command.VariableId), (key, oldValue) => ServerVariableBase.Get(command.VariableId));
+            }
+        }
+        else if (command.VariableType == VariableType.GuildVariable)
+        {
+            if (changed)
+            {
+                guild.StartCommonEventsWithTriggerForAll(CommonEventTrigger.GuildVariableChange, "", command.VariableId.ToString());
+                guild.UpdatedVariables.AddOrUpdate(command.VariableId, GuildVariableBase.Get(command.VariableId), (key, oldValue) => GuildVariableBase.Get(command.VariableId));
+            }
+        }
+        else if (command.VariableType == VariableType.UserVariable)
+        {
+            if (changed)
+            {
+                player.User.StartCommonEventsWithTriggerForAll(CommonEventTrigger.UserVariableChange, "", command.VariableId.ToString());
+                player.User.UpdatedVariables.AddOrUpdate(command.VariableId, UserVariableBase.Get(command.VariableId), (key, oldValue) => UserVariableBase.Get(command.VariableId));
+            }
+        }
+    }
 
-            if (command.VariableType == VariableType.PlayerVariable)
+    private static void ProcessVariableModification(
+        SetVariableCommand command,
+        IntegerVariableMod mod,
+        Player player,
+        Event instance
+    )
+    {
+        VariableValue value = null;
+        Guild guild = null;
+
+        if (command.VariableType == VariableType.PlayerVariable)
+        {
+            value = player.GetVariableValue(command.VariableId);
+        }
+        else if (command.VariableType == VariableType.ServerVariable)
+        {
+            value = ServerVariableBase.Get(command.VariableId)?.Value;
+        }
+        else if (command.VariableType == VariableType.GuildVariable)
+        {
+            guild = player.Guild;
+            if (guild == null)
             {
-                value = player.GetVariableValue(command.VariableId);
+                return;
             }
-            else if (command.VariableType == VariableType.ServerVariable)
-            {
-                value = ServerVariableBase.Get(command.VariableId)?.Value;
-            }
-            else if (command.VariableType == VariableType.GuildVariable)
-            {
-                guild = player.Guild;
-                if (guild == null)
+            value = guild.GetVariableValue(command.VariableId);
+        }
+        else if (command.VariableType == VariableType.UserVariable)
+        {
+            value = player.User.GetVariableValue(command.VariableId);
+        }
+
+        if (value == null)
+        {
+            value = new VariableValue();
+        }
+
+        var originalValue = value.Integer;
+
+        switch (mod.ModType)
+        {
+            case VariableMod.Set:
+                value.Integer = mod.Value;
+
+                break;
+            case VariableMod.Add:
+                value.Integer += mod.Value;
+
+                break;
+            case VariableMod.Subtract:
+                value.Integer -= mod.Value;
+
+                break;
+            case VariableMod.Multiply:
+                value.Integer *= mod.Value;
+
+                break;
+            case VariableMod.Divide:
+                if (mod.Value != 0)  //Idiot proofing divide by 0 LOL
                 {
-                    return;
+                    value.Integer /= mod.Value;
                 }
-                value = guild.GetVariableValue(command.VariableId);
-            }
-            else if (command.VariableType == VariableType.UserVariable)
-            {
-                value = player.User.GetVariableValue(command.VariableId);
-            }
 
-            if (value == null)
-            {
-                value = new VariableValue();
-            }
+                break;
+            case VariableMod.LeftShift:
+                value.Integer = value.Integer << (int)mod.Value;
 
-            var originalValue = value.String;
+                break;
+            case VariableMod.RightShift:
+                value.Integer = value.Integer >> (int)mod.Value;
 
-            switch (mod.ModType)
-            {
-                case VariableMod.Set:
-                    value.String = ParseEventText(mod.Value, player, instance);
+                break;
+            case VariableMod.Random:
+                //TODO: Fix - Random doesnt work with longs lolz
+                value.Integer = Randomization.Next((int)mod.Value, (int)mod.HighValue + 1);
 
-                    break;
-                case VariableMod.Replace:
-                    var find = ParseEventText(mod.Value, player, instance);
-                    var replace = ParseEventText(mod.Replace, player, instance);
-                    value.String = value.String.Replace(find, replace);
+                break;
+            case VariableMod.SystemTime:
+                value.Integer = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
 
-                    break;
-            }
+                break;
+            case VariableMod.DupPlayerVar:
+                value.Integer = player.GetVariableValue(mod.DuplicateVariableId).Integer;
 
-            var changed = value.String != originalValue;
-
-            if (command.VariableType == VariableType.PlayerVariable)
-            {
-                if (changed)
+                break;
+            case VariableMod.DupGlobalVar:
+                var dupServerVariable = ServerVariableBase.Get(mod.DuplicateVariableId);
+                if (dupServerVariable != null)
                 {
-                    player.StartCommonEventsWithTrigger(CommonEventTrigger.PlayerVariableChange, "", command.VariableId.ToString());
+                    value.Integer = dupServerVariable.Value.Integer;
                 }
 
-                // Set the party member switches too if Sync Party enabled!
-                if (command.SyncParty)
+                break;
+            case VariableMod.AddPlayerVar:
+                value.Integer += player.GetVariableValue(mod.DuplicateVariableId).Integer;
+
+                break;
+            case VariableMod.AddGlobalVar:
+                var asv = ServerVariableBase.Get(mod.DuplicateVariableId);
+                if (asv != null)
                 {
-                    foreach (var partyMember in player.Party)
+                    value.Integer += asv.Value.Integer;
+                }
+
+                break;
+            case VariableMod.SubtractPlayerVar:
+                value.Integer -= player.GetVariableValue(mod.DuplicateVariableId).Integer;
+
+                break;
+            case VariableMod.SubtractGlobalVar:
+                var ssv = ServerVariableBase.Get(mod.DuplicateVariableId);
+                if (ssv != null)
+                {
+                    value.Integer -= ssv.Value.Integer;
+                }
+
+                break;
+            case VariableMod.MultiplyPlayerVar:
+                value.Integer *= player.GetVariableValue(mod.DuplicateVariableId).Integer;
+
+                break;
+            case VariableMod.MultiplyGlobalVar:
+                var msv = ServerVariableBase.Get(mod.DuplicateVariableId);
+                if (msv != null)
+                {
+                    value.Integer *= msv.Value.Integer;
+                }
+
+                break;
+            case VariableMod.DividePlayerVar:
+                if (player.GetVariableValue(mod.DuplicateVariableId).Integer != 0) //Idiot proofing divide by 0 LOL
+                {
+                    value.Integer /= player.GetVariableValue(mod.DuplicateVariableId).Integer;
+                }
+
+                break;
+            case VariableMod.DivideGlobalVar:
+                var dsv = ServerVariableBase.Get(mod.DuplicateVariableId);
+                if (dsv != null)
+                {
+                    if (dsv.Value != 0) //Idiot proofing divide by 0 LOL
                     {
-                        if (partyMember != player)
-                        {
-                            partyMember.SetVariableValue(command.VariableId, value.String);
-                        }
+                        value.Integer /= dsv.Value.Integer;
+                    }
+                }
+
+                break;
+            case VariableMod.LeftShiftPlayerVar:
+                value.Integer = value.Integer << (int)player.GetVariableValue(mod.DuplicateVariableId).Integer;
+
+                break;
+            case VariableMod.LeftShiftGlobalVar:
+                var lhsv = ServerVariableBase.Get(mod.DuplicateVariableId);
+                if (lhsv != null)
+                {
+                    value.Integer = value.Integer << (int)lhsv.Value.Integer;
+                }
+
+                break;
+            case VariableMod.RightShiftPlayerVar:
+                value.Integer = value.Integer >> (int)player.GetVariableValue(mod.DuplicateVariableId).Integer;
+
+                break;
+            case VariableMod.RightShiftGlobalVar:
+                var rhsv = ServerVariableBase.Get(mod.DuplicateVariableId);
+                if (rhsv != null)
+                {
+                    value.Integer = value.Integer >> (int)rhsv.Value.Integer;
+                }
+
+                break;
+        }
+
+        var changed = value.Integer != originalValue;
+
+        if (command.VariableType == VariableType.PlayerVariable)
+        {
+            if (changed)
+            {
+                player.StartCommonEventsWithTrigger(CommonEventTrigger.PlayerVariableChange, "", command.VariableId.ToString());
+            }
+
+            // Set the party member switches too if Sync Party enabled!
+            if (command.SyncParty)
+            {
+                foreach (var partyMember in player.Party)
+                {
+                    if (partyMember != player)
+                    {
+                        partyMember.SetVariableValue(command.VariableId, value.Integer);
+                        partyMember.StartCommonEventsWithTrigger(CommonEventTrigger.PlayerVariableChange, string.Empty, command.VariableId.ToString());
                     }
                 }
             }
-            else if (command.VariableType == VariableType.ServerVariable)
+        }
+        else if (command.VariableType == VariableType.ServerVariable)
+        {
+            if (changed)
             {
-                if (changed)
-                {
-                    Player.StartCommonEventsWithTriggerForAll(CommonEventTrigger.ServerVariableChange, "", command.VariableId.ToString());
-                    DbInterface.UpdatedServerVariables.AddOrUpdate(command.VariableId, ServerVariableBase.Get(command.VariableId), (key, oldValue) => ServerVariableBase.Get(command.VariableId));
-                }
+                Player.StartCommonEventsWithTriggerForAll(CommonEventTrigger.ServerVariableChange, "", command.VariableId.ToString());
+                DbInterface.UpdatedServerVariables.AddOrUpdate(command.VariableId, ServerVariableBase.Get(command.VariableId), (key, oldValue) => ServerVariableBase.Get(command.VariableId));
             }
-            else if (command.VariableType == VariableType.GuildVariable)
+        }
+        else if (command.VariableType == VariableType.GuildVariable)
+        {
+            if (changed)
             {
-                if (changed)
-                {
-                    guild.StartCommonEventsWithTriggerForAll(CommonEventTrigger.GuildVariableChange, "", command.VariableId.ToString());
-                    guild.UpdatedVariables.AddOrUpdate(command.VariableId, GuildVariableBase.Get(command.VariableId), (key, oldValue) => GuildVariableBase.Get(command.VariableId));
-                }
+                guild.StartCommonEventsWithTriggerForAll(CommonEventTrigger.GuildVariableChange, "", command.VariableId.ToString());
+                guild.UpdatedVariables.AddOrUpdate(command.VariableId, GuildVariableBase.Get(command.VariableId), (key, oldValue) => GuildVariableBase.Get(command.VariableId));
             }
-            else if (command.VariableType == VariableType.UserVariable)
+        }
+        else if (command.VariableType == VariableType.UserVariable)
+        {
+            if (changed)
             {
-                if (changed)
+                player.User.StartCommonEventsWithTriggerForAll(CommonEventTrigger.UserVariableChange, "", command.VariableId.ToString());
+                player.User.UpdatedVariables.AddOrUpdate(command.VariableId, UserVariableBase.Get(command.VariableId), (key, oldValue) => UserVariableBase.Get(command.VariableId));
+            }
+        }
+    }
+
+    private static void ProcessVariableModification(
+        SetVariableCommand command,
+        StringVariableMod mod,
+        Player player,
+        Event instance
+    )
+    {
+        VariableValue value = null;
+        Guild guild = null;
+
+        if (command.VariableType == VariableType.PlayerVariable)
+        {
+            value = player.GetVariableValue(command.VariableId);
+        }
+        else if (command.VariableType == VariableType.ServerVariable)
+        {
+            value = ServerVariableBase.Get(command.VariableId)?.Value;
+        }
+        else if (command.VariableType == VariableType.GuildVariable)
+        {
+            guild = player.Guild;
+            if (guild == null)
+            {
+                return;
+            }
+            value = guild.GetVariableValue(command.VariableId);
+        }
+        else if (command.VariableType == VariableType.UserVariable)
+        {
+            value = player.User.GetVariableValue(command.VariableId);
+        }
+
+        if (value == null)
+        {
+            value = new VariableValue();
+        }
+
+        var originalValue = value.String;
+
+        switch (mod.ModType)
+        {
+            case VariableMod.Set:
+                value.String = ParseEventText(mod.Value, player, instance);
+
+                break;
+            case VariableMod.Replace:
+                var find = ParseEventText(mod.Value, player, instance);
+                var replace = ParseEventText(mod.Replace, player, instance);
+                value.String = value.String.Replace(find, replace);
+
+                break;
+        }
+
+        var changed = value.String != originalValue;
+
+        if (command.VariableType == VariableType.PlayerVariable)
+        {
+            if (changed)
+            {
+                player.StartCommonEventsWithTrigger(CommonEventTrigger.PlayerVariableChange, "", command.VariableId.ToString());
+            }
+
+            // Set the party member switches too if Sync Party enabled!
+            if (command.SyncParty)
+            {
+                foreach (var partyMember in player.Party)
                 {
-                    player.User.StartCommonEventsWithTriggerForAll(CommonEventTrigger.UserVariableChange, "", command.VariableId.ToString());
-                    player.User.UpdatedVariables.AddOrUpdate(command.VariableId, UserVariableBase.Get(command.VariableId), (key, oldValue) => UserVariableBase.Get(command.VariableId));
+                    if (partyMember != player)
+                    {
+                        partyMember.SetVariableValue(command.VariableId, value.String);
+                    }
                 }
             }
         }
-
+        else if (command.VariableType == VariableType.ServerVariable)
+        {
+            if (changed)
+            {
+                Player.StartCommonEventsWithTriggerForAll(CommonEventTrigger.ServerVariableChange, "", command.VariableId.ToString());
+                DbInterface.UpdatedServerVariables.AddOrUpdate(command.VariableId, ServerVariableBase.Get(command.VariableId), (key, oldValue) => ServerVariableBase.Get(command.VariableId));
+            }
+        }
+        else if (command.VariableType == VariableType.GuildVariable)
+        {
+            if (changed)
+            {
+                guild.StartCommonEventsWithTriggerForAll(CommonEventTrigger.GuildVariableChange, "", command.VariableId.ToString());
+                guild.UpdatedVariables.AddOrUpdate(command.VariableId, GuildVariableBase.Get(command.VariableId), (key, oldValue) => GuildVariableBase.Get(command.VariableId));
+            }
+        }
+        else if (command.VariableType == VariableType.UserVariable)
+        {
+            if (changed)
+            {
+                player.User.StartCommonEventsWithTriggerForAll(CommonEventTrigger.UserVariableChange, "", command.VariableId.ToString());
+                player.User.UpdatedVariables.AddOrUpdate(command.VariableId, UserVariableBase.Get(command.VariableId), (key, oldValue) => UserVariableBase.Get(command.VariableId));
+            }
+        }
     }
 
 }

--- a/Intersect.Server.Core/Entities/Events/ConditionHandlerRegistry.cs
+++ b/Intersect.Server.Core/Entities/Events/ConditionHandlerRegistry.cs
@@ -2,74 +2,73 @@ using Intersect.GameObjects;
 using Intersect.GameObjects.Events;
 using System.Reflection;
 
-namespace Intersect.Server.Entities.Events
+namespace Intersect.Server.Entities.Events;
+
+public static partial class ConditionHandlerRegistry
 {
-    public static partial class ConditionHandlerRegistry
+    private delegate bool HandleCondition(Condition condition, Player player, Event eventInstance, QuestBase questBase);
+    private delegate bool HandleConditionBool<TCondition>(TCondition condition, Player player, Event eventInstance, QuestBase questBase) where TCondition : Condition;
+    private static Dictionary<Type, HandleCondition> MeetsConditionFunctions = new Dictionary<Type, HandleCondition>();
+    private static MethodInfo CreateWeaklyTypedDelegateForMethodInfoInfo;
+    private static bool Initialized = false;
+    private static object mLock = new object();
+
+
+    public static void Init()
     {
-        private delegate bool HandleCondition(Condition condition, Player player, Event eventInstance, QuestBase questBase);
-        private delegate bool HandleConditionBool<TCondition>(TCondition condition, Player player, Event eventInstance, QuestBase questBase) where TCondition : Condition;
-        private static Dictionary<Type, HandleCondition> MeetsConditionFunctions = new Dictionary<Type, HandleCondition>();
-        private static MethodInfo CreateWeaklyTypedDelegateForMethodInfoInfo;
-        private static bool Initialized = false;
-        private static object mLock = new object();
+        if (CreateWeaklyTypedDelegateForMethodInfoInfo == null)
+            CreateWeaklyTypedDelegateForMethodInfoInfo = typeof(ConditionHandlerRegistry).GetMethod(nameof(CreateWeaklyTypedDelegateForConditionMethodInfo), BindingFlags.Static | BindingFlags.NonPublic);
 
-
-        public static void Init()
+        if (MeetsConditionFunctions.Count == 0)
         {
-            if (CreateWeaklyTypedDelegateForMethodInfoInfo == null)
-                CreateWeaklyTypedDelegateForMethodInfoInfo = typeof(ConditionHandlerRegistry).GetMethod(nameof(CreateWeaklyTypedDelegateForConditionMethodInfo), BindingFlags.Static | BindingFlags.NonPublic);
-
-            if (MeetsConditionFunctions.Count == 0)
+            var methods = typeof(Conditions).GetMethods(BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.Static).Where(m => m.Name == "MeetsCondition");
+            foreach (var method in methods)
             {
-                var methods = typeof(Conditions).GetMethods(BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.Static).Where(m => m.Name == "MeetsCondition");
-                foreach (var method in methods)
-                {
-                    var conditionType = method.GetParameters()[0].ParameterType;
-                    var typedDelegateFactory = CreateWeaklyTypedDelegateForMethodInfoInfo.MakeGenericMethod(conditionType);
+                var conditionType = method.GetParameters()[0].ParameterType;
+                var typedDelegateFactory = CreateWeaklyTypedDelegateForMethodInfoInfo.MakeGenericMethod(conditionType);
 
-                    var weakDelegate = typedDelegateFactory.Invoke(null, new object[] { method, null }) as HandleCondition;
-                    MeetsConditionFunctions.Add(conditionType, weakDelegate);
-                }
+                var weakDelegate = typedDelegateFactory.Invoke(null, new object[] { method, null }) as HandleCondition;
+                MeetsConditionFunctions.Add(conditionType, weakDelegate);
             }
-
-            Initialized = true;
         }
 
-        public static bool CheckCondition(Condition condition, Player player, Event eventInstance, QuestBase questBase)
-        {
-            if (!Initialized)
-            {
-                lock (mLock)
-                {
-                    if (!Initialized)
-                    {
-                        Init();
-                    }
-                }
-            }
-
-            return MeetsConditionFunctions[condition.GetType()](condition, player, eventInstance, questBase);
-        }
-
-
-        private static HandleCondition CreateWeaklyTypedDelegateForConditionMethodInfo<TCondition>(MethodInfo methodInfo, object target = null) where TCondition : Condition
-        {
-            if (methodInfo == null)
-            {
-                throw new ArgumentNullException(nameof(methodInfo));
-            }
-
-            var stronglyTyped =
-                    Delegate.CreateDelegate(typeof(HandleConditionBool<TCondition>), target, methodInfo) as
-                        HandleConditionBool<TCondition>;
-
-            return (Condition condition, Player player, Event eventInstance, QuestBase questBase) => stronglyTyped(
-                (TCondition)condition, player, eventInstance, questBase
-            );
-
-            throw new ArgumentException($"Unsupported condition handler return type '{methodInfo.ReturnType.FullName}'.");
-        }
-
-
+        Initialized = true;
     }
+
+    public static bool CheckCondition(Condition condition, Player player, Event eventInstance, QuestBase questBase)
+    {
+        if (!Initialized)
+        {
+            lock (mLock)
+            {
+                if (!Initialized)
+                {
+                    Init();
+                }
+            }
+        }
+
+        return MeetsConditionFunctions[condition.GetType()](condition, player, eventInstance, questBase);
+    }
+
+
+    private static HandleCondition CreateWeaklyTypedDelegateForConditionMethodInfo<TCondition>(MethodInfo methodInfo, object target = null) where TCondition : Condition
+    {
+        if (methodInfo == null)
+        {
+            throw new ArgumentNullException(nameof(methodInfo));
+        }
+
+        var stronglyTyped =
+                Delegate.CreateDelegate(typeof(HandleConditionBool<TCondition>), target, methodInfo) as
+                    HandleConditionBool<TCondition>;
+
+        return (Condition condition, Player player, Event eventInstance, QuestBase questBase) => stronglyTyped(
+            (TCondition)condition, player, eventInstance, questBase
+        );
+
+        throw new ArgumentException($"Unsupported condition handler return type '{methodInfo.ReturnType.FullName}'.");
+    }
+
+
 }

--- a/Intersect.Server.Core/Entities/Events/Conditions.cs
+++ b/Intersect.Server.Core/Entities/Events/Conditions.cs
@@ -6,707 +6,705 @@ using Intersect.GameObjects.Switches_and_Variables;
 using Intersect.Server.General;
 using Intersect.Server.Maps;
 
-namespace Intersect.Server.Entities.Events
+namespace Intersect.Server.Entities.Events;
+
+public static partial class Conditions
 {
-    public static partial class Conditions
+    public static bool CanSpawnPage(EventPage page, Player player, Event activeInstance)
     {
-        public static bool CanSpawnPage(EventPage page, Player player, Event activeInstance)
+        return MeetsConditionLists(page.ConditionLists, player, activeInstance);
+    }
+
+    public static bool MeetsConditionLists(
+        ConditionLists lists,
+        Player player,
+        Event eventInstance,
+        bool singleList = true,
+        QuestBase questBase = null
+    )
+    {
+        if (player == null)
         {
-            return MeetsConditionLists(page.ConditionLists, player, activeInstance);
+            return false;
         }
 
-        public static bool MeetsConditionLists(
-            ConditionLists lists,
-            Player player,
-            Event eventInstance,
-            bool singleList = true,
-            QuestBase questBase = null
-        )
+        //If no condition lists then this passes
+        if (lists.Lists.Count == 0)
         {
-            if (player == null)
+            return true;
+        }
+
+        for (var i = 0; i < lists.Lists.Count; i++)
+        {
+            if (MeetsConditionList(lists.Lists[i], player, eventInstance, questBase))
+
+            //Checks to see if all conditions in this list are met
+            {
+                //If all conditions are met.. and we only need a single list to pass then return true
+                if (singleList)
+                {
+                    return true;
+                }
+
+                continue;
+            }
+
+            //If not.. and we need all lists to pass then return false
+            if (!singleList)
             {
                 return false;
             }
-
-            //If no condition lists then this passes
-            if (lists.Lists.Count == 0)
-            {
-                return true;
-            }
-
-            for (var i = 0; i < lists.Lists.Count; i++)
-            {
-                if (MeetsConditionList(lists.Lists[i], player, eventInstance, questBase))
-
-                //Checks to see if all conditions in this list are met
-                {
-                    //If all conditions are met.. and we only need a single list to pass then return true
-                    if (singleList)
-                    {
-                        return true;
-                    }
-
-                    continue;
-                }
-
-                //If not.. and we need all lists to pass then return false
-                if (!singleList)
-                {
-                    return false;
-                }
-            }
-
-            //There were condition lists. If single list was true then we failed every single list and should return false.
-            //If single list was false (meaning we needed to pass all lists) then we've made it.. return true.
-            return !singleList;
         }
 
-        public static bool MeetsConditionList(
-            ConditionList list,
-            Player player,
-            Event eventInstance,
-            QuestBase questBase
-        )
-        {
-            for (var i = 0; i < list.Conditions.Count; i++)
-            {
-                var meetsCondition = MeetsCondition(list.Conditions[i], player, eventInstance, questBase);
+        //There were condition lists. If single list was true then we failed every single list and should return false.
+        //If single list was false (meaning we needed to pass all lists) then we've made it.. return true.
+        return !singleList;
+    }
 
-                if (!meetsCondition)
+    public static bool MeetsConditionList(
+        ConditionList list,
+        Player player,
+        Event eventInstance,
+        QuestBase questBase
+    )
+    {
+        for (var i = 0; i < list.Conditions.Count; i++)
+        {
+            var meetsCondition = MeetsCondition(list.Conditions[i], player, eventInstance, questBase);
+
+            if (!meetsCondition)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    
+
+    public static bool MeetsCondition(
+        Condition condition,
+        Player player,
+        Event eventInstance,
+        QuestBase questBase
+    )
+    {
+        var result = ConditionHandlerRegistry.CheckCondition(condition, player, eventInstance, questBase);
+        if (condition.Negated)
+        {
+            result = !result;
+        }
+        return result;
+    }
+
+    public static bool MeetsCondition(
+        VariableIsCondition condition,
+        Player player,
+        Event eventInstance,
+        QuestBase questBase
+    )
+    {
+        VariableValue value = null;
+        if (condition.VariableType == VariableType.PlayerVariable)
+        {
+            value = player.GetVariableValue(condition.VariableId);
+        }
+        else if (condition.VariableType == VariableType.ServerVariable)
+        {
+            value = ServerVariableBase.Get(condition.VariableId)?.Value;
+        }
+        else if (condition.VariableType == VariableType.GuildVariable)
+        {
+            value = player.Guild?.GetVariableValue(condition.VariableId);
+        }
+        else if (condition.VariableType == VariableType.UserVariable)
+        {
+            value = player.User.GetVariableValue(condition.VariableId);
+        }
+
+        if (value == null)
+        {
+            value = new VariableValue();
+        }
+
+        return CheckVariableComparison(value, condition.Comparison, player, eventInstance);
+    }
+
+    public static bool MeetsCondition(
+        HasItemCondition condition,
+        Player player,
+        Event eventInstance,
+        QuestBase questBase
+    )
+    {
+        var quantity = condition.Quantity;
+        if (condition.UseVariable)
+        {
+            switch (condition.VariableType)
+            {
+                case VariableType.PlayerVariable:
+                    quantity = (int)player.GetVariableValue(condition.VariableId).Integer;
+
+                    break;
+                case VariableType.ServerVariable:
+                    quantity = (int)ServerVariableBase.Get(condition.VariableId)?.Value.Integer;
+
+                    break;
+                case VariableType.GuildVariable:
+                    quantity = (int)player.Guild?.GetVariableValue(condition.VariableId).Integer;
+
+                    break;
+            }
+        }
+
+        return player.CountItems(condition.ItemId, true, condition.CheckBank) >= quantity;
+    }
+
+    public static bool MeetsCondition(
+        ClassIsCondition condition,
+        Player player,
+        Event eventInstance,
+        QuestBase questBase
+    )
+    {
+        if (player.ClassId == condition.ClassId)
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    public static bool MeetsCondition(
+        KnowsSpellCondition condition,
+        Player player,
+        Event eventInstance,
+        QuestBase questBase
+    )
+    {
+        if (player.KnowsSpell(condition.SpellId))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    public static bool MeetsCondition(
+        LevelOrStatCondition condition,
+        Player player,
+        Event eventInstance,
+        QuestBase questBase
+    )
+    {
+        var lvlStat = 0;
+        if (condition.ComparingLevel)
+        {
+            lvlStat = player.Level;
+        }
+        else
+        {
+            lvlStat = player.Stat[(int)condition.Stat].Value();
+            if (condition.IgnoreBuffs)
+            {
+                lvlStat = player.Stat[(int)condition.Stat].BaseStat +
+                          player.StatPointAllocations[(int)condition.Stat];
+            }
+        }
+
+        switch (condition.Comparator) //Comparator
+        {
+            case VariableComparator.Equal:
+                if (lvlStat == condition.Value)
                 {
-                    return false;
+                    return true;
+                }
+
+                break;
+            case VariableComparator.GreaterOrEqual:
+                if (lvlStat >= condition.Value)
+                {
+                    return true;
+                }
+
+                break;
+            case VariableComparator.LesserOrEqual:
+                if (lvlStat <= condition.Value)
+                {
+                    return true;
+                }
+
+                break;
+            case VariableComparator.Greater:
+                if (lvlStat > condition.Value)
+                {
+                    return true;
+                }
+
+                break;
+            case VariableComparator.Less:
+                if (lvlStat < condition.Value)
+                {
+                    return true;
+                }
+
+                break;
+            case VariableComparator.NotEqual:
+                if (lvlStat != condition.Value)
+                {
+                    return true;
+                }
+
+                break;
+        }
+
+        return false;
+    }
+
+    public static bool MeetsCondition(
+        SelfSwitchCondition condition,
+        Player player,
+        Event eventInstance,
+        QuestBase questBase
+    )
+    {
+        if (eventInstance != null)
+        {
+            if (eventInstance.Global && MapController.TryGetInstanceFromMap(eventInstance.MapId, player.MapInstanceId, out var instance))
+            {
+                if (instance.GlobalEventInstances.TryGetValue(eventInstance.BaseEvent, out Event evt))
+                {
+                    if (evt != null)
+                    {
+                        return evt.SelfSwitch[condition.SwitchIndex] == condition.Value;
+                    }
+                }
+            }
+            else
+            {
+                return eventInstance.SelfSwitch[condition.SwitchIndex] == condition.Value;
+            }
+        }
+
+        return false;
+    }
+
+    public static bool MeetsCondition(
+        AccessIsCondition condition,
+        Player player,
+        Event eventInstance,
+        QuestBase questBase
+    )
+    {
+        var power = player.Power;
+        if (condition.Access == 0)
+        {
+            return power.Ban || power.Kick || power.Mute;
+        }
+        else if (condition.Access > 0)
+        {
+            return power.Editor;
+        }
+
+        return false;
+    }
+
+    public static bool MeetsCondition(
+        TimeBetweenCondition condition,
+        Player player,
+        Event eventInstance,
+        QuestBase questBase
+    )
+    {
+        if (condition.Ranges[0] > -1 &&
+            condition.Ranges[1] > -1 &&
+            condition.Ranges[0] < 1440 / TimeBase.GetTimeBase().RangeInterval &&
+            condition.Ranges[1] < 1440 / TimeBase.GetTimeBase().RangeInterval)
+        {
+            return Time.GetTimeRange() >= condition.Ranges[0] && Time.GetTimeRange() <= condition.Ranges[1];
+        }
+
+        return true;
+    }
+
+    public static bool MeetsCondition(
+        CanStartQuestCondition condition,
+        Player player,
+        Event eventInstance,
+        QuestBase questBase
+    )
+    {
+        var startQuest = QuestBase.Get(condition.QuestId);
+        if (startQuest == questBase)
+        {
+            //We cannot check and see if we meet quest requirements if we are already checking to see if we meet quest requirements :P
+            return true;
+        }
+
+        if (startQuest != null)
+        {
+            return player.CanStartQuest(startQuest);
+        }
+
+        return false;
+    }
+
+    public static bool MeetsCondition(
+        QuestInProgressCondition condition,
+        Player player,
+        Event eventInstance,
+        QuestBase questBase
+    )
+    {
+        return player.QuestInProgress(condition.QuestId, condition.Progress, condition.TaskId);
+    }
+
+    public static bool MeetsCondition(
+        QuestCompletedCondition condition,
+        Player player,
+        Event eventInstance,
+        QuestBase questBase
+    )
+    {
+        return player.QuestCompleted(condition.QuestId);
+    }
+
+    public static bool MeetsCondition(
+        NoNpcsOnMapCondition condition,
+        Player player,
+        Event eventInstance,
+        QuestBase questBase
+    )
+    {
+        var map = MapController.Get(eventInstance?.MapId ?? Guid.Empty);
+        if (map == null)
+        {
+            // If we couldn't get an entity's map, use the player's map
+            map = MapController.Get(player.MapId);
+        }
+
+        if (map != null && map.TryGetInstance(player.MapInstanceId, out var mapInstance))
+        {
+            var entities = mapInstance.GetEntities();
+            foreach (var en in entities)
+            {
+                if (en is Npc npc)
+                {
+                    if (!condition.SpecificNpc || npc.Base?.Id == condition.NpcId)
+                    {
+                        return false;
+                    }
                 }
             }
 
             return true;
         }
 
-        
+        return false;
+    }
 
-        public static bool MeetsCondition(
-            Condition condition,
-            Player player,
-            Event eventInstance,
-            QuestBase questBase
-        )
+    public static bool MeetsCondition(
+        GenderIsCondition condition,
+        Player player,
+        Event eventInstance,
+        QuestBase questBase
+    )
+    {
+        return player.Gender == condition.Gender;
+    }
+
+    public static bool MeetsCondition(
+        MapIsCondition condition,
+        Player player,
+        Event eventInstance,
+        QuestBase questBase
+    )
+    {
+        return player.MapId == condition.MapId;
+    }
+
+    public static bool MeetsCondition(
+        IsItemEquippedCondition condition,
+        Player player,
+        Event eventInstance,
+        QuestBase questBase
+    )
+    {
+        if (player == null || condition == null)
         {
-            var result = ConditionHandlerRegistry.CheckCondition(condition, player, eventInstance, questBase);
-            if (condition.Negated)
-            {
-                result = !result;
-            }
-            return result;
-        }
-
-        public static bool MeetsCondition(
-            VariableIsCondition condition,
-            Player player,
-            Event eventInstance,
-            QuestBase questBase
-        )
-        {
-            VariableValue value = null;
-            if (condition.VariableType == VariableType.PlayerVariable)
-            {
-                value = player.GetVariableValue(condition.VariableId);
-            }
-            else if (condition.VariableType == VariableType.ServerVariable)
-            {
-                value = ServerVariableBase.Get(condition.VariableId)?.Value;
-            }
-            else if (condition.VariableType == VariableType.GuildVariable)
-            {
-                value = player.Guild?.GetVariableValue(condition.VariableId);
-            }
-            else if (condition.VariableType == VariableType.UserVariable)
-            {
-                value = player.User.GetVariableValue(condition.VariableId);
-            }
-
-            if (value == null)
-            {
-                value = new VariableValue();
-            }
-
-            return CheckVariableComparison(value, condition.Comparison, player, eventInstance);
-        }
-
-        public static bool MeetsCondition(
-            HasItemCondition condition,
-            Player player,
-            Event eventInstance,
-            QuestBase questBase
-        )
-        {
-            var quantity = condition.Quantity;
-            if (condition.UseVariable)
-            {
-                switch (condition.VariableType)
-                {
-                    case VariableType.PlayerVariable:
-                        quantity = (int)player.GetVariableValue(condition.VariableId).Integer;
-
-                        break;
-                    case VariableType.ServerVariable:
-                        quantity = (int)ServerVariableBase.Get(condition.VariableId)?.Value.Integer;
-
-                        break;
-                    case VariableType.GuildVariable:
-                        quantity = (int)player.Guild?.GetVariableValue(condition.VariableId).Integer;
-
-                        break;
-                }
-            }
-
-            return player.CountItems(condition.ItemId, true, condition.CheckBank) >= quantity;
-        }
-
-        public static bool MeetsCondition(
-            ClassIsCondition condition,
-            Player player,
-            Event eventInstance,
-            QuestBase questBase
-        )
-        {
-            if (player.ClassId == condition.ClassId)
-            {
-                return true;
-            }
-
             return false;
         }
 
-        public static bool MeetsCondition(
-            KnowsSpellCondition condition,
-            Player player,
-            Event eventInstance,
-            QuestBase questBase
-        )
-        {
-            if (player.KnowsSpell(condition.SpellId))
-            {
-                return true;
-            }
+        var equipmentIds = player.EquippedItems.Select(item => item.Descriptor.Id).ToArray();
 
+        return equipmentIds?.Contains(condition.ItemId) ?? false;
+    }
+
+    public static bool MeetsCondition(
+        CheckEquippedSlot condition,
+        Player player,
+        Event eventInstance,
+        QuestBase questBase
+    )
+    {
+        if (player == null || condition == null)
+        {
             return false;
         }
 
-        public static bool MeetsCondition(
-            LevelOrStatCondition condition,
-            Player player,
-            Event eventInstance,
-            QuestBase questBase
-        )
+        var equipmentIndex = Options.EquipmentSlots.IndexOf(condition.Name);
+        return player.TryGetEquipmentSlot(equipmentIndex, out _);
+    }
+
+    public static bool MeetsCondition(
+        HasFreeInventorySlots condition,
+        Player player,
+        Event eventInstance,
+        QuestBase questBase
+    )
+    {
+
+        var quantity = condition.Quantity;
+        if (condition.UseVariable)
         {
-            var lvlStat = 0;
-            if (condition.ComparingLevel)
+            switch (condition.VariableType)
             {
-                lvlStat = player.Level;
-            }
-            else
-            {
-                lvlStat = player.Stat[(int)condition.Stat].Value();
-                if (condition.IgnoreBuffs)
-                {
-                    lvlStat = player.Stat[(int)condition.Stat].BaseStat +
-                              player.StatPointAllocations[(int)condition.Stat];
-                }
-            }
-
-            switch (condition.Comparator) //Comparator
-            {
-                case VariableComparator.Equal:
-                    if (lvlStat == condition.Value)
-                    {
-                        return true;
-                    }
+                case VariableType.PlayerVariable:
+                    quantity = (int)player.GetVariableValue(condition.VariableId).Integer;
 
                     break;
-                case VariableComparator.GreaterOrEqual:
-                    if (lvlStat >= condition.Value)
-                    {
-                        return true;
-                    }
+                case VariableType.ServerVariable:
+                    quantity = (int)ServerVariableBase.Get(condition.VariableId)?.Value.Integer;
 
                     break;
-                case VariableComparator.LesserOrEqual:
-                    if (lvlStat <= condition.Value)
-                    {
-                        return true;
-                    }
-
-                    break;
-                case VariableComparator.Greater:
-                    if (lvlStat > condition.Value)
-                    {
-                        return true;
-                    }
-
-                    break;
-                case VariableComparator.Less:
-                    if (lvlStat < condition.Value)
-                    {
-                        return true;
-                    }
-
-                    break;
-                case VariableComparator.NotEqual:
-                    if (lvlStat != condition.Value)
-                    {
-                        return true;
-                    }
+                case VariableType.GuildVariable:
+                    quantity = (int)player.Guild?.GetVariableValue(condition.VariableId).Integer;
 
                     break;
             }
+        }
 
+        // Check if the user has (or does not have when negated) the desired amount of inventory slots.
+        var slots = player.FindOpenInventorySlots().Count;
+
+        return slots >= quantity;
+    }
+
+    public static bool MeetsCondition(
+        InGuildWithRank condition,
+        Player player,
+        Event eventInstance,
+        QuestBase questBase
+    )
+    {
+        return player.Guild != null && player.GuildRank <= condition.Rank;
+    }
+
+    public static bool MeetsCondition(
+        MapZoneTypeIs condition,
+        Player player,
+        Event eventInstance,
+        QuestBase questBase)
+    {
+        return player.Map?.ZoneType == condition.ZoneType;
+    }
+
+    //Variable Comparison Processing
+
+    public static bool CheckVariableComparison(
+        VariableValue currentValue,
+        VariableComparison comparison,
+        Player player,
+        Event instance
+    )
+    {
+        return VariableCheckHandlerRegistry.CheckVariableComparison(currentValue, comparison, player, instance);
+    }
+
+    public static bool CheckVariableComparison(
+        VariableValue currentValue,
+        BooleanVariableComparison comparison,
+        Player player,
+        Event instance
+    )
+    {
+        VariableValue compValue = null;
+        if (comparison.CompareVariableId != Guid.Empty)
+        {
+            if (comparison.CompareVariableType == VariableType.PlayerVariable)
+            {
+                compValue = player.GetVariableValue(comparison.CompareVariableId);
+            }
+            else if (comparison.CompareVariableType == VariableType.ServerVariable)
+            {
+                compValue = ServerVariableBase.Get(comparison.CompareVariableId)?.Value;
+            }
+            else if (comparison.CompareVariableType == VariableType.GuildVariable)
+            {
+                compValue = player.Guild?.GetVariableValue(comparison.CompareVariableId);
+            }
+            else if (comparison.CompareVariableType == VariableType.UserVariable)
+            {
+                compValue = player.User.GetVariableValue(comparison.CompareVariableId);
+            }
+        }
+        else
+        {
+            compValue = new VariableValue();
+            compValue.Boolean = comparison.Value;
+        }
+
+        if (compValue == null)
+        {
+            compValue = new VariableValue();
+        }
+
+        if (currentValue.Type == 0)
+        {
+            currentValue.Boolean = false;
+        }
+
+        if (compValue.Type != currentValue.Type)
+        {
             return false;
         }
 
-        public static bool MeetsCondition(
-            SelfSwitchCondition condition,
-            Player player,
-            Event eventInstance,
-            QuestBase questBase
-        )
+        if (comparison.ComparingEqual)
         {
-            if (eventInstance != null)
-            {
-                if (eventInstance.Global && MapController.TryGetInstanceFromMap(eventInstance.MapId, player.MapInstanceId, out var instance))
-                {
-                    if (instance.GlobalEventInstances.TryGetValue(eventInstance.BaseEvent, out Event evt))
-                    {
-                        if (evt != null)
-                        {
-                            return evt.SelfSwitch[condition.SwitchIndex] == condition.Value;
-                        }
-                    }
-                }
-                else
-                {
-                    return eventInstance.SelfSwitch[condition.SwitchIndex] == condition.Value;
-                }
-            }
+            return currentValue.Boolean == compValue.Boolean;
+        }
+        else
+        {
+            return currentValue.Boolean != compValue.Boolean;
+        }
+    }
 
+    public static bool CheckVariableComparison(
+        VariableValue currentValue,
+        IntegerVariableComparison comparison,
+        Player player,
+        Event instance
+    )
+    {
+        long compareAgainst = 0;
+
+        VariableValue compValue = null;
+        if (comparison.CompareVariableId != Guid.Empty)
+        {
+            if (comparison.CompareVariableType == VariableType.PlayerVariable)
+            {
+                compValue = player.GetVariableValue(comparison.CompareVariableId);
+            }
+            else if (comparison.CompareVariableType == VariableType.ServerVariable)
+            {
+                compValue = ServerVariableBase.Get(comparison.CompareVariableId)?.Value;
+            }
+            else if (comparison.CompareVariableType == VariableType.GuildVariable)
+            {
+                compValue = player.Guild?.GetVariableValue(comparison.CompareVariableId);
+            }
+            else if (comparison.CompareVariableType == VariableType.UserVariable)
+            {
+                compValue = player.User.GetVariableValue(comparison.CompareVariableId);
+            }
+        }
+        else if (comparison.TimeSystem)
+        {
+            compValue = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        }
+        else
+        {
+            compValue = new VariableValue();
+            compValue.Integer = comparison.Value;
+        }
+
+        if (compValue == null)
+        {
+            compValue = new VariableValue();
+        }
+
+        if (currentValue.Type == 0)
+        {
+            currentValue.Integer = 0;
+        }
+
+        if (compValue.Type != currentValue.Type)
+        {
             return false;
         }
 
-        public static bool MeetsCondition(
-            AccessIsCondition condition,
-            Player player,
-            Event eventInstance,
-            QuestBase questBase
-        )
+        var varVal = currentValue.Integer;
+        compareAgainst = compValue.Integer;
+
+        switch (comparison.Comparator) //Comparator
         {
-            var power = player.Power;
-            if (condition.Access == 0)
-            {
-                return power.Ban || power.Kick || power.Mute;
-            }
-            else if (condition.Access > 0)
-            {
-                return power.Editor;
-            }
-
-            return false;
-        }
-
-        public static bool MeetsCondition(
-            TimeBetweenCondition condition,
-            Player player,
-            Event eventInstance,
-            QuestBase questBase
-        )
-        {
-            if (condition.Ranges[0] > -1 &&
-                condition.Ranges[1] > -1 &&
-                condition.Ranges[0] < 1440 / TimeBase.GetTimeBase().RangeInterval &&
-                condition.Ranges[1] < 1440 / TimeBase.GetTimeBase().RangeInterval)
-            {
-                return Time.GetTimeRange() >= condition.Ranges[0] && Time.GetTimeRange() <= condition.Ranges[1];
-            }
-
-            return true;
-        }
-
-        public static bool MeetsCondition(
-            CanStartQuestCondition condition,
-            Player player,
-            Event eventInstance,
-            QuestBase questBase
-        )
-        {
-            var startQuest = QuestBase.Get(condition.QuestId);
-            if (startQuest == questBase)
-            {
-                //We cannot check and see if we meet quest requirements if we are already checking to see if we meet quest requirements :P
-                return true;
-            }
-
-            if (startQuest != null)
-            {
-                return player.CanStartQuest(startQuest);
-            }
-
-            return false;
-        }
-
-        public static bool MeetsCondition(
-            QuestInProgressCondition condition,
-            Player player,
-            Event eventInstance,
-            QuestBase questBase
-        )
-        {
-            return player.QuestInProgress(condition.QuestId, condition.Progress, condition.TaskId);
-        }
-
-        public static bool MeetsCondition(
-            QuestCompletedCondition condition,
-            Player player,
-            Event eventInstance,
-            QuestBase questBase
-        )
-        {
-            return player.QuestCompleted(condition.QuestId);
-        }
-
-        public static bool MeetsCondition(
-            NoNpcsOnMapCondition condition,
-            Player player,
-            Event eventInstance,
-            QuestBase questBase
-        )
-        {
-            var map = MapController.Get(eventInstance?.MapId ?? Guid.Empty);
-            if (map == null)
-            {
-                // If we couldn't get an entity's map, use the player's map
-                map = MapController.Get(player.MapId);
-            }
-
-            if (map != null && map.TryGetInstance(player.MapInstanceId, out var mapInstance))
-            {
-                var entities = mapInstance.GetEntities();
-                foreach (var en in entities)
+            case VariableComparator.Equal:
+                if (varVal == compareAgainst)
                 {
-                    if (en is Npc npc)
-                    {
-                        if (!condition.SpecificNpc || npc.Base?.Id == condition.NpcId)
-                        {
-                            return false;
-                        }
-                    }
+                    return true;
                 }
 
-                return true;
-            }
-
-            return false;
-        }
-
-        public static bool MeetsCondition(
-            GenderIsCondition condition,
-            Player player,
-            Event eventInstance,
-            QuestBase questBase
-        )
-        {
-            return player.Gender == condition.Gender;
-        }
-
-        public static bool MeetsCondition(
-            MapIsCondition condition,
-            Player player,
-            Event eventInstance,
-            QuestBase questBase
-        )
-        {
-            return player.MapId == condition.MapId;
-        }
-
-        public static bool MeetsCondition(
-            IsItemEquippedCondition condition,
-            Player player,
-            Event eventInstance,
-            QuestBase questBase
-        )
-        {
-            if (player == null || condition == null)
-            {
-                return false;
-            }
-
-            var equipmentIds = player.EquippedItems.Select(item => item.Descriptor.Id).ToArray();
-
-            return equipmentIds?.Contains(condition.ItemId) ?? false;
-        }
-
-        public static bool MeetsCondition(
-            CheckEquippedSlot condition,
-            Player player,
-            Event eventInstance,
-            QuestBase questBase
-        )
-        {
-            if (player == null || condition == null)
-            {
-                return false;
-            }
-
-            var equipmentIndex = Options.EquipmentSlots.IndexOf(condition.Name);
-            return player.TryGetEquipmentSlot(equipmentIndex, out _);
-        }
-
-        public static bool MeetsCondition(
-            HasFreeInventorySlots condition,
-            Player player,
-            Event eventInstance,
-            QuestBase questBase
-        )
-        {
-
-            var quantity = condition.Quantity;
-            if (condition.UseVariable)
-            {
-                switch (condition.VariableType)
+                break;
+            case VariableComparator.GreaterOrEqual:
+                if (varVal >= compareAgainst)
                 {
-                    case VariableType.PlayerVariable:
-                        quantity = (int)player.GetVariableValue(condition.VariableId).Integer;
-
-                        break;
-                    case VariableType.ServerVariable:
-                        quantity = (int)ServerVariableBase.Get(condition.VariableId)?.Value.Integer;
-
-                        break;
-                    case VariableType.GuildVariable:
-                        quantity = (int)player.Guild?.GetVariableValue(condition.VariableId).Integer;
-
-                        break;
+                    return true;
                 }
-            }
 
-            // Check if the user has (or does not have when negated) the desired amount of inventory slots.
-            var slots = player.FindOpenInventorySlots().Count;
+                break;
+            case VariableComparator.LesserOrEqual:
+                if (varVal <= compareAgainst)
+                {
+                    return true;
+                }
 
-            return slots >= quantity;
+                break;
+            case VariableComparator.Greater:
+                if (varVal > compareAgainst)
+                {
+                    return true;
+                }
+
+                break;
+            case VariableComparator.Less:
+                if (varVal < compareAgainst)
+                {
+                    return true;
+                }
+
+                break;
+            case VariableComparator.NotEqual:
+                if (varVal != compareAgainst)
+                {
+                    return true;
+                }
+
+                break;
         }
 
-        public static bool MeetsCondition(
-            InGuildWithRank condition,
-            Player player,
-            Event eventInstance,
-            QuestBase questBase
-        )
+        return false;
+    }
+
+    public static bool CheckVariableComparison(
+        VariableValue currentValue,
+        StringVariableComparison comparison,
+        Player player,
+        Event instance
+    )
+    {
+        var varVal = CommandProcessing.ParseEventText(currentValue.String ?? "", player, instance);
+        var compareAgainst = CommandProcessing.ParseEventText(comparison.Value ?? "", player, instance);
+
+        switch (comparison.Comparator)
         {
-            return player.Guild != null && player.GuildRank <= condition.Rank;
+            case StringVariableComparator.Equal:
+                return varVal == compareAgainst;
+            case StringVariableComparator.Contains:
+                return varVal.Contains(compareAgainst);
         }
 
-        public static bool MeetsCondition(
-            MapZoneTypeIs condition,
-            Player player,
-            Event eventInstance,
-            QuestBase questBase)
-        {
-            return player.Map?.ZoneType == condition.ZoneType;
-        }
-
-        //Variable Comparison Processing
-
-        public static bool CheckVariableComparison(
-            VariableValue currentValue,
-            VariableComparison comparison,
-            Player player,
-            Event instance
-        )
-        {
-            return VariableCheckHandlerRegistry.CheckVariableComparison(currentValue, comparison, player, instance);
-        }
-
-        public static bool CheckVariableComparison(
-            VariableValue currentValue,
-            BooleanVariableComparison comparison,
-            Player player,
-            Event instance
-        )
-        {
-            VariableValue compValue = null;
-            if (comparison.CompareVariableId != Guid.Empty)
-            {
-                if (comparison.CompareVariableType == VariableType.PlayerVariable)
-                {
-                    compValue = player.GetVariableValue(comparison.CompareVariableId);
-                }
-                else if (comparison.CompareVariableType == VariableType.ServerVariable)
-                {
-                    compValue = ServerVariableBase.Get(comparison.CompareVariableId)?.Value;
-                }
-                else if (comparison.CompareVariableType == VariableType.GuildVariable)
-                {
-                    compValue = player.Guild?.GetVariableValue(comparison.CompareVariableId);
-                }
-                else if (comparison.CompareVariableType == VariableType.UserVariable)
-                {
-                    compValue = player.User.GetVariableValue(comparison.CompareVariableId);
-                }
-            }
-            else
-            {
-                compValue = new VariableValue();
-                compValue.Boolean = comparison.Value;
-            }
-
-            if (compValue == null)
-            {
-                compValue = new VariableValue();
-            }
-
-            if (currentValue.Type == 0)
-            {
-                currentValue.Boolean = false;
-            }
-
-            if (compValue.Type != currentValue.Type)
-            {
-                return false;
-            }
-
-            if (comparison.ComparingEqual)
-            {
-                return currentValue.Boolean == compValue.Boolean;
-            }
-            else
-            {
-                return currentValue.Boolean != compValue.Boolean;
-            }
-        }
-
-        public static bool CheckVariableComparison(
-            VariableValue currentValue,
-            IntegerVariableComparison comparison,
-            Player player,
-            Event instance
-        )
-        {
-            long compareAgainst = 0;
-
-            VariableValue compValue = null;
-            if (comparison.CompareVariableId != Guid.Empty)
-            {
-                if (comparison.CompareVariableType == VariableType.PlayerVariable)
-                {
-                    compValue = player.GetVariableValue(comparison.CompareVariableId);
-                }
-                else if (comparison.CompareVariableType == VariableType.ServerVariable)
-                {
-                    compValue = ServerVariableBase.Get(comparison.CompareVariableId)?.Value;
-                }
-                else if (comparison.CompareVariableType == VariableType.GuildVariable)
-                {
-                    compValue = player.Guild?.GetVariableValue(comparison.CompareVariableId);
-                }
-                else if (comparison.CompareVariableType == VariableType.UserVariable)
-                {
-                    compValue = player.User.GetVariableValue(comparison.CompareVariableId);
-                }
-            }
-            else if (comparison.TimeSystem)
-            {
-                compValue = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
-            }
-            else
-            {
-                compValue = new VariableValue();
-                compValue.Integer = comparison.Value;
-            }
-
-            if (compValue == null)
-            {
-                compValue = new VariableValue();
-            }
-
-            if (currentValue.Type == 0)
-            {
-                currentValue.Integer = 0;
-            }
-
-            if (compValue.Type != currentValue.Type)
-            {
-                return false;
-            }
-
-            var varVal = currentValue.Integer;
-            compareAgainst = compValue.Integer;
-
-            switch (comparison.Comparator) //Comparator
-            {
-                case VariableComparator.Equal:
-                    if (varVal == compareAgainst)
-                    {
-                        return true;
-                    }
-
-                    break;
-                case VariableComparator.GreaterOrEqual:
-                    if (varVal >= compareAgainst)
-                    {
-                        return true;
-                    }
-
-                    break;
-                case VariableComparator.LesserOrEqual:
-                    if (varVal <= compareAgainst)
-                    {
-                        return true;
-                    }
-
-                    break;
-                case VariableComparator.Greater:
-                    if (varVal > compareAgainst)
-                    {
-                        return true;
-                    }
-
-                    break;
-                case VariableComparator.Less:
-                    if (varVal < compareAgainst)
-                    {
-                        return true;
-                    }
-
-                    break;
-                case VariableComparator.NotEqual:
-                    if (varVal != compareAgainst)
-                    {
-                        return true;
-                    }
-
-                    break;
-            }
-
-            return false;
-        }
-
-        public static bool CheckVariableComparison(
-            VariableValue currentValue,
-            StringVariableComparison comparison,
-            Player player,
-            Event instance
-        )
-        {
-            var varVal = CommandProcessing.ParseEventText(currentValue.String ?? "", player, instance);
-            var compareAgainst = CommandProcessing.ParseEventText(comparison.Value ?? "", player, instance);
-
-            switch (comparison.Comparator)
-            {
-                case StringVariableComparator.Equal:
-                    return varVal == compareAgainst;
-                case StringVariableComparator.Contains:
-                    return varVal.Contains(compareAgainst);
-            }
-
-            return false;
-        }
-
+        return false;
     }
 
 }

--- a/Intersect.Server.Core/Entities/Events/Event.cs
+++ b/Intersect.Server.Core/Entities/Events/Event.cs
@@ -7,437 +7,435 @@ using Intersect.Server.Maps;
 using Intersect.Server.Networking;
 using Intersect.Utilities;
 
-namespace Intersect.Server.Entities.Events
+namespace Intersect.Server.Entities.Events;
+
+
+public partial class Event
 {
 
-    public partial class Event
+    public EventBase BaseEvent;
+
+    public Stack<CommandInstance> CallStack = new Stack<CommandInstance>();
+
+    public bool Global;
+
+    public EventPageInstance[] GlobalPageInstance;
+
+    public bool HoldingPlayer;
+
+    public Guid Id;
+
+    public Guid MapId;
+
+    public Guid MapInstanceId;
+
+    public MapController MapController;
+
+    private Dictionary<string, string> mParams = new Dictionary<string, string>();
+
+    public int PageIndex;
+
+    public EventPageInstance PageInstance;
+
+    public Player Player;
+
+    //Special conditions
+    public bool PlayerHasDied;
+
+    public int SpawnX;
+
+    public int SpawnY;
+
+    public long WaitTimer;
+
+    public int X;
+
+    public int Y;
+
+    public Event(Guid instanceId, MapController map, Player player, EventBase baseEvent)
     {
+        Id = instanceId;
+        MapInstanceId = player.MapInstanceId;
+        MapId = map?.Id ?? Guid.Empty;
+        MapController = map;
+        Player = player;
+        SelfSwitch = new bool[4];
+        BaseEvent = baseEvent;
+        X = baseEvent.SpawnX;
+        Y = baseEvent.SpawnY;
+    }
 
-        public EventBase BaseEvent;
-
-        public Stack<CommandInstance> CallStack = new Stack<CommandInstance>();
-
-        public bool Global;
-
-        public EventPageInstance[] GlobalPageInstance;
-
-        public bool HoldingPlayer;
-
-        public Guid Id;
-
-        public Guid MapId;
-
-        public Guid MapInstanceId;
-
-        public MapController MapController;
-
-        private Dictionary<string, string> mParams = new Dictionary<string, string>();
-
-        public int PageIndex;
-
-        public EventPageInstance PageInstance;
-
-        public Player Player;
-
-        //Special conditions
-        public bool PlayerHasDied;
-
-        public int SpawnX;
-
-        public int SpawnY;
-
-        public long WaitTimer;
-
-        public int X;
-
-        public int Y;
-
-        public Event(Guid instanceId, MapController map, Player player, EventBase baseEvent)
+    public Event(Guid instanceId, EventBase baseEvent, MapController map, Guid mapInstanceId) //Global constructor
+    {
+        Id = instanceId;
+        MapInstanceId = mapInstanceId;
+        Global = true;
+        MapId = map?.Id ?? Guid.Empty;
+        MapController = map;
+        BaseEvent = baseEvent;
+        SelfSwitch = new bool[4];
+        GlobalPageInstance = new EventPageInstance[BaseEvent.Pages.Count];
+        X = (byte) baseEvent.SpawnX;
+        Y = baseEvent.SpawnY;
+        for (var i = 0; i < BaseEvent.Pages.Count; i++)
         {
-            Id = instanceId;
-            MapInstanceId = player.MapInstanceId;
-            MapId = map?.Id ?? Guid.Empty;
-            MapController = map;
-            Player = player;
-            SelfSwitch = new bool[4];
-            BaseEvent = baseEvent;
-            X = baseEvent.SpawnX;
-            Y = baseEvent.SpawnY;
+            GlobalPageInstance[i] = new EventPageInstance(BaseEvent, BaseEvent.Pages[i], MapId, mapInstanceId, this, null);
         }
+    }
 
-        public Event(Guid instanceId, EventBase baseEvent, MapController map, Guid mapInstanceId) //Global constructor
+    public bool[] SelfSwitch { get; set; }
+
+    public void Update(long timeMs, MapController map)
+    {
+        var sendLeave = false;
+        var originalPageInstance = PageInstance;
+        if (PageInstance != null)
         {
-            Id = instanceId;
-            MapInstanceId = mapInstanceId;
-            Global = true;
-            MapId = map?.Id ?? Guid.Empty;
-            MapController = map;
-            BaseEvent = baseEvent;
-            SelfSwitch = new bool[4];
-            GlobalPageInstance = new EventPageInstance[BaseEvent.Pages.Count];
-            X = (byte) baseEvent.SpawnX;
-            Y = baseEvent.SpawnY;
-            for (var i = 0; i < BaseEvent.Pages.Count; i++)
+            //Check for despawn
+            if (PageInstance.ShouldDespawn(map))
             {
-                GlobalPageInstance[i] = new EventPageInstance(BaseEvent, BaseEvent.Pages[i], MapId, mapInstanceId, this, null);
-            }
-        }
-
-        public bool[] SelfSwitch { get; set; }
-
-        public void Update(long timeMs, MapController map)
-        {
-            var sendLeave = false;
-            var originalPageInstance = PageInstance;
-            if (PageInstance != null)
-            {
-                //Check for despawn
-                if (PageInstance.ShouldDespawn(map))
+                X = PageInstance.X;
+                Y = PageInstance.Y;
+                if (PageInstance.GlobalClone != null)
                 {
-                    X = PageInstance.X;
-                    Y = PageInstance.Y;
-                    if (PageInstance.GlobalClone != null)
-                    {
-                        Player.GlobalPageInstanceLookup.TryRemove(PageInstance.GlobalClone, out Event val);
-                    }
-                    PageInstance = null;
-                    CallStack.Clear();
-                    PlayerHasDied = false;
-                    if (HoldingPlayer)
-                    {
-                        PacketSender.SendReleasePlayer(Player, Id);
-                        HoldingPlayer = false;
-                    }
-
-                    sendLeave = true;
+                    Player.GlobalPageInstanceLookup.TryRemove(PageInstance.GlobalClone, out Event val);
                 }
-                else
+                PageInstance = null;
+                CallStack.Clear();
+                PlayerHasDied = false;
+                if (HoldingPlayer)
                 {
-                    if (!Global)
+                    PacketSender.SendReleasePlayer(Player, Id);
+                    HoldingPlayer = false;
+                }
+
+                sendLeave = true;
+            }
+            else
+            {
+                if (!Global)
+                {
+                    PageInstance.Update(
+                        CallStack.Count > 0, timeMs
+                    ); //Process movement and stuff that is client specific
+                }
+
+                //Check to see if we should process event commands
+                if (CallStack.Count > 0)
+                {
+                    var curStack = CallStack.Peek();
+                    if (curStack == null)
                     {
-                        PageInstance.Update(
-                            CallStack.Count > 0, timeMs
-                        ); //Process movement and stuff that is client specific
+                        Log.Error("Curstack variable in event update is null.. not sure how nor how to recover so just gonna let this crash now..");
+                    }
+                    if (Player == null)
+                    {
+                        Log.Error("Player variable in event update is null.. not sure how nor how to recover so just gonna let this crash now..");
+                    }
+                    if (curStack.WaitingForResponse == CommandInstance.EventResponse.Shop && Player.InShop == null)
+                    {
+                        curStack.WaitingForResponse = CommandInstance.EventResponse.None;
                     }
 
-                    //Check to see if we should process event commands
-                    if (CallStack.Count > 0)
+                    if (curStack.WaitingForResponse == CommandInstance.EventResponse.Crafting &&
+                        Player.OpenCraftingTableId == Guid.Empty)
                     {
-                        var curStack = CallStack.Peek();
-                        if (curStack == null)
-                        {
-                            Log.Error("Curstack variable in event update is null.. not sure how nor how to recover so just gonna let this crash now..");
-                        }
-                        if (Player == null)
-                        {
-                            Log.Error("Player variable in event update is null.. not sure how nor how to recover so just gonna let this crash now..");
-                        }
-                        if (curStack.WaitingForResponse == CommandInstance.EventResponse.Shop && Player.InShop == null)
-                        {
-                            curStack.WaitingForResponse = CommandInstance.EventResponse.None;
-                        }
+                        curStack.WaitingForResponse = CommandInstance.EventResponse.None;
+                    }
 
-                        if (curStack.WaitingForResponse == CommandInstance.EventResponse.Crafting &&
-                            Player.OpenCraftingTableId == Guid.Empty)
-                        {
-                            curStack.WaitingForResponse = CommandInstance.EventResponse.None;
-                        }
+                    if (curStack.WaitingForResponse == CommandInstance.EventResponse.Bank && Player.InBank == false)
+                    {
+                        curStack.WaitingForResponse = CommandInstance.EventResponse.None;
+                    }
 
-                        if (curStack.WaitingForResponse == CommandInstance.EventResponse.Bank && Player.InBank == false)
-                        {
-                            curStack.WaitingForResponse = CommandInstance.EventResponse.None;
-                        }
+                    if (curStack.WaitingForResponse == CommandInstance.EventResponse.Quest &&
+                        !Player.QuestOffers.Contains(((StartQuestCommand) curStack.WaitingOnCommand).QuestId))
+                    {
+                        curStack.WaitingForResponse = CommandInstance.EventResponse.None;
+                    }
 
-                        if (curStack.WaitingForResponse == CommandInstance.EventResponse.Quest &&
-                            !Player.QuestOffers.Contains(((StartQuestCommand) curStack.WaitingOnCommand).QuestId))
-                        {
-                            curStack.WaitingForResponse = CommandInstance.EventResponse.None;
-                        }
+                    if (curStack.WaitingForResponse == CommandInstance.EventResponse.Timer &&
+                        WaitTimer < Timing.Global.Milliseconds)
+                    {
+                        curStack.WaitingForResponse = CommandInstance.EventResponse.None;
+                    }
 
-                        if (curStack.WaitingForResponse == CommandInstance.EventResponse.Timer &&
-                            WaitTimer < Timing.Global.Milliseconds)
-                        {
-                            curStack.WaitingForResponse = CommandInstance.EventResponse.None;
-                        }
+                    if (curStack.WaitingForResponse == CommandInstance.EventResponse.Fade &&
+                        !Player.IsFading)
+                    {
+                        curStack.WaitingForResponse = CommandInstance.EventResponse.None;
+                    }
 
-                        if (curStack.WaitingForResponse == CommandInstance.EventResponse.Fade &&
-                            !Player.IsFading)
+                    var commandsExecuted = 0;
+                    while (curStack != null && curStack.WaitingForResponse == CommandInstance.EventResponse.None &&
+                           !(PageInstance?.ShouldDespawn(map) ?? false) &&
+                           commandsExecuted < Options.EventWatchdogKillThreshhold)
+                    {
+                        if (curStack.WaitingForRoute != Guid.Empty)
                         {
-                            curStack.WaitingForResponse = CommandInstance.EventResponse.None;
-                        }
-
-                        var commandsExecuted = 0;
-                        while (curStack != null && curStack.WaitingForResponse == CommandInstance.EventResponse.None &&
-                               !(PageInstance?.ShouldDespawn(map) ?? false) &&
-                               commandsExecuted < Options.EventWatchdogKillThreshhold)
-                        {
-                            if (curStack.WaitingForRoute != Guid.Empty)
+                            if (curStack.WaitingForRoute == Player.Id)
                             {
-                                if (curStack.WaitingForRoute == Player.Id)
+                                if (Player.MoveRoute == null ||
+                                    Player.MoveRoute.Complete && Player.MoveTimer < Timing.Global.Milliseconds)
                                 {
-                                    if (Player.MoveRoute == null ||
-                                        Player.MoveRoute.Complete && Player.MoveTimer < Timing.Global.Milliseconds)
-                                    {
-                                        curStack.WaitingForRoute = Guid.Empty;
-                                        curStack.WaitingForRouteMap = Guid.Empty;
-                                    }
-                                }
-                                else
-                                {
-                                    //Check if the exist exists && if the move route is completed.
-                                    foreach (var evt in Player.EventLookup)
-                                    {
-                                        if (evt.Value.MapId == curStack.WaitingForRouteMap &&
-                                            evt.Value.BaseEvent.Id == curStack.WaitingForRoute)
-                                        {
-                                            if (evt.Value.PageInstance == null)
-                                            {
-                                                break;
-                                            }
-
-                                            if (!evt.Value.PageInstance.MoveRoute.Complete)
-                                            {
-                                                break;
-                                            }
-
-                                            curStack.WaitingForRoute = Guid.Empty;
-                                            curStack.WaitingForRouteMap = Guid.Empty;
-
-                                            break;
-                                        }
-                                    }
-                                }
-
-                                if (curStack.WaitingForRoute != Guid.Empty)
-                                {
-                                    break;
+                                    curStack.WaitingForRoute = Guid.Empty;
+                                    curStack.WaitingForRouteMap = Guid.Empty;
                                 }
                             }
                             else
                             {
-                                if (curStack.CommandIndex >= curStack.CommandList.Count)
+                                //Check if the exist exists && if the move route is completed.
+                                foreach (var evt in Player.EventLookup)
                                 {
-                                    CallStack.Pop();
-                                }
-                                else
-                                {
-                                    if (WaitTimer < Timing.Global.Milliseconds)
+                                    if (evt.Value.MapId == curStack.WaitingForRouteMap &&
+                                        evt.Value.BaseEvent.Id == curStack.WaitingForRoute)
                                     {
-                                        CommandProcessing.ProcessCommand(curStack.Command, Player, this);
-                                        commandsExecuted++;
-                                    }
-                                    else
-                                    {
+                                        if (evt.Value.PageInstance == null)
+                                        {
+                                            break;
+                                        }
+
+                                        if (!evt.Value.PageInstance.MoveRoute.Complete)
+                                        {
+                                            break;
+                                        }
+
+                                        curStack.WaitingForRoute = Guid.Empty;
+                                        curStack.WaitingForRouteMap = Guid.Empty;
+
                                         break;
                                     }
                                 }
+                            }
 
-                                if (CallStack.Count == 0)
+                            if (curStack.WaitingForRoute != Guid.Empty)
+                            {
+                                break;
+                            }
+                        }
+                        else
+                        {
+                            if (curStack.CommandIndex >= curStack.CommandList.Count)
+                            {
+                                CallStack.Pop();
+                            }
+                            else
+                            {
+                                if (WaitTimer < Timing.Global.Milliseconds)
                                 {
-                                    PlayerHasDied = false;
-
+                                    CommandProcessing.ProcessCommand(curStack.Command, Player, this);
+                                    commandsExecuted++;
+                                }
+                                else
+                                {
                                     break;
                                 }
                             }
 
-                            curStack = CallStack.Peek();
+                            if (CallStack.Count == 0)
+                            {
+                                PlayerHasDied = false;
+
+                                break;
+                            }
                         }
 
-                        if (commandsExecuted >= Options.EventWatchdogKillThreshhold)
+                        curStack = CallStack.Peek();
+                    }
+
+                    if (commandsExecuted >= Options.EventWatchdogKillThreshhold)
+                    {
+                        CallStack.Clear(); //Killing this event, we're over it.
+                        if (this.BaseEvent.MapId == Guid.Empty)
                         {
-                            CallStack.Clear(); //Killing this event, we're over it.
-                            if (this.BaseEvent.MapId == Guid.Empty)
+                            Log.Error(Strings.Events.watchdogkillcommon.ToString(BaseEvent.Name));
+                            if (Player.Power.IsModerator)
                             {
-                                Log.Error(Strings.Events.watchdogkillcommon.ToString(BaseEvent.Name));
-                                if (Player.Power.IsModerator)
-                                {
-                                    PacketSender.SendChatMsg(
-                                        Player, Strings.Events.watchdogkillcommon.ToString(BaseEvent.Name), ChatMessageType.Error, Color.Red
-                                    );
-                                }
+                                PacketSender.SendChatMsg(
+                                    Player, Strings.Events.watchdogkillcommon.ToString(BaseEvent.Name), ChatMessageType.Error, Color.Red
+                                );
                             }
-                            else
+                        }
+                        else
+                        {
+                            Log.Error(Strings.Events.watchdogkill.ToString(map.Name, BaseEvent.Name));
+                            if (Player.Power.IsModerator)
                             {
-                                Log.Error(Strings.Events.watchdogkill.ToString(map.Name, BaseEvent.Name));
-                                if (Player.Power.IsModerator)
+                                PacketSender.SendChatMsg(
+                                    Player, Strings.Events.watchdogkill.ToString(map.Name, BaseEvent.Name),
+                                    ChatMessageType.Error, Color.Red
+                                );
+                            }
+                        }
+                    }
+                }
+                else
+                {
+                    if (PageInstance.Trigger == EventTrigger.Autorun && WaitTimer < Timing.Global.Milliseconds)
+                    {
+                        var newStack = new CommandInstance(PageInstance.MyPage);
+                        CallStack.Push(newStack);
+                    }
+                }
+            }
+        }
+
+        if (PageInstance == null)
+        {
+            //Try to Spawn a PageInstance.. if we can
+            for (var i = BaseEvent.Pages.Count - 1; i >= 0; i--)
+            {
+                if (Conditions.CanSpawnPage(BaseEvent.Pages[i], Player, this))
+                {
+                    if (Global)
+                    {
+                        if (MapController.TryGetInstanceFromMap(map.Id, Player.MapInstanceId, out var mapInstance))
+                        {
+                            var globalEvent = mapInstance.GetGlobalEventInstance(BaseEvent);
+                            if (globalEvent != null)
+                            {
+                                PageInstance = new EventPageInstance(
+                                    BaseEvent, BaseEvent.Pages[i], BaseEvent.Id, MapId, Player.MapInstanceId, this, Player,
+                                    globalEvent.GlobalPageInstance[i]
+                                );
+
+                                if (PageInstance.GlobalClone != null)
                                 {
-                                    PacketSender.SendChatMsg(
-                                        Player, Strings.Events.watchdogkill.ToString(map.Name, BaseEvent.Name),
-                                        ChatMessageType.Error, Color.Red
-                                    );
+                                    Player.GlobalPageInstanceLookup.AddOrUpdate(globalEvent.GlobalPageInstance[i], this, (key, oldValue) => this);
                                 }
+
+                                sendLeave = false;
+                                PageIndex = i;
                             }
                         }
                     }
                     else
                     {
-                        if (PageInstance.Trigger == EventTrigger.Autorun && WaitTimer < Timing.Global.Milliseconds)
-                        {
-                            var newStack = new CommandInstance(PageInstance.MyPage);
-                            CallStack.Push(newStack);
-                        }
+                        PageInstance = new EventPageInstance(BaseEvent, BaseEvent.Pages[i], MapId, Player.MapInstanceId, this, Player);
+                        sendLeave = false;
+                        PageIndex = i;
                     }
+
+                    break;
                 }
             }
 
-            if (PageInstance == null)
+            if (sendLeave && originalPageInstance != null)
             {
-                //Try to Spawn a PageInstance.. if we can
-                for (var i = BaseEvent.Pages.Count - 1; i >= 0; i--)
-                {
-                    if (Conditions.CanSpawnPage(BaseEvent.Pages[i], Player, this))
-                    {
-                        if (Global)
-                        {
-                            if (MapController.TryGetInstanceFromMap(map.Id, Player.MapInstanceId, out var mapInstance))
-                            {
-                                var globalEvent = mapInstance.GetGlobalEventInstance(BaseEvent);
-                                if (globalEvent != null)
-                                {
-                                    PageInstance = new EventPageInstance(
-                                        BaseEvent, BaseEvent.Pages[i], BaseEvent.Id, MapId, Player.MapInstanceId, this, Player,
-                                        globalEvent.GlobalPageInstance[i]
-                                    );
-
-                                    if (PageInstance.GlobalClone != null)
-                                    {
-                                        Player.GlobalPageInstanceLookup.AddOrUpdate(globalEvent.GlobalPageInstance[i], this, (key, oldValue) => this);
-                                    }
-
-                                    sendLeave = false;
-                                    PageIndex = i;
-                                }
-                            }
-                        }
-                        else
-                        {
-                            PageInstance = new EventPageInstance(BaseEvent, BaseEvent.Pages[i], MapId, Player.MapInstanceId, this, Player);
-                            sendLeave = false;
-                            PageIndex = i;
-                        }
-
-                        break;
-                    }
-                }
-
-                if (sendLeave && originalPageInstance != null)
-                {
-                    PacketSender.SendEntityLeaveTo(Player, originalPageInstance);
-                }
+                PacketSender.SendEntityLeaveTo(Player, originalPageInstance);
             }
         }
+    }
 
-        public Dictionary<string, string> GetParams(Player player)
+    public Dictionary<string, string> GetParams(Player player)
+    {
+        var prams = new Dictionary<string, string>();
+
+        foreach (var prm in mParams)
         {
-            var prams = new Dictionary<string, string>();
-
-            foreach (var prm in mParams)
-            {
-                prams.Add(prm.Key, prm.Value);
-            }
-
-            prams.Add("evtName", BaseEvent.Name);
-
-            var map = MapController.Get(BaseEvent.MapId);
-            if (map != null)
-            {
-                prams.Add("evtMap", map.Name);
-            }
-
-            if (MapId != Guid.Empty)
-            {
-                if (Global && MapController.TryGetInstanceFromMap(MapId, MapInstanceId, out var mapInstance))
-                {
-                    var globalEvent = mapInstance.GetGlobalEventInstance(BaseEvent);
-                    if (globalEvent.GlobalPageInstance != null)
-                    {
-                        prams.Add("evtX", globalEvent.GlobalPageInstance[globalEvent.PageIndex].X.ToString());
-                        prams.Add("evtY", globalEvent.GlobalPageInstance[globalEvent.PageIndex].Y.ToString());
-                    }
-                }
-                else if (PageInstance != null)
-                {
-                    prams.Add("evtX", PageInstance.X.ToString());
-                    prams.Add("evtY", PageInstance.Y.ToString());
-                }
-            }
-
-            if (player != null)
-            {
-                //Player Name, Map, X, Y, Z?
-                //Player Vitals, Player Stats, Player Sprite?
-                //More later.. good start now
-                prams.Add("plyrName", player.Name);
-                prams.Add("plyrMap", player.Map.Name);
-                prams.Add("plyrX", player.X.ToString());
-                prams.Add("plyrY", player.Y.ToString());
-                prams.Add("plyrZ", player.Z.ToString());
-                prams.Add("plyrSprite", player.Sprite);
-                prams.Add("plyrFace", player.Face);
-                prams.Add("plyrLvl", player.Level.ToString());
-
-                //Vitals
-                for (var i = 0; i < player.GetVitals().Length; i++)
-                {
-                    prams.Add("plyrVit" + i, player.GetVital(i).ToString());
-                    prams.Add("plyrMaxVit" + i, player.GetMaxVital(i).ToString());
-                }
-
-                //Stats
-                var stats = player.GetStatValues();
-                for (var i = 0; i < stats.Length; i++)
-                {
-                    prams.Add("plyrStat" + i, stats[i].ToString());
-                }
-            }
-
-            return prams;
+            prams.Add(prm.Key, prm.Value);
         }
 
-        public void SetParam(string key, string value)
+        prams.Add("evtName", BaseEvent.Name);
+
+        var map = MapController.Get(BaseEvent.MapId);
+        if (map != null)
         {
-            key = key.ToLower();
-            if (mParams.ContainsKey(key))
-            {
-                mParams[key] = value;
-            }
-            else
-            {
-                mParams.Add(key, value);
-            }
+            prams.Add("evtMap", map.Name);
         }
 
-        public string GetParam(Player player, string key)
+        if (MapId != Guid.Empty)
         {
-            key = key.ToLower();
-
-            var prams = GetParams(player);
-
-            foreach (var pair in prams)
+            if (Global && MapController.TryGetInstanceFromMap(MapId, MapInstanceId, out var mapInstance))
             {
-                if (string.Equals(pair.Key, key, StringComparison.OrdinalIgnoreCase))
+                var globalEvent = mapInstance.GetGlobalEventInstance(BaseEvent);
+                if (globalEvent.GlobalPageInstance != null)
                 {
-                    return pair.Value;
+                    prams.Add("evtX", globalEvent.GlobalPageInstance[globalEvent.PageIndex].X.ToString());
+                    prams.Add("evtY", globalEvent.GlobalPageInstance[globalEvent.PageIndex].Y.ToString());
                 }
             }
-
-            return "";
+            else if (PageInstance != null)
+            {
+                prams.Add("evtX", PageInstance.X.ToString());
+                prams.Add("evtY", PageInstance.Y.ToString());
+            }
         }
 
-        public string FormatParameters(Player player)
+        if (player != null)
         {
-            var prams = GetParams(player);
-            var output = "{" + Environment.NewLine;
-            foreach (var p in prams)
+            //Player Name, Map, X, Y, Z?
+            //Player Vitals, Player Stats, Player Sprite?
+            //More later.. good start now
+            prams.Add("plyrName", player.Name);
+            prams.Add("plyrMap", player.Map.Name);
+            prams.Add("plyrX", player.X.ToString());
+            prams.Add("plyrY", player.Y.ToString());
+            prams.Add("plyrZ", player.Z.ToString());
+            prams.Add("plyrSprite", player.Sprite);
+            prams.Add("plyrFace", player.Face);
+            prams.Add("plyrLvl", player.Level.ToString());
+
+            //Vitals
+            for (var i = 0; i < player.GetVitals().Length; i++)
             {
-                output += "\t\t\t\"" + p.Key + "\":\t\t\"" + p.Value + "\"," + Environment.NewLine;
+                prams.Add("plyrVit" + i, player.GetVital(i).ToString());
+                prams.Add("plyrMaxVit" + i, player.GetMaxVital(i).ToString());
             }
 
-            output += "}";
-
-            return output;
+            //Stats
+            var stats = player.GetStatValues();
+            for (var i = 0; i < stats.Length; i++)
+            {
+                prams.Add("plyrStat" + i, stats[i].ToString());
+            }
         }
 
+        return prams;
+    }
+
+    public void SetParam(string key, string value)
+    {
+        key = key.ToLower();
+        if (mParams.ContainsKey(key))
+        {
+            mParams[key] = value;
+        }
+        else
+        {
+            mParams.Add(key, value);
+        }
+    }
+
+    public string GetParam(Player player, string key)
+    {
+        key = key.ToLower();
+
+        var prams = GetParams(player);
+
+        foreach (var pair in prams)
+        {
+            if (string.Equals(pair.Key, key, StringComparison.OrdinalIgnoreCase))
+            {
+                return pair.Value;
+            }
+        }
+
+        return "";
+    }
+
+    public string FormatParameters(Player player)
+    {
+        var prams = GetParams(player);
+        var output = "{" + Environment.NewLine;
+        foreach (var p in prams)
+        {
+            output += "\t\t\t\"" + p.Key + "\":\t\t\"" + p.Value + "\"," + Environment.NewLine;
+        }
+
+        output += "}";
+
+        return output;
     }
 
 }

--- a/Intersect.Server.Core/Entities/Events/EventPageInstance.cs
+++ b/Intersect.Server.Core/Entities/Events/EventPageInstance.cs
@@ -7,294 +7,214 @@ using Intersect.Server.Maps;
 using Intersect.Server.Networking;
 using Intersect.Utilities;
 
-namespace Intersect.Server.Entities.Events
+namespace Intersect.Server.Entities.Events;
+
+
+public partial class EventPageInstance : Entity
 {
 
-    public partial class EventPageInstance : Entity
+    public EventBase BaseEvent;
+
+    public bool DisablePreview;
+
+    public EventPageInstance GlobalClone;
+
+    private bool mDirectionFix;
+
+    private EventMovementSpeed mMovementSpeed;
+
+    public EventMovementFrequency MovementFreq;
+
+    public EventMovementType MovementType;
+
+    private int mPageNum;
+
+    private Pathfinder mPathFinder;
+
+    private EventRenderLayer mRenderLayer = EventRenderLayer.SameAsPlayer;
+
+    private bool mWalkingAnim;
+
+    public Event MyEventIndex;
+
+    public EventGraphic MyGraphic = new EventGraphic();
+
+    public EventPage MyPage;
+
+    public string Param;
+
+    public Player Player;
+
+    public EventTrigger Trigger;
+
+    public int Speed = 20;
+
+    protected override bool IgnoresNpcAvoid => MyPage.IgnoreNpcAvoids;
+
+    protected override bool CanMoveOntoSlide(Direction movementDirection, Direction slideDirection) => false;
+
+    public EventPageInstance(
+        EventBase myEvent,
+        EventPage myPage,
+        Guid mapId,
+        Guid mapInstanceId,
+        Event eventIndex,
+        Player player
+    ) : base()
     {
-
-        public EventBase BaseEvent;
-
-        public bool DisablePreview;
-
-        public EventPageInstance GlobalClone;
-
-        private bool mDirectionFix;
-
-        private EventMovementSpeed mMovementSpeed;
-
-        public EventMovementFrequency MovementFreq;
-
-        public EventMovementType MovementType;
-
-        private int mPageNum;
-
-        private Pathfinder mPathFinder;
-
-        private EventRenderLayer mRenderLayer = EventRenderLayer.SameAsPlayer;
-
-        private bool mWalkingAnim;
-
-        public Event MyEventIndex;
-
-        public EventGraphic MyGraphic = new EventGraphic();
-
-        public EventPage MyPage;
-
-        public string Param;
-
-        public Player Player;
-
-        public EventTrigger Trigger;
-
-        public int Speed = 20;
-
-        protected override bool IgnoresNpcAvoid => MyPage.IgnoreNpcAvoids;
-
-        protected override bool CanMoveOntoSlide(Direction movementDirection, Direction slideDirection) => false;
-
-        public EventPageInstance(
-            EventBase myEvent,
-            EventPage myPage,
-            Guid mapId,
-            Guid mapInstanceId,
-            Event eventIndex,
-            Player player
-        ) : base()
+        BaseEvent = myEvent;
+        Id = BaseEvent.Id;
+        MyPage = myPage;
+        MapId = mapId;
+        MapInstanceId = mapInstanceId;
+        X = eventIndex.X;
+        Y = eventIndex.Y;
+        Name = myEvent.Name;
+        MovementType = MyPage.Movement.Type;
+        MovementFreq = MyPage.Movement.Frequency;
+        MovementSpeed = MyPage.Movement.Speed;
+        DisablePreview = MyPage.DisablePreview;
+        Trigger = MyPage.Trigger;
+        Passable = MyPage.Passable;
+        HideName = MyPage.HideName;
+        MyEventIndex = eventIndex;
+        MoveRoute = new EventMoveRoute();
+        MoveRoute.CopyFrom(MyPage.Movement.Route);
+        mPathFinder = new Pathfinder(this);
+        SetMovementSpeed(MyPage.Movement.Speed);
+        MyGraphic.Type = MyPage.Graphic.Type;
+        MyGraphic.Filename = MyPage.Graphic.Filename;
+        MyGraphic.X = MyPage.Graphic.X;
+        MyGraphic.Y = MyPage.Graphic.Y;
+        MyGraphic.Width = MyPage.Graphic.Width;
+        MyGraphic.Height = MyPage.Graphic.Height;
+        Sprite = MyPage.Graphic.Filename;
+        mDirectionFix = MyPage.DirectionFix;
+        mWalkingAnim = MyPage.WalkingAnimation;
+        mRenderLayer = MyPage.Layer;
+        if (MyGraphic.Type == EventGraphicType.Sprite)
         {
-            BaseEvent = myEvent;
-            Id = BaseEvent.Id;
-            MyPage = myPage;
-            MapId = mapId;
-            MapInstanceId = mapInstanceId;
-            X = eventIndex.X;
-            Y = eventIndex.Y;
-            Name = myEvent.Name;
-            MovementType = MyPage.Movement.Type;
-            MovementFreq = MyPage.Movement.Frequency;
-            MovementSpeed = MyPage.Movement.Speed;
-            DisablePreview = MyPage.DisablePreview;
-            Trigger = MyPage.Trigger;
-            Passable = MyPage.Passable;
-            HideName = MyPage.HideName;
-            MyEventIndex = eventIndex;
-            MoveRoute = new EventMoveRoute();
-            MoveRoute.CopyFrom(MyPage.Movement.Route);
-            mPathFinder = new Pathfinder(this);
-            SetMovementSpeed(MyPage.Movement.Speed);
-            MyGraphic.Type = MyPage.Graphic.Type;
-            MyGraphic.Filename = MyPage.Graphic.Filename;
-            MyGraphic.X = MyPage.Graphic.X;
-            MyGraphic.Y = MyPage.Graphic.Y;
-            MyGraphic.Width = MyPage.Graphic.Width;
-            MyGraphic.Height = MyPage.Graphic.Height;
-            Sprite = MyPage.Graphic.Filename;
-            mDirectionFix = MyPage.DirectionFix;
-            mWalkingAnim = MyPage.WalkingAnimation;
-            mRenderLayer = MyPage.Layer;
-            if (MyGraphic.Type == EventGraphicType.Sprite)
+            switch (MyGraphic.Y)
             {
-                switch (MyGraphic.Y)
-                {
-                    case 0:
-                        Dir = Direction.Down;
+                case 0:
+                    Dir = Direction.Down;
 
-                        break;
-                    case 1:
-                        Dir = Direction.Left;
+                    break;
+                case 1:
+                    Dir = Direction.Left;
 
-                        break;
-                    case 2:
-                        Dir = Direction.Right;
+                    break;
+                case 2:
+                    Dir = Direction.Right;
 
-                        break;
-                    case 3:
-                        Dir = Direction.Up;
+                    break;
+                case 3:
+                    Dir = Direction.Up;
 
-                        break;
-                }
-            }
-
-            if (myPage.AnimationId != Guid.Empty)
-            {
-                Animations.Add(myPage.AnimationId);
-            }
-
-            Face = MyPage.FaceGraphic;
-            mPageNum = BaseEvent.Pages.IndexOf(MyPage);
-            Player = player;
-            SendToPlayer();
-        }
-
-        public EventPageInstance(
-            EventBase myEvent,
-            EventPage myPage,
-            Guid instanceId,
-            Guid mapId,
-            Guid mapInstanceId,
-            Event eventIndex,
-            Player player,
-            EventPageInstance globalClone
-        ) : base(instanceId, Guid.Empty)
-        {
-            BaseEvent = myEvent;
-            Id = BaseEvent.Id;
-            GlobalClone = globalClone;
-            MyPage = myPage;
-            MapId = mapId;
-            MapInstanceId = mapInstanceId;
-            X = globalClone.X;
-            Y = globalClone.Y;
-            Name = myEvent.Name;
-            MovementType = globalClone.MovementType;
-            MovementFreq = globalClone.MovementFreq;
-            MovementSpeed = globalClone.MovementSpeed;
-            DisablePreview = globalClone.DisablePreview;
-            Trigger = MyPage.Trigger;
-            Passable = globalClone.Passable;
-            HideName = globalClone.HideName;
-            MyEventIndex = eventIndex;
-            MoveRoute = globalClone.MoveRoute;
-            mPathFinder = new Pathfinder(this);
-            SetMovementSpeed(MyPage.Movement.Speed);
-            MyGraphic.Type = globalClone.MyGraphic.Type;
-            MyGraphic.Filename = globalClone.MyGraphic.Filename;
-            MyGraphic.X = globalClone.MyGraphic.X;
-            MyGraphic.Y = globalClone.MyGraphic.Y;
-            MyGraphic.Width = globalClone.MyGraphic.Width;
-            MyGraphic.Height = globalClone.MyGraphic.Height;
-            Sprite = MyPage.Graphic.Filename;
-            mDirectionFix = MyPage.DirectionFix;
-            mWalkingAnim = MyPage.WalkingAnimation;
-            mRenderLayer = MyPage.Layer;
-            if (globalClone.MyGraphic.Type == EventGraphicType.Sprite)
-            {
-                switch (MyPage.Graphic.Y)
-                {
-                    case 0:
-                        Dir = Direction.Down;
-
-                        break;
-                    case 1:
-                        Dir = Direction.Left;
-
-                        break;
-                    case 2:
-                        Dir = Direction.Right;
-
-                        break;
-                    case 3:
-                        Dir = Direction.Up;
-
-                        break;
-                }
-            }
-
-            if (myPage.AnimationId != Guid.Empty)
-            {
-                Animations.Add(myPage.AnimationId);
-            }
-
-            Face = MyPage.FaceGraphic;
-            mPageNum = BaseEvent.Pages.IndexOf(MyPage);
-            Player = player;
-            SendToPlayer();
-        }
-
-        public EventMovementSpeed MovementSpeed
-        {
-            get => mMovementSpeed;
-            set
-            {
-                mMovementSpeed = value;
-                switch (mMovementSpeed)
-                {
-                    case EventMovementSpeed.Slowest:
-                        Speed = 2;
-
-                        break;
-                    case EventMovementSpeed.Slower:
-                        Speed = 5;
-
-                        break;
-                    case EventMovementSpeed.Normal:
-                        Speed = 20;
-
-                        break;
-                    case EventMovementSpeed.Faster:
-                        Speed = 30;
-
-                        break;
-                    case EventMovementSpeed.Fastest:
-                        Speed = 40;
-
-                        break;
-                }
+                    break;
             }
         }
 
-        public void SendToPlayer()
+        if (myPage.AnimationId != Guid.Empty)
         {
-            if (Player != null)
+            Animations.Add(myPage.AnimationId);
+        }
+
+        Face = MyPage.FaceGraphic;
+        mPageNum = BaseEvent.Pages.IndexOf(MyPage);
+        Player = player;
+        SendToPlayer();
+    }
+
+    public EventPageInstance(
+        EventBase myEvent,
+        EventPage myPage,
+        Guid instanceId,
+        Guid mapId,
+        Guid mapInstanceId,
+        Event eventIndex,
+        Player player,
+        EventPageInstance globalClone
+    ) : base(instanceId, Guid.Empty)
+    {
+        BaseEvent = myEvent;
+        Id = BaseEvent.Id;
+        GlobalClone = globalClone;
+        MyPage = myPage;
+        MapId = mapId;
+        MapInstanceId = mapInstanceId;
+        X = globalClone.X;
+        Y = globalClone.Y;
+        Name = myEvent.Name;
+        MovementType = globalClone.MovementType;
+        MovementFreq = globalClone.MovementFreq;
+        MovementSpeed = globalClone.MovementSpeed;
+        DisablePreview = globalClone.DisablePreview;
+        Trigger = MyPage.Trigger;
+        Passable = globalClone.Passable;
+        HideName = globalClone.HideName;
+        MyEventIndex = eventIndex;
+        MoveRoute = globalClone.MoveRoute;
+        mPathFinder = new Pathfinder(this);
+        SetMovementSpeed(MyPage.Movement.Speed);
+        MyGraphic.Type = globalClone.MyGraphic.Type;
+        MyGraphic.Filename = globalClone.MyGraphic.Filename;
+        MyGraphic.X = globalClone.MyGraphic.X;
+        MyGraphic.Y = globalClone.MyGraphic.Y;
+        MyGraphic.Width = globalClone.MyGraphic.Width;
+        MyGraphic.Height = globalClone.MyGraphic.Height;
+        Sprite = MyPage.Graphic.Filename;
+        mDirectionFix = MyPage.DirectionFix;
+        mWalkingAnim = MyPage.WalkingAnimation;
+        mRenderLayer = MyPage.Layer;
+        if (globalClone.MyGraphic.Type == EventGraphicType.Sprite)
+        {
+            switch (MyPage.Graphic.Y)
             {
-                PacketSender.SendEntityDataTo(Player, this);
-            }
-            else
-            {
-                PacketSender.SendEntityDataToProximity(this, null);
+                case 0:
+                    Dir = Direction.Down;
+
+                    break;
+                case 1:
+                    Dir = Direction.Left;
+
+                    break;
+                case 2:
+                    Dir = Direction.Right;
+
+                    break;
+                case 3:
+                    Dir = Direction.Up;
+
+                    break;
             }
         }
 
-        public override EntityType GetEntityType()
+        if (myPage.AnimationId != Guid.Empty)
         {
-            return EntityType.Event;
+            Animations.Add(myPage.AnimationId);
         }
 
-        public override EntityPacket EntityPacket(EntityPacket packet = null, Player forPlayer = null)
+        Face = MyPage.FaceGraphic;
+        mPageNum = BaseEvent.Pages.IndexOf(MyPage);
+        Player = player;
+        SendToPlayer();
+    }
+
+    public EventMovementSpeed MovementSpeed
+    {
+        get => mMovementSpeed;
+        set
         {
-            if (packet == null)
-            {
-                packet = new EventEntityPacket();
-            }
-
-            if (GlobalClone != null)
-            {
-                Sprite = GlobalClone.Sprite;
-                Face = GlobalClone.Face;
-                Level = GlobalClone.Level;
-                X = GlobalClone.X;
-                Y = GlobalClone.Y;
-                Z = GlobalClone.Z;
-                Dir = GlobalClone.Dir;
-                Passable = GlobalClone.Passable;
-                HideName = GlobalClone.HideName;
-            }
-
-            packet = base.EntityPacket(packet, forPlayer);
-
-            var pkt = (EventEntityPacket)packet;
-            pkt.HideName = HideName;
-            pkt.DirectionFix = mDirectionFix;
-            pkt.WalkingAnim = mWalkingAnim;
-            pkt.DisablePreview = DisablePreview;
-            pkt.Description = MyPage.Description;
-            pkt.Graphic = MyGraphic;
-            pkt.RenderLayer = (byte)mRenderLayer;
-            pkt.Trigger = Trigger;
-
-            return pkt;
-        }
-
-        public void SetMovementSpeed(EventMovementSpeed speed)
-        {
-            switch (speed)
+            mMovementSpeed = value;
+            switch (mMovementSpeed)
             {
                 case EventMovementSpeed.Slowest:
-                    Speed = 5;
+                    Speed = 2;
 
                     break;
                 case EventMovementSpeed.Slower:
-                    Speed = 10;
+                    Speed = 5;
 
                     break;
                 case EventMovementSpeed.Normal:
@@ -311,151 +231,220 @@ namespace Intersect.Server.Entities.Events
                     break;
             }
         }
+    }
 
-        public override int[] GetStatValues()
+    public void SendToPlayer()
+    {
+        if (Player != null)
         {
-            var stats = new int[Enum.GetValues<Stat>().Length];
-            stats[(int)Enums.Stat.Speed] = Speed;
-            return stats;
+            PacketSender.SendEntityDataTo(Player, this);
+        }
+        else
+        {
+            PacketSender.SendEntityDataToProximity(this, null);
+        }
+    }
+
+    public override EntityType GetEntityType()
+    {
+        return EntityType.Event;
+    }
+
+    public override EntityPacket EntityPacket(EntityPacket packet = null, Player forPlayer = null)
+    {
+        if (packet == null)
+        {
+            packet = new EventEntityPacket();
         }
 
-        public void Update(bool isActive, long timeMs)
+        if (GlobalClone != null)
         {
-            if (MoveTimer >= Timing.Global.Milliseconds || GlobalClone != null || isActive && MyPage.InteractionFreeze)
-            {
-                return;
-            }
+            Sprite = GlobalClone.Sprite;
+            Face = GlobalClone.Face;
+            Level = GlobalClone.Level;
+            X = GlobalClone.X;
+            Y = GlobalClone.Y;
+            Z = GlobalClone.Z;
+            Dir = GlobalClone.Dir;
+            Passable = GlobalClone.Passable;
+            HideName = GlobalClone.HideName;
+        }
 
-            if (MovementType == EventMovementType.MoveRoute && MoveRoute != null)
+        packet = base.EntityPacket(packet, forPlayer);
+
+        var pkt = (EventEntityPacket)packet;
+        pkt.HideName = HideName;
+        pkt.DirectionFix = mDirectionFix;
+        pkt.WalkingAnim = mWalkingAnim;
+        pkt.DisablePreview = DisablePreview;
+        pkt.Description = MyPage.Description;
+        pkt.Graphic = MyGraphic;
+        pkt.RenderLayer = (byte)mRenderLayer;
+        pkt.Trigger = Trigger;
+
+        return pkt;
+    }
+
+    public void SetMovementSpeed(EventMovementSpeed speed)
+    {
+        switch (speed)
+        {
+            case EventMovementSpeed.Slowest:
+                Speed = 5;
+
+                break;
+            case EventMovementSpeed.Slower:
+                Speed = 10;
+
+                break;
+            case EventMovementSpeed.Normal:
+                Speed = 20;
+
+                break;
+            case EventMovementSpeed.Faster:
+                Speed = 30;
+
+                break;
+            case EventMovementSpeed.Fastest:
+                Speed = 40;
+
+                break;
+        }
+    }
+
+    public override int[] GetStatValues()
+    {
+        var stats = new int[Enum.GetValues<Stat>().Length];
+        stats[(int)Enums.Stat.Speed] = Speed;
+        return stats;
+    }
+
+    public void Update(bool isActive, long timeMs)
+    {
+        if (MoveTimer >= Timing.Global.Milliseconds || GlobalClone != null || isActive && MyPage.InteractionFreeze)
+        {
+            return;
+        }
+
+        if (MovementType == EventMovementType.MoveRoute && MoveRoute != null)
+        {
+            ProcessMoveRoute(Player, timeMs);
+        }
+        else
+        {
+            if (MovementType == EventMovementType.Random) //Random
             {
-                ProcessMoveRoute(Player, timeMs);
-            }
-            else
-            {
-                if (MovementType == EventMovementType.Random) //Random
+                if (Randomization.Next(0, 2) != 0)
                 {
-                    if (Randomization.Next(0, 2) != 0)
-                    {
-                        return;
-                    }
+                    return;
+                }
 
-                    var dir = Randomization.NextDirection();
-                    if (CanMoveInDirection(dir))
-                    {
-                        Move(dir, Player);
-                    }
-                    MoveTimer = Timing.Global.Milliseconds + (long)GetMovementTime();
+                var dir = Randomization.NextDirection();
+                if (CanMoveInDirection(dir))
+                {
+                    Move(dir, Player);
+                }
+                MoveTimer = Timing.Global.Milliseconds + (long)GetMovementTime();
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public override void Move(Direction moveDir, Player forPlayer, bool doNotUpdate = false,
+        bool correction = false)
+    {
+        base.Move(moveDir, forPlayer, doNotUpdate, correction);
+
+        if (Trigger == EventTrigger.PlayerCollide && Passable && MapController.TryGetInstanceFromMap(Map.Id, MapInstanceId, out var instance))
+        {
+            var players = instance.GetPlayers();
+            foreach (var player in players)
+            {
+                if (player.X == X && player.Y == Y && player.Z == Z)
+                {
+                    player.HandleEventCollision(this.MyEventIndex, mPageNum);
                 }
             }
         }
+    }
 
-        /// <inheritdoc />
-        public override void Move(Direction moveDir, Player forPlayer, bool doNotUpdate = false,
-            bool correction = false)
+    protected override bool ProcessMoveRoute(Player forPlayer, long timeMs)
+    {
+        if (!base.ProcessMoveRoute(forPlayer, timeMs))
         {
-            base.Move(moveDir, forPlayer, doNotUpdate, correction);
-
-            if (Trigger == EventTrigger.PlayerCollide && Passable && MapController.TryGetInstanceFromMap(Map.Id, MapInstanceId, out var instance))
+            var moved = false;
+            var shouldSendUpdate = false;
+            Direction lookDir;
+            Direction moveDir;
+            if (MoveRoute.ActionIndex < MoveRoute.Actions.Count)
             {
-                var players = instance.GetPlayers();
-                foreach (var player in players)
+                switch (MoveRoute.Actions[MoveRoute.ActionIndex].Type)
                 {
-                    if (player.X == X && player.Y == Y && player.Z == Z)
-                    {
-                        player.HandleEventCollision(this.MyEventIndex, mPageNum);
-                    }
-                }
-            }
-        }
-
-        protected override bool ProcessMoveRoute(Player forPlayer, long timeMs)
-        {
-            if (!base.ProcessMoveRoute(forPlayer, timeMs))
-            {
-                var moved = false;
-                var shouldSendUpdate = false;
-                Direction lookDir;
-                Direction moveDir;
-                if (MoveRoute.ActionIndex < MoveRoute.Actions.Count)
-                {
-                    switch (MoveRoute.Actions[MoveRoute.ActionIndex].Type)
-                    {
-                        case MoveRouteEnum.MoveTowardsPlayer:
-                            //Pathfinding required.. this will be weird.
-                            if (forPlayer != null && GlobalClone == null) //Local Event
+                    case MoveRouteEnum.MoveTowardsPlayer:
+                        //Pathfinding required.. this will be weird.
+                        if (forPlayer != null && GlobalClone == null) //Local Event
+                        {
+                            if (mPathFinder.GetTarget() == null ||
+                                mPathFinder.GetTarget().TargetMapId != forPlayer.MapId ||
+                                mPathFinder.GetTarget().TargetX != forPlayer.X ||
+                                mPathFinder.GetTarget().TargetY != forPlayer.Y)
                             {
-                                if (mPathFinder.GetTarget() == null ||
-                                    mPathFinder.GetTarget().TargetMapId != forPlayer.MapId ||
-                                    mPathFinder.GetTarget().TargetX != forPlayer.X ||
-                                    mPathFinder.GetTarget().TargetY != forPlayer.Y)
-                                {
-                                    mPathFinder.SetTarget(
-                                        new PathfinderTarget(forPlayer.MapId, forPlayer.X, forPlayer.Y, forPlayer.Z)
-                                    );
-                                }
-
-                                //Todo check if next to or on top of player.. if so don't run pathfinder.
-                                if (mPathFinder.Update(timeMs) == PathfinderResult.Success)
-                                {
-                                    var pathDir = mPathFinder.GetMove();
-                                    if (pathDir > Direction.None)
-                                    {
-                                        if (CanMoveInDirection(pathDir))
-                                        {
-                                            Move(pathDir, forPlayer);
-                                            moved = true;
-                                        }
-                                        else
-                                        {
-                                            mPathFinder.PathFailed(timeMs);
-                                        }
-                                    }
-                                }
+                                mPathFinder.SetTarget(
+                                    new PathfinderTarget(forPlayer.MapId, forPlayer.X, forPlayer.Y, forPlayer.Z)
+                                );
                             }
 
-                            break;
-                        case MoveRouteEnum.MoveAwayFromPlayer:
-                            //This won't be anything special.
-                            if (forPlayer != null && GlobalClone == null) //Local Event
+                            //Todo check if next to or on top of player.. if so don't run pathfinder.
+                            if (mPathFinder.Update(timeMs) == PathfinderResult.Success)
                             {
-                                moveDir = GetDirectionTo(forPlayer);
-                                if (moveDir > Direction.None)
+                                var pathDir = mPathFinder.GetMove();
+                                if (pathDir > Direction.None)
                                 {
-                                    switch (moveDir)
+                                    if (CanMoveInDirection(pathDir))
                                     {
-                                        case Direction.Up:
-                                            moveDir = Direction.Down;
-
-                                            break;
-                                        case Direction.Down:
-                                            moveDir = Direction.Up;
-
-                                            break;
-                                        case Direction.Left:
-                                            moveDir = Direction.Right;
-
-                                            break;
-                                        case Direction.Right:
-                                            moveDir = Direction.Left;
-
-                                            break;
-                                    }
-
-                                    if (CanMoveInDirection(moveDir))
-                                    {
-                                        Move(moveDir, forPlayer);
+                                        Move(pathDir, forPlayer);
                                         moved = true;
                                     }
                                     else
                                     {
-                                        //Move Randomly
-                                        moveDir = Randomization.NextDirection();
-                                        if (CanMoveInDirection(moveDir))
-                                        {
-                                            Move(moveDir, forPlayer);
-                                            moved = true;
-                                        }
+                                        mPathFinder.PathFailed(timeMs);
                                     }
+                                }
+                            }
+                        }
+
+                        break;
+                    case MoveRouteEnum.MoveAwayFromPlayer:
+                        //This won't be anything special.
+                        if (forPlayer != null && GlobalClone == null) //Local Event
+                        {
+                            moveDir = GetDirectionTo(forPlayer);
+                            if (moveDir > Direction.None)
+                            {
+                                switch (moveDir)
+                                {
+                                    case Direction.Up:
+                                        moveDir = Direction.Down;
+
+                                        break;
+                                    case Direction.Down:
+                                        moveDir = Direction.Up;
+
+                                        break;
+                                    case Direction.Left:
+                                        moveDir = Direction.Right;
+
+                                        break;
+                                    case Direction.Right:
+                                        moveDir = Direction.Left;
+
+                                        break;
+                                }
+
+                                if (CanMoveInDirection(moveDir))
+                                {
+                                    Move(moveDir, forPlayer);
+                                    moved = true;
                                 }
                                 else
                                 {
@@ -468,431 +457,440 @@ namespace Intersect.Server.Entities.Events
                                     }
                                 }
                             }
-
-                            break;
-                        case MoveRouteEnum.FacePlayer:
-                            if (forPlayer != null && GlobalClone == null) //Local Event
+                            else
                             {
-                                lookDir = GetDirectionTo(forPlayer);
-                                if (lookDir > Direction.None)
+                                //Move Randomly
+                                moveDir = Randomization.NextDirection();
+                                if (CanMoveInDirection(moveDir))
                                 {
-                                    ChangeDir(lookDir);
+                                    Move(moveDir, forPlayer);
                                     moved = true;
                                 }
                             }
-
-                            break;
-                        case MoveRouteEnum.FaceAwayFromPlayer:
-                            if (forPlayer != null && GlobalClone == null) //Local Event
-                            {
-                                lookDir = GetDirectionTo(forPlayer);
-                                if (lookDir > Direction.None)
-                                {
-                                    switch (lookDir)
-                                    {
-                                        case Direction.Up:
-                                            lookDir = Direction.Down;
-
-                                            break;
-                                        case Direction.Down:
-                                            lookDir = Direction.Up;
-
-                                            break;
-                                        case Direction.Left:
-                                            lookDir = Direction.Right;
-
-                                            break;
-                                        case Direction.Right:
-                                            lookDir = Direction.Left;
-
-                                            break;
-                                    }
-
-                                    ChangeDir(lookDir);
-                                    moved = true;
-                                }
-                            }
-
-                            break;
-                        case MoveRouteEnum.SetSpeedSlowest:
-                            SetMovementSpeed(EventMovementSpeed.Slowest);
-                            shouldSendUpdate = true;
-                            moved = true;
-
-                            break;
-                        case MoveRouteEnum.SetSpeedSlower:
-                            SetMovementSpeed(EventMovementSpeed.Slower);
-                            shouldSendUpdate = true;
-                            moved = true;
-
-                            break;
-                        case MoveRouteEnum.SetSpeedNormal:
-                            SetMovementSpeed(EventMovementSpeed.Normal);
-                            shouldSendUpdate = true;
-                            moved = true;
-
-                            break;
-                        case MoveRouteEnum.SetSpeedFaster:
-                            SetMovementSpeed(EventMovementSpeed.Faster);
-                            shouldSendUpdate = true;
-                            moved = true;
-
-                            break;
-                        case MoveRouteEnum.SetSpeedFastest:
-                            SetMovementSpeed(EventMovementSpeed.Fastest);
-                            shouldSendUpdate = true;
-                            moved = true;
-
-                            break;
-                        case MoveRouteEnum.SetFreqLowest:
-                            MovementFreq = EventMovementFrequency.Lowest;
-                            moved = true;
-
-                            break;
-                        case MoveRouteEnum.SetFreqLower:
-                            MovementFreq = EventMovementFrequency.Lower;
-                            moved = true;
-
-                            break;
-                        case MoveRouteEnum.SetFreqNormal:
-                            MovementFreq = EventMovementFrequency.Normal;
-                            moved = true;
-
-                            break;
-                        case MoveRouteEnum.SetFreqHigher:
-                            MovementFreq = EventMovementFrequency.Higher;
-                            moved = true;
-
-                            break;
-                        case MoveRouteEnum.SetFreqHighest:
-                            MovementFreq = EventMovementFrequency.Highest;
-                            moved = true;
-
-                            break;
-                        case MoveRouteEnum.WalkingAnimOn:
-                            mWalkingAnim = true;
-                            shouldSendUpdate = true;
-                            moved = true;
-
-                            break;
-                        case MoveRouteEnum.WalkingAnimOff:
-                            mWalkingAnim = false;
-                            shouldSendUpdate = true;
-                            moved = true;
-
-                            break;
-                        case MoveRouteEnum.DirectionFixOn:
-                            mDirectionFix = true;
-                            moved = true;
-
-                            break;
-                        case MoveRouteEnum.DirectionFixOff:
-                            mDirectionFix = false;
-                            moved = true;
-
-                            break;
-                        case MoveRouteEnum.WalkthroughOn:
-                            Passable = true;
-                            shouldSendUpdate = true;
-                            moved = true;
-
-                            break;
-                        case MoveRouteEnum.WalkthroughOff:
-                            Passable = false;
-                            shouldSendUpdate = true;
-                            moved = true;
-
-                            break;
-                        case MoveRouteEnum.ShowName:
-                            HideName = false;
-                            shouldSendUpdate = true;
-                            moved = true;
-
-                            break;
-                        case MoveRouteEnum.HideName:
-                            HideName = true;
-                            shouldSendUpdate = true;
-                            moved = true;
-
-                            break;
-                        case MoveRouteEnum.SetLevelBelow:
-                            mRenderLayer = EventRenderLayer.BelowPlayer;
-                            shouldSendUpdate = true;
-                            moved = true;
-
-                            break;
-                        case MoveRouteEnum.SetLevelNormal:
-                            mRenderLayer = EventRenderLayer.SameAsPlayer;
-                            shouldSendUpdate = true;
-                            moved = true;
-
-                            break;
-                        case MoveRouteEnum.SetLevelAbove:
-                            mRenderLayer = EventRenderLayer.AbovePlayer;
-                            shouldSendUpdate = true;
-                            moved = true;
-
-                            break;
-                        case MoveRouteEnum.SetGraphic:
-                            MyGraphic.Type = MoveRoute.Actions[MoveRoute.ActionIndex].Graphic.Type;
-                            MyGraphic.Filename = MoveRoute.Actions[MoveRoute.ActionIndex].Graphic.Filename;
-                            MyGraphic.X = MoveRoute.Actions[MoveRoute.ActionIndex].Graphic.X;
-                            MyGraphic.Y = MoveRoute.Actions[MoveRoute.ActionIndex].Graphic.Y;
-                            MyGraphic.Width = MoveRoute.Actions[MoveRoute.ActionIndex].Graphic.Width;
-                            MyGraphic.Height = MoveRoute.Actions[MoveRoute.ActionIndex].Graphic.Height;
-                            if (MyGraphic.Type == EventGraphicType.Sprite)
-                            {
-                                switch (MoveRoute.Actions[MoveRoute.ActionIndex].Graphic.Y)
-                                {
-                                    case 0:
-                                        Dir = Direction.Down;
-
-                                        break;
-                                    case 1:
-                                        Dir = Direction.Left;
-
-                                        break;
-                                    case 2:
-                                        Dir = Direction.Right;
-
-                                        break;
-                                    case 3:
-                                        Dir = Direction.Up;
-
-                                        break;
-                                }
-                            }
-
-                            shouldSendUpdate = true;
-                            moved = true;
-
-                            break;
-                        case MoveRouteEnum.SetAnimation:
-                            Animations.Clear();
-                            var anim = AnimationBase.Get(MoveRoute.Actions[MoveRoute.ActionIndex].AnimationId);
-                            if (anim != null)
-                            {
-                                Animations.Add(MoveRoute.Actions[MoveRoute.ActionIndex].AnimationId);
-                            }
-
-                            shouldSendUpdate = true;
-                            moved = true;
-
-                            break;
-                        default:
-                            //Gonna end up returning false because command not found
-                            return false;
-                    }
-
-                    if (moved || MoveRoute.IgnoreIfBlocked)
-                    {
-                        MoveRoute.ActionIndex++;
-                        if (MoveRoute.ActionIndex >= MoveRoute.Actions.Count)
-                        {
-                            if (MoveRoute.RepeatRoute)
-                            {
-                                MoveRoute.ActionIndex = 0;
-                            }
-
-                            MoveRoute.Complete = true;
                         }
-                    }
 
-                    if (shouldSendUpdate)
-                    {
-                        //Send Update
-                        SendToPlayer();
-                    }
+                        break;
+                    case MoveRouteEnum.FacePlayer:
+                        if (forPlayer != null && GlobalClone == null) //Local Event
+                        {
+                            lookDir = GetDirectionTo(forPlayer);
+                            if (lookDir > Direction.None)
+                            {
+                                ChangeDir(lookDir);
+                                moved = true;
+                            }
+                        }
 
-                    if (MoveTimer < Timing.Global.Milliseconds)
+                        break;
+                    case MoveRouteEnum.FaceAwayFromPlayer:
+                        if (forPlayer != null && GlobalClone == null) //Local Event
+                        {
+                            lookDir = GetDirectionTo(forPlayer);
+                            if (lookDir > Direction.None)
+                            {
+                                switch (lookDir)
+                                {
+                                    case Direction.Up:
+                                        lookDir = Direction.Down;
+
+                                        break;
+                                    case Direction.Down:
+                                        lookDir = Direction.Up;
+
+                                        break;
+                                    case Direction.Left:
+                                        lookDir = Direction.Right;
+
+                                        break;
+                                    case Direction.Right:
+                                        lookDir = Direction.Left;
+
+                                        break;
+                                }
+
+                                ChangeDir(lookDir);
+                                moved = true;
+                            }
+                        }
+
+                        break;
+                    case MoveRouteEnum.SetSpeedSlowest:
+                        SetMovementSpeed(EventMovementSpeed.Slowest);
+                        shouldSendUpdate = true;
+                        moved = true;
+
+                        break;
+                    case MoveRouteEnum.SetSpeedSlower:
+                        SetMovementSpeed(EventMovementSpeed.Slower);
+                        shouldSendUpdate = true;
+                        moved = true;
+
+                        break;
+                    case MoveRouteEnum.SetSpeedNormal:
+                        SetMovementSpeed(EventMovementSpeed.Normal);
+                        shouldSendUpdate = true;
+                        moved = true;
+
+                        break;
+                    case MoveRouteEnum.SetSpeedFaster:
+                        SetMovementSpeed(EventMovementSpeed.Faster);
+                        shouldSendUpdate = true;
+                        moved = true;
+
+                        break;
+                    case MoveRouteEnum.SetSpeedFastest:
+                        SetMovementSpeed(EventMovementSpeed.Fastest);
+                        shouldSendUpdate = true;
+                        moved = true;
+
+                        break;
+                    case MoveRouteEnum.SetFreqLowest:
+                        MovementFreq = EventMovementFrequency.Lowest;
+                        moved = true;
+
+                        break;
+                    case MoveRouteEnum.SetFreqLower:
+                        MovementFreq = EventMovementFrequency.Lower;
+                        moved = true;
+
+                        break;
+                    case MoveRouteEnum.SetFreqNormal:
+                        MovementFreq = EventMovementFrequency.Normal;
+                        moved = true;
+
+                        break;
+                    case MoveRouteEnum.SetFreqHigher:
+                        MovementFreq = EventMovementFrequency.Higher;
+                        moved = true;
+
+                        break;
+                    case MoveRouteEnum.SetFreqHighest:
+                        MovementFreq = EventMovementFrequency.Highest;
+                        moved = true;
+
+                        break;
+                    case MoveRouteEnum.WalkingAnimOn:
+                        mWalkingAnim = true;
+                        shouldSendUpdate = true;
+                        moved = true;
+
+                        break;
+                    case MoveRouteEnum.WalkingAnimOff:
+                        mWalkingAnim = false;
+                        shouldSendUpdate = true;
+                        moved = true;
+
+                        break;
+                    case MoveRouteEnum.DirectionFixOn:
+                        mDirectionFix = true;
+                        moved = true;
+
+                        break;
+                    case MoveRouteEnum.DirectionFixOff:
+                        mDirectionFix = false;
+                        moved = true;
+
+                        break;
+                    case MoveRouteEnum.WalkthroughOn:
+                        Passable = true;
+                        shouldSendUpdate = true;
+                        moved = true;
+
+                        break;
+                    case MoveRouteEnum.WalkthroughOff:
+                        Passable = false;
+                        shouldSendUpdate = true;
+                        moved = true;
+
+                        break;
+                    case MoveRouteEnum.ShowName:
+                        HideName = false;
+                        shouldSendUpdate = true;
+                        moved = true;
+
+                        break;
+                    case MoveRouteEnum.HideName:
+                        HideName = true;
+                        shouldSendUpdate = true;
+                        moved = true;
+
+                        break;
+                    case MoveRouteEnum.SetLevelBelow:
+                        mRenderLayer = EventRenderLayer.BelowPlayer;
+                        shouldSendUpdate = true;
+                        moved = true;
+
+                        break;
+                    case MoveRouteEnum.SetLevelNormal:
+                        mRenderLayer = EventRenderLayer.SameAsPlayer;
+                        shouldSendUpdate = true;
+                        moved = true;
+
+                        break;
+                    case MoveRouteEnum.SetLevelAbove:
+                        mRenderLayer = EventRenderLayer.AbovePlayer;
+                        shouldSendUpdate = true;
+                        moved = true;
+
+                        break;
+                    case MoveRouteEnum.SetGraphic:
+                        MyGraphic.Type = MoveRoute.Actions[MoveRoute.ActionIndex].Graphic.Type;
+                        MyGraphic.Filename = MoveRoute.Actions[MoveRoute.ActionIndex].Graphic.Filename;
+                        MyGraphic.X = MoveRoute.Actions[MoveRoute.ActionIndex].Graphic.X;
+                        MyGraphic.Y = MoveRoute.Actions[MoveRoute.ActionIndex].Graphic.Y;
+                        MyGraphic.Width = MoveRoute.Actions[MoveRoute.ActionIndex].Graphic.Width;
+                        MyGraphic.Height = MoveRoute.Actions[MoveRoute.ActionIndex].Graphic.Height;
+                        if (MyGraphic.Type == EventGraphicType.Sprite)
+                        {
+                            switch (MoveRoute.Actions[MoveRoute.ActionIndex].Graphic.Y)
+                            {
+                                case 0:
+                                    Dir = Direction.Down;
+
+                                    break;
+                                case 1:
+                                    Dir = Direction.Left;
+
+                                    break;
+                                case 2:
+                                    Dir = Direction.Right;
+
+                                    break;
+                                case 3:
+                                    Dir = Direction.Up;
+
+                                    break;
+                            }
+                        }
+
+                        shouldSendUpdate = true;
+                        moved = true;
+
+                        break;
+                    case MoveRouteEnum.SetAnimation:
+                        Animations.Clear();
+                        var anim = AnimationBase.Get(MoveRoute.Actions[MoveRoute.ActionIndex].AnimationId);
+                        if (anim != null)
+                        {
+                            Animations.Add(MoveRoute.Actions[MoveRoute.ActionIndex].AnimationId);
+                        }
+
+                        shouldSendUpdate = true;
+                        moved = true;
+
+                        break;
+                    default:
+                        //Gonna end up returning false because command not found
+                        return false;
+                }
+
+                if (moved || MoveRoute.IgnoreIfBlocked)
+                {
+                    MoveRoute.ActionIndex++;
+                    if (MoveRoute.ActionIndex >= MoveRoute.Actions.Count)
                     {
-                        MoveTimer = Timing.Global.Milliseconds + (long)GetMovementTime();
+                        if (MoveRoute.RepeatRoute)
+                        {
+                            MoveRoute.ActionIndex = 0;
+                        }
+
+                        MoveRoute.Complete = true;
                     }
                 }
-            }
 
+                if (shouldSendUpdate)
+                {
+                    //Send Update
+                    SendToPlayer();
+                }
+
+                if (MoveTimer < Timing.Global.Milliseconds)
+                {
+                    MoveTimer = Timing.Global.Milliseconds + (long)GetMovementTime();
+                }
+            }
+        }
+
+        return true;
+    }
+
+    public override float GetMovementTime()
+    {
+        switch (MovementFreq)
+        {
+            case EventMovementFrequency.Lowest:
+                return 4000;
+            case EventMovementFrequency.Lower:
+                return 2000;
+            case EventMovementFrequency.Normal:
+                return 1000;
+            case EventMovementFrequency.Higher:
+                return 500;
+            case EventMovementFrequency.Highest:
+                return 250;
+            default:
+                return 1000;
+        }
+    }
+
+    /// <inheritdoc />
+    public override bool CanMoveInDirection(
+        Direction direction,
+        out MovementBlockerType blockerType,
+        out EntityType entityType
+    )
+    {
+        entityType = default;
+
+        if (Player == default && mPageNum != 0)
+        {
+            blockerType = MovementBlockerType.OutOfBounds;
+            return false;
+        }
+
+        switch (direction)
+        {
+            case Direction.Up:
+                if (Y == 0)
+                {
+                    blockerType = MovementBlockerType.OutOfBounds;
+                    return false;
+                }
+                break;
+
+            case Direction.Down:
+                if (Y == Options.MapHeight - 1)
+                {
+                    blockerType = MovementBlockerType.OutOfBounds;
+                    return false;
+                }
+                break;
+
+            case Direction.Left:
+                if (X == 0)
+                {
+                    blockerType = MovementBlockerType.OutOfBounds;
+                    return false;
+                }
+                break;
+
+            case Direction.Right:
+                if (X == Options.MapWidth - 1)
+                {
+                    blockerType = MovementBlockerType.OutOfBounds;
+                    return false;
+                }
+                break;
+
+            case Direction.UpLeft:
+                if (Y == 0 || X == 0)
+                {
+                    blockerType = MovementBlockerType.OutOfBounds;
+                    return false;
+                }
+                break;
+
+            case Direction.UpRight:
+                if (Y == 0 || X == Options.MapWidth - 1)
+                {
+                    blockerType = MovementBlockerType.OutOfBounds;
+                    return false;
+                }
+                break;
+
+            case Direction.DownRight:
+                if (Y == Options.MapHeight - 1 || X == Options.MapWidth - 1)
+                {
+                    blockerType = MovementBlockerType.OutOfBounds;
+                    return false;
+                }
+                break;
+
+            case Direction.DownLeft:
+                if (Y == Options.MapHeight - 1 || X == 0)
+                {
+                    blockerType = MovementBlockerType.OutOfBounds;
+                    return false;
+                }
+                break;
+
+            case Direction.None:
+            default:
+                break;
+        }
+
+        return base.CanMoveInDirection(direction, out blockerType, out entityType);
+    }
+
+    protected override bool CanLookInDirection(Direction direction)
+    {
+        return !mDirectionFix && base.CanLookInDirection(direction);
+    }
+
+    public void TurnTowardsPlayer()
+    {
+        if (mDirectionFix)
+        {
+            return;
+        }
+
+        // Local Event
+        if (Player == null || GlobalClone != null)
+        {
+            return;
+        }
+
+        var lookDir = GetDirectionTo(Player);
+        if (!Enum.IsDefined(lookDir) || lookDir == Direction.None)
+        {
+            return;
+        }
+
+        ChangeDir(lookDir);
+    }
+
+    public bool ShouldDespawn(MapController map)
+    {
+        //Should despawn if conditions are not met OR an earlier page can spawn
+        if (!Conditions.MeetsConditionLists(MyPage.ConditionLists, MyEventIndex.Player, MyEventIndex))
+        {
             return true;
         }
 
-        public override float GetMovementTime()
+        if (map != null && !map.GetSurroundingMapIds(true).Contains(MyEventIndex.Player.MapId))
         {
-            switch (MovementFreq)
-            {
-                case EventMovementFrequency.Lowest:
-                    return 4000;
-                case EventMovementFrequency.Lower:
-                    return 2000;
-                case EventMovementFrequency.Normal:
-                    return 1000;
-                case EventMovementFrequency.Higher:
-                    return 500;
-                case EventMovementFrequency.Highest:
-                    return 250;
-                default:
-                    return 1000;
-            }
+            return true;
         }
 
-        /// <inheritdoc />
-        public override bool CanMoveInDirection(
-            Direction direction,
-            out MovementBlockerType blockerType,
-            out EntityType entityType
-        )
+        for (var i = 0; i < BaseEvent.Pages.Count; i++)
         {
-            entityType = default;
-
-            if (Player == default && mPageNum != 0)
+            if (i != mPageNum && Conditions.CanSpawnPage(BaseEvent.Pages[i], MyEventIndex.Player, MyEventIndex))
             {
-                blockerType = MovementBlockerType.OutOfBounds;
-                return false;
-            }
-
-            switch (direction)
-            {
-                case Direction.Up:
-                    if (Y == 0)
-                    {
-                        blockerType = MovementBlockerType.OutOfBounds;
-                        return false;
-                    }
-                    break;
-
-                case Direction.Down:
-                    if (Y == Options.MapHeight - 1)
-                    {
-                        blockerType = MovementBlockerType.OutOfBounds;
-                        return false;
-                    }
-                    break;
-
-                case Direction.Left:
-                    if (X == 0)
-                    {
-                        blockerType = MovementBlockerType.OutOfBounds;
-                        return false;
-                    }
-                    break;
-
-                case Direction.Right:
-                    if (X == Options.MapWidth - 1)
-                    {
-                        blockerType = MovementBlockerType.OutOfBounds;
-                        return false;
-                    }
-                    break;
-
-                case Direction.UpLeft:
-                    if (Y == 0 || X == 0)
-                    {
-                        blockerType = MovementBlockerType.OutOfBounds;
-                        return false;
-                    }
-                    break;
-
-                case Direction.UpRight:
-                    if (Y == 0 || X == Options.MapWidth - 1)
-                    {
-                        blockerType = MovementBlockerType.OutOfBounds;
-                        return false;
-                    }
-                    break;
-
-                case Direction.DownRight:
-                    if (Y == Options.MapHeight - 1 || X == Options.MapWidth - 1)
-                    {
-                        blockerType = MovementBlockerType.OutOfBounds;
-                        return false;
-                    }
-                    break;
-
-                case Direction.DownLeft:
-                    if (Y == Options.MapHeight - 1 || X == 0)
-                    {
-                        blockerType = MovementBlockerType.OutOfBounds;
-                        return false;
-                    }
-                    break;
-
-                case Direction.None:
-                default:
-                    break;
-            }
-
-            return base.CanMoveInDirection(direction, out blockerType, out entityType);
-        }
-
-        protected override bool CanLookInDirection(Direction direction)
-        {
-            return !mDirectionFix && base.CanLookInDirection(direction);
-        }
-
-        public void TurnTowardsPlayer()
-        {
-            if (mDirectionFix)
-            {
-                return;
-            }
-
-            // Local Event
-            if (Player == null || GlobalClone != null)
-            {
-                return;
-            }
-
-            var lookDir = GetDirectionTo(Player);
-            if (!Enum.IsDefined(lookDir) || lookDir == Direction.None)
-            {
-                return;
-            }
-
-            ChangeDir(lookDir);
-        }
-
-        public bool ShouldDespawn(MapController map)
-        {
-            //Should despawn if conditions are not met OR an earlier page can spawn
-            if (!Conditions.MeetsConditionLists(MyPage.ConditionLists, MyEventIndex.Player, MyEventIndex))
-            {
-                return true;
-            }
-
-            if (map != null && !map.GetSurroundingMapIds(true).Contains(MyEventIndex.Player.MapId))
-            {
-                return true;
-            }
-
-            for (var i = 0; i < BaseEvent.Pages.Count; i++)
-            {
-                if (i != mPageNum && Conditions.CanSpawnPage(BaseEvent.Pages[i], MyEventIndex.Player, MyEventIndex))
-                {
-                    if (i > mPageNum)
-                    {
-                        return true;
-                    }
-                }
-            }
-
-            if (GlobalClone != null)
-            {
-                //Removing this line because the global clone MUST be on the same map and its hindering performance.
-                //var map = MapController.Get(GlobalClone.MapId);
-                if (MapController.TryGetInstanceFromMap(map.Id, MapInstanceId, out var mapInstance))
-                {
-                    if (!mapInstance.FindEvent(GlobalClone.BaseEvent, GlobalClone))
-                    {
-                        return true;
-                    }
-                }
-                else // Couldn't get map or mapInstance
+                if (i > mPageNum)
                 {
                     return true;
                 }
             }
-
-            return false;
         }
 
+        if (GlobalClone != null)
+        {
+            //Removing this line because the global clone MUST be on the same map and its hindering performance.
+            //var map = MapController.Get(GlobalClone.MapId);
+            if (MapController.TryGetInstanceFromMap(map.Id, MapInstanceId, out var mapInstance))
+            {
+                if (!mapInstance.FindEvent(GlobalClone.BaseEvent, GlobalClone))
+                {
+                    return true;
+                }
+            }
+            else // Couldn't get map or mapInstance
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
 }

--- a/Intersect.Server.Core/Entities/Events/VariableCheckHandlerRegistry.cs
+++ b/Intersect.Server.Core/Entities/Events/VariableCheckHandlerRegistry.cs
@@ -2,74 +2,73 @@ using Intersect.GameObjects.Events;
 using Intersect.GameObjects.Switches_and_Variables;
 using System.Reflection;
 
-namespace Intersect.Server.Entities.Events
+namespace Intersect.Server.Entities.Events;
+
+public static partial class VariableCheckHandlerRegistry
 {
-    public static partial class VariableCheckHandlerRegistry
+    private static Dictionary<Type, HandleVariableComparison> CheckVariableComparisonFunctions = new Dictionary<Type, HandleVariableComparison>();
+    private delegate bool HandleVariableComparison(VariableValue currentValue, VariableComparison comparison, Player player, Event eventInstance);
+    private delegate bool HandleVariableComparisonBool<TComparison>(VariableValue currentValue, TComparison comparison, Player player, Event eventInstance) where TComparison : VariableComparison;
+    private static MethodInfo CreateWeaklyTypedDelegateForVariableCheckMethodInfoInfo;
+    private static bool Initialized = false;
+    private static object mLock = new object();
+
+
+    public static void Init()
     {
-        private static Dictionary<Type, HandleVariableComparison> CheckVariableComparisonFunctions = new Dictionary<Type, HandleVariableComparison>();
-        private delegate bool HandleVariableComparison(VariableValue currentValue, VariableComparison comparison, Player player, Event eventInstance);
-        private delegate bool HandleVariableComparisonBool<TComparison>(VariableValue currentValue, TComparison comparison, Player player, Event eventInstance) where TComparison : VariableComparison;
-        private static MethodInfo CreateWeaklyTypedDelegateForVariableCheckMethodInfoInfo;
-        private static bool Initialized = false;
-        private static object mLock = new object();
+        if (CreateWeaklyTypedDelegateForVariableCheckMethodInfoInfo == null)
+            CreateWeaklyTypedDelegateForVariableCheckMethodInfoInfo = typeof(VariableCheckHandlerRegistry).GetMethod(nameof(CreateWeaklyTypedDelegateForVariableCheckMethodInfo), BindingFlags.Static | BindingFlags.NonPublic);
 
-
-        public static void Init()
+        if (CheckVariableComparisonFunctions.Count == 0)
         {
-            if (CreateWeaklyTypedDelegateForVariableCheckMethodInfoInfo == null)
-                CreateWeaklyTypedDelegateForVariableCheckMethodInfoInfo = typeof(VariableCheckHandlerRegistry).GetMethod(nameof(CreateWeaklyTypedDelegateForVariableCheckMethodInfo), BindingFlags.Static | BindingFlags.NonPublic);
-
-            if (CheckVariableComparisonFunctions.Count == 0)
+            var methods = typeof(Conditions).GetMethods(BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.Static).Where(m => m.Name == "CheckVariableComparison");
+            foreach (var method in methods)
             {
-                var methods = typeof(Conditions).GetMethods(BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.Static).Where(m => m.Name == "CheckVariableComparison");
-                foreach (var method in methods)
-                {
-                    var conditionType = method.GetParameters()[1].ParameterType;
-                    var typedDelegateFactory = CreateWeaklyTypedDelegateForVariableCheckMethodInfoInfo.MakeGenericMethod(conditionType);
+                var conditionType = method.GetParameters()[1].ParameterType;
+                var typedDelegateFactory = CreateWeaklyTypedDelegateForVariableCheckMethodInfoInfo.MakeGenericMethod(conditionType);
 
-                    var weakDelegate = typedDelegateFactory.Invoke(null, new object[] { method, null }) as HandleVariableComparison;
-                    CheckVariableComparisonFunctions.Add(conditionType, weakDelegate);
-                }
+                var weakDelegate = typedDelegateFactory.Invoke(null, new object[] { method, null }) as HandleVariableComparison;
+                CheckVariableComparisonFunctions.Add(conditionType, weakDelegate);
             }
-
-            Initialized = true;
         }
 
-        public static bool CheckVariableComparison(VariableValue currentValue, VariableComparison comparison, Player player, Event instance)
-        {
-            if (!Initialized)
-            {
-                lock (mLock)
-                {
-                    if (!Initialized)
-                    {
-                        Init();
-                    }
-                }
-            }
-
-            return CheckVariableComparisonFunctions[comparison.GetType()](currentValue, comparison, player, instance);
-        }
-
-
-        private static HandleVariableComparison CreateWeaklyTypedDelegateForVariableCheckMethodInfo<TComparison>(MethodInfo methodInfo, object target = null) where TComparison : VariableComparison
-        {
-            if (methodInfo == null)
-            {
-                throw new ArgumentNullException(nameof(methodInfo));
-            }
-
-            var stronglyTyped =
-                    Delegate.CreateDelegate(typeof(HandleVariableComparisonBool<TComparison>), target, methodInfo) as
-                        HandleVariableComparisonBool<TComparison>;
-
-            return (VariableValue currentValue, VariableComparison comparison, Player player, Event eventInstance) => stronglyTyped(
-                currentValue, (TComparison)comparison, player, eventInstance
-            );
-
-            throw new ArgumentException($"Unsupported packet handler return type '{methodInfo.ReturnType.FullName}'.");
-        }
-
-
+        Initialized = true;
     }
+
+    public static bool CheckVariableComparison(VariableValue currentValue, VariableComparison comparison, Player player, Event instance)
+    {
+        if (!Initialized)
+        {
+            lock (mLock)
+            {
+                if (!Initialized)
+                {
+                    Init();
+                }
+            }
+        }
+
+        return CheckVariableComparisonFunctions[comparison.GetType()](currentValue, comparison, player, instance);
+    }
+
+
+    private static HandleVariableComparison CreateWeaklyTypedDelegateForVariableCheckMethodInfo<TComparison>(MethodInfo methodInfo, object target = null) where TComparison : VariableComparison
+    {
+        if (methodInfo == null)
+        {
+            throw new ArgumentNullException(nameof(methodInfo));
+        }
+
+        var stronglyTyped =
+                Delegate.CreateDelegate(typeof(HandleVariableComparisonBool<TComparison>), target, methodInfo) as
+                    HandleVariableComparisonBool<TComparison>;
+
+        return (VariableValue currentValue, VariableComparison comparison, Player player, Event eventInstance) => stronglyTyped(
+            currentValue, (TComparison)comparison, player, eventInstance
+        );
+
+        throw new ArgumentException($"Unsupported packet handler return type '{methodInfo.ReturnType.FullName}'.");
+    }
+
+
 }

--- a/Intersect.Server.Core/Entities/Label.cs
+++ b/Intersect.Server.Core/Entities/Label.cs
@@ -1,21 +1,19 @@
 ﻿using Newtonsoft.Json;
 
-namespace Intersect.Server.Entities
+namespace Intersect.Server.Entities;
+
+
+public partial struct Label
 {
 
-    public partial struct Label
+    [JsonProperty("Label")] public string Text;
+
+    public Color Color;
+
+    public Label(string label, Color color)
     {
-
-        [JsonProperty("Label")] public string Text;
-
-        public Color Color;
-
-        public Label(string label, Color color)
-        {
-            Text = label;
-            Color = color;
-        }
-
+        Text = label;
+        Color = color;
     }
 
 }

--- a/Intersect.Server.Core/Entities/MovementBlockerType.cs
+++ b/Intersect.Server.Core/Entities/MovementBlockerType.cs
@@ -1,12 +1,11 @@
-namespace Intersect.Server.Entities
+namespace Intersect.Server.Entities;
+
+public enum MovementBlockerType
 {
-    public enum MovementBlockerType
-    {
-        NotBlocked = 0,
-        OutOfBounds,
-        MapAttribute,
-        Slide,
-        Entity,
-        ZDimension,
-    }
+    NotBlocked = 0,
+    OutOfBounds,
+    MapAttribute,
+    Slide,
+    Entity,
+    ZDimension,
 }

--- a/Intersect.Server.Core/Entities/Npc.cs
+++ b/Intersect.Server.Core/Entities/Npc.cs
@@ -13,1517 +13,1498 @@ using Intersect.Server.Networking;
 using Intersect.Utilities;
 using Stat = Intersect.Enums.Stat;
 
-namespace Intersect.Server.Entities
+namespace Intersect.Server.Entities;
+
+
+public partial class Npc : Entity
 {
 
-    public partial class Npc : Entity
+    //Spell casting
+    public long CastFreq;
+
+    /// <summary>
+    /// Damage Map - Keep track of who is doing the most damage to this npc and focus accordingly
+    /// </summary>
+    public ConcurrentDictionary<Entity, long> DamageMap = new ConcurrentDictionary<Entity, long>();
+
+    public ConcurrentDictionary<Guid, bool> LootMap = new ConcurrentDictionary<Guid, bool>();
+
+    public Guid[] LootMapCache = Array.Empty<Guid>();
+
+    /// <summary>
+    /// Returns the entity that ranks the highest on this NPC's damage map.
+    /// </summary>
+    public Entity DamageMapHighest
     {
-
-        //Spell casting
-        public long CastFreq;
-
-        /// <summary>
-        /// Damage Map - Keep track of who is doing the most damage to this npc and focus accordingly
-        /// </summary>
-        public ConcurrentDictionary<Entity, long> DamageMap = new ConcurrentDictionary<Entity, long>();
-
-        public ConcurrentDictionary<Guid, bool> LootMap = new ConcurrentDictionary<Guid, bool>();
-
-        public Guid[] LootMapCache = Array.Empty<Guid>();
-
-        /// <summary>
-        /// Returns the entity that ranks the highest on this NPC's damage map.
-        /// </summary>
-        public Entity DamageMapHighest
+        get
         {
-            get
+            long damage = 0;
+            Entity top = null;
+            foreach (var pair in DamageMap)
             {
-                long damage = 0;
-                Entity top = null;
-                foreach (var pair in DamageMap)
+                // Only include players on the current instance
+                if (pair.Value > damage && pair.Key.MapInstanceId == MapInstanceId)
                 {
-                    // Only include players on the current instance
-                    if (pair.Value > damage && pair.Key.MapInstanceId == MapInstanceId)
+                    top = pair.Key;
+                    damage = pair.Value;
+                }
+            }
+            return top;
+        }
+    }
+
+    public bool Despawnable;
+
+    //Moving
+    public long LastRandomMove;
+
+    //Pathfinding
+    private Pathfinder mPathFinder;
+
+    private Task mPathfindingTask;
+
+    public byte Range;
+
+    //Respawn/Despawn
+    public long RespawnTime;
+
+    public long FindTargetWaitTime;
+    public int FindTargetDelay = 500;
+
+    private int mTargetFailCounter = 0;
+    private int mTargetFailMax = 10;
+
+    private int mResetDistance = 0;
+    private int mResetCounter = 0;
+    private int mResetMax = 100;
+    private bool mResetting = false;
+
+    /// <summary>
+    /// The map on which this NPC was "aggro'd" and started chasing a target.
+    /// </summary>
+    public MapController AggroCenterMap;
+
+    /// <summary>
+    /// The X value on which this NPC was "aggro'd" and started chasing a target.
+    /// </summary>
+    public int AggroCenterX;
+
+    /// <summary>
+    /// The Y value on which this NPC was "aggro'd" and started chasing a target.
+    /// </summary>
+    public int AggroCenterY;
+
+    /// <summary>
+    /// The Z value on which this NPC was "aggro'd" and started chasing a target.
+    /// </summary>
+    public int AggroCenterZ;
+
+    public Npc(NpcBase myBase, bool despawnable = false) : base()
+    {
+        Name = myBase.Name;
+        Sprite = myBase.Sprite;
+        Color = myBase.Color;
+        Level = myBase.Level;
+        Immunities = myBase.Immunities;
+        Base = myBase;
+        Despawnable = despawnable;
+
+        for (var i = 0; i < Enum.GetValues<Stat>().Length; i++)
+        {
+            BaseStats[i] = myBase.Stats[i];
+            Stat[i] = new Combat.Stat((Stat)i, this);
+        }
+
+        var spellSlot = 0;
+        for (var I = 0; I < Base.Spells.Count; I++)
+        {
+            var slot = new SpellSlot(spellSlot);
+            slot.Set(new Spell(Base.Spells[I]));
+            Spells.Add(slot);
+            spellSlot++;
+        }
+
+        //Give NPC Drops
+        var itemSlot = 0;
+        foreach (var drop in myBase.Drops)
+        {
+            var slot = new InventorySlot(itemSlot);
+            slot.Set(new Item(drop.ItemId, drop.Quantity));
+            slot.DropChance = drop.Chance;
+            Items.Add(slot);
+            itemSlot++;
+        }
+
+        for (var i = 0; i < Enum.GetValues<Vital>().Length; i++)
+        {
+            SetMaxVital(i, myBase.MaxVital[i]);
+            SetVital(i, myBase.MaxVital[i]);
+        }
+
+        Range = (byte)myBase.SightRange;
+        mPathFinder = new Pathfinder(this);
+    }
+
+    public NpcBase Base { get; private set; }
+
+    private bool IsStunnedOrSleeping => CachedStatuses.Any(PredicateStunnedOrSleeping);
+
+    private bool IsUnableToCastSpells => CachedStatuses.Any(PredicateUnableToCastSpells);
+
+    public override EntityType GetEntityType()
+    {
+        return EntityType.GlobalEntity;
+    }
+
+    public override void Die(bool generateLoot = true, Entity killer = null)
+    {
+        lock (EntityLock)
+        {
+            base.Die(generateLoot, killer);
+
+            AggroCenterMap = null;
+            AggroCenterX = 0;
+            AggroCenterY = 0;
+            AggroCenterZ = 0;
+
+            if (MapController.TryGetInstanceFromMap(MapId, MapInstanceId, out var instance))
+            {
+                instance.RemoveEntity(this);
+            }
+            PacketSender.SendEntityDie(this);
+            PacketSender.SendEntityLeave(this);
+        }
+    }
+
+    protected override bool ShouldDropItem(Entity killer, ItemBase itemDescriptor, Item item, float dropRateModifier, out Guid lootOwner)
+    {
+        lootOwner = (killer as Player)?.Id ?? Id;
+        return base.ShouldDropItem(killer, itemDescriptor, item, dropRateModifier, out _);
+    }
+
+    public bool TargetHasStealth(Entity target)
+    {
+        return target == null || target.CachedStatuses.Any(s => s.Type == SpellEffect.Stealth);
+    }
+
+    //Targeting
+    public void AssignTarget(Entity en)
+    {
+        var oldTarget = Target;
+
+        // Are we resetting? If so, do not allow for a new target.
+        var pathTarget = mPathFinder?.GetTarget();
+        if (AggroCenterMap != null && pathTarget != null &&
+            pathTarget.TargetMapId == AggroCenterMap.Id && pathTarget.TargetX == AggroCenterX && pathTarget.TargetY == AggroCenterY)
+        {
+            if (en == null)
+            {
+                return;
+
+            }
+            else
+            {
+                return;
+
+            }
+        }
+
+        //Why are we doing all of this logic if we are assigning a target that we already have?
+        if (en != null && en != Target)
+        {
+            // Can't assign a new target if taunted, unless we're resetting their target somehow.
+            // Also make sure the taunter is in range.. If they're dead or gone, we go for someone else!
+            if ((pathTarget != null && AggroCenterMap != null && (pathTarget.TargetMapId != AggroCenterMap.Id || pathTarget.TargetX != AggroCenterX || pathTarget.TargetY != AggroCenterY)))
+            {
+                foreach (var status in CachedStatuses)
+                {
+                    if (status.Type == SpellEffect.Taunt && en != status.Attacker && GetDistanceTo(status.Attacker) != 9999)
                     {
-                        top = pair.Key;
-                        damage = pair.Value;
+                        return;
                     }
                 }
-                return top;
-            }
-        }
-
-        public bool Despawnable;
-
-        //Moving
-        public long LastRandomMove;
-
-        //Pathfinding
-        private Pathfinder mPathFinder;
-
-        private Task mPathfindingTask;
-
-        public byte Range;
-
-        //Respawn/Despawn
-        public long RespawnTime;
-
-        public long FindTargetWaitTime;
-        public int FindTargetDelay = 500;
-
-        private int mTargetFailCounter = 0;
-        private int mTargetFailMax = 10;
-
-        private int mResetDistance = 0;
-        private int mResetCounter = 0;
-        private int mResetMax = 100;
-        private bool mResetting = false;
-
-        /// <summary>
-        /// The map on which this NPC was "aggro'd" and started chasing a target.
-        /// </summary>
-        public MapController AggroCenterMap;
-
-        /// <summary>
-        /// The X value on which this NPC was "aggro'd" and started chasing a target.
-        /// </summary>
-        public int AggroCenterX;
-
-        /// <summary>
-        /// The Y value on which this NPC was "aggro'd" and started chasing a target.
-        /// </summary>
-        public int AggroCenterY;
-
-        /// <summary>
-        /// The Z value on which this NPC was "aggro'd" and started chasing a target.
-        /// </summary>
-        public int AggroCenterZ;
-
-        public Npc(NpcBase myBase, bool despawnable = false) : base()
-        {
-            Name = myBase.Name;
-            Sprite = myBase.Sprite;
-            Color = myBase.Color;
-            Level = myBase.Level;
-            Immunities = myBase.Immunities;
-            Base = myBase;
-            Despawnable = despawnable;
-
-            for (var i = 0; i < Enum.GetValues<Stat>().Length; i++)
-            {
-                BaseStats[i] = myBase.Stats[i];
-                Stat[i] = new Combat.Stat((Stat)i, this);
             }
 
-            var spellSlot = 0;
-            for (var I = 0; I < Base.Spells.Count; I++)
+            if (en is Projectile projectile)
             {
-                var slot = new SpellSlot(spellSlot);
-                slot.Set(new Spell(Base.Spells[I]));
-                Spells.Add(slot);
-                spellSlot++;
-            }
-
-            //Give NPC Drops
-            var itemSlot = 0;
-            foreach (var drop in myBase.Drops)
-            {
-                var slot = new InventorySlot(itemSlot);
-                slot.Set(new Item(drop.ItemId, drop.Quantity));
-                slot.DropChance = drop.Chance;
-                Items.Add(slot);
-                itemSlot++;
-            }
-
-            for (var i = 0; i < Enum.GetValues<Vital>().Length; i++)
-            {
-                SetMaxVital(i, myBase.MaxVital[i]);
-                SetVital(i, myBase.MaxVital[i]);
-            }
-
-            Range = (byte)myBase.SightRange;
-            mPathFinder = new Pathfinder(this);
-        }
-
-        public NpcBase Base { get; private set; }
-
-        private bool IsStunnedOrSleeping => CachedStatuses.Any(PredicateStunnedOrSleeping);
-
-        private bool IsUnableToCastSpells => CachedStatuses.Any(PredicateUnableToCastSpells);
-
-        public override EntityType GetEntityType()
-        {
-            return EntityType.GlobalEntity;
-        }
-
-        public override void Die(bool generateLoot = true, Entity killer = null)
-        {
-            lock (EntityLock)
-            {
-                base.Die(generateLoot, killer);
-
-                AggroCenterMap = null;
-                AggroCenterX = 0;
-                AggroCenterY = 0;
-                AggroCenterZ = 0;
-
-                if (MapController.TryGetInstanceFromMap(MapId, MapInstanceId, out var instance))
+                if (projectile.Owner != this && !TargetHasStealth(projectile))
                 {
-                    instance.RemoveEntity(this);
-                }
-                PacketSender.SendEntityDie(this);
-                PacketSender.SendEntityLeave(this);
-            }
-        }
-
-        protected override bool ShouldDropItem(Entity killer, ItemBase itemDescriptor, Item item, float dropRateModifier, out Guid lootOwner)
-        {
-            lootOwner = (killer as Player)?.Id ?? Id;
-            return base.ShouldDropItem(killer, itemDescriptor, item, dropRateModifier, out _);
-        }
-
-        public bool TargetHasStealth(Entity target)
-        {
-            return target == null || target.CachedStatuses.Any(s => s.Type == SpellEffect.Stealth);
-        }
-
-        //Targeting
-        public void AssignTarget(Entity en)
-        {
-            var oldTarget = Target;
-
-            // Are we resetting? If so, do not allow for a new target.
-            var pathTarget = mPathFinder?.GetTarget();
-            if (AggroCenterMap != null && pathTarget != null &&
-                pathTarget.TargetMapId == AggroCenterMap.Id && pathTarget.TargetX == AggroCenterX && pathTarget.TargetY == AggroCenterY)
-            {
-                if (en == null)
-                {
-                    return;
-
-                }
-                else
-                {
-                    return;
-
+                    Target = projectile.Owner;
                 }
             }
-
-            //Why are we doing all of this logic if we are assigning a target that we already have?
-            if (en != null && en != Target)
+            else
             {
-                // Can't assign a new target if taunted, unless we're resetting their target somehow.
-                // Also make sure the taunter is in range.. If they're dead or gone, we go for someone else!
-                if ((pathTarget != null && AggroCenterMap != null && (pathTarget.TargetMapId != AggroCenterMap.Id || pathTarget.TargetX != AggroCenterX || pathTarget.TargetY != AggroCenterY)))
+                if (en is Npc npc)
                 {
-                    foreach (var status in CachedStatuses)
+                    if (npc.Base == Base)
                     {
-                        if (status.Type == SpellEffect.Taunt && en != status.Attacker && GetDistanceTo(status.Attacker) != 9999)
+                        if (Base.AttackAllies == false)
                         {
                             return;
                         }
                     }
                 }
 
-                if (en is Projectile projectile)
+                if (en is Player)
                 {
-                    if (projectile.Owner != this && !TargetHasStealth(projectile))
+                    //TODO Make sure that the npc can target the player
+                    if (this != en && !TargetHasStealth(en))
                     {
-                        Target = projectile.Owner;
+                        Target = en;
                     }
                 }
                 else
                 {
-                    if (en is Npc npc)
+                    if (this != en && !TargetHasStealth(en))
                     {
-                        if (npc.Base == Base)
+                        Target = en;
+                    }
+                }
+            }
+
+            // Are we configured to handle resetting NPCs after they chase a target for a specified amount of tiles?
+            if (Options.Npc.AllowResetRadius)
+            {
+                // Are we configured to allow new reset locations before they move to their original location, or do we simply not have an original location yet?
+                if (Options.Npc.AllowNewResetLocationBeforeFinish || AggroCenterMap == null)
+                {
+                    AggroCenterMap = Map;
+                    AggroCenterX = X;
+                    AggroCenterY = Y;
+                    AggroCenterZ = Z;
+                }
+            }
+        }
+        else
+        {
+            Target = en;
+        }
+
+        if (Target != oldTarget)
+        {
+            CombatTimer = Timing.Global.Milliseconds + Options.CombatTime;
+            PacketSender.SendNpcAggressionToProximity(this);
+        }
+        mTargetFailCounter = 0;
+    }
+
+    public void RemoveFromDamageMap(Entity en)
+    {
+        DamageMap.TryRemove(en, out _);
+    }
+
+    public void RemoveTarget()
+    {
+        AssignTarget(null);
+    }
+
+    public override int CalculateAttackTime()
+    {
+        if (Base.AttackSpeedModifier == 1) //Static
+        {
+            return Base.AttackSpeedValue;
+        }
+
+        return base.CalculateAttackTime();
+    }
+
+    public override bool CanAttack(Entity entity, SpellBase spell)
+    {
+        if (!base.CanAttack(entity, spell))
+        {
+            return false;
+        }
+
+        if (entity is EventPageInstance)
+        {
+            return false;
+        }
+
+        //Check if the attacker is stunned or blinded.
+        foreach (var status in CachedStatuses)
+        {
+            if (status.Type == SpellEffect.Stun || status.Type == SpellEffect.Sleep)
+            {
+                return false;
+            }
+        }
+
+        if (TargetHasStealth(entity))
+        {
+            return false;
+        }
+
+        if (entity is Resource)
+        {
+            if (!entity.Passable)
+            {
+                return false;
+            }
+        }
+        else if (entity is Npc)
+        {
+            return CanNpcCombat(entity, spell != null && spell.Combat.Friendly) || entity == this;
+        }
+        else if (entity is Player player)
+        {
+            var friendly = spell != null && spell.Combat.Friendly;
+            if (friendly && IsAllyOf(player))
+            {
+                return true;
+            }
+
+            if (!friendly && !IsAllyOf(player))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        return true;
+    }
+
+    public override void TryAttack(Entity target)
+    {
+        if (target.IsDisposed)
+        {
+            return;
+        }
+
+        if (!CanAttack(target, null))
+        {
+            return;
+        }
+
+        if (!IsOneBlockAway(target))
+        {
+            return;
+        }
+
+        if (!IsFacingTarget(target))
+        {
+            return;
+        }
+
+        var deadAnimations = new List<KeyValuePair<Guid, Direction>>();
+        var aliveAnimations = new List<KeyValuePair<Guid, Direction>>();
+
+        //We were forcing at LEAST 1hp base damage.. but then you can't have guards that won't hurt the player.
+        //https://www.ascensiongamedev.com/community/bug_tracker/intersect/npc-set-at-0-attack-damage-still-damages-player-by-1-initially-r915/
+        if (IsAttacking)
+        {
+            return;
+        }
+
+        if (Base.AttackAnimation != null)
+        {
+            PacketSender.SendAnimationToProximity(
+                Base.AttackAnimationId, -1, Guid.Empty, target.MapId, (byte)target.X, (byte)target.Y,
+                Dir, target.MapInstanceId
+            );
+        }
+
+        base.TryAttack(
+            target, Base.Damage, (DamageType)Base.DamageType, (Stat)Base.ScalingStat, Base.Scaling,
+            Base.CritChance, Base.CritMultiplier, deadAnimations, aliveAnimations
+        );
+
+        PacketSender.SendEntityAttack(this, CalculateAttackTime());
+    }
+
+    public bool CanNpcCombat(Entity enemy, bool friendly = false)
+    {
+        //Check for NpcVsNpc Combat, both must be enabled and the attacker must have it as an enemy or attack all types of npc.
+        if (!friendly)
+        {
+            if (enemy != null && enemy is Npc enemyNpc && Base != null)
+            {
+                if (enemyNpc.Base.NpcVsNpcEnabled == false)
+                {
+                    return false;
+                }
+
+                if (Base.AttackAllies && enemyNpc.Base == Base)
+                {
+                    return true;
+                }
+
+                for (var i = 0; i < Base.AggroList.Count; i++)
+                {
+                    if (NpcBase.Get(Base.AggroList[i]) == enemyNpc.Base)
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
+            if (enemy is Player)
+            {
+                return true;
+            }
+        }
+        else if (enemy is Npc enemyNpc && Base != null && enemyNpc.Base == Base && Base.AttackAllies == false)
+        {
+            return true;
+        }
+        else if (enemy is Player)
+        {
+            return false;
+        }
+
+        return false;
+    }
+
+    private static bool PredicateStunnedOrSleeping(Status status)
+    {
+        switch (status?.Type)
+        {
+            case SpellEffect.Sleep:
+            case SpellEffect.Stun:
+                return true;
+
+            case SpellEffect.Silence:
+            case SpellEffect.None:
+            case SpellEffect.Snare:
+            case SpellEffect.Blind:
+            case SpellEffect.Stealth:
+            case SpellEffect.Transform:
+            case SpellEffect.Cleanse:
+            case SpellEffect.Invulnerable:
+            case SpellEffect.Shield:
+            case SpellEffect.OnHit:
+            case SpellEffect.Taunt:
+            case null:
+                return false;
+
+            default:
+                throw new ArgumentOutOfRangeException();
+        }
+    }
+
+    private static bool PredicateUnableToCastSpells(Status status)
+    {
+        switch (status?.Type)
+        {
+            case SpellEffect.Silence:
+            case SpellEffect.Sleep:
+            case SpellEffect.Stun:
+                return true;
+
+            case SpellEffect.None:
+            case SpellEffect.Snare:
+            case SpellEffect.Blind:
+            case SpellEffect.Stealth:
+            case SpellEffect.Transform:
+            case SpellEffect.Cleanse:
+            case SpellEffect.Invulnerable:
+            case SpellEffect.Shield:
+            case SpellEffect.OnHit:
+            case SpellEffect.Taunt:
+            case null:
+                return false;
+
+            default:
+                throw new ArgumentOutOfRangeException();
+        }
+    }
+
+    protected override bool IgnoresNpcAvoid => false;
+
+    /// <inheritdoc />
+    public override bool CanMoveInDirection(
+        Direction direction,
+        out MovementBlockerType blockerType,
+        out EntityType entityType
+    )
+    {
+        entityType = default;
+
+        if (Base.Movement == (byte)NpcMovement.Static)
+        {
+            blockerType = MovementBlockerType.MapAttribute;
+            return false;
+        }
+
+        if (
+            !base.CanMoveInDirection(direction, out blockerType, out entityType)
+            && blockerType == MovementBlockerType.Entity
+            && Options.Instance.NpcOpts.IntangibleDuringReset
+        )
+        {
+            if (mResetting)
+            {
+                blockerType = MovementBlockerType.NotBlocked;
+            }
+        }
+
+        if ((blockerType != MovementBlockerType.NotBlocked && blockerType != MovementBlockerType.Slide) ||
+            !IsFleeing() ||
+            !Options.Instance.NpcOpts.AllowResetRadius)
+        {
+            return blockerType == MovementBlockerType.NotBlocked;
+        }
+
+        var yOffset = 0;
+        var xOffset = 0;
+        var tile = new TileHelper(MapId, X, Y);
+        switch (direction)
+        {
+            case Direction.Up:
+                yOffset--;
+                break;
+
+            case Direction.Down:
+                yOffset++;
+                break;
+
+            case Direction.Left:
+                xOffset--;
+                break;
+
+            case Direction.Right:
+                xOffset++;
+                break;
+
+            case Direction.UpLeft:
+                yOffset--;
+                xOffset--;
+                break;
+
+            case Direction.UpRight:
+                yOffset--;
+                xOffset++;
+                break;
+
+            case Direction.DownLeft:
+                yOffset++;
+                xOffset--;
+                break;
+
+            case Direction.DownRight:
+                yOffset++;
+                xOffset++;
+                break;
+
+            case Direction.None:
+            default:
+                break;
+        }
+
+        // ReSharper disable once InvertIf
+        if (tile.Translate(xOffset, yOffset))
+        {
+            // If this would move us past our reset radius then we cannot move.
+            var dist = GetDistanceBetween(
+                AggroCenterMap,
+                tile.GetMap(),
+                AggroCenterX,
+                tile.GetX(),
+                AggroCenterY,
+                tile.GetY()
+            );
+
+            // ReSharper disable once InvertIf
+            if (dist > Math.Max(Options.Npc.ResetRadius, Base.ResetRadius))
+            {
+                blockerType = MovementBlockerType.MapAttribute;
+                return false;
+            }
+        }
+
+        return blockerType == MovementBlockerType.NotBlocked;
+    }
+
+    private void TryCastSpells()
+    {
+        var target = Target;
+
+        if (target == null || mPathFinder.GetTarget() == null)
+        {
+            return;
+        }
+
+        // Check if NPC is stunned/sleeping
+        if (IsStunnedOrSleeping)
+        {
+            return;
+        }
+
+        //Check if NPC is casting a spell
+        if (IsCasting)
+        {
+            return; //can't move while casting
+        }
+
+        if (CastFreq >= Timing.Global.Milliseconds)
+        {
+            return;
+        }
+
+        // Check if the NPC is able to cast spells
+        if (IsUnableToCastSpells)
+        {
+            return;
+        }
+
+        if (Base.Spells is not { Count: > 0 })
+        {
+            return;
+        }
+
+        // Pick a random spell
+        var spellIndex = Randomization.Next(0, Spells.Count);
+        var spellId = Base.Spells[spellIndex];
+        if (!SpellBase.TryGet(spellId, out var spellBase))
+        {
+            return;
+        }
+
+        if (spellBase.Combat == null)
+        {
+            Log.Warn($"Combat data missing for {spellBase.Id}.");
+        }
+
+        // Check if we are even allowed to cast this spell.
+        if (!CanCastSpell(spellBase, target, true, out _))
+        {
+            return;
+        }
+
+        var targetType = spellBase.Combat?.TargetType ?? SpellTargetType.Single;
+        var projectileBase = spellBase.Combat?.Projectile;
+
+        if (spellBase.SpellType == SpellType.CombatSpell &&
+            targetType == SpellTargetType.Projectile &&
+            projectileBase != null &&
+            InRangeOf(target, projectileBase.Range))
+        {
+            var dirToEnemy = DirectionToTarget(target);
+            if (dirToEnemy != Dir)
+            {
+                if (LastRandomMove >= Timing.Global.Milliseconds)
+                {
+                    return;
+                }
+
+                //Face the target -- next frame fire -- then go on with life
+                ChangeDir(dirToEnemy); // Gotta get dir to enemy
+                LastRandomMove = Timing.Global.Milliseconds + Randomization.Next(1000, 3000);
+
+                return;
+            }
+        }
+
+        CastTime = Timing.Global.Milliseconds + spellBase.CastDuration;
+
+        if ((spellBase.Combat?.Friendly ?? false) && spellBase.SpellType != SpellType.WarpTo)
+        {
+            CastTarget = this;
+        }
+        else
+        {
+            CastTarget = target;
+        }
+
+        switch (Base.SpellFrequency)
+        {
+            case 0:
+                CastFreq = Timing.Global.Milliseconds + 30000;
+
+                break;
+
+            case 1:
+                CastFreq = Timing.Global.Milliseconds + 15000;
+
+                break;
+
+            case 2:
+                CastFreq = Timing.Global.Milliseconds + 8000;
+
+                break;
+
+            case 3:
+                CastFreq = Timing.Global.Milliseconds + 4000;
+
+                break;
+
+            case 4:
+                CastFreq = Timing.Global.Milliseconds + 2000;
+
+                break;
+        }
+
+        SpellCastSlot = spellIndex;
+
+        if (spellBase.CastAnimationId != Guid.Empty)
+        {
+            PacketSender.SendAnimationToProximity(spellBase.CastAnimationId, 1, Id, MapId, 0, 0, Dir, MapInstanceId);
+
+            //Target Type 1 will be global entity
+        }
+
+        PacketSender.SendEntityCastTime(this, spellId);
+    }
+
+    public bool IsFleeing()
+    {
+        if (Base.FleeHealthPercentage > 0)
+        {
+            var fleeHpCutoff = GetMaxVital(Vital.Health) * (Base.FleeHealthPercentage / 100f);
+            if (GetVital(Vital.Health) < fleeHpCutoff)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // TODO: Improve NPC movement to be more fluid like a player
+    //General Updating
+    public override void Update(long timeMs)
+    {
+        var lockObtained = false;
+        try
+        {
+            Monitor.TryEnter(EntityLock, ref lockObtained);
+            if (lockObtained)
+            {
+                var curMapLink = MapId;
+                base.Update(timeMs);
+                var tempTarget = Target;
+
+                foreach (var status in CachedStatuses)
+                {
+                    if (status.Type == SpellEffect.Stun || status.Type == SpellEffect.Sleep)
+                    {
+                        return;
+                    }
+                }
+
+                var fleeing = IsFleeing();
+
+                if (MoveTimer < Timing.Global.Milliseconds)
+                {
+                    var targetMap = Guid.Empty;
+                    var targetX = 0;
+                    var targetY = 0;
+                    var targetZ = 0;
+
+                    //TODO Clear Damage Map if out of combat (target is null and combat timer is to the point that regen has started)
+                    if (tempTarget != null && (Options.Instance.NpcOpts.ResetIfCombatTimerExceeded && Timing.Global.Milliseconds > CombatTimer))
+                    {
+                        if (CheckForResetLocation(true))
                         {
-                            if (Base.AttackAllies == false)
+                            if (Target != tempTarget)
                             {
-                                return;
+                                PacketSender.SendNpcAggressionToProximity(this);
+                            }
+                            return;
+                        }
+                    }
+
+                    // Are we resetting? If so, regenerate completely!
+                    if (mResetting)
+                    {
+                        var distance = GetDistanceTo(AggroCenterMap, AggroCenterX, AggroCenterY);
+                        // Have we reached our destination? If so, clear it.
+                        if (distance < 1)
+                        {
+                            ResetAggroCenter(out targetMap);
+                        }
+
+                        Reset(Options.Instance.NpcOpts.ContinuouslyResetVitalsAndStatuses);
+                        tempTarget = Target;
+
+                        if (distance != mResetDistance)
+                        {
+                            mResetDistance = distance;
+                        }
+                        else
+                        {
+                            // Something is fishy here.. We appear to be stuck in a reset loop?
+                            // Give it a few more attempts and reset the NPC's center if we're stuck!
+                            mResetCounter++;
+                            if (mResetCounter > mResetMax)
+                            {
+                                ResetAggroCenter(out targetMap);
+                                mResetCounter = 0;
+                                mResetDistance = 0;
+                            }
+                        }
+
+                    }
+
+                    if (tempTarget != null && (tempTarget.IsDead() || !InRangeOf(tempTarget, Options.MapWidth * 2)))
+                    {
+                        TryFindNewTarget(Timing.Global.Milliseconds, tempTarget.Id);
+                        tempTarget = Target;
+                    }
+
+                    //Check if there is a target, if so, run their ass down.
+                    if (tempTarget != null)
+                    {
+                        if (!tempTarget.IsDead() && CanAttack(tempTarget, null))
+                        {
+                            targetMap = tempTarget.MapId;
+                            targetX = tempTarget.X;
+                            targetY = tempTarget.Y;
+                            targetZ = tempTarget.Z;
+                            foreach (var targetStatus in tempTarget.CachedStatuses)
+                            {
+                                if (targetStatus.Type == SpellEffect.Stealth)
+                                {
+                                    targetMap = Guid.Empty;
+                                    targetX = 0;
+                                    targetY = 0;
+                                    targetZ = 0;
+                                }
+                            }
+                        }
+                    }
+                    else //Find a target if able
+                    {
+                        // Check if attack on sight or have other npc's to target
+                        TryFindNewTarget(timeMs);
+                        tempTarget = Target;
+                    }
+
+                    if (targetMap != Guid.Empty)
+                    {
+                        //Check if target map is on one of the surrounding maps, if not then we are not even going to look.
+                        if (targetMap != MapId)
+                        {
+                            var found = false;
+                            foreach (var map in MapController.Get(MapId).SurroundingMaps)
+                            {
+                                if (map.Id == targetMap)
+                                {
+                                    found = true;
+                                    break;
+                                }
+                            }
+                            if (!found)
+                            {
+                                targetMap = Guid.Empty;
                             }
                         }
                     }
 
-                    if (en is Player)
+                    if (targetMap != Guid.Empty)
                     {
-                        //TODO Make sure that the npc can target the player
-                        if (this != en && !TargetHasStealth(en))
+                        if (mPathFinder.GetTarget() != null)
                         {
-                            Target = en;
+                            if (targetMap != mPathFinder.GetTarget().TargetMapId ||
+                                targetX != mPathFinder.GetTarget().TargetX ||
+                                targetY != mPathFinder.GetTarget().TargetY)
+                            {
+                                mPathFinder.SetTarget(null);
+                            }
+                        }
+
+                        if (mPathFinder.GetTarget() == null)
+                        {
+                            mPathFinder.SetTarget(new PathfinderTarget(targetMap, targetX, targetY, targetZ));
+
+                            if (tempTarget != Target)
+                            {
+                                tempTarget = Target;
+                            }
+                        }
+
+                    }
+
+                    if (mPathFinder.GetTarget() != null && Base.Movement != (int)NpcMovement.Static)
+                    {
+                        TryCastSpells();
+                        // TODO: Make resetting mobs actually return to their starting location.
+                        if ((!mResetting && !IsOneBlockAway(
+                            mPathFinder.GetTarget().TargetMapId, mPathFinder.GetTarget().TargetX,
+                            mPathFinder.GetTarget().TargetY, mPathFinder.GetTarget().TargetZ
+                        )) ||
+                        (mResetting && GetDistanceTo(AggroCenterMap, AggroCenterX, AggroCenterY) != 0)
+                        )
+                        {
+                            switch (mPathFinder.Update(timeMs))
+                            {
+                                case PathfinderResult.Success:
+
+                                    var dir = mPathFinder.GetMove();
+                                    if (dir > Direction.None)
+                                    {
+                                        if (fleeing)
+                                        {
+                                            switch (dir)
+                                            {
+                                                case Direction.Up:
+                                                    dir = Direction.Down;
+
+                                                    break;
+                                                case Direction.Down:
+                                                    dir = Direction.Up;
+
+                                                    break;
+                                                case Direction.Left:
+                                                    dir = Direction.Right;
+
+                                                    break;
+                                                case Direction.Right:
+                                                    dir = Direction.Left;
+
+                                                    break;
+                                                case Direction.UpLeft:
+                                                    dir = Direction.UpRight;
+
+                                                    break;
+                                                case Direction.UpRight:
+                                                    dir = Direction.UpLeft;
+
+                                                    break;
+                                                case Direction.DownRight:
+                                                    dir = Direction.DownLeft;
+
+                                                    break;
+                                                case Direction.DownLeft:
+                                                    dir = Direction.DownRight;
+
+                                                    break;
+                                            }
+                                        }
+
+                                        if (CanMoveInDirection(dir, out var blockerType, out _) || blockerType == MovementBlockerType.Slide)
+                                        {
+                                            //check if NPC is snared or stunned
+                                            foreach (var status in CachedStatuses)
+                                            {
+                                                if (status.Type == SpellEffect.Stun ||
+                                                    status.Type == SpellEffect.Snare ||
+                                                    status.Type == SpellEffect.Sleep)
+                                                {
+                                                    return;
+                                                }
+                                            }
+
+                                            Move(dir, null);
+                                        }
+                                        else
+                                        {
+                                            mPathFinder.PathFailed(timeMs);
+                                        }
+
+                                        // Are we resetting?
+                                        if (mResetting)
+                                        {
+                                            // Have we reached our destination? If so, clear it.
+                                            if (GetDistanceTo(AggroCenterMap, AggroCenterX, AggroCenterY) == 0)
+                                            {
+                                                targetMap = Guid.Empty;
+
+                                                // Reset our aggro center so we can get "pulled" again.
+                                                AggroCenterMap = null;
+                                                AggroCenterX = 0;
+                                                AggroCenterY = 0;
+                                                AggroCenterZ = 0;
+                                                mPathFinder?.SetTarget(null);
+                                                mResetting = false;
+                                            }
+                                        }
+                                    }
+
+                                    break;
+                                case PathfinderResult.OutOfRange:
+                                    TryFindNewTarget(timeMs, tempTarget?.Id ?? Guid.Empty, true);
+                                    tempTarget = Target;
+                                    targetMap = Guid.Empty;
+
+                                    break;
+                                case PathfinderResult.NoPathToTarget:
+                                    TryFindNewTarget(timeMs, tempTarget?.Id ?? Guid.Empty, true);
+                                    tempTarget = Target;
+                                    targetMap = Guid.Empty;
+
+                                    break;
+                                case PathfinderResult.Failure:
+                                    targetMap = Guid.Empty;
+                                    TryFindNewTarget(timeMs, tempTarget?.Id ?? Guid.Empty, true);
+                                    tempTarget = Target;
+
+                                    break;
+                                case PathfinderResult.Wait:
+                                    targetMap = Guid.Empty;
+
+                                    break;
+                                default:
+                                    throw new ArgumentOutOfRangeException();
+                            }
+                        }
+                        else
+                        {
+                            var fleed = false;
+                            if (tempTarget != null && fleeing)
+                            {
+                                var dir = DirectionToTarget(tempTarget);
+                                switch (dir)
+                                {
+                                    case Direction.Up:
+                                        dir = Direction.Down;
+
+                                        break;
+                                    case Direction.Down:
+                                        dir = Direction.Up;
+
+                                        break;
+                                    case Direction.Left:
+                                        dir = Direction.Right;
+
+                                        break;
+                                    case Direction.Right:
+                                        dir = Direction.Left;
+
+                                        break;
+                                    case Direction.UpLeft:
+                                        dir = Direction.UpRight;
+
+                                        break;
+                                    case Direction.UpRight:
+                                        dir = Direction.UpLeft;
+                                        break;
+
+                                    case Direction.DownRight:
+                                        dir = Direction.DownLeft;
+
+                                        break;
+                                    case Direction.DownLeft:
+                                        dir = Direction.DownRight;
+
+                                        break;
+                                }
+
+                                if (CanMoveInDirection(dir, out var blockerType, out _) || blockerType == MovementBlockerType.Slide)
+                                {
+                                    //check if NPC is snared or stunned
+                                    foreach (var status in CachedStatuses)
+                                    {
+                                        if (status.Type == SpellEffect.Stun ||
+                                            status.Type == SpellEffect.Snare ||
+                                            status.Type == SpellEffect.Sleep)
+                                        {
+                                            return;
+                                        }
+                                    }
+
+                                    Move(dir, null);
+                                    fleed = true;
+                                }
+                            }
+
+                            if (!fleed)
+                            {
+                                if (tempTarget != null)
+                                {
+                                    if (Dir != DirectionToTarget(tempTarget) && DirectionToTarget(tempTarget) != Direction.None)
+                                    {
+                                        ChangeDir(DirectionToTarget(tempTarget));
+                                    }
+                                    else
+                                    {
+                                        if (tempTarget.IsDisposed)
+                                        {
+                                            TryFindNewTarget(timeMs);
+                                            tempTarget = Target;
+                                        }
+                                        else
+                                        {
+                                            if (CanAttack(tempTarget, null))
+                                            {
+                                                TryAttack(tempTarget);
+                                            }
+                                        }
+                                    }
+                                }
+                            }
                         }
                     }
-                    else
+
+                    CheckForResetLocation();
+
+                    //Move randomly
+                    if (targetMap != Guid.Empty)
                     {
-                        if (this != en && !TargetHasStealth(en))
+                        return;
+                    }
+
+                    if (LastRandomMove >= Timing.Global.Milliseconds || IsCasting)
+                    {
+                        return;
+                    }
+
+                    if (Base.Movement == (int)NpcMovement.StandStill)
+                    {
+                        LastRandomMove = Timing.Global.Milliseconds + Randomization.Next(1000, 3000);
+
+                        return;
+                    }
+                    else if (Base.Movement == (int)NpcMovement.TurnRandomly)
+                    {
+                        ChangeDir(Randomization.NextDirection());
+                        LastRandomMove = Timing.Global.Milliseconds + Randomization.Next(1000, 3000);
+
+                        return;
+                    }
+
+                    var i = Randomization.Next(0, 1);
+                    if (i == 0)
+                    {
+                        var direction = Randomization.NextDirection();
+                        if (CanMoveInDirection(direction))
                         {
-                            Target = en;
+                            //check if NPC is snared or stunned
+                            foreach (var status in CachedStatuses)
+                            {
+                                if (status.Type == SpellEffect.Stun ||
+                                    status.Type == SpellEffect.Snare ||
+                                    status.Type == SpellEffect.Sleep)
+                                {
+                                    return;
+                                }
+                            }
+
+                            Move(direction, null);
+                        }
+                    }
+
+                    LastRandomMove = Timing.Global.Milliseconds + Randomization.Next(1000, 3000);
+
+                    if (fleeing)
+                    {
+                        LastRandomMove = Timing.Global.Milliseconds + (long)GetMovementTime();
+                    }
+                }
+
+                //If we switched maps, lets update the maps
+                if (curMapLink != MapId)
+                {
+                    if (curMapLink == Guid.Empty)
+                    {
+                        if (MapController.TryGetInstanceFromMap(curMapLink, MapInstanceId, out var instance))
+                        {
+                            instance.RemoveEntity(this);
+                        }
+                    }
+
+                    if (MapId != Guid.Empty)
+                    {
+                        if (MapController.TryGetInstanceFromMap(MapId, MapInstanceId, out var instance))
+                        {
+                            instance.AddEntity(this);
                         }
                     }
                 }
+            }
+        }
+        finally
+        {
+            if (lockObtained)
+            {
+                Monitor.Exit(EntityLock);
+            }
+        }
+    }
 
-                // Are we configured to handle resetting NPCs after they chase a target for a specified amount of tiles?
-                if (Options.Npc.AllowResetRadius)
+    /// <summary>
+    /// Resets the NPCs position to be "pulled" from
+    /// </summary>
+    /// <param name="targetMap">For referencing the map that the enemy's target WAS on before a reset.</param>
+    private void ResetAggroCenter(out Guid targetMap)
+    {
+        targetMap = Guid.Empty;
+
+        // Reset our aggro center so we can get "pulled" again.
+        AggroCenterMap = null;
+        AggroCenterX = 0;
+        AggroCenterY = 0;
+        AggroCenterZ = 0;
+        mPathFinder?.SetTarget(null);
+        mResetting = false;
+    }
+
+    private bool CheckForResetLocation(bool forceDistance = false)
+    {
+        // Check if we've moved out of our range we're allowed to move from after being "aggro'd" by something.
+        // If so, remove target and move back to the origin point.
+        if (Options.Npc.AllowResetRadius && AggroCenterMap != null && (GetDistanceTo(AggroCenterMap, AggroCenterX, AggroCenterY) > Math.Max(Options.Npc.ResetRadius, Math.Min(Base.ResetRadius, Math.Max(Options.MapWidth, Options.MapHeight))) || forceDistance))
+        {
+            Reset(Options.Npc.ResetVitalsAndStatusses);
+
+            mResetCounter = 0;
+            mResetDistance = 0;
+
+            // Try and move back to where we came from before we started chasing something.
+            mResetting = true;
+            mPathFinder.SetTarget(new PathfinderTarget(AggroCenterMap.Id, AggroCenterX, AggroCenterY, AggroCenterZ));
+            return true;
+        }
+        return false;
+    }
+
+    private void Reset(bool resetVitals, bool clearLocation = false)
+    {
+        // Remove our target.
+        RemoveTarget();
+
+        DamageMap.Clear();
+        LootMap.Clear();
+        LootMapCache = Array.Empty<Guid>();
+
+        if (clearLocation)
+        {
+            mPathFinder.SetTarget(null);
+            AggroCenterMap = null;
+            AggroCenterX = 0;
+            AggroCenterY = 0;
+            AggroCenterZ = 0;
+        }
+
+        // Reset our vitals and statusses when configured.
+        if (resetVitals)
+        {
+            Statuses.Clear();
+            CachedStatuses = Statuses.Values.ToArray();
+            DoT.Clear();
+            CachedDots = DoT.Values.ToArray();
+            for (var v = 0; v < Enum.GetValues<Vital>().Length; v++)
+            {
+                RestoreVital((Vital)v);
+            }
+        }
+    }
+
+    // Completely resets an Npc to full health and its spawnpoint if it's current chasing something.
+    public override void Reset()
+    {
+        if (AggroCenterMap != null)
+        {
+            Warp(AggroCenterMap.Id, AggroCenterX, AggroCenterY);
+        }
+
+        Reset(true, true);
+    }
+
+    public override void NotifySwarm(Entity attacker)
+    {
+        if (MapController.TryGetInstanceFromMap(MapId, MapInstanceId, out var instance))
+        {
+            foreach (var en in instance.GetEntities(true))
+            {
+                if (en is Npc npc)
                 {
-                    // Are we configured to allow new reset locations before they move to their original location, or do we simply not have an original location yet?
-                    if (Options.Npc.AllowNewResetLocationBeforeFinish || AggroCenterMap == null)
+                    if (npc.Target == null && npc.Base == Base && npc.Base.Swarm)
                     {
-                        AggroCenterMap = Map;
-                        AggroCenterX = X;
-                        AggroCenterY = Y;
-                        AggroCenterZ = Z;
+                        if (npc.InRangeOf(attacker, npc.Base.SightRange))
+                        {
+                            npc.AssignTarget(attacker);
+                        }
                     }
                 }
             }
-            else
-            {
-                Target = en;
-            }
+        }
+    }
 
-            if (Target != oldTarget)
-            {
-                CombatTimer = Timing.Global.Milliseconds + Options.CombatTime;
-                PacketSender.SendNpcAggressionToProximity(this);
-            }
-            mTargetFailCounter = 0;
+    public bool CanPlayerAttack(Player en)
+    {
+        //Check to see if the npc is a friend/protector...
+        if (IsAllyOf(en))
+        {
+            return false;
         }
 
-        public void RemoveFromDamageMap(Entity en)
+        //If not then check and see if player meets the conditions to attack the npc...
+        if (Base.PlayerCanAttackConditions.Lists.Count == 0 ||
+            Conditions.MeetsConditionLists(Base.PlayerCanAttackConditions, en, null))
         {
-            DamageMap.TryRemove(en, out _);
+            return true;
         }
 
-        public void RemoveTarget()
+        return false;
+    }
+
+    public override bool IsAllyOf(Entity otherEntity)
+    {
+        switch (otherEntity)
         {
-            AssignTarget(null);
-        }
-
-        public override int CalculateAttackTime()
-        {
-            if (Base.AttackSpeedModifier == 1) //Static
-            {
-                return Base.AttackSpeedValue;
-            }
-
-            return base.CalculateAttackTime();
-        }
-
-        public override bool CanAttack(Entity entity, SpellBase spell)
-        {
-            if (!base.CanAttack(entity, spell))
-            {
-                return false;
-            }
-
-            if (entity is EventPageInstance)
-            {
-                return false;
-            }
-
-            //Check if the attacker is stunned or blinded.
-            foreach (var status in CachedStatuses)
-            {
-                if (status.Type == SpellEffect.Stun || status.Type == SpellEffect.Sleep)
-                {
-                    return false;
-                }
-            }
-
-            if (TargetHasStealth(entity))
-            {
-                return false;
-            }
-
-            if (entity is Resource)
-            {
-                if (!entity.Passable)
-                {
-                    return false;
-                }
-            }
-            else if (entity is Npc)
-            {
-                return CanNpcCombat(entity, spell != null && spell.Combat.Friendly) || entity == this;
-            }
-            else if (entity is Player player)
-            {
-                var friendly = spell != null && spell.Combat.Friendly;
-                if (friendly && IsAllyOf(player))
+            case Npc otherNpc:
+                if (!Base.NpcVsNpcEnabled && !otherNpc.Base.NpcVsNpcEnabled)
                 {
                     return true;
                 }
 
-                if (!friendly && !IsAllyOf(player))
+                return !otherNpc.CanNpcCombat(this);
+            case Player otherPlayer:
+                var conditionLists = Base.PlayerFriendConditions;
+                if ((conditionLists?.Count ?? 0) == 0)
                 {
-                    return true;
+                    return false;
                 }
 
+                return Conditions.MeetsConditionLists(conditionLists, otherPlayer, null);
+            default:
+                return base.IsAllyOf(otherEntity);
+        }
+    }
+
+    public bool ShouldAttackPlayerOnSight(Player en)
+    {
+        if (IsAllyOf(en))
+        {
+            return false;
+        }
+
+        if (Base.Aggressive)
+        {
+            if (Base.AttackOnSightConditions.Lists.Count > 0 &&
+                Conditions.MeetsConditionLists(Base.AttackOnSightConditions, en, null))
+            {
                 return false;
             }
 
             return true;
         }
-
-        public override void TryAttack(Entity target)
+        else
         {
-            if (target.IsDisposed)
-            {
-                return;
-            }
-
-            if (!CanAttack(target, null))
-            {
-                return;
-            }
-
-            if (!IsOneBlockAway(target))
-            {
-                return;
-            }
-
-            if (!IsFacingTarget(target))
-            {
-                return;
-            }
-
-            var deadAnimations = new List<KeyValuePair<Guid, Direction>>();
-            var aliveAnimations = new List<KeyValuePair<Guid, Direction>>();
-
-            //We were forcing at LEAST 1hp base damage.. but then you can't have guards that won't hurt the player.
-            //https://www.ascensiongamedev.com/community/bug_tracker/intersect/npc-set-at-0-attack-damage-still-damages-player-by-1-initially-r915/
-            if (IsAttacking)
-            {
-                return;
-            }
-
-            if (Base.AttackAnimation != null)
-            {
-                PacketSender.SendAnimationToProximity(
-                    Base.AttackAnimationId, -1, Guid.Empty, target.MapId, (byte)target.X, (byte)target.Y,
-                    Dir, target.MapInstanceId
-                );
-            }
-
-            base.TryAttack(
-                target, Base.Damage, (DamageType)Base.DamageType, (Stat)Base.ScalingStat, Base.Scaling,
-                Base.CritChance, Base.CritMultiplier, deadAnimations, aliveAnimations
-            );
-
-            PacketSender.SendEntityAttack(this, CalculateAttackTime());
-        }
-
-        public bool CanNpcCombat(Entity enemy, bool friendly = false)
-        {
-            //Check for NpcVsNpc Combat, both must be enabled and the attacker must have it as an enemy or attack all types of npc.
-            if (!friendly)
-            {
-                if (enemy != null && enemy is Npc enemyNpc && Base != null)
-                {
-                    if (enemyNpc.Base.NpcVsNpcEnabled == false)
-                    {
-                        return false;
-                    }
-
-                    if (Base.AttackAllies && enemyNpc.Base == Base)
-                    {
-                        return true;
-                    }
-
-                    for (var i = 0; i < Base.AggroList.Count; i++)
-                    {
-                        if (NpcBase.Get(Base.AggroList[i]) == enemyNpc.Base)
-                        {
-                            return true;
-                        }
-                    }
-
-                    return false;
-                }
-
-                if (enemy is Player)
-                {
-                    return true;
-                }
-            }
-            else if (enemy is Npc enemyNpc && Base != null && enemyNpc.Base == Base && Base.AttackAllies == false)
+            if (Base.AttackOnSightConditions.Lists.Count > 0 &&
+                Conditions.MeetsConditionLists(Base.AttackOnSightConditions, en, null))
             {
                 return true;
             }
-            else if (enemy is Player)
-            {
-                return false;
-            }
-
-            return false;
         }
 
-        private static bool PredicateStunnedOrSleeping(Status status)
+        return false;
+    }
+
+    public void TryFindNewTarget(long timeMs, Guid avoidId = new Guid(), bool ignoreTimer = false, Entity attackedBy = null)
+    {
+        if (!ignoreTimer && FindTargetWaitTime > timeMs)
         {
-            switch (status?.Type)
-            {
-                case SpellEffect.Sleep:
-                case SpellEffect.Stun:
-                    return true;
-
-                case SpellEffect.Silence:
-                case SpellEffect.None:
-                case SpellEffect.Snare:
-                case SpellEffect.Blind:
-                case SpellEffect.Stealth:
-                case SpellEffect.Transform:
-                case SpellEffect.Cleanse:
-                case SpellEffect.Invulnerable:
-                case SpellEffect.Shield:
-                case SpellEffect.OnHit:
-                case SpellEffect.Taunt:
-                case null:
-                    return false;
-
-                default:
-                    throw new ArgumentOutOfRangeException();
-            }
+            return;
         }
 
-        private static bool PredicateUnableToCastSpells(Status status)
+        // Are we resetting? If so, do not allow for a new target.
+        var pathTarget = mPathFinder?.GetTarget();
+        if (AggroCenterMap != null && pathTarget != null &&
+            pathTarget.TargetMapId == AggroCenterMap.Id && pathTarget.TargetX == AggroCenterX && pathTarget.TargetY == AggroCenterY)
         {
-            switch (status?.Type)
-            {
-                case SpellEffect.Silence:
-                case SpellEffect.Sleep:
-                case SpellEffect.Stun:
-                    return true;
-
-                case SpellEffect.None:
-                case SpellEffect.Snare:
-                case SpellEffect.Blind:
-                case SpellEffect.Stealth:
-                case SpellEffect.Transform:
-                case SpellEffect.Cleanse:
-                case SpellEffect.Invulnerable:
-                case SpellEffect.Shield:
-                case SpellEffect.OnHit:
-                case SpellEffect.Taunt:
-                case null:
-                    return false;
-
-                default:
-                    throw new ArgumentOutOfRangeException();
-            }
-        }
-
-        protected override bool IgnoresNpcAvoid => false;
-
-        /// <inheritdoc />
-        public override bool CanMoveInDirection(
-            Direction direction,
-            out MovementBlockerType blockerType,
-            out EntityType entityType
-        )
-        {
-            entityType = default;
-
-            if (Base.Movement == (byte)NpcMovement.Static)
-            {
-                blockerType = MovementBlockerType.MapAttribute;
-                return false;
-            }
-
-            if (
-                !base.CanMoveInDirection(direction, out blockerType, out entityType)
-                && blockerType == MovementBlockerType.Entity
-                && Options.Instance.NpcOpts.IntangibleDuringReset
-            )
-            {
-                if (mResetting)
-                {
-                    blockerType = MovementBlockerType.NotBlocked;
-                }
-            }
-
-            if ((blockerType != MovementBlockerType.NotBlocked && blockerType != MovementBlockerType.Slide) ||
-                !IsFleeing() ||
-                !Options.Instance.NpcOpts.AllowResetRadius)
-            {
-                return blockerType == MovementBlockerType.NotBlocked;
-            }
-
-            var yOffset = 0;
-            var xOffset = 0;
-            var tile = new TileHelper(MapId, X, Y);
-            switch (direction)
-            {
-                case Direction.Up:
-                    yOffset--;
-                    break;
-
-                case Direction.Down:
-                    yOffset++;
-                    break;
-
-                case Direction.Left:
-                    xOffset--;
-                    break;
-
-                case Direction.Right:
-                    xOffset++;
-                    break;
-
-                case Direction.UpLeft:
-                    yOffset--;
-                    xOffset--;
-                    break;
-
-                case Direction.UpRight:
-                    yOffset--;
-                    xOffset++;
-                    break;
-
-                case Direction.DownLeft:
-                    yOffset++;
-                    xOffset--;
-                    break;
-
-                case Direction.DownRight:
-                    yOffset++;
-                    xOffset++;
-                    break;
-
-                case Direction.None:
-                default:
-                    break;
-            }
-
-            // ReSharper disable once InvertIf
-            if (tile.Translate(xOffset, yOffset))
-            {
-                // If this would move us past our reset radius then we cannot move.
-                var dist = GetDistanceBetween(
-                    AggroCenterMap,
-                    tile.GetMap(),
-                    AggroCenterX,
-                    tile.GetX(),
-                    AggroCenterY,
-                    tile.GetY()
-                );
-
-                // ReSharper disable once InvertIf
-                if (dist > Math.Max(Options.Npc.ResetRadius, Base.ResetRadius))
-                {
-                    blockerType = MovementBlockerType.MapAttribute;
-                    return false;
-                }
-            }
-
-            return blockerType == MovementBlockerType.NotBlocked;
-        }
-
-        private void TryCastSpells()
-        {
-            var target = Target;
-
-            if (target == null || mPathFinder.GetTarget() == null)
+            if (!Options.Instance.NpcOpts.AllowEngagingWhileResetting || attackedBy == null || attackedBy.GetDistanceTo(AggroCenterMap, AggroCenterX, AggroCenterY) > Math.Max(Options.Instance.NpcOpts.ResetRadius, Base.ResetRadius))
             {
                 return;
-            }
-
-            // Check if NPC is stunned/sleeping
-            if (IsStunnedOrSleeping)
-            {
-                return;
-            }
-
-            //Check if NPC is casting a spell
-            if (IsCasting)
-            {
-                return; //can't move while casting
-            }
-
-            if (CastFreq >= Timing.Global.Milliseconds)
-            {
-                return;
-            }
-
-            // Check if the NPC is able to cast spells
-            if (IsUnableToCastSpells)
-            {
-                return;
-            }
-
-            if (Base.Spells is not { Count: > 0 })
-            {
-                return;
-            }
-
-            // Pick a random spell
-            var spellIndex = Randomization.Next(0, Spells.Count);
-            var spellId = Base.Spells[spellIndex];
-            if (!SpellBase.TryGet(spellId, out var spellBase))
-            {
-                return;
-            }
-
-            if (spellBase.Combat == null)
-            {
-                Log.Warn($"Combat data missing for {spellBase.Id}.");
-            }
-
-            // Check if we are even allowed to cast this spell.
-            if (!CanCastSpell(spellBase, target, true, out _))
-            {
-                return;
-            }
-
-            var targetType = spellBase.Combat?.TargetType ?? SpellTargetType.Single;
-            var projectileBase = spellBase.Combat?.Projectile;
-
-            if (spellBase.SpellType == SpellType.CombatSpell &&
-                targetType == SpellTargetType.Projectile &&
-                projectileBase != null &&
-                InRangeOf(target, projectileBase.Range))
-            {
-                var dirToEnemy = DirectionToTarget(target);
-                if (dirToEnemy != Dir)
-                {
-                    if (LastRandomMove >= Timing.Global.Milliseconds)
-                    {
-                        return;
-                    }
-
-                    //Face the target -- next frame fire -- then go on with life
-                    ChangeDir(dirToEnemy); // Gotta get dir to enemy
-                    LastRandomMove = Timing.Global.Milliseconds + Randomization.Next(1000, 3000);
-
-                    return;
-                }
-            }
-
-            CastTime = Timing.Global.Milliseconds + spellBase.CastDuration;
-
-            if ((spellBase.Combat?.Friendly ?? false) && spellBase.SpellType != SpellType.WarpTo)
-            {
-                CastTarget = this;
             }
             else
             {
-                CastTarget = target;
-            }
-
-            switch (Base.SpellFrequency)
-            {
-                case 0:
-                    CastFreq = Timing.Global.Milliseconds + 30000;
-
-                    break;
-
-                case 1:
-                    CastFreq = Timing.Global.Milliseconds + 15000;
-
-                    break;
-
-                case 2:
-                    CastFreq = Timing.Global.Milliseconds + 8000;
-
-                    break;
-
-                case 3:
-                    CastFreq = Timing.Global.Milliseconds + 4000;
-
-                    break;
-
-                case 4:
-                    CastFreq = Timing.Global.Milliseconds + 2000;
-
-                    break;
-            }
-
-            SpellCastSlot = spellIndex;
-
-            if (spellBase.CastAnimationId != Guid.Empty)
-            {
-                PacketSender.SendAnimationToProximity(spellBase.CastAnimationId, 1, Id, MapId, 0, 0, Dir, MapInstanceId);
-
-                //Target Type 1 will be global entity
-            }
-
-            PacketSender.SendEntityCastTime(this, spellId);
-        }
-
-        public bool IsFleeing()
-        {
-            if (Base.FleeHealthPercentage > 0)
-            {
-                var fleeHpCutoff = GetMaxVital(Vital.Health) * (Base.FleeHealthPercentage / 100f);
-                if (GetVital(Vital.Health) < fleeHpCutoff)
-                {
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        // TODO: Improve NPC movement to be more fluid like a player
-        //General Updating
-        public override void Update(long timeMs)
-        {
-            var lockObtained = false;
-            try
-            {
-                Monitor.TryEnter(EntityLock, ref lockObtained);
-                if (lockObtained)
-                {
-                    var curMapLink = MapId;
-                    base.Update(timeMs);
-                    var tempTarget = Target;
-
-                    foreach (var status in CachedStatuses)
-                    {
-                        if (status.Type == SpellEffect.Stun || status.Type == SpellEffect.Sleep)
-                        {
-                            return;
-                        }
-                    }
-
-                    var fleeing = IsFleeing();
-
-                    if (MoveTimer < Timing.Global.Milliseconds)
-                    {
-                        var targetMap = Guid.Empty;
-                        var targetX = 0;
-                        var targetY = 0;
-                        var targetZ = 0;
-
-                        //TODO Clear Damage Map if out of combat (target is null and combat timer is to the point that regen has started)
-                        if (tempTarget != null && (Options.Instance.NpcOpts.ResetIfCombatTimerExceeded && Timing.Global.Milliseconds > CombatTimer))
-                        {
-                            if (CheckForResetLocation(true))
-                            {
-                                if (Target != tempTarget)
-                                {
-                                    PacketSender.SendNpcAggressionToProximity(this);
-                                }
-                                return;
-                            }
-                        }
-
-                        // Are we resetting? If so, regenerate completely!
-                        if (mResetting)
-                        {
-                            var distance = GetDistanceTo(AggroCenterMap, AggroCenterX, AggroCenterY);
-                            // Have we reached our destination? If so, clear it.
-                            if (distance < 1)
-                            {
-                                ResetAggroCenter(out targetMap);
-                            }
-
-                            Reset(Options.Instance.NpcOpts.ContinuouslyResetVitalsAndStatuses);
-                            tempTarget = Target;
-
-                            if (distance != mResetDistance)
-                            {
-                                mResetDistance = distance;
-                            }
-                            else
-                            {
-                                // Something is fishy here.. We appear to be stuck in a reset loop?
-                                // Give it a few more attempts and reset the NPC's center if we're stuck!
-                                mResetCounter++;
-                                if (mResetCounter > mResetMax)
-                                {
-                                    ResetAggroCenter(out targetMap);
-                                    mResetCounter = 0;
-                                    mResetDistance = 0;
-                                }
-                            }
-
-                        }
-
-                        if (tempTarget != null && (tempTarget.IsDead() || !InRangeOf(tempTarget, Options.MapWidth * 2)))
-                        {
-                            TryFindNewTarget(Timing.Global.Milliseconds, tempTarget.Id);
-                            tempTarget = Target;
-                        }
-
-                        //Check if there is a target, if so, run their ass down.
-                        if (tempTarget != null)
-                        {
-                            if (!tempTarget.IsDead() && CanAttack(tempTarget, null))
-                            {
-                                targetMap = tempTarget.MapId;
-                                targetX = tempTarget.X;
-                                targetY = tempTarget.Y;
-                                targetZ = tempTarget.Z;
-                                foreach (var targetStatus in tempTarget.CachedStatuses)
-                                {
-                                    if (targetStatus.Type == SpellEffect.Stealth)
-                                    {
-                                        targetMap = Guid.Empty;
-                                        targetX = 0;
-                                        targetY = 0;
-                                        targetZ = 0;
-                                    }
-                                }
-                            }
-                        }
-                        else //Find a target if able
-                        {
-                            // Check if attack on sight or have other npc's to target
-                            TryFindNewTarget(timeMs);
-                            tempTarget = Target;
-                        }
-
-                        if (targetMap != Guid.Empty)
-                        {
-                            //Check if target map is on one of the surrounding maps, if not then we are not even going to look.
-                            if (targetMap != MapId)
-                            {
-                                var found = false;
-                                foreach (var map in MapController.Get(MapId).SurroundingMaps)
-                                {
-                                    if (map.Id == targetMap)
-                                    {
-                                        found = true;
-                                        break;
-                                    }
-                                }
-                                if (!found)
-                                {
-                                    targetMap = Guid.Empty;
-                                }
-                            }
-                        }
-
-                        if (targetMap != Guid.Empty)
-                        {
-                            if (mPathFinder.GetTarget() != null)
-                            {
-                                if (targetMap != mPathFinder.GetTarget().TargetMapId ||
-                                    targetX != mPathFinder.GetTarget().TargetX ||
-                                    targetY != mPathFinder.GetTarget().TargetY)
-                                {
-                                    mPathFinder.SetTarget(null);
-                                }
-                            }
-
-                            if (mPathFinder.GetTarget() == null)
-                            {
-                                mPathFinder.SetTarget(new PathfinderTarget(targetMap, targetX, targetY, targetZ));
-
-                                if (tempTarget != Target)
-                                {
-                                    tempTarget = Target;
-                                }
-                            }
-
-                        }
-
-                        if (mPathFinder.GetTarget() != null && Base.Movement != (int)NpcMovement.Static)
-                        {
-                            TryCastSpells();
-                            // TODO: Make resetting mobs actually return to their starting location.
-                            if ((!mResetting && !IsOneBlockAway(
-                                mPathFinder.GetTarget().TargetMapId, mPathFinder.GetTarget().TargetX,
-                                mPathFinder.GetTarget().TargetY, mPathFinder.GetTarget().TargetZ
-                            )) ||
-                            (mResetting && GetDistanceTo(AggroCenterMap, AggroCenterX, AggroCenterY) != 0)
-                            )
-                            {
-                                switch (mPathFinder.Update(timeMs))
-                                {
-                                    case PathfinderResult.Success:
-
-                                        var dir = mPathFinder.GetMove();
-                                        if (dir > Direction.None)
-                                        {
-                                            if (fleeing)
-                                            {
-                                                switch (dir)
-                                                {
-                                                    case Direction.Up:
-                                                        dir = Direction.Down;
-
-                                                        break;
-                                                    case Direction.Down:
-                                                        dir = Direction.Up;
-
-                                                        break;
-                                                    case Direction.Left:
-                                                        dir = Direction.Right;
-
-                                                        break;
-                                                    case Direction.Right:
-                                                        dir = Direction.Left;
-
-                                                        break;
-                                                    case Direction.UpLeft:
-                                                        dir = Direction.UpRight;
-
-                                                        break;
-                                                    case Direction.UpRight:
-                                                        dir = Direction.UpLeft;
-
-                                                        break;
-                                                    case Direction.DownRight:
-                                                        dir = Direction.DownLeft;
-
-                                                        break;
-                                                    case Direction.DownLeft:
-                                                        dir = Direction.DownRight;
-
-                                                        break;
-                                                }
-                                            }
-
-                                            if (CanMoveInDirection(dir, out var blockerType, out _) || blockerType == MovementBlockerType.Slide)
-                                            {
-                                                //check if NPC is snared or stunned
-                                                foreach (var status in CachedStatuses)
-                                                {
-                                                    if (status.Type == SpellEffect.Stun ||
-                                                        status.Type == SpellEffect.Snare ||
-                                                        status.Type == SpellEffect.Sleep)
-                                                    {
-                                                        return;
-                                                    }
-                                                }
-
-                                                Move(dir, null);
-                                            }
-                                            else
-                                            {
-                                                mPathFinder.PathFailed(timeMs);
-                                            }
-
-                                            // Are we resetting?
-                                            if (mResetting)
-                                            {
-                                                // Have we reached our destination? If so, clear it.
-                                                if (GetDistanceTo(AggroCenterMap, AggroCenterX, AggroCenterY) == 0)
-                                                {
-                                                    targetMap = Guid.Empty;
-
-                                                    // Reset our aggro center so we can get "pulled" again.
-                                                    AggroCenterMap = null;
-                                                    AggroCenterX = 0;
-                                                    AggroCenterY = 0;
-                                                    AggroCenterZ = 0;
-                                                    mPathFinder?.SetTarget(null);
-                                                    mResetting = false;
-                                                }
-                                            }
-                                        }
-
-                                        break;
-                                    case PathfinderResult.OutOfRange:
-                                        TryFindNewTarget(timeMs, tempTarget?.Id ?? Guid.Empty, true);
-                                        tempTarget = Target;
-                                        targetMap = Guid.Empty;
-
-                                        break;
-                                    case PathfinderResult.NoPathToTarget:
-                                        TryFindNewTarget(timeMs, tempTarget?.Id ?? Guid.Empty, true);
-                                        tempTarget = Target;
-                                        targetMap = Guid.Empty;
-
-                                        break;
-                                    case PathfinderResult.Failure:
-                                        targetMap = Guid.Empty;
-                                        TryFindNewTarget(timeMs, tempTarget?.Id ?? Guid.Empty, true);
-                                        tempTarget = Target;
-
-                                        break;
-                                    case PathfinderResult.Wait:
-                                        targetMap = Guid.Empty;
-
-                                        break;
-                                    default:
-                                        throw new ArgumentOutOfRangeException();
-                                }
-                            }
-                            else
-                            {
-                                var fleed = false;
-                                if (tempTarget != null && fleeing)
-                                {
-                                    var dir = DirectionToTarget(tempTarget);
-                                    switch (dir)
-                                    {
-                                        case Direction.Up:
-                                            dir = Direction.Down;
-
-                                            break;
-                                        case Direction.Down:
-                                            dir = Direction.Up;
-
-                                            break;
-                                        case Direction.Left:
-                                            dir = Direction.Right;
-
-                                            break;
-                                        case Direction.Right:
-                                            dir = Direction.Left;
-
-                                            break;
-                                        case Direction.UpLeft:
-                                            dir = Direction.UpRight;
-
-                                            break;
-                                        case Direction.UpRight:
-                                            dir = Direction.UpLeft;
-                                            break;
-
-                                        case Direction.DownRight:
-                                            dir = Direction.DownLeft;
-
-                                            break;
-                                        case Direction.DownLeft:
-                                            dir = Direction.DownRight;
-
-                                            break;
-                                    }
-
-                                    if (CanMoveInDirection(dir, out var blockerType, out _) || blockerType == MovementBlockerType.Slide)
-                                    {
-                                        //check if NPC is snared or stunned
-                                        foreach (var status in CachedStatuses)
-                                        {
-                                            if (status.Type == SpellEffect.Stun ||
-                                                status.Type == SpellEffect.Snare ||
-                                                status.Type == SpellEffect.Sleep)
-                                            {
-                                                return;
-                                            }
-                                        }
-
-                                        Move(dir, null);
-                                        fleed = true;
-                                    }
-                                }
-
-                                if (!fleed)
-                                {
-                                    if (tempTarget != null)
-                                    {
-                                        if (Dir != DirectionToTarget(tempTarget) && DirectionToTarget(tempTarget) != Direction.None)
-                                        {
-                                            ChangeDir(DirectionToTarget(tempTarget));
-                                        }
-                                        else
-                                        {
-                                            if (tempTarget.IsDisposed)
-                                            {
-                                                TryFindNewTarget(timeMs);
-                                                tempTarget = Target;
-                                            }
-                                            else
-                                            {
-                                                if (CanAttack(tempTarget, null))
-                                                {
-                                                    TryAttack(tempTarget);
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-
-                        CheckForResetLocation();
-
-                        //Move randomly
-                        if (targetMap != Guid.Empty)
-                        {
-                            return;
-                        }
-
-                        if (LastRandomMove >= Timing.Global.Milliseconds || IsCasting)
-                        {
-                            return;
-                        }
-
-                        if (Base.Movement == (int)NpcMovement.StandStill)
-                        {
-                            LastRandomMove = Timing.Global.Milliseconds + Randomization.Next(1000, 3000);
-
-                            return;
-                        }
-                        else if (Base.Movement == (int)NpcMovement.TurnRandomly)
-                        {
-                            ChangeDir(Randomization.NextDirection());
-                            LastRandomMove = Timing.Global.Milliseconds + Randomization.Next(1000, 3000);
-
-                            return;
-                        }
-
-                        var i = Randomization.Next(0, 1);
-                        if (i == 0)
-                        {
-                            var direction = Randomization.NextDirection();
-                            if (CanMoveInDirection(direction))
-                            {
-                                //check if NPC is snared or stunned
-                                foreach (var status in CachedStatuses)
-                                {
-                                    if (status.Type == SpellEffect.Stun ||
-                                        status.Type == SpellEffect.Snare ||
-                                        status.Type == SpellEffect.Sleep)
-                                    {
-                                        return;
-                                    }
-                                }
-
-                                Move(direction, null);
-                            }
-                        }
-
-                        LastRandomMove = Timing.Global.Milliseconds + Randomization.Next(1000, 3000);
-
-                        if (fleeing)
-                        {
-                            LastRandomMove = Timing.Global.Milliseconds + (long)GetMovementTime();
-                        }
-                    }
-
-                    //If we switched maps, lets update the maps
-                    if (curMapLink != MapId)
-                    {
-                        if (curMapLink == Guid.Empty)
-                        {
-                            if (MapController.TryGetInstanceFromMap(curMapLink, MapInstanceId, out var instance))
-                            {
-                                instance.RemoveEntity(this);
-                            }
-                        }
-
-                        if (MapId != Guid.Empty)
-                        {
-                            if (MapController.TryGetInstanceFromMap(MapId, MapInstanceId, out var instance))
-                            {
-                                instance.AddEntity(this);
-                            }
-                        }
-                    }
-                }
-            }
-            finally
-            {
-                if (lockObtained)
-                {
-                    Monitor.Exit(EntityLock);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Resets the NPCs position to be "pulled" from
-        /// </summary>
-        /// <param name="targetMap">For referencing the map that the enemy's target WAS on before a reset.</param>
-        private void ResetAggroCenter(out Guid targetMap)
-        {
-            targetMap = Guid.Empty;
-
-            // Reset our aggro center so we can get "pulled" again.
-            AggroCenterMap = null;
-            AggroCenterX = 0;
-            AggroCenterY = 0;
-            AggroCenterZ = 0;
-            mPathFinder?.SetTarget(null);
-            mResetting = false;
-        }
-
-        private bool CheckForResetLocation(bool forceDistance = false)
-        {
-            // Check if we've moved out of our range we're allowed to move from after being "aggro'd" by something.
-            // If so, remove target and move back to the origin point.
-            if (Options.Npc.AllowResetRadius && AggroCenterMap != null && (GetDistanceTo(AggroCenterMap, AggroCenterX, AggroCenterY) > Math.Max(Options.Npc.ResetRadius, Math.Min(Base.ResetRadius, Math.Max(Options.MapWidth, Options.MapHeight))) || forceDistance))
-            {
-                Reset(Options.Npc.ResetVitalsAndStatusses);
-
-                mResetCounter = 0;
-                mResetDistance = 0;
-
-                // Try and move back to where we came from before we started chasing something.
-                mResetting = true;
-                mPathFinder.SetTarget(new PathfinderTarget(AggroCenterMap.Id, AggroCenterX, AggroCenterY, AggroCenterZ));
-                return true;
-            }
-            return false;
-        }
-
-        private void Reset(bool resetVitals, bool clearLocation = false)
-        {
-            // Remove our target.
-            RemoveTarget();
-
-            DamageMap.Clear();
-            LootMap.Clear();
-            LootMapCache = Array.Empty<Guid>();
-
-            if (clearLocation)
-            {
-                mPathFinder.SetTarget(null);
-                AggroCenterMap = null;
-                AggroCenterX = 0;
-                AggroCenterY = 0;
-                AggroCenterZ = 0;
-            }
-
-            // Reset our vitals and statusses when configured.
-            if (resetVitals)
-            {
-                Statuses.Clear();
-                CachedStatuses = Statuses.Values.ToArray();
-                DoT.Clear();
-                CachedDots = DoT.Values.ToArray();
-                for (var v = 0; v < Enum.GetValues<Vital>().Length; v++)
-                {
-                    RestoreVital((Vital)v);
-                }
-            }
-        }
-
-        // Completely resets an Npc to full health and its spawnpoint if it's current chasing something.
-        public override void Reset()
-        {
-            if (AggroCenterMap != null)
-            {
-                Warp(AggroCenterMap.Id, AggroCenterX, AggroCenterY);
-            }
-
-            Reset(true, true);
-        }
-
-        public override void NotifySwarm(Entity attacker)
-        {
-            if (MapController.TryGetInstanceFromMap(MapId, MapInstanceId, out var instance))
-            {
-                foreach (var en in instance.GetEntities(true))
-                {
-                    if (en is Npc npc)
-                    {
-                        if (npc.Target == null && npc.Base == Base && npc.Base.Swarm)
-                        {
-                            if (npc.InRangeOf(attacker, npc.Base.SightRange))
-                            {
-                                npc.AssignTarget(attacker);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        public bool CanPlayerAttack(Player en)
-        {
-            //Check to see if the npc is a friend/protector...
-            if (IsAllyOf(en))
-            {
-                return false;
-            }
-
-            //If not then check and see if player meets the conditions to attack the npc...
-            if (Base.PlayerCanAttackConditions.Lists.Count == 0 ||
-                Conditions.MeetsConditionLists(Base.PlayerCanAttackConditions, en, null))
-            {
-                return true;
-            }
-
-            return false;
-        }
-
-        public override bool IsAllyOf(Entity otherEntity)
-        {
-            switch (otherEntity)
-            {
-                case Npc otherNpc:
-                    if (!Base.NpcVsNpcEnabled && !otherNpc.Base.NpcVsNpcEnabled)
-                    {
-                        return true;
-                    }
-
-                    return !otherNpc.CanNpcCombat(this);
-                case Player otherPlayer:
-                    var conditionLists = Base.PlayerFriendConditions;
-                    if ((conditionLists?.Count ?? 0) == 0)
-                    {
-                        return false;
-                    }
-
-                    return Conditions.MeetsConditionLists(conditionLists, otherPlayer, null);
-                default:
-                    return base.IsAllyOf(otherEntity);
-            }
-        }
-
-        public bool ShouldAttackPlayerOnSight(Player en)
-        {
-            if (IsAllyOf(en))
-            {
-                return false;
-            }
-
-            if (Base.Aggressive)
-            {
-                if (Base.AttackOnSightConditions.Lists.Count > 0 &&
-                    Conditions.MeetsConditionLists(Base.AttackOnSightConditions, en, null))
-                {
-                    return false;
-                }
-
-                return true;
-            }
-            else
-            {
-                if (Base.AttackOnSightConditions.Lists.Count > 0 &&
-                    Conditions.MeetsConditionLists(Base.AttackOnSightConditions, en, null))
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        public void TryFindNewTarget(long timeMs, Guid avoidId = new Guid(), bool ignoreTimer = false, Entity attackedBy = null)
-        {
-            if (!ignoreTimer && FindTargetWaitTime > timeMs)
-            {
+                //We're resetting and just got attacked, and we allow reengagement.. let's stop resetting and fight!
+                mPathFinder?.SetTarget(null);
+                mResetting = false;
+                AssignTarget(attackedBy);
                 return;
             }
+        }
 
-            // Are we resetting? If so, do not allow for a new target.
-            var pathTarget = mPathFinder?.GetTarget();
-            if (AggroCenterMap != null && pathTarget != null &&
-                pathTarget.TargetMapId == AggroCenterMap.Id && pathTarget.TargetX == AggroCenterX && pathTarget.TargetY == AggroCenterY)
+        var possibleTargets = new List<Entity>();
+        var closestRange = Range + 1; //If the range is out of range we didn't find anything.
+        var closestIndex = -1;
+        var highestDmgIndex = -1;
+
+        if (DamageMap.Count > 0)
+        {
+            // Go through all of our potential targets in order of damage done as instructed and select the first matching one.
+            long highestDamage = 0;
+            foreach (var en in DamageMap.ToArray())
             {
-                if (!Options.Instance.NpcOpts.AllowEngagingWhileResetting || attackedBy == null || attackedBy.GetDistanceTo(AggroCenterMap, AggroCenterX, AggroCenterY) > Math.Max(Options.Instance.NpcOpts.ResetRadius, Base.ResetRadius))
+                // Are we supposed to avoid this one?
+                if (en.Key.Id == avoidId)
                 {
-                    return;
+                    continue;
                 }
-                else
+
+                // Is this entry dead?, if so skip it.
+                if (en.Key.IsDead())
                 {
-                    //We're resetting and just got attacked, and we allow reengagement.. let's stop resetting and fight!
-                    mPathFinder?.SetTarget(null);
-                    mResetting = false;
-                    AssignTarget(attackedBy);
-                    return;
+                    continue;
                 }
-            }
 
-            var possibleTargets = new List<Entity>();
-            var closestRange = Range + 1; //If the range is out of range we didn't find anything.
-            var closestIndex = -1;
-            var highestDmgIndex = -1;
-
-            if (DamageMap.Count > 0)
-            {
-                // Go through all of our potential targets in order of damage done as instructed and select the first matching one.
-                long highestDamage = 0;
-                foreach (var en in DamageMap.ToArray())
+                // Is this entity on our instance anymore? If not skip it, but don't remove it in case they come back and need item drop determined
+                if (en.Key.MapInstanceId != MapInstanceId)
                 {
-                    // Are we supposed to avoid this one?
-                    if (en.Key.Id == avoidId)
+                    continue;
+                }
+
+                // Are we at a valid distance? (9999 means not on this map or somehow null!)
+                if (GetDistanceTo(en.Key) != 9999)
+                {
+                    possibleTargets.Add(en.Key);
+
+                    // Do we have the highest damage?
+                    if (en.Value > highestDamage)
                     {
-                        continue;
+                        highestDmgIndex = possibleTargets.Count - 1;
+                        highestDamage = en.Value;
                     }
 
-                    // Is this entry dead?, if so skip it.
-                    if (en.Key.IsDead())
-                    {
-                        continue;
-                    }
-
-                    // Is this entity on our instance anymore? If not skip it, but don't remove it in case they come back and need item drop determined
-                    if (en.Key.MapInstanceId != MapInstanceId)
-                    {
-                        continue;
-                    }
-
-                    // Are we at a valid distance? (9999 means not on this map or somehow null!)
-                    if (GetDistanceTo(en.Key) != 9999)
-                    {
-                        possibleTargets.Add(en.Key);
-
-                        // Do we have the highest damage?
-                        if (en.Value > highestDamage)
-                        {
-                            highestDmgIndex = possibleTargets.Count - 1;
-                            highestDamage = en.Value;
-                        }
-
-                    }
                 }
             }
+        }
 
-            // Scan for nearby targets
-            foreach (var instance in MapController.GetSurroundingMapInstances(MapId, MapInstanceId, true))
+        // Scan for nearby targets
+        foreach (var instance in MapController.GetSurroundingMapInstances(MapId, MapInstanceId, true))
+        {
+            foreach (var entity in instance.GetCachedEntities())
             {
-                foreach (var entity in instance.GetCachedEntities())
+                if (entity != null && !entity.IsDead() && entity != this && entity.Id != avoidId)
                 {
-                    if (entity != null && !entity.IsDead() && entity != this && entity.Id != avoidId)
+                    //TODO Check if NPC is allowed to attack player with new conditions
+                    if (entity is Player player)
                     {
-                        //TODO Check if NPC is allowed to attack player with new conditions
-                        if (entity is Player player)
+                        // Are we aggressive towards this player or have they hit us?
+                        if (ShouldAttackPlayerOnSight(player) || (DamageMap.ContainsKey(entity) && entity.MapInstanceId == MapInstanceId))
                         {
-                            // Are we aggressive towards this player or have they hit us?
-                            if (ShouldAttackPlayerOnSight(player) || (DamageMap.ContainsKey(entity) && entity.MapInstanceId == MapInstanceId))
+                            var dist = GetDistanceTo(entity);
+                            if (dist <= Range && dist < closestRange)
                             {
-                                var dist = GetDistanceTo(entity);
-                                if (dist <= Range && dist < closestRange)
-                                {
-                                    possibleTargets.Add(entity);
-                                    closestIndex = possibleTargets.Count - 1;
-                                    closestRange = dist;
-                                }
+                                possibleTargets.Add(entity);
+                                closestIndex = possibleTargets.Count - 1;
+                                closestRange = dist;
                             }
                         }
-                        else if (entity is Npc npc)
+                    }
+                    else if (entity is Npc npc)
+                    {
+                        if (Base.Aggressive && Base.AggroList.Contains(npc.Base.Id))
                         {
-                            if (Base.Aggressive && Base.AggroList.Contains(npc.Base.Id))
+                            var dist = GetDistanceTo(entity);
+                            if (dist <= Range && dist < closestRange)
                             {
-                                var dist = GetDistanceTo(entity);
-                                if (dist <= Range && dist < closestRange)
-                                {
-                                    possibleTargets.Add(entity);
-                                    closestIndex = possibleTargets.Count - 1;
-                                    closestRange = dist;
-                                }
+                                possibleTargets.Add(entity);
+                                closestIndex = possibleTargets.Count - 1;
+                                closestRange = dist;
                             }
                         }
                     }
                 }
             }
+        }
 
-            // Assign our target if we've found one!
-            if (Base.FocusHighestDamageDealer && highestDmgIndex != -1)
+        // Assign our target if we've found one!
+        if (Base.FocusHighestDamageDealer && highestDmgIndex != -1)
+        {
+            // We're focussed on whoever has the most threat! o7
+            AssignTarget(possibleTargets[highestDmgIndex]);
+        }
+        else if (Target != null && possibleTargets.Count > 0)
+        {
+            // Time to randomize who we target.. Since we don't actively care who we attack!
+            // 10% chance to just go for someone else.
+            if (Randomization.Next(1, 101) > 90)
             {
-                // We're focussed on whoever has the most threat! o7
-                AssignTarget(possibleTargets[highestDmgIndex]);
-            }
-            else if (Target != null && possibleTargets.Count > 0)
-            {
-                // Time to randomize who we target.. Since we don't actively care who we attack!
-                // 10% chance to just go for someone else.
-                if (Randomization.Next(1, 101) > 90)
-                {
-                    if (possibleTargets.Count > 1)
-                    {
-                        var target = Randomization.Next(0, possibleTargets.Count - 1);
-                        AssignTarget(possibleTargets[target]);
-                    }
-                    else
-                    {
-                        AssignTarget(possibleTargets[0]);
-                    }
-                }
-            }
-            else if (Target == null && Base.Aggressive && closestIndex != -1)
-            {
-                // Aggressively attack closest person!
-                AssignTarget(possibleTargets[closestIndex]);
-            }
-            else if (possibleTargets.Count > 0)
-            {
-                // Not aggressive but no target, so just try and attack SOMEONE on the damage table!
                 if (possibleTargets.Count > 1)
                 {
                     var target = Randomization.Next(0, possibleTargets.Count - 1);
@@ -1534,144 +1515,161 @@ namespace Intersect.Server.Entities
                     AssignTarget(possibleTargets[0]);
                 }
             }
-            else
-            {
-                // ??? What the frick is going on here?
-                // We can't find a valid target somehow, keep it up a few times and reset if this keeps failing!
-                mTargetFailCounter += 1;
-                if (mTargetFailCounter > mTargetFailMax)
-                {
-                    CheckForResetLocation(true);
-                }
-            }
-
-            FindTargetWaitTime = timeMs + FindTargetDelay;
         }
-
-        public override void ProcessRegen()
+        else if (Target == null && Base.Aggressive && closestIndex != -1)
         {
-            if (Base == null)
-            {
-                return;
-            }
-
-            foreach (Vital vital in Enum.GetValues(typeof(Vital)))
-            {
-                if (!Enum.IsDefined(vital))
-                {
-                    continue;
-                }
-
-                var vitalId = (int)vital;
-                var vitalValue = GetVital(vital);
-                var maxVitalValue = GetMaxVital(vital);
-                if (vitalValue >= maxVitalValue)
-                {
-                    continue;
-                }
-
-                var vitalRegenRate = Base.VitalRegen[vitalId] / 100f;
-                var regenValue = (long)Math.Max(1, maxVitalValue * vitalRegenRate) *
-                                 Math.Abs(Math.Sign(vitalRegenRate));
-
-                AddVital(vital, regenValue);
-            }
+            // Aggressively attack closest person!
+            AssignTarget(possibleTargets[closestIndex]);
         }
-
-        public override void Warp(Guid newMapId,
-            float newX,
-            float newY,
-            Direction newDir,
-            bool adminWarp = false,
-            int zOverride = 0,
-            bool mapSave = false,
-            bool fromWarpEvent = false,
-            MapInstanceType? mapInstanceType = null,
-            bool fromLogin = false,
-            bool forceInstanceChange = false)
+        else if (possibleTargets.Count > 0)
         {
-            if (!MapController.TryGetInstanceFromMap(newMapId, MapInstanceId, out var map))
+            // Not aggressive but no target, so just try and attack SOMEONE on the damage table!
+            if (possibleTargets.Count > 1)
             {
-                return;
-            }
-
-            X = (int)newX;
-            Y = (int)newY;
-            Z = zOverride;
-            Dir = newDir;
-            if (newMapId != MapId)
-            {
-                if (MapController.TryGetInstanceFromMap(MapId, MapInstanceId, out var oldMap))
-                {
-                    oldMap.RemoveEntity(this);
-                }
-
-                PacketSender.SendEntityLeave(this);
-                MapId = newMapId;
-                PacketSender.SendEntityDataToProximity(this);
-                PacketSender.SendEntityPositionToAll(this);
+                var target = Randomization.Next(0, possibleTargets.Count - 1);
+                AssignTarget(possibleTargets[target]);
             }
             else
             {
-                PacketSender.SendEntityPositionToAll(this);
-                PacketSender.SendEntityStats(this);
+                AssignTarget(possibleTargets[0]);
+            }
+        }
+        else
+        {
+            // ??? What the frick is going on here?
+            // We can't find a valid target somehow, keep it up a few times and reset if this keeps failing!
+            mTargetFailCounter += 1;
+            if (mTargetFailCounter > mTargetFailMax)
+            {
+                CheckForResetLocation(true);
             }
         }
 
-        /// <summary>
-        /// Determines the aggression of this NPC towards a player.
-        /// </summary>
-        /// <param name="player">The player to check the relationship with.</param>
-        /// <returns>The NPC's aggression towards the player.</returns>
-        public NpcAggression GetAggression(Player player)
+        FindTargetWaitTime = timeMs + FindTargetDelay;
+    }
+
+    public override void ProcessRegen()
+    {
+        if (Base == null)
         {
-            if (this.Target != null)
+            return;
+        }
+
+        foreach (Vital vital in Enum.GetValues(typeof(Vital)))
+        {
+            if (!Enum.IsDefined(vital))
             {
-                return NpcAggression.Aggressive;
+                continue;
             }
 
-            var ally = IsAllyOf(player);
-            var attackOnSight = ShouldAttackPlayerOnSight(player);
-            var canPlayerAttack = CanPlayerAttack(player);
-
-            if (ally && !canPlayerAttack)
+            var vitalId = (int)vital;
+            var vitalValue = GetVital(vital);
+            var maxVitalValue = GetMaxVital(vital);
+            if (vitalValue >= maxVitalValue)
             {
-                return NpcAggression.Guard;
+                continue;
             }
 
-            if (attackOnSight)
+            var vitalRegenRate = Base.VitalRegen[vitalId] / 100f;
+            var regenValue = (long)Math.Max(1, maxVitalValue * vitalRegenRate) *
+                             Math.Abs(Math.Sign(vitalRegenRate));
+
+            AddVital(vital, regenValue);
+        }
+    }
+
+    public override void Warp(Guid newMapId,
+        float newX,
+        float newY,
+        Direction newDir,
+        bool adminWarp = false,
+        int zOverride = 0,
+        bool mapSave = false,
+        bool fromWarpEvent = false,
+        MapInstanceType? mapInstanceType = null,
+        bool fromLogin = false,
+        bool forceInstanceChange = false)
+    {
+        if (!MapController.TryGetInstanceFromMap(newMapId, MapInstanceId, out var map))
+        {
+            return;
+        }
+
+        X = (int)newX;
+        Y = (int)newY;
+        Z = zOverride;
+        Dir = newDir;
+        if (newMapId != MapId)
+        {
+            if (MapController.TryGetInstanceFromMap(MapId, MapInstanceId, out var oldMap))
             {
-                return NpcAggression.AttackOnSight;
+                oldMap.RemoveEntity(this);
             }
 
-            if (!ally && !attackOnSight && canPlayerAttack)
-            {
-                return NpcAggression.AttackWhenAttacked;
-            }
+            PacketSender.SendEntityLeave(this);
+            MapId = newMapId;
+            PacketSender.SendEntityDataToProximity(this);
+            PacketSender.SendEntityPositionToAll(this);
+        }
+        else
+        {
+            PacketSender.SendEntityPositionToAll(this);
+            PacketSender.SendEntityStats(this);
+        }
+    }
 
-            if (!ally && !attackOnSight && !canPlayerAttack)
-            {
-                return NpcAggression.Neutral;
-            }
+    /// <summary>
+    /// Determines the aggression of this NPC towards a player.
+    /// </summary>
+    /// <param name="player">The player to check the relationship with.</param>
+    /// <returns>The NPC's aggression towards the player.</returns>
+    public NpcAggression GetAggression(Player player)
+    {
+        if (this.Target != null)
+        {
+            return NpcAggression.Aggressive;
+        }
 
+        var ally = IsAllyOf(player);
+        var attackOnSight = ShouldAttackPlayerOnSight(player);
+        var canPlayerAttack = CanPlayerAttack(player);
+
+        if (ally && !canPlayerAttack)
+        {
+            return NpcAggression.Guard;
+        }
+
+        if (attackOnSight)
+        {
+            return NpcAggression.AttackOnSight;
+        }
+
+        if (!ally && !attackOnSight && canPlayerAttack)
+        {
+            return NpcAggression.AttackWhenAttacked;
+        }
+
+        if (!ally && !attackOnSight && !canPlayerAttack)
+        {
             return NpcAggression.Neutral;
         }
 
-        public override EntityPacket EntityPacket(EntityPacket packet = null, Player forPlayer = null)
+        return NpcAggression.Neutral;
+    }
+
+    public override EntityPacket EntityPacket(EntityPacket packet = null, Player forPlayer = null)
+    {
+        if (packet == null)
         {
-            if (packet == null)
-            {
-                packet = new NpcEntityPacket();
-            }
-
-            packet = base.EntityPacket(packet, forPlayer);
-
-            var pkt = (NpcEntityPacket)packet;
-            pkt.Aggression = GetAggression(forPlayer);
-
-            return pkt;
+            packet = new NpcEntityPacket();
         }
 
+        packet = base.EntityPacket(packet, forPlayer);
+
+        var pkt = (NpcEntityPacket)packet;
+        pkt.Aggression = GetAggression(forPlayer);
+
+        return pkt;
     }
 
 }

--- a/Intersect.Server.Core/Entities/Pathfinding/Pathfinder.cs
+++ b/Intersect.Server.Core/Entities/Pathfinding/Pathfinder.cs
@@ -1,289 +1,285 @@
-using System;
-using System.Collections.Generic;
-
 using Intersect.Enums;
 using Intersect.Logging;
 using Intersect.Server.Database;
 using Intersect.Server.Entities.Events;
 using Intersect.Server.Maps;
 
-namespace Intersect.Server.Entities.Pathfinding
+namespace Intersect.Server.Entities.Pathfinding;
+
+
+public enum PathfinderResult
 {
 
-    public enum PathfinderResult
+    Success,
+
+    OutOfRange,
+
+    NoPathToTarget,
+
+    Failure, //No Map, No Target, Who Knows?
+
+    Wait, //Pathfinder won't run due to recent failures and trying to conserve cpu
+
+}
+
+partial class Pathfinder
+{
+
+    private int mConsecutiveFails;
+
+    private Entity mEntity;
+
+    private IEnumerable<PathNode> mPath;
+
+    private PathfinderTarget mTarget;
+
+    private long mWaitTime;
+
+    private PathNode[,] mGrid = new PathNode[Options.MapWidth * 3, Options.MapHeight * 3];
+
+    public Pathfinder(Entity parent)
     {
-
-        Success,
-
-        OutOfRange,
-
-        NoPathToTarget,
-
-        Failure, //No Map, No Target, Who Knows?
-
-        Wait, //Pathfinder won't run due to recent failures and trying to conserve cpu
-
+        mEntity = parent;
     }
 
-    partial class Pathfinder
+    public void SetTarget(PathfinderTarget target)
     {
+        mTarget = target;
+    }
 
-        private int mConsecutiveFails;
+    public PathfinderTarget GetTarget()
+    {
+        return mTarget;
+    }
 
-        private Entity mEntity;
+    public PathfinderResult Update(long timeMs)
+    {
+        //TODO: Pull this out into server config :) 
+        var pathfindingRange = Math.Max(
+            Options.MapWidth, Options.MapHeight
+        ); //Search as far as 1 map out.. maximum.
 
-        private IEnumerable<PathNode> mPath;
-
-        private PathfinderTarget mTarget;
-
-        private long mWaitTime;
-
-        private PathNode[,] mGrid = new PathNode[Options.MapWidth * 3, Options.MapHeight * 3];
-
-        public Pathfinder(Entity parent)
+        //Do lots of logic eventually leading up to an A* pathfinding run if needed.
+        var returnVal = PathfinderResult.Failure;
+        try
         {
-            mEntity = parent;
-        }
-
-        public void SetTarget(PathfinderTarget target)
-        {
-            mTarget = target;
-        }
-
-        public PathfinderTarget GetTarget()
-        {
-            return mTarget;
-        }
-
-        public PathfinderResult Update(long timeMs)
-        {
-            //TODO: Pull this out into server config :) 
-            var pathfindingRange = Math.Max(
-                Options.MapWidth, Options.MapHeight
-            ); //Search as far as 1 map out.. maximum.
-
-            //Do lots of logic eventually leading up to an A* pathfinding run if needed.
-            var returnVal = PathfinderResult.Failure;
-            try
+            PathNode[,] mapGrid;
+            SpatialAStar aStar;
+            var path = mPath;
+            if (mWaitTime < timeMs)
             {
-                PathNode[,] mapGrid;
-                SpatialAStar aStar;
-                var path = mPath;
-                if (mWaitTime < timeMs)
+                var currentMap = MapController.Get(mEntity.MapId);
+                if (currentMap != null && mTarget != null)
                 {
-                    var currentMap = MapController.Get(mEntity.MapId);
-                    if (currentMap != null && mTarget != null)
+                    var grid = DbInterface.GetGrid(currentMap.MapGrid);
+                    var gridX = currentMap.MapGridX;
+                    var gridY = currentMap.MapGridY;
+
+                    var targetFound = false;
+                    var targetX = -1;
+                    var targetY = -1;
+                    var sourceX = Options.MapWidth + mEntity.X;
+                    var sourceY = Options.MapHeight + mEntity.Y;
+
+                    //Loop through surrouding maps to see if our target is even around.
+                    for (var x = gridX - 1; x <= gridX + 1; x++)
                     {
-                        var grid = DbInterface.GetGrid(currentMap.MapGrid);
-                        var gridX = currentMap.MapGridX;
-                        var gridY = currentMap.MapGridY;
-
-                        var targetFound = false;
-                        var targetX = -1;
-                        var targetY = -1;
-                        var sourceX = Options.MapWidth + mEntity.X;
-                        var sourceY = Options.MapHeight + mEntity.Y;
-
-                        //Loop through surrouding maps to see if our target is even around.
-                        for (var x = gridX - 1; x <= gridX + 1; x++)
+                        if (x == -1 || x >= grid.Width)
                         {
-                            if (x == -1 || x >= grid.Width)
+                            continue;
+                        }
+
+                        for (var y = gridY - 1; y <= gridY + 1; y++)
+                        {
+                            if (y == -1 || y >= grid.Height)
                             {
                                 continue;
                             }
 
-                            for (var y = gridY - 1; y <= gridY + 1; y++)
+                            if (grid.MapIdGrid[x, y] != Guid.Empty)
                             {
-                                if (y == -1 || y >= grid.Height)
+                                if (grid.MapIdGrid[x, y] == mTarget.TargetMapId)
                                 {
-                                    continue;
-                                }
-
-                                if (grid.MapIdGrid[x, y] != Guid.Empty)
-                                {
-                                    if (grid.MapIdGrid[x, y] == mTarget.TargetMapId)
-                                    {
-                                        targetX = (x - gridX + 1) * Options.MapWidth + mTarget.TargetX;
-                                        targetY = (y - gridY + 1) * Options.MapHeight + mTarget.TargetY;
-                                        targetFound = true;
-                                    }
+                                    targetX = (x - gridX + 1) * Options.MapWidth + mTarget.TargetX;
+                                    targetY = (y - gridY + 1) * Options.MapHeight + mTarget.TargetY;
+                                    targetFound = true;
                                 }
                             }
                         }
+                    }
 
-                        if (targetFound)
+                    if (targetFound)
+                    {
+                        if (AlongPath(mPath, targetX, targetY, mEntity.Passable))
                         {
-                            if (AlongPath(mPath, targetX, targetY, mEntity.Passable))
+                            path = mPath;
+                            returnVal = PathfinderResult.Success;
+                        }
+                        else
+                        {
+                            //See if the target is physically within range:
+                            if (Math.Abs(sourceX - targetX) + Math.Abs(sourceY - targetY) < pathfindingRange)
                             {
-                                path = mPath;
-                                returnVal = PathfinderResult.Success;
-                            }
-                            else
-                            {
-                                //See if the target is physically within range:
-                                if (Math.Abs(sourceX - targetX) + Math.Abs(sourceY - targetY) < pathfindingRange)
+                                //Doing good...
+                                mapGrid = mGrid;
+
+                                for (var x = 0; x < Options.MapWidth * 3; x++)
                                 {
-                                    //Doing good...
-                                    mapGrid = mGrid;
-
-                                    for (var x = 0; x < Options.MapWidth * 3; x++)
+                                    for (var y = 0; y < Options.MapHeight * 3; y++)
                                     {
-                                        for (var y = 0; y < Options.MapHeight * 3; y++)
+                                        if (mapGrid[x, y] == null)
                                         {
-                                            if (mapGrid[x, y] == null)
-                                            {
-                                                mapGrid[x, y] = new PathNode(x, y, false);
-                                                
-                                            }
-                                            else
-                                            {
-                                                mapGrid[x, y].Reset();
-                                            }
+                                            mapGrid[x, y] = new PathNode(x, y, false);
+                                            
+                                        }
+                                        else
+                                        {
+                                            mapGrid[x, y].Reset();
+                                        }
 
-                                            if (x < sourceX - pathfindingRange ||
-                                                    x > sourceX + pathfindingRange ||
-                                                    y < sourceY - pathfindingRange ||
-                                                    y > sourceY + pathfindingRange)
-                                            {
-                                                mapGrid[x, y].IsWall = true;
-                                            }
+                                        if (x < sourceX - pathfindingRange ||
+                                                x > sourceX + pathfindingRange ||
+                                                y < sourceY - pathfindingRange ||
+                                                y > sourceY + pathfindingRange)
+                                        {
+                                            mapGrid[x, y].IsWall = true;
                                         }
                                     }
+                                }
 
-                                    //loop through all surrounding maps.. gather blocking elements, resources, players, npcs, global events, and local events (if this is a local event)
-                                    for (var x = gridX - 1; x <= gridX + 1; x++)
+                                //loop through all surrounding maps.. gather blocking elements, resources, players, npcs, global events, and local events (if this is a local event)
+                                for (var x = gridX - 1; x <= gridX + 1; x++)
+                                {
+                                    if (x == -1 || x >= grid.Width)
                                     {
-                                        if (x == -1 || x >= grid.Width)
+                                        for (var y = 0; y < 3; y++)
                                         {
-                                            for (var y = 0; y < 3; y++)
-                                            {
-                                                FillArea(
-                                                    mapGrid, (x + 1 - gridX) * Options.MapWidth, y * Options.MapHeight,
-                                                    Options.MapWidth, Options.MapHeight
-                                                );
-                                            }
+                                            FillArea(
+                                                mapGrid, (x + 1 - gridX) * Options.MapWidth, y * Options.MapHeight,
+                                                Options.MapWidth, Options.MapHeight
+                                            );
+                                        }
+
+                                        continue;
+                                    }
+
+                                    for (var y = gridY - 1; y <= gridY + 1; y++)
+                                    {
+                                        if (y == -1 || y >= grid.Height)
+                                        {
+                                            FillArea(
+                                                mapGrid, (x + 1 - gridX) * Options.MapWidth,
+                                                (y + 1 - gridY) * Options.MapHeight, Options.MapWidth,
+                                                Options.MapHeight
+                                            );
 
                                             continue;
                                         }
 
-                                        for (var y = gridY - 1; y <= gridY + 1; y++)
+                                        if (MapController.TryGetInstanceFromMap(grid.MapIdGrid[x, y], mEntity.MapInstanceId, out var instance))
                                         {
-                                            if (y == -1 || y >= grid.Height)
-                                            {
-                                                FillArea(
-                                                    mapGrid, (x + 1 - gridX) * Options.MapWidth,
-                                                    (y + 1 - gridY) * Options.MapHeight, Options.MapWidth,
-                                                    Options.MapHeight
-                                                );
+                                            //Copy the cached array of tile blocks
 
-                                                continue;
+                                            var blocks = instance.GetCachedBlocks(mEntity is Player);
+
+                                            foreach (var block in blocks)
+                                            {
+                                                mapGrid[(x + 1 - gridX) * Options.MapWidth + block.X,
+                                                        (y + 1 - gridY) * Options.MapHeight + block.Y]
+                                                    .IsWall = true;
                                             }
 
-                                            if (MapController.TryGetInstanceFromMap(grid.MapIdGrid[x, y], mEntity.MapInstanceId, out var instance))
+                                            //Block of Players, Npcs, and Resources
+                                            foreach (var en in instance.GetEntities())
                                             {
-                                                //Copy the cached array of tile blocks
-
-                                                var blocks = instance.GetCachedBlocks(mEntity is Player);
-
-                                                foreach (var block in blocks)
+                                                if (!en.IsPassable() && en.X > -1 && en.X < Options.MapWidth && en.Y > -1 && en.Y < Options.MapHeight)
                                                 {
-                                                    mapGrid[(x + 1 - gridX) * Options.MapWidth + block.X,
-                                                            (y + 1 - gridY) * Options.MapHeight + block.Y]
+                                                    mapGrid[(x + 1 - gridX) * Options.MapWidth + en.X,
+                                                            (y + 1 - gridY) * Options.MapHeight + en.Y]
                                                         .IsWall = true;
                                                 }
+                                            }
 
-                                                //Block of Players, Npcs, and Resources
-                                                foreach (var en in instance.GetEntities())
+                                            foreach (var en in instance.GlobalEventInstances)
+                                            {
+                                                if (en.Value != null && en.Value.X > -1 && en.Value.X < Options.MapWidth && en.Value.Y > -1 && en.Value.Y < Options.MapHeight)
                                                 {
-                                                    if (!en.IsPassable() && en.X > -1 && en.X < Options.MapWidth && en.Y > -1 && en.Y < Options.MapHeight)
+                                                    foreach (var page in en.Value.GlobalPageInstance)
                                                     {
-                                                        mapGrid[(x + 1 - gridX) * Options.MapWidth + en.X,
-                                                                (y + 1 - gridY) * Options.MapHeight + en.Y]
-                                                            .IsWall = true;
-                                                    }
-                                                }
-
-                                                foreach (var en in instance.GlobalEventInstances)
-                                                {
-                                                    if (en.Value != null && en.Value.X > -1 && en.Value.X < Options.MapWidth && en.Value.Y > -1 && en.Value.Y < Options.MapHeight)
-                                                    {
-                                                        foreach (var page in en.Value.GlobalPageInstance)
+                                                        if (!page.Passable)
                                                         {
-                                                            if (!page.Passable)
-                                                            {
-                                                                mapGrid[
-                                                                        (x + 1 - gridX) * Options.MapWidth +
-                                                                        en.Value.X,
-                                                                        (y + 1 - gridY) * Options.MapHeight +
-                                                                        en.Value.Y]
-                                                                    .IsWall = true;
-                                                            }
+                                                            mapGrid[
+                                                                    (x + 1 - gridX) * Options.MapWidth +
+                                                                    en.Value.X,
+                                                                    (y + 1 - gridY) * Options.MapHeight +
+                                                                    en.Value.Y]
+                                                                .IsWall = true;
                                                         }
                                                     }
                                                 }
+                                            }
 
-                                                //If this is a local event then we gotta loop through all other local events for the player
-                                                if (mEntity is EventPageInstance eventPage)
+                                            //If this is a local event then we gotta loop through all other local events for the player
+                                            if (mEntity is EventPageInstance eventPage)
+                                            {
+                                                //Make sure this is a local event
+                                                if (!eventPage.Passable && eventPage.Player != null)
                                                 {
-                                                    //Make sure this is a local event
-                                                    if (!eventPage.Passable && eventPage.Player != null)
+                                                    var player = eventPage.Player;
+                                                    if (player != null)
                                                     {
-                                                        var player = eventPage.Player;
-                                                        if (player != null)
+                                                        if (player.EventLookup.Values.Count >
+                                                            Options.MapWidth * Options.MapHeight)
                                                         {
-                                                            if (player.EventLookup.Values.Count >
-                                                                Options.MapWidth * Options.MapHeight)
+                                                            //Find all events on this map (since events can't switch maps)
+                                                            for (var mapX = 0; mapX < Options.MapWidth; mapX++)
                                                             {
-                                                                //Find all events on this map (since events can't switch maps)
-                                                                for (var mapX = 0; mapX < Options.MapWidth; mapX++)
+                                                                for (var mapY = 0;
+                                                                    mapY < Options.MapHeight;
+                                                                    mapY++)
                                                                 {
-                                                                    for (var mapY = 0;
-                                                                        mapY < Options.MapHeight;
-                                                                        mapY++)
-                                                                    {
-                                                                        var evt = player.EventExists(new MapTileLoc(
-                                                                            eventPage.MapId, mapX, mapY
-                                                                        ));
+                                                                    var evt = player.EventExists(new MapTileLoc(
+                                                                        eventPage.MapId, mapX, mapY
+                                                                    ));
 
-                                                                        if (evt != null)
+                                                                    if (evt != null)
+                                                                    {
+                                                                        if (evt.PageInstance != null &&
+                                                                            !evt.PageInstance.Passable &&
+                                                                            evt.PageInstance.X > -1 &&
+                                                                            evt.PageInstance.Y > -1)
                                                                         {
-                                                                            if (evt.PageInstance != null &&
-                                                                                !evt.PageInstance.Passable &&
-                                                                                evt.PageInstance.X > -1 &&
-                                                                                evt.PageInstance.Y > -1)
-                                                                            {
-                                                                                mapGrid[
-                                                                                        (x + 1 - gridX) *
-                                                                                        Options.MapWidth +
-                                                                                        evt.X,
-                                                                                        (y + 1 - gridY) *
-                                                                                        Options.MapHeight +
-                                                                                        evt.Y]
-                                                                                    .IsWall = true;
-                                                                            }
+                                                                            mapGrid[
+                                                                                    (x + 1 - gridX) *
+                                                                                    Options.MapWidth +
+                                                                                    evt.X,
+                                                                                    (y + 1 - gridY) *
+                                                                                    Options.MapHeight +
+                                                                                    evt.Y]
+                                                                                .IsWall = true;
                                                                         }
                                                                     }
                                                                 }
                                                             }
-                                                            else
+                                                        }
+                                                        else
+                                                        {
+                                                            var playerEvents = player.EventLookup.Values;
+                                                            foreach (var evt in playerEvents)
                                                             {
-                                                                var playerEvents = player.EventLookup.Values;
-                                                                foreach (var evt in playerEvents)
+                                                                if (evt != null &&
+                                                                    evt.PageInstance != null &&
+                                                                    !evt.PageInstance.Passable &&
+                                                                    evt.PageInstance.X > -1 &&
+                                                                    evt.PageInstance.Y > -1)
                                                                 {
-                                                                    if (evt != null &&
-                                                                        evt.PageInstance != null &&
-                                                                        !evt.PageInstance.Passable &&
-                                                                        evt.PageInstance.X > -1 &&
-                                                                        evt.PageInstance.Y > -1)
-                                                                    {
-                                                                        mapGrid[
-                                                                                (x + 1 - gridX) * Options.MapWidth +
-                                                                                evt.PageInstance.X,
-                                                                                (y + 1 - gridY) *
-                                                                                Options.MapHeight +
-                                                                                evt.PageInstance.Y]
-                                                                            .IsWall = true;
-                                                                    }
+                                                                    mapGrid[
+                                                                            (x + 1 - gridX) * Options.MapWidth +
+                                                                            evt.PageInstance.X,
+                                                                            (y + 1 - gridY) *
+                                                                            Options.MapHeight +
+                                                                            evt.PageInstance.Y]
+                                                                        .IsWall = true;
                                                                 }
                                                             }
                                                         }
@@ -292,238 +288,237 @@ namespace Intersect.Server.Entities.Pathfinding
                                             }
                                         }
                                     }
+                                }
 
-                                    //Optionally, move the along path check down here.. see if each tile is still open before returning success.
-                                    //That would be more processor intensive but would also provide ai that recognize blocks in their path quicker.
+                                //Optionally, move the along path check down here.. see if each tile is still open before returning success.
+                                //That would be more processor intensive but would also provide ai that recognize blocks in their path quicker.
 
-                                    //Finally done.. let's get a path from the pathfinder.
-                                    mapGrid[targetX, targetY].IsWall = false;
-                                    aStar = new SpatialAStar(mapGrid);
-                                    path = aStar.Search(new Point(sourceX, sourceY), new Point(targetX, targetY), null);
-                                    if (path == null)
-                                    {
-                                        returnVal = PathfinderResult.NoPathToTarget;
-                                    }
-                                    else
-                                    {
-                                        returnVal = PathfinderResult.Success;
-                                    }
+                                //Finally done.. let's get a path from the pathfinder.
+                                mapGrid[targetX, targetY].IsWall = false;
+                                aStar = new SpatialAStar(mapGrid);
+                                path = aStar.Search(new Point(sourceX, sourceY), new Point(targetX, targetY), null);
+                                if (path == null)
+                                {
+                                    returnVal = PathfinderResult.NoPathToTarget;
                                 }
                                 else
                                 {
-                                    returnVal = PathfinderResult.OutOfRange;
+                                    returnVal = PathfinderResult.Success;
                                 }
                             }
-                        }
-                        else
-                        {
-                            returnVal = PathfinderResult.OutOfRange;
+                            else
+                            {
+                                returnVal = PathfinderResult.OutOfRange;
+                            }
                         }
                     }
                     else
                     {
-                        mPath = null;
-                        returnVal = PathfinderResult.Failure;
+                        returnVal = PathfinderResult.OutOfRange;
                     }
                 }
                 else
                 {
-                    returnVal = PathfinderResult.Wait;
+                    mPath = null;
+                    returnVal = PathfinderResult.Failure;
                 }
-
-                switch (returnVal)
-                {
-                    case PathfinderResult.Success:
-                        //Use the same path for at least a second before trying again.
-                        mWaitTime = timeMs + 200;
-                        mConsecutiveFails = 0;
-
-                        break;
-                    case PathfinderResult.OutOfRange:
-                        //Npc might immediately find a new target. Give it a 500ms wait but make this wait grow if we keep finding targets out of range.
-                        mConsecutiveFails++;
-                        mWaitTime = timeMs + mConsecutiveFails * 500;
-
-                        break;
-                    case PathfinderResult.NoPathToTarget:
-                        //Wait 2 seconds and try again. This will move the npc randomly and might allow other npcs or players to get out of the way
-                        mConsecutiveFails++;
-                        mWaitTime = timeMs + 1000 + mConsecutiveFails * 500;
-
-                        break;
-                    case PathfinderResult.Failure:
-                        //Can try again in a second.. we don't waste much processing time on failures
-                        mWaitTime = timeMs + 500;
-                        mConsecutiveFails = 0;
-
-                        break;
-                    case PathfinderResult.Wait:
-                        //Nothing to do here.. we are already waiting.
-                        break;
-                    default:
-                        throw new ArgumentOutOfRangeException();
-                }
-
-                mPath = path;
             }
-            catch (Exception exception)
+            else
             {
-                Log.Error(exception);
+                returnVal = PathfinderResult.Wait;
             }
 
-            return returnVal;
+            switch (returnVal)
+            {
+                case PathfinderResult.Success:
+                    //Use the same path for at least a second before trying again.
+                    mWaitTime = timeMs + 200;
+                    mConsecutiveFails = 0;
+
+                    break;
+                case PathfinderResult.OutOfRange:
+                    //Npc might immediately find a new target. Give it a 500ms wait but make this wait grow if we keep finding targets out of range.
+                    mConsecutiveFails++;
+                    mWaitTime = timeMs + mConsecutiveFails * 500;
+
+                    break;
+                case PathfinderResult.NoPathToTarget:
+                    //Wait 2 seconds and try again. This will move the npc randomly and might allow other npcs or players to get out of the way
+                    mConsecutiveFails++;
+                    mWaitTime = timeMs + 1000 + mConsecutiveFails * 500;
+
+                    break;
+                case PathfinderResult.Failure:
+                    //Can try again in a second.. we don't waste much processing time on failures
+                    mWaitTime = timeMs + 500;
+                    mConsecutiveFails = 0;
+
+                    break;
+                case PathfinderResult.Wait:
+                    //Nothing to do here.. we are already waiting.
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+
+            mPath = path;
+        }
+        catch (Exception exception)
+        {
+            Log.Error(exception);
         }
 
-        private void FillArea(PathNode[,] dest, int startX, int startY, int width, int height)
+        return returnVal;
+    }
+
+    private void FillArea(PathNode[,] dest, int startX, int startY, int width, int height)
+    {
+        for (var x = startX; x < startX + width; x++)
         {
-            for (var x = startX; x < startX + width; x++)
+            for (var y = startY; y < startY + height; y++)
             {
-                for (var y = startY; y < startY + height; y++)
-                {
-                    dest[x, y].IsWall = true;
-                }
+                dest[x, y].IsWall = true;
             }
-        }
-
-        public bool AlongPath(IEnumerable<PathNode> path, int x, int y, bool exact)
-        {
-            if (path == null)
-            {
-                return false;
-            }
-
-            var foundUs = false;
-            var enm = path.GetEnumerator();
-            while (enm.MoveNext())
-            {
-                if (enm.Current.X - Options.MapWidth == mEntity.X && enm.Current.Y - Options.MapHeight == mEntity.Y)
-                {
-                    foundUs = true;
-                }
-
-                if (foundUs && enm.Current.X == x)
-                {
-                    if (enm.Current.Y == y || (enm.Current.Y - 1 == y || enm.Current.Y + 1 == y) & !exact)
-                    {
-                        enm.Dispose();
-
-                        return true;
-                    }
-                }
-
-                if (foundUs && enm.Current.Y == y)
-                {
-                    if (enm.Current.X == x || (enm.Current.X - 1 == x || enm.Current.X + 1 == x) & !exact)
-                    {
-                        enm.Dispose();
-
-                        return true;
-                    }
-                }
-            }
-
-            enm.Dispose();
-
-            return false;
-        }
-
-        public void PathFailed(long timeMs)
-        {
-            mPath = null;
-            mConsecutiveFails++;
-            mWaitTime = timeMs + 1000;
-        }
-
-        public Direction GetMove()
-        {
-            if (mPath == null)
-            {
-                return Direction.None;
-            }
-
-            using (var enm = mPath.GetEnumerator())
-            {
-                while (enm.MoveNext())
-                {
-                    if (enm.Current.X - Options.MapWidth != mEntity.X || enm.Current.Y - Options.MapHeight != mEntity.Y)
-                    {
-                        continue;
-                    }
-
-                    if (!enm.MoveNext())
-                    {
-                        continue;
-                    }
-
-                    var newX = enm.Current.X - Options.MapWidth;
-                    var newY = enm.Current.Y - Options.MapHeight;
-
-                    if (mEntity.Y > newY && mEntity.X == newX)
-                    {
-                        return Direction.Up;
-                    }
-
-                    if (mEntity.Y < newY && mEntity.X == newX)
-                    {
-                        return Direction.Down;
-                    }
-
-                    if (mEntity.X > newX && mEntity.Y == newY)
-                    {
-                        return Direction.Left;
-                    }
-
-                    if (mEntity.X < newX && mEntity.Y == newY)
-                    {
-                        return Direction.Right;
-                    }
-
-                    if (Options.Instance.MapOpts.EnableDiagonalMovement)
-                    {
-                        if (mEntity.Y > newY && mEntity.X > newX)
-                        {
-                            return Direction.UpLeft;
-                        }
-
-                        if (mEntity.Y > newY && mEntity.X < newX)
-                        {
-                            return Direction.UpRight;
-                        }
-
-                        if (mEntity.Y < newY && mEntity.X < newX)
-                        {
-                            return Direction.DownRight;
-                        }
-
-                        if (mEntity.Y < newY && mEntity.X > newX)
-                        {
-                            return Direction.DownLeft;
-                        }
-                    }
-                }
-            }
-
-            return Direction.None;
         }
     }
 
-    public partial class AStarSolver : SpatialAStar
+    public bool AlongPath(IEnumerable<PathNode> path, int x, int y, bool exact)
     {
-
-        public AStarSolver(PathNode[,] inGrid) : base(inGrid)
+        if (path == null)
         {
+            return false;
         }
 
-        protected override double Heuristic(PathNode inStart, PathNode inEnd)
+        var foundUs = false;
+        var enm = path.GetEnumerator();
+        while (enm.MoveNext())
         {
-            return Math.Abs(inStart.X - inEnd.X) + Math.Abs(inStart.Y - inEnd.Y);
+            if (enm.Current.X - Options.MapWidth == mEntity.X && enm.Current.Y - Options.MapHeight == mEntity.Y)
+            {
+                foundUs = true;
+            }
+
+            if (foundUs && enm.Current.X == x)
+            {
+                if (enm.Current.Y == y || (enm.Current.Y - 1 == y || enm.Current.Y + 1 == y) & !exact)
+                {
+                    enm.Dispose();
+
+                    return true;
+                }
+            }
+
+            if (foundUs && enm.Current.Y == y)
+            {
+                if (enm.Current.X == x || (enm.Current.X - 1 == x || enm.Current.X + 1 == x) & !exact)
+                {
+                    enm.Dispose();
+
+                    return true;
+                }
+            }
         }
 
-        protected override double NeighborDistance(PathNode inStart, PathNode inEnd)
+        enm.Dispose();
+
+        return false;
+    }
+
+    public void PathFailed(long timeMs)
+    {
+        mPath = null;
+        mConsecutiveFails++;
+        mWaitTime = timeMs + 1000;
+    }
+
+    public Direction GetMove()
+    {
+        if (mPath == null)
         {
-            return Heuristic(inStart, inEnd);
+            return Direction.None;
         }
 
+        using (var enm = mPath.GetEnumerator())
+        {
+            while (enm.MoveNext())
+            {
+                if (enm.Current.X - Options.MapWidth != mEntity.X || enm.Current.Y - Options.MapHeight != mEntity.Y)
+                {
+                    continue;
+                }
+
+                if (!enm.MoveNext())
+                {
+                    continue;
+                }
+
+                var newX = enm.Current.X - Options.MapWidth;
+                var newY = enm.Current.Y - Options.MapHeight;
+
+                if (mEntity.Y > newY && mEntity.X == newX)
+                {
+                    return Direction.Up;
+                }
+
+                if (mEntity.Y < newY && mEntity.X == newX)
+                {
+                    return Direction.Down;
+                }
+
+                if (mEntity.X > newX && mEntity.Y == newY)
+                {
+                    return Direction.Left;
+                }
+
+                if (mEntity.X < newX && mEntity.Y == newY)
+                {
+                    return Direction.Right;
+                }
+
+                if (Options.Instance.MapOpts.EnableDiagonalMovement)
+                {
+                    if (mEntity.Y > newY && mEntity.X > newX)
+                    {
+                        return Direction.UpLeft;
+                    }
+
+                    if (mEntity.Y > newY && mEntity.X < newX)
+                    {
+                        return Direction.UpRight;
+                    }
+
+                    if (mEntity.Y < newY && mEntity.X < newX)
+                    {
+                        return Direction.DownRight;
+                    }
+
+                    if (mEntity.Y < newY && mEntity.X > newX)
+                    {
+                        return Direction.DownLeft;
+                    }
+                }
+            }
+        }
+
+        return Direction.None;
+    }
+}
+
+public partial class AStarSolver : SpatialAStar
+{
+
+    public AStarSolver(PathNode[,] inGrid) : base(inGrid)
+    {
+    }
+
+    protected override double Heuristic(PathNode inStart, PathNode inEnd)
+    {
+        return Math.Abs(inStart.X - inEnd.X) + Math.Abs(inStart.Y - inEnd.Y);
+    }
+
+    protected override double NeighborDistance(PathNode inStart, PathNode inEnd)
+    {
+        return Heuristic(inStart, inEnd);
     }
 
 }

--- a/Intersect.Server.Core/Entities/Pathfinding/PathfinderTarget.cs
+++ b/Intersect.Server.Core/Entities/Pathfinding/PathfinderTarget.cs
@@ -1,27 +1,23 @@
-﻿using System;
+﻿namespace Intersect.Server.Entities.Pathfinding;
 
-namespace Intersect.Server.Entities.Pathfinding
+
+public partial class PathfinderTarget
 {
 
-    public partial class PathfinderTarget
+    public Guid TargetMapId;
+
+    public int TargetX;
+
+    public int TargetY;
+
+    public int TargetZ;
+
+    public PathfinderTarget(Guid mapId, int x, int y, int z)
     {
-
-        public Guid TargetMapId;
-
-        public int TargetX;
-
-        public int TargetY;
-
-        public int TargetZ;
-
-        public PathfinderTarget(Guid mapId, int x, int y, int z)
-        {
-            TargetMapId = mapId;
-            TargetX = x;
-            TargetY = y;
-            TargetZ = z;
-        }
-
+        TargetMapId = mapId;
+        TargetX = x;
+        TargetY = y;
+        TargetZ = z;
     }
 
 }

--- a/Intersect.Server.Core/Entities/Pathfinding/PriorityQueue.cs
+++ b/Intersect.Server.Core/Entities/Pathfinding/PriorityQueue.cs
@@ -1,165 +1,161 @@
-﻿using System.Collections.Generic;
+﻿namespace Intersect.Server.Entities.Pathfinding;
 
-namespace Intersect.Server.Entities.Pathfinding
+
+internal partial class PriorityQueue<T> where T : IIndexedObject
 {
 
-    internal partial class PriorityQueue<T> where T : IIndexedObject
+    protected IComparer<T> mComparer;
+
+    protected List<T> mInnerList = new List<T>();
+
+    public PriorityQueue()
     {
+        mComparer = Comparer<T>.Default;
+    }
 
-        protected IComparer<T> mComparer;
+    public PriorityQueue(IComparer<T> comparer)
+    {
+        mComparer = comparer;
+    }
 
-        protected List<T> mInnerList = new List<T>();
+    public PriorityQueue(IComparer<T> comparer, int capacity)
+    {
+        mComparer = comparer;
+        mInnerList.Capacity = capacity;
+    }
 
-        public PriorityQueue()
+    public int Count => mInnerList.Count;
+
+    protected void SwitchElements(int i, int j)
+    {
+        var h = mInnerList[i];
+        mInnerList[i] = mInnerList[j];
+        mInnerList[j] = h;
+
+        mInnerList[i].Index = i;
+        mInnerList[j].Index = j;
+    }
+
+    protected virtual int OnCompare(int i, int j)
+    {
+        return mComparer.Compare(mInnerList[i], mInnerList[j]);
+    }
+
+    /// <summary>
+    ///     Push an object onto the PQ
+    /// </summary>
+    /// <param name="item">The new object</param>
+    /// <returns>
+    ///     The index in the list where the object is _now_. This will change when objects are taken from or put onto the
+    ///     PQ.
+    /// </returns>
+    public int Push(T item)
+    {
+        int p = mInnerList.Count, p2;
+        item.Index = mInnerList.Count;
+        mInnerList.Add(item); // E[p] = O
+
+        do
         {
-            mComparer = Comparer<T>.Default;
-        }
-
-        public PriorityQueue(IComparer<T> comparer)
-        {
-            mComparer = comparer;
-        }
-
-        public PriorityQueue(IComparer<T> comparer, int capacity)
-        {
-            mComparer = comparer;
-            mInnerList.Capacity = capacity;
-        }
-
-        public int Count => mInnerList.Count;
-
-        protected void SwitchElements(int i, int j)
-        {
-            var h = mInnerList[i];
-            mInnerList[i] = mInnerList[j];
-            mInnerList[j] = h;
-
-            mInnerList[i].Index = i;
-            mInnerList[j].Index = j;
-        }
-
-        protected virtual int OnCompare(int i, int j)
-        {
-            return mComparer.Compare(mInnerList[i], mInnerList[j]);
-        }
-
-        /// <summary>
-        ///     Push an object onto the PQ
-        /// </summary>
-        /// <param name="item">The new object</param>
-        /// <returns>
-        ///     The index in the list where the object is _now_. This will change when objects are taken from or put onto the
-        ///     PQ.
-        /// </returns>
-        public int Push(T item)
-        {
-            int p = mInnerList.Count, p2;
-            item.Index = mInnerList.Count;
-            mInnerList.Add(item); // E[p] = O
-
-            do
+            if (p == 0)
             {
-                if (p == 0)
-                {
-                    break;
-                }
-
-                p2 = (p - 1) / 2;
-                if (OnCompare(p, p2) < 0)
-                {
-                    SwitchElements(p, p2);
-                    p = p2;
-                }
-                else
-                {
-                    break;
-                }
-            } while (true);
-
-            return p;
-        }
-
-        /// <summary>
-        ///     Get the smallest object and remove it.
-        /// </summary>
-        /// <returns>The smallest object</returns>
-        public T Pop()
-        {
-            var result = mInnerList[0];
-            int p = 0, p1, p2, pn;
-
-            mInnerList[0] = mInnerList[mInnerList.Count - 1];
-            mInnerList[0].Index = 0;
-
-            mInnerList.RemoveAt(mInnerList.Count - 1);
-
-            result.Index = -1;
-
-            do
-            {
-                pn = p;
-                p1 = 2 * p + 1;
-                p2 = 2 * p + 2;
-                if (mInnerList.Count > p1 && OnCompare(p, p1) > 0) // links kleiner
-                {
-                    p = p1;
-                }
-
-                if (mInnerList.Count > p2 && OnCompare(p, p2) > 0) // rechts noch kleiner
-                {
-                    p = p2;
-                }
-
-                if (p == pn)
-                {
-                    break;
-                }
-
-                SwitchElements(p, pn);
-            } while (true);
-
-            return result;
-        }
-
-        /// <summary>
-        ///     Notify the PQ that the object at position i has changed
-        ///     and the PQ needs to restore order.
-        /// </summary>
-        public void Update(T item)
-        {
-            var count = mInnerList.Count;
-
-            // usually we only need to switch some elements, since estimation won't change that much.
-            while (item.Index - 1 >= 0 && OnCompare(item.Index - 1, item.Index) > 0)
-            {
-                SwitchElements(item.Index - 1, item.Index);
+                break;
             }
 
-            while (item.Index + 1 < count && OnCompare(item.Index + 1, item.Index) < 0)
+            p2 = (p - 1) / 2;
+            if (OnCompare(p, p2) < 0)
             {
-                SwitchElements(item.Index + 1, item.Index);
+                SwitchElements(p, p2);
+                p = p2;
             }
-        }
-
-        /// <summary>
-        ///     Get the smallest object without removing it.
-        /// </summary>
-        /// <returns>The smallest object</returns>
-        public T Peek()
-        {
-            if (mInnerList.Count > 0)
+            else
             {
-                return mInnerList[0];
+                break;
+            }
+        } while (true);
+
+        return p;
+    }
+
+    /// <summary>
+    ///     Get the smallest object and remove it.
+    /// </summary>
+    /// <returns>The smallest object</returns>
+    public T Pop()
+    {
+        var result = mInnerList[0];
+        int p = 0, p1, p2, pn;
+
+        mInnerList[0] = mInnerList[mInnerList.Count - 1];
+        mInnerList[0].Index = 0;
+
+        mInnerList.RemoveAt(mInnerList.Count - 1);
+
+        result.Index = -1;
+
+        do
+        {
+            pn = p;
+            p1 = 2 * p + 1;
+            p2 = 2 * p + 2;
+            if (mInnerList.Count > p1 && OnCompare(p, p1) > 0) // links kleiner
+            {
+                p = p1;
             }
 
-            return default(T);
-        }
+            if (mInnerList.Count > p2 && OnCompare(p, p2) > 0) // rechts noch kleiner
+            {
+                p = p2;
+            }
 
-        public void Clear()
+            if (p == pn)
+            {
+                break;
+            }
+
+            SwitchElements(p, pn);
+        } while (true);
+
+        return result;
+    }
+
+    /// <summary>
+    ///     Notify the PQ that the object at position i has changed
+    ///     and the PQ needs to restore order.
+    /// </summary>
+    public void Update(T item)
+    {
+        var count = mInnerList.Count;
+
+        // usually we only need to switch some elements, since estimation won't change that much.
+        while (item.Index - 1 >= 0 && OnCompare(item.Index - 1, item.Index) > 0)
         {
-            mInnerList.Clear();
+            SwitchElements(item.Index - 1, item.Index);
         }
 
+        while (item.Index + 1 < count && OnCompare(item.Index + 1, item.Index) < 0)
+        {
+            SwitchElements(item.Index + 1, item.Index);
+        }
+    }
+
+    /// <summary>
+    ///     Get the smallest object without removing it.
+    /// </summary>
+    /// <returns>The smallest object</returns>
+    public T Peek()
+    {
+        if (mInnerList.Count > 0)
+        {
+            return mInnerList[0];
+        }
+
+        return default(T);
+    }
+
+    public void Clear()
+    {
+        mInnerList.Clear();
     }
 
 }

--- a/Intersect.Server.Core/Entities/Pathfinding/SpatialAStar.cs
+++ b/Intersect.Server.Core/Entities/Pathfinding/SpatialAStar.cs
@@ -1,415 +1,410 @@
-﻿using System;
-using System.Collections.Generic;
+﻿namespace Intersect.Server.Entities.Pathfinding;
 
-namespace Intersect.Server.Entities.Pathfinding
+
+public interface IIndexedObject
 {
 
-    public interface IIndexedObject
+    int Index { get; set; }
+
+}
+
+public partial class PathNode : IComparer<PathNode>, IIndexedObject
+{
+
+    public static readonly PathNode Comparer = new PathNode(0, 0, false);
+
+    public PathNode(int inX, int inY, bool isWall)
     {
-
-        int Index { get; set; }
-
+        X = inX;
+        Y = inY;
+        IsWall = isWall;
     }
 
-    public partial class PathNode : IComparer<PathNode>, IIndexedObject
+    public double G { get; internal set; }
+
+    public double H { get; internal set; }
+
+    public double F { get; internal set; }
+
+    public int X { get; set; }
+
+    public int Y { get; set; }
+
+    public bool IsWall { get; set; }
+
+    public int Compare(PathNode x, PathNode y)
     {
-
-        public static readonly PathNode Comparer = new PathNode(0, 0, false);
-
-        public PathNode(int inX, int inY, bool isWall)
+        if (x.F < y.F)
         {
-            X = inX;
-            Y = inY;
-            IsWall = isWall;
+            return -1;
+        }
+        else if (x.F > y.F)
+        {
+            return 1;
         }
 
-        public double G { get; internal set; }
+        return 0;
+    }
 
-        public double H { get; internal set; }
+    public int Index { get; set; }
 
-        public double F { get; internal set; }
+    public void Reset()
+    {
+        G = 0.0;
+        H = 0.0;
+        F = 0.0;
+        IsWall = false;
+    }
 
-        public int X { get; set; }
+}
 
-        public int Y { get; set; }
+/// <summary>
+///     Uses about 50 MB for a 1024x1024 grid.
+/// </summary>
+public partial class SpatialAStar
+{
 
-        public bool IsWall { get; set; }
+    private static readonly double Sqrt2 = Math.Sqrt(2);
 
-        public int Compare(PathNode x, PathNode y)
+    private PathNode[,] mCameFrom;
+
+    private OpenCloseMap mClosedSet;
+
+    private OpenCloseMap mOpenSet;
+
+    private PriorityQueue<PathNode> mOrderedOpenSet;
+
+    private OpenCloseMap mRuntimeGrid;
+
+    private PathNode[,] mSearchSpace;
+
+    public SpatialAStar(PathNode[,] inGrid)
+    {
+        SearchSpace = inGrid;
+        Width = inGrid.GetLength(0);
+        Height = inGrid.GetLength(1);
+        mSearchSpace = inGrid;
+        mClosedSet = new OpenCloseMap(Width, Height);
+        mOpenSet = new OpenCloseMap(Width, Height);
+        mCameFrom = new PathNode[Width, Height];
+        mRuntimeGrid = new OpenCloseMap(Width, Height);
+        mOrderedOpenSet = new PriorityQueue<PathNode>(PathNode.Comparer);
+    }
+
+    public PathNode[,] SearchSpace { get; private set; }
+
+    public int Width { get; private set; }
+
+    public int Height { get; private set; }
+
+    protected virtual double Heuristic(PathNode inStart, PathNode inEnd)
+    {
+        return Math.Sqrt(
+            (inStart.X - inEnd.X) * (inStart.X - inEnd.X) + (inStart.Y - inEnd.Y) * (inStart.Y - inEnd.Y)
+        );
+    }
+
+    protected virtual double NeighborDistance(PathNode inStart, PathNode inEnd)
+    {
+        var diffX = Math.Abs(inStart.X - inEnd.X);
+        var diffY = Math.Abs(inStart.Y - inEnd.Y);
+
+        switch (diffX + diffY)
         {
-            if (x.F < y.F)
-            {
-                return -1;
-            }
-            else if (x.F > y.F)
-            {
+            case 1:
                 return 1;
-            }
-
-            return 0;
+            case 2:
+                return Sqrt2;
+            case 0:
+                return 0;
+            default:
+                throw new ApplicationException();
         }
-
-        public int Index { get; set; }
-
-        public void Reset()
-        {
-            G = 0.0;
-            H = 0.0;
-            F = 0.0;
-            IsWall = false;
-        }
-
     }
+
+    //private List<Int64> elapsed = new List<long>();
 
     /// <summary>
-    ///     Uses about 50 MB for a 1024x1024 grid.
+    ///     Returns null, if no path is found. Start- and End-Node are included in returned path. The user context
+    ///     is passed to IsWalkable().
     /// </summary>
-    public partial class SpatialAStar
+    public LinkedList<PathNode> Search(Point inStartNode, Point inEndNode, PathNode inUserContext)
     {
+        var startNode = mSearchSpace[inStartNode.X, inStartNode.Y];
+        var endNode = mSearchSpace[inEndNode.X, inEndNode.Y];
 
-        private static readonly double Sqrt2 = Math.Sqrt(2);
+        //System.Diagnostics.Stopwatch watch = new System.Diagnostics.Stopwatch();
+        //watch.Start();
 
-        private PathNode[,] mCameFrom;
-
-        private OpenCloseMap mClosedSet;
-
-        private OpenCloseMap mOpenSet;
-
-        private PriorityQueue<PathNode> mOrderedOpenSet;
-
-        private OpenCloseMap mRuntimeGrid;
-
-        private PathNode[,] mSearchSpace;
-
-        public SpatialAStar(PathNode[,] inGrid)
+        if (startNode == endNode)
         {
-            SearchSpace = inGrid;
-            Width = inGrid.GetLength(0);
-            Height = inGrid.GetLength(1);
-            mSearchSpace = inGrid;
-            mClosedSet = new OpenCloseMap(Width, Height);
-            mOpenSet = new OpenCloseMap(Width, Height);
-            mCameFrom = new PathNode[Width, Height];
-            mRuntimeGrid = new OpenCloseMap(Width, Height);
-            mOrderedOpenSet = new PriorityQueue<PathNode>(PathNode.Comparer);
+            return new LinkedList<PathNode>(new PathNode[] {startNode});
         }
 
-        public PathNode[,] SearchSpace { get; private set; }
+        var neighborNodes = new PathNode[8];
+
+        mClosedSet.Clear();
+        mOpenSet.Clear();
+        mRuntimeGrid.Clear();
+        mOrderedOpenSet.Clear();
+
+        for (var x = 0; x < Width; x++)
+        {
+            for (var y = 0; y < Height; y++)
+            {
+                mCameFrom[x, y] = null;
+            }
+        }
+
+        startNode.G = 0;
+        startNode.H = Heuristic(startNode, endNode);
+        startNode.F = startNode.H;
+
+        mOpenSet.Add(startNode);
+        mOrderedOpenSet.Push(startNode);
+
+        mRuntimeGrid.Add(startNode);
+
+        var nodes = 0;
+        PathNode closestNode = null;
+
+        while (!mOpenSet.IsEmpty)
+        {
+            var x = mOrderedOpenSet.Pop();
+
+            if (x == endNode)
+            {
+                // watch.Stop();
+
+                //elapsed.Add(watch.ElapsedMilliseconds);
+
+                var result = ReconstructPath(mCameFrom, mCameFrom[endNode.X, endNode.Y]);
+
+                result.AddLast(endNode);
+
+                return result;
+            }
+
+            mOpenSet.Remove(x);
+            mClosedSet.Add(x);
+
+            StoreNeighborNodes(x, neighborNodes);
+
+            for (var i = 0; i < neighborNodes.Length; i++)
+            {
+                var y = neighborNodes[i];
+                bool tentativeIsBetter;
+
+                if (y == null)
+                {
+                    continue;
+                }
+
+                if (y.IsWall)
+                {
+                    continue;
+                }
+
+                if (mClosedSet.Contains(y))
+                {
+                    continue;
+                }
+
+                nodes++;
+
+                var tentativeGScore = mRuntimeGrid[x].G + NeighborDistance(x, y);
+                var wasAdded = false;
+
+                if (!mOpenSet.Contains(y))
+                {
+                    mOpenSet.Add(y);
+                    tentativeIsBetter = true;
+                    wasAdded = true;
+                }
+                else if (tentativeGScore < mRuntimeGrid[y].G)
+                {
+                    tentativeIsBetter = true;
+                }
+                else
+                {
+                    tentativeIsBetter = false;
+                }
+
+                if (tentativeIsBetter)
+                {
+                    mCameFrom[y.X, y.Y] = x;
+
+                    if (!mRuntimeGrid.Contains(y))
+                    {
+                        mRuntimeGrid.Add(y);
+                    }
+
+                    mRuntimeGrid[y].G = tentativeGScore;
+                    mRuntimeGrid[y].H = Heuristic(y, endNode);
+                    mRuntimeGrid[y].F = mRuntimeGrid[y].G + mRuntimeGrid[y].H;
+
+                    if (wasAdded)
+                    {
+                        mOrderedOpenSet.Push(y);
+                    }
+                    else
+                    {
+                        mOrderedOpenSet.Update(y);
+                    }
+
+                    if (closestNode == null || closestNode.H > y.H)
+                    {
+                        closestNode = y;
+                    }
+                }
+            }
+        }
+
+        if (closestNode != null && closestNode.H < startNode.H)
+        {
+            var result = ReconstructPath(mCameFrom, mCameFrom[closestNode.X, closestNode.Y]);
+            result.AddLast(closestNode);
+            return result;
+        }
+
+        return null;
+    }
+
+    private LinkedList<PathNode> ReconstructPath(PathNode[,] cameFrom, PathNode currentNode)
+    {
+        var result = new LinkedList<PathNode>();
+
+        ReconstructPathRecursive(cameFrom, currentNode, result);
+
+        return result;
+    }
+
+    private void ReconstructPathRecursive(PathNode[,] cameFrom, PathNode currentNode, LinkedList<PathNode> result)
+    {
+        var item = cameFrom[currentNode.X, currentNode.Y];
+
+        if (item != null)
+        {
+            ReconstructPathRecursive(cameFrom, item, result);
+
+            result.AddLast(currentNode);
+        }
+        else
+        {
+            result.AddLast(currentNode);
+        }
+    }
+
+    private void StoreNeighborNodes(PathNode inAround, IList<PathNode> inNeighbors)
+    {
+        var x = inAround.X;
+        var y = inAround.Y;
+
+        inNeighbors[1] = y > 0 ? mSearchSpace[x, y - 1] : null; // Up
+        inNeighbors[3] = x > 0 ? mSearchSpace[x - 1, y] : null; // Left
+        inNeighbors[4] = x < Width - 1 ? mSearchSpace[x + 1, y] : null; // Right
+        inNeighbors[6] = y < Height - 1 ? mSearchSpace[x, y + 1] : null; // Down
+
+        if (Options.Instance.MapOpts.EnableDiagonalMovement)
+        {
+            inNeighbors[0] = y > 0 && x > 0 ? mSearchSpace[x - 1, y - 1] : null; // UpLeft
+            inNeighbors[2] = y > 0 && x < Width - 1 ? mSearchSpace[x + 1, y - 1] : null; // UpRight
+            inNeighbors[5] = y < Height - 1 && x > 0 ? mSearchSpace[x - 1, y + 1] : null; // DownLeft
+            inNeighbors[7] = y < Height - 1 && x < Width - 1 ? mSearchSpace[x + 1, y + 1] : null; // DownRight
+        }
+        else
+        {
+            inNeighbors[0] = null;
+            inNeighbors[2] = null;
+            inNeighbors[5] = null;
+            inNeighbors[7] = null;
+        }
+    }
+
+    private partial class OpenCloseMap
+    {
+
+        private PathNode[,] mMap;
+
+        public OpenCloseMap(int inWidth, int inHeight)
+        {
+            mMap = new PathNode[inWidth, inHeight];
+            Width = inWidth;
+            Height = inHeight;
+        }
 
         public int Width { get; private set; }
 
         public int Height { get; private set; }
 
-        protected virtual double Heuristic(PathNode inStart, PathNode inEnd)
+        public int Count { get; private set; }
+
+        public PathNode this[int x, int y] => mMap[x, y];
+
+        public PathNode this[PathNode node] => mMap[node.X, node.Y];
+
+        public bool IsEmpty => Count == 0;
+
+        public void Add(PathNode inValue)
         {
-            return Math.Sqrt(
-                (inStart.X - inEnd.X) * (inStart.X - inEnd.X) + (inStart.Y - inEnd.Y) * (inStart.Y - inEnd.Y)
-            );
+            var item = mMap[inValue.X, inValue.Y];
+
+#if DEBUG
+            if (item != null)
+            {
+                throw new ApplicationException();
+            }
+#endif
+
+            Count++;
+            mMap[inValue.X, inValue.Y] = inValue;
         }
 
-        protected virtual double NeighborDistance(PathNode inStart, PathNode inEnd)
+        public bool Contains(PathNode inValue)
         {
-            var diffX = Math.Abs(inStart.X - inEnd.X);
-            var diffY = Math.Abs(inStart.Y - inEnd.Y);
+            var item = mMap[inValue.X, inValue.Y];
 
-            switch (diffX + diffY)
+            if (item == null)
             {
-                case 1:
-                    return 1;
-                case 2:
-                    return Sqrt2;
-                case 0:
-                    return 0;
-                default:
-                    throw new ApplicationException();
+                return false;
             }
+
+#if DEBUG
+            if (!inValue.Equals(item))
+            {
+                throw new ApplicationException();
+            }
+#endif
+
+            return true;
         }
 
-        //private List<Int64> elapsed = new List<long>();
-
-        /// <summary>
-        ///     Returns null, if no path is found. Start- and End-Node are included in returned path. The user context
-        ///     is passed to IsWalkable().
-        /// </summary>
-        public LinkedList<PathNode> Search(Point inStartNode, Point inEndNode, PathNode inUserContext)
+        public void Remove(PathNode inValue)
         {
-            var startNode = mSearchSpace[inStartNode.X, inStartNode.Y];
-            var endNode = mSearchSpace[inEndNode.X, inEndNode.Y];
+            var item = mMap[inValue.X, inValue.Y];
 
-            //System.Diagnostics.Stopwatch watch = new System.Diagnostics.Stopwatch();
-            //watch.Start();
-
-            if (startNode == endNode)
+#if DEBUG
+            if (!inValue.Equals(item))
             {
-                return new LinkedList<PathNode>(new PathNode[] {startNode});
+                throw new ApplicationException();
             }
+#endif
 
-            var neighborNodes = new PathNode[8];
+            Count--;
+            mMap[inValue.X, inValue.Y] = null;
+        }
 
-            mClosedSet.Clear();
-            mOpenSet.Clear();
-            mRuntimeGrid.Clear();
-            mOrderedOpenSet.Clear();
+        public void Clear()
+        {
+            Count = 0;
 
             for (var x = 0; x < Width; x++)
             {
                 for (var y = 0; y < Height; y++)
                 {
-                    mCameFrom[x, y] = null;
+                    mMap[x, y] = null;
                 }
             }
-
-            startNode.G = 0;
-            startNode.H = Heuristic(startNode, endNode);
-            startNode.F = startNode.H;
-
-            mOpenSet.Add(startNode);
-            mOrderedOpenSet.Push(startNode);
-
-            mRuntimeGrid.Add(startNode);
-
-            var nodes = 0;
-            PathNode closestNode = null;
-
-            while (!mOpenSet.IsEmpty)
-            {
-                var x = mOrderedOpenSet.Pop();
-
-                if (x == endNode)
-                {
-                    // watch.Stop();
-
-                    //elapsed.Add(watch.ElapsedMilliseconds);
-
-                    var result = ReconstructPath(mCameFrom, mCameFrom[endNode.X, endNode.Y]);
-
-                    result.AddLast(endNode);
-
-                    return result;
-                }
-
-                mOpenSet.Remove(x);
-                mClosedSet.Add(x);
-
-                StoreNeighborNodes(x, neighborNodes);
-
-                for (var i = 0; i < neighborNodes.Length; i++)
-                {
-                    var y = neighborNodes[i];
-                    bool tentativeIsBetter;
-
-                    if (y == null)
-                    {
-                        continue;
-                    }
-
-                    if (y.IsWall)
-                    {
-                        continue;
-                    }
-
-                    if (mClosedSet.Contains(y))
-                    {
-                        continue;
-                    }
-
-                    nodes++;
-
-                    var tentativeGScore = mRuntimeGrid[x].G + NeighborDistance(x, y);
-                    var wasAdded = false;
-
-                    if (!mOpenSet.Contains(y))
-                    {
-                        mOpenSet.Add(y);
-                        tentativeIsBetter = true;
-                        wasAdded = true;
-                    }
-                    else if (tentativeGScore < mRuntimeGrid[y].G)
-                    {
-                        tentativeIsBetter = true;
-                    }
-                    else
-                    {
-                        tentativeIsBetter = false;
-                    }
-
-                    if (tentativeIsBetter)
-                    {
-                        mCameFrom[y.X, y.Y] = x;
-
-                        if (!mRuntimeGrid.Contains(y))
-                        {
-                            mRuntimeGrid.Add(y);
-                        }
-
-                        mRuntimeGrid[y].G = tentativeGScore;
-                        mRuntimeGrid[y].H = Heuristic(y, endNode);
-                        mRuntimeGrid[y].F = mRuntimeGrid[y].G + mRuntimeGrid[y].H;
-
-                        if (wasAdded)
-                        {
-                            mOrderedOpenSet.Push(y);
-                        }
-                        else
-                        {
-                            mOrderedOpenSet.Update(y);
-                        }
-
-                        if (closestNode == null || closestNode.H > y.H)
-                        {
-                            closestNode = y;
-                        }
-                    }
-                }
-            }
-
-            if (closestNode != null && closestNode.H < startNode.H)
-            {
-                var result = ReconstructPath(mCameFrom, mCameFrom[closestNode.X, closestNode.Y]);
-                result.AddLast(closestNode);
-                return result;
-            }
-
-            return null;
-        }
-
-        private LinkedList<PathNode> ReconstructPath(PathNode[,] cameFrom, PathNode currentNode)
-        {
-            var result = new LinkedList<PathNode>();
-
-            ReconstructPathRecursive(cameFrom, currentNode, result);
-
-            return result;
-        }
-
-        private void ReconstructPathRecursive(PathNode[,] cameFrom, PathNode currentNode, LinkedList<PathNode> result)
-        {
-            var item = cameFrom[currentNode.X, currentNode.Y];
-
-            if (item != null)
-            {
-                ReconstructPathRecursive(cameFrom, item, result);
-
-                result.AddLast(currentNode);
-            }
-            else
-            {
-                result.AddLast(currentNode);
-            }
-        }
-
-        private void StoreNeighborNodes(PathNode inAround, IList<PathNode> inNeighbors)
-        {
-            var x = inAround.X;
-            var y = inAround.Y;
-
-            inNeighbors[1] = y > 0 ? mSearchSpace[x, y - 1] : null; // Up
-            inNeighbors[3] = x > 0 ? mSearchSpace[x - 1, y] : null; // Left
-            inNeighbors[4] = x < Width - 1 ? mSearchSpace[x + 1, y] : null; // Right
-            inNeighbors[6] = y < Height - 1 ? mSearchSpace[x, y + 1] : null; // Down
-
-            if (Options.Instance.MapOpts.EnableDiagonalMovement)
-            {
-                inNeighbors[0] = y > 0 && x > 0 ? mSearchSpace[x - 1, y - 1] : null; // UpLeft
-                inNeighbors[2] = y > 0 && x < Width - 1 ? mSearchSpace[x + 1, y - 1] : null; // UpRight
-                inNeighbors[5] = y < Height - 1 && x > 0 ? mSearchSpace[x - 1, y + 1] : null; // DownLeft
-                inNeighbors[7] = y < Height - 1 && x < Width - 1 ? mSearchSpace[x + 1, y + 1] : null; // DownRight
-            }
-            else
-            {
-                inNeighbors[0] = null;
-                inNeighbors[2] = null;
-                inNeighbors[5] = null;
-                inNeighbors[7] = null;
-            }
-        }
-
-        private partial class OpenCloseMap
-        {
-
-            private PathNode[,] mMap;
-
-            public OpenCloseMap(int inWidth, int inHeight)
-            {
-                mMap = new PathNode[inWidth, inHeight];
-                Width = inWidth;
-                Height = inHeight;
-            }
-
-            public int Width { get; private set; }
-
-            public int Height { get; private set; }
-
-            public int Count { get; private set; }
-
-            public PathNode this[int x, int y] => mMap[x, y];
-
-            public PathNode this[PathNode node] => mMap[node.X, node.Y];
-
-            public bool IsEmpty => Count == 0;
-
-            public void Add(PathNode inValue)
-            {
-                var item = mMap[inValue.X, inValue.Y];
-
-#if DEBUG
-                if (item != null)
-                {
-                    throw new ApplicationException();
-                }
-#endif
-
-                Count++;
-                mMap[inValue.X, inValue.Y] = inValue;
-            }
-
-            public bool Contains(PathNode inValue)
-            {
-                var item = mMap[inValue.X, inValue.Y];
-
-                if (item == null)
-                {
-                    return false;
-                }
-
-#if DEBUG
-                if (!inValue.Equals(item))
-                {
-                    throw new ApplicationException();
-                }
-#endif
-
-                return true;
-            }
-
-            public void Remove(PathNode inValue)
-            {
-                var item = mMap[inValue.X, inValue.Y];
-
-#if DEBUG
-                if (!inValue.Equals(item))
-                {
-                    throw new ApplicationException();
-                }
-#endif
-
-                Count--;
-                mMap[inValue.X, inValue.Y] = null;
-            }
-
-            public void Clear()
-            {
-                Count = 0;
-
-                for (var x = 0; x < Width; x++)
-                {
-                    for (var y = 0; y < Height; y++)
-                    {
-                        mMap[x, y] = null;
-                    }
-                }
-            }
-
         }
 
     }

--- a/Intersect.Server.Core/Entities/Player.Database.cs
+++ b/Intersect.Server.Core/Entities/Player.Database.cs
@@ -12,487 +12,485 @@ using Microsoft.EntityFrameworkCore;
 
 using Newtonsoft.Json;
 
-namespace Intersect.Server.Entities
+namespace Intersect.Server.Entities;
+
+
+public partial class Player
 {
+    private volatile bool _saving;
+    private readonly object _savingLock = new();
 
-    public partial class Player
+    #region Account
+
+    [ForeignKey(nameof(User))]
+    public Guid UserId { get; private set; }
+
+    [JsonIgnore]
+    public virtual User User { get; private set; }
+
+    [NotMapped, JsonIgnore]
+    public long SaveTimer { get; set; } = Timing.Global.Milliseconds + Options.Instance.Processing.PlayerSaveInterval;
+
+    #endregion
+
+    #region Entity Framework
+
+    #region Lookup
+
+    public static Tuple<Client, Player> Fetch(LookupKey lookupKey)
     {
-        private volatile bool _saving;
-        private readonly object _savingLock = new();
-
-        #region Account
-
-        [ForeignKey(nameof(User))]
-        public Guid UserId { get; private set; }
-
-        [JsonIgnore]
-        public virtual User User { get; private set; }
-
-        [NotMapped, JsonIgnore]
-        public long SaveTimer { get; set; } = Timing.Global.Milliseconds + Options.Instance.Processing.PlayerSaveInterval;
-
-        #endregion
-
-        #region Entity Framework
-
-        #region Lookup
-
-        public static Tuple<Client, Player> Fetch(LookupKey lookupKey)
+        if (!lookupKey.HasName && !lookupKey.HasId)
         {
-            if (!lookupKey.HasName && !lookupKey.HasId)
-            {
-                return new Tuple<Client, Player>(null, null);
-            }
-
-            // HasName checks if null or empty
-            // ReSharper disable once AssignNullToNotNullAttribute
-            return lookupKey.HasId ? Fetch(lookupKey.Id) : Fetch(lookupKey.Name);
+            return new Tuple<Client, Player>(null, null);
         }
 
-        public static Tuple<Client, Player> Fetch(string playerName)
-        {
-            var client = Globals.Clients.Find(queryClient => Entity.CompareName(playerName, queryClient?.Entity?.Name));
+        // HasName checks if null or empty
+        // ReSharper disable once AssignNullToNotNullAttribute
+        return lookupKey.HasId ? Fetch(lookupKey.Id) : Fetch(lookupKey.Name);
+    }
 
-            return new Tuple<Client, Player>(client, client?.Entity ?? Player.Find(playerName));
+    public static Tuple<Client, Player> Fetch(string playerName)
+    {
+        var client = Globals.Clients.Find(queryClient => Entity.CompareName(playerName, queryClient?.Entity?.Name));
+
+        return new Tuple<Client, Player>(client, client?.Entity ?? Player.Find(playerName));
+    }
+
+    public static Tuple<Client, Player> Fetch(Guid playerId)
+    {
+        var client = Globals.Clients.Find(queryClient => playerId == queryClient?.Entity?.Id);
+
+        return new Tuple<Client, Player>(client, client?.Entity ?? Player.Find(playerId));
+    }
+
+    public static Player Find(Guid playerId)
+    {
+        if (playerId == Guid.Empty)
+        {
+            return null;
         }
 
-        public static Tuple<Client, Player> Fetch(Guid playerId)
+        var player = Player.FindOnline(playerId);
+        if (player != null)
         {
-            var client = Globals.Clients.Find(queryClient => playerId == queryClient?.Entity?.Id);
-
-            return new Tuple<Client, Player>(client, client?.Entity ?? Player.Find(playerId));
-        }
-
-        public static Player Find(Guid playerId)
-        {
-            if (playerId == Guid.Empty)
-            {
-                return null;
-            }
-
-            var player = Player.FindOnline(playerId);
-            if (player != null)
-            {
-                return player;
-            }
-
-            try
-            {
-                using (var context = DbInterface.CreatePlayerContext())
-                {
-                    return Validate(QueryPlayerById(context, playerId));
-                }
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex);
-                return null;
-            }
-        }
-
-        public static Player Find(string playerName)
-        {
-            if (string.IsNullOrWhiteSpace(playerName))
-            {
-                return null;
-            }
-
-            var player = Player.FindOnline(playerName);
-            if (player != null)
-            {
-                return player;
-            }
-
-            try
-            {
-                using (var context = DbInterface.CreatePlayerContext())
-                {
-                    return Validate(QueryPlayerByName(context, playerName));
-                }
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex);
-                return null;
-            }
-        }
-
-        public static bool PlayerExists(string name)
-        {
-            if (string.IsNullOrWhiteSpace(name))
-            {
-                return false;
-            }
-
-            var player = FindOnline(name);
-            if (player != null)
-            {
-                return true;
-            }
-
-            try
-            {
-                using (var context = DbInterface.CreatePlayerContext())
-                {
-                    return AnyPlayerByName(context, name);
-                }
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex);
-                return false;
-            }
-        }
-
-        #endregion
-
-        #region Loading
-
-        public void LoadRelationships(PlayerContext playerContext)
-        {
-            lock (_savingLock)
-            {
-                if (_saving)
-                {
-                    Log.Warn($"Skipping loading relationships for player {Id} because it is being saved.");
-                    return;
-                }
-            }
-
-            var entityEntry = playerContext.Players.Attach(this);
-            entityEntry.Collection(p => p.Bank).Load();
-            entityEntry.Collection(p => p.Hotbar).Load();
-            entityEntry.Collection(p => p.Items).Load();
-            entityEntry.Collection(p => p.Quests).Load();
-            entityEntry.Collection(p => p.Spells).Load();
-            entityEntry.Collection(p => p.Variables).Load();
-            Validate(this);
-        }
-
-        public static Player Load(Guid playerId)
-        {
-            var player = Find(playerId);
-
-            return Validate(player);
-        }
-
-        public static Player Load(string playerName)
-        {
-            var player = Find(playerName);
-
-            return Validate(player);
-        }
-
-        public static Player Validate(Player player)
-        {
-            if (player == null)
-            {
-                return null;
-            }
-
-            // ReSharper disable once InvertIf
-            if (!player.ValidateLists())
-            {
-                player.Bank = player.Bank.OrderBy(bankSlot => bankSlot?.Slot).ToList();
-                player.Items = player.Items.OrderBy(inventorySlot => inventorySlot?.Slot).ToList();
-                player.Hotbar = player.Hotbar.OrderBy(hotbarSlot => hotbarSlot?.Slot).ToList();
-                player.Spells = player.Spells.OrderBy(spellSlot => spellSlot?.Slot).ToList();
-            }
-
             return player;
         }
 
-        #endregion
-
-        #region Friends
-
-        public void LoadFriends()
-        {
-            try
-            {
-                using (var context = DbInterface.CreatePlayerContext())
-                {
-                    CachedFriends = context.Player_Friends.Where(f => f.Owner.Id == Id).Select(t => new { t.Target.Id, t.Target.Name }).ToDictionary(t => t.Id, t => t.Name);
-                }
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, $"Failed to load friends for {Name}.");
-                //ServerContext.DispatchUnhandledException(new Exception("Failed to save user, shutting down to prevent rollbacks!"), true);
-            }
-        }
-
-        public bool TryAddFriend(Player friend)
-        {
-            if (friend == this)
-            {
-                return true;
-            }
-
-            if (CachedFriends.ContainsKey(friend.Id))
-            {
-                return true;
-            }
-
-            //No passing in custom contexts here.. they may already have this user in the change tracker and things just get weird.
-            //The cost of making a new context is almost nil.
-            try
-            {
-                CachedFriends.Add(friend.Id, friend.Name);
-
-                using (var context = DbInterface.CreatePlayerContext(readOnly: false))
-                {
-                    var friendship = new Database.PlayerData.Players.Friend(this, friend);
-                    context.Entry(friendship).State = EntityState.Added;
-                    if (context.SaveChanges() >= 0)
-                    {
-                        return true;
-                    }
-                }
-
-                Client.LogAndDisconnect(Id, nameof(TryAddFriend));
-                return false;
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, "Failed to add friend " + friend.Name + " to " + Name + "'s friends list.");
-                return false;
-            }
-        }
-
-        public static bool TryRemoveFriendship(Guid id, Guid otherId)
-        {
-            if (id == Guid.Empty || otherId == Guid.Empty)
-            {
-                return true;
-            }
-
-            //No passing in custom contexts here.. they may already have this user in the change tracker and things just get weird.
-            //The cost of making a new context is almost nil.
-            try
-            {
-                using (var context = DbInterface.CreatePlayerContext(readOnly: false))
-                {
-                    var friendship = context.Player_Friends.Where(f => f.Owner.Id == id && f.Target.Id == otherId).FirstOrDefault();
-                    if (friendship != null)
-                    {
-                        context.Entry(friendship).State = EntityState.Deleted;
-                    }
-
-                    var otherFriendship = context.Player_Friends.Where(f => f.Owner.Id == otherId && f.Target.Id == id).FirstOrDefault();
-                    if (otherFriendship != null)
-                    {
-                        context.Entry(otherFriendship).State = EntityState.Deleted;
-                    }
-
-                    return context.SaveChanges() >= 0;
-                }
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, $"Failed to remove friendship between {id} and {otherId}.");
-                return false;
-            }
-        }
-        #endregion
-
-        #region "Guilds"
-        public void LoadGuild()
+        try
         {
             using (var context = DbInterface.CreatePlayerContext())
             {
-                var guildId = context.Players.Where(p => p.Id == Id && p.DbGuild.Id != null && p.DbGuild.Id != Guid.Empty).Select(p => p.DbGuild.Id).FirstOrDefault();
-                if (guildId != default)
-                {
-                    Guild = Guild.LoadGuild(guildId);
-                }
-            }
-
-            if (GuildRank > Options.Instance.Guild.Ranks.Length - 1)
-            {
-                GuildRank = Options.Instance.Guild.Ranks.Length - 1;
+                return Validate(QueryPlayerById(context, playerId));
             }
         }
-        #endregion
-
-        #region Listing
-
-        public static int Count()
+        catch (Exception ex)
         {
-            try
-            {
-                using (var context = DbInterface.CreatePlayerContext())
-                {
-                    return context.Players.Count();
-                }
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex);
-                return 0;
-            }
+            Log.Error(ex);
+            return null;
         }
-
-        public static IList<Player> List(string query, string sortBy, SortDirection sortDirection, int skip, int take, out int total, Guid guildId = default(Guid))
-        {
-            try
-            {
-                using (var context = DbInterface.CreatePlayerContext())
-                {
-                    var compiledQuery = string.IsNullOrWhiteSpace(query) ? context.Players : context.Players.Where(p => EF.Functions.Like(p.Name, $"%{query}%"));
-
-                    if (guildId != Guid.Empty)
-                    {
-                        compiledQuery = compiledQuery.Where(p => p.DbGuild.Id == guildId);
-                    }
-
-                    total = compiledQuery.Count();
-
-                    switch (sortBy?.ToLower() ?? "")
-                    {
-                        case "level":
-                            compiledQuery = sortDirection == SortDirection.Ascending ? compiledQuery.OrderBy(u => u.Level).ThenBy(u => u.Exp) : compiledQuery.OrderByDescending(u => u.Level).ThenByDescending(u => u.Exp);
-                            break;
-                        case "creationdate":
-                            compiledQuery = sortDirection == SortDirection.Ascending ? compiledQuery.OrderBy(u => u.CreationDate) : compiledQuery.OrderByDescending(u => u.CreationDate);
-                            break;
-                        case "playtime":
-                            compiledQuery = sortDirection == SortDirection.Ascending ? compiledQuery.OrderBy(u => u.PlayTimeSeconds) : compiledQuery.OrderByDescending(u => u.PlayTimeSeconds);
-                            break;
-                        case "guildrank":
-                            compiledQuery = sortDirection == SortDirection.Ascending ? compiledQuery.OrderBy(u => u.GuildRank) : compiledQuery.OrderByDescending(u => u.GuildRank);
-                            break;
-                        case "name":
-                        default:
-                            compiledQuery = sortDirection == SortDirection.Ascending ? compiledQuery.OrderBy(u => u.Name.ToUpper()) : compiledQuery.OrderByDescending(u => u.Name.ToUpper());
-                            break;
-                    }
-                    
-                    return compiledQuery.Skip(skip).Take(take).ToList();
-                }
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex);
-                total = 0;
-                return null;
-            }
-        }
-
-        public static IEnumerable<Player> Rank(
-            int page,
-            int count,
-            SortDirection sortDirection
-        )
-        {
-            try
-            {
-                using (var context = DbInterface.CreatePlayerContext())
-                {
-                    var results = sortDirection == SortDirection.Ascending
-                        ? QueryPlayersWithRankAscending(context, page * count, count)
-                        : QueryPlayersWithRank(context, page * count, count);
-
-                    return results?.ToList();
-                }
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex);
-                return null;
-            }
-        }
-
-        #endregion
-
-        #region Compiled Queries
-
-        private static readonly Func<PlayerContext, int, int, IEnumerable<Player>> QueryPlayersWithRank =
-            EF.CompileQuery(
-                (PlayerContext context, int offset, int count) => context.Players
-                    .OrderByDescending(entity => EF.Property<dynamic>(entity, "Level"))
-                    .ThenByDescending(entity => EF.Property<dynamic>(entity, "Exp"))
-                    .Skip(offset)
-                    .Take(count)
-                    .Include(p => p.Bank)
-                    .Include(p => p.Hotbar)
-                    .Include(p => p.Quests)
-                    .Include(p => p.Variables)
-                    .Include(p => p.Items)
-                    .Include(p => p.Spells)
-                    .AsSplitQuery()
-            ) ??
-            throw new InvalidOperationException();
-
-        private static readonly Func<PlayerContext, int, int, IEnumerable<Player>> QueryPlayersWithRankAscending =
-            EF.CompileQuery(
-                (PlayerContext context, int offset, int count) => context.Players
-                    .OrderBy(entity => EF.Property<dynamic>(entity, "Level"))
-                    .ThenBy(entity => EF.Property<dynamic>(entity, "Exp"))
-                    .Skip(offset)
-                    .Take(count)
-                    .Include(p => p.Bank)
-                    .Include(p => p.Hotbar)
-                    .Include(p => p.Quests)
-                    .Include(p => p.Variables)
-                    .Include(p => p.Items)
-                    .Include(p => p.Spells)
-                    .AsSplitQuery()
-            ) ??
-            throw new InvalidOperationException();
-
-        private static readonly Func<PlayerContext, Guid, Player> QueryPlayerById =
-            EF.CompileQuery(
-                (PlayerContext context, Guid id) => context.Players.Where(p => p.Id == id)
-                    .Include(p => p.Bank)
-                    .Include(p => p.Hotbar)
-                    .Include(p => p.Quests)
-                    .Include(p => p.Variables)
-                    .Include(p => p.Items)
-                    .Include(p => p.Spells)
-                    .AsSplitQuery()
-                    .FirstOrDefault()
-            ) ??
-            throw new InvalidOperationException();
-
-        private static readonly Func<PlayerContext, string, Player> QueryPlayerByName =
-            EF.CompileQuery(
-                (PlayerContext context, string name) => context.Players
-                .Where(p => p.Name == name)
-                    .Include(p => p.Bank)
-                    .Include(p => p.Hotbar)
-                    .Include(p => p.Quests)
-                    .Include(p => p.Variables)
-                    .Include(p => p.Items)
-                    .Include(p => p.Spells)
-                    .AsSplitQuery()
-                    .FirstOrDefault()
-            ) ??
-            throw new InvalidOperationException();
-
-        private static readonly Func<PlayerContext, string, bool> AnyPlayerByName =
-            EF.CompileQuery(
-                (PlayerContext context, string name) => context.Players.Where(p => p.Name == name).Any());
-
-        internal static readonly Func<PlayerContext, Guid, Player> QueryPlayerByGuidWithLoading =
-            EF.CompileQuery(
-                // ReSharper disable once SpecifyStringComparison
-                (PlayerContext context, Guid playerId) => context.Players.Where(p => p.Id == playerId)
-                    .Include(c => c.Bank)
-                    .Include(c => c.Hotbar)
-                    .Include(c => c.Items)
-                    .Include(c => c.Quests)
-                    .Include(c => c.Spells)
-                    .Include(c => c.Variables)
-                    .AsSplitQuery()
-                    .FirstOrDefault()
-            ) ??
-            throw new InvalidOperationException();
-
-        #endregion
-
-        #endregion
-
     }
+
+    public static Player Find(string playerName)
+    {
+        if (string.IsNullOrWhiteSpace(playerName))
+        {
+            return null;
+        }
+
+        var player = Player.FindOnline(playerName);
+        if (player != null)
+        {
+            return player;
+        }
+
+        try
+        {
+            using (var context = DbInterface.CreatePlayerContext())
+            {
+                return Validate(QueryPlayerByName(context, playerName));
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex);
+            return null;
+        }
+    }
+
+    public static bool PlayerExists(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return false;
+        }
+
+        var player = FindOnline(name);
+        if (player != null)
+        {
+            return true;
+        }
+
+        try
+        {
+            using (var context = DbInterface.CreatePlayerContext())
+            {
+                return AnyPlayerByName(context, name);
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex);
+            return false;
+        }
+    }
+
+    #endregion
+
+    #region Loading
+
+    public void LoadRelationships(PlayerContext playerContext)
+    {
+        lock (_savingLock)
+        {
+            if (_saving)
+            {
+                Log.Warn($"Skipping loading relationships for player {Id} because it is being saved.");
+                return;
+            }
+        }
+
+        var entityEntry = playerContext.Players.Attach(this);
+        entityEntry.Collection(p => p.Bank).Load();
+        entityEntry.Collection(p => p.Hotbar).Load();
+        entityEntry.Collection(p => p.Items).Load();
+        entityEntry.Collection(p => p.Quests).Load();
+        entityEntry.Collection(p => p.Spells).Load();
+        entityEntry.Collection(p => p.Variables).Load();
+        Validate(this);
+    }
+
+    public static Player Load(Guid playerId)
+    {
+        var player = Find(playerId);
+
+        return Validate(player);
+    }
+
+    public static Player Load(string playerName)
+    {
+        var player = Find(playerName);
+
+        return Validate(player);
+    }
+
+    public static Player Validate(Player player)
+    {
+        if (player == null)
+        {
+            return null;
+        }
+
+        // ReSharper disable once InvertIf
+        if (!player.ValidateLists())
+        {
+            player.Bank = player.Bank.OrderBy(bankSlot => bankSlot?.Slot).ToList();
+            player.Items = player.Items.OrderBy(inventorySlot => inventorySlot?.Slot).ToList();
+            player.Hotbar = player.Hotbar.OrderBy(hotbarSlot => hotbarSlot?.Slot).ToList();
+            player.Spells = player.Spells.OrderBy(spellSlot => spellSlot?.Slot).ToList();
+        }
+
+        return player;
+    }
+
+    #endregion
+
+    #region Friends
+
+    public void LoadFriends()
+    {
+        try
+        {
+            using (var context = DbInterface.CreatePlayerContext())
+            {
+                CachedFriends = context.Player_Friends.Where(f => f.Owner.Id == Id).Select(t => new { t.Target.Id, t.Target.Name }).ToDictionary(t => t.Id, t => t.Name);
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, $"Failed to load friends for {Name}.");
+            //ServerContext.DispatchUnhandledException(new Exception("Failed to save user, shutting down to prevent rollbacks!"), true);
+        }
+    }
+
+    public bool TryAddFriend(Player friend)
+    {
+        if (friend == this)
+        {
+            return true;
+        }
+
+        if (CachedFriends.ContainsKey(friend.Id))
+        {
+            return true;
+        }
+
+        //No passing in custom contexts here.. they may already have this user in the change tracker and things just get weird.
+        //The cost of making a new context is almost nil.
+        try
+        {
+            CachedFriends.Add(friend.Id, friend.Name);
+
+            using (var context = DbInterface.CreatePlayerContext(readOnly: false))
+            {
+                var friendship = new Database.PlayerData.Players.Friend(this, friend);
+                context.Entry(friendship).State = EntityState.Added;
+                if (context.SaveChanges() >= 0)
+                {
+                    return true;
+                }
+            }
+
+            Client.LogAndDisconnect(Id, nameof(TryAddFriend));
+            return false;
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Failed to add friend " + friend.Name + " to " + Name + "'s friends list.");
+            return false;
+        }
+    }
+
+    public static bool TryRemoveFriendship(Guid id, Guid otherId)
+    {
+        if (id == Guid.Empty || otherId == Guid.Empty)
+        {
+            return true;
+        }
+
+        //No passing in custom contexts here.. they may already have this user in the change tracker and things just get weird.
+        //The cost of making a new context is almost nil.
+        try
+        {
+            using (var context = DbInterface.CreatePlayerContext(readOnly: false))
+            {
+                var friendship = context.Player_Friends.Where(f => f.Owner.Id == id && f.Target.Id == otherId).FirstOrDefault();
+                if (friendship != null)
+                {
+                    context.Entry(friendship).State = EntityState.Deleted;
+                }
+
+                var otherFriendship = context.Player_Friends.Where(f => f.Owner.Id == otherId && f.Target.Id == id).FirstOrDefault();
+                if (otherFriendship != null)
+                {
+                    context.Entry(otherFriendship).State = EntityState.Deleted;
+                }
+
+                return context.SaveChanges() >= 0;
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, $"Failed to remove friendship between {id} and {otherId}.");
+            return false;
+        }
+    }
+    #endregion
+
+    #region "Guilds"
+    public void LoadGuild()
+    {
+        using (var context = DbInterface.CreatePlayerContext())
+        {
+            var guildId = context.Players.Where(p => p.Id == Id && p.DbGuild.Id != null && p.DbGuild.Id != Guid.Empty).Select(p => p.DbGuild.Id).FirstOrDefault();
+            if (guildId != default)
+            {
+                Guild = Guild.LoadGuild(guildId);
+            }
+        }
+
+        if (GuildRank > Options.Instance.Guild.Ranks.Length - 1)
+        {
+            GuildRank = Options.Instance.Guild.Ranks.Length - 1;
+        }
+    }
+    #endregion
+
+    #region Listing
+
+    public static int Count()
+    {
+        try
+        {
+            using (var context = DbInterface.CreatePlayerContext())
+            {
+                return context.Players.Count();
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex);
+            return 0;
+        }
+    }
+
+    public static IList<Player> List(string query, string sortBy, SortDirection sortDirection, int skip, int take, out int total, Guid guildId = default(Guid))
+    {
+        try
+        {
+            using (var context = DbInterface.CreatePlayerContext())
+            {
+                var compiledQuery = string.IsNullOrWhiteSpace(query) ? context.Players : context.Players.Where(p => EF.Functions.Like(p.Name, $"%{query}%"));
+
+                if (guildId != Guid.Empty)
+                {
+                    compiledQuery = compiledQuery.Where(p => p.DbGuild.Id == guildId);
+                }
+
+                total = compiledQuery.Count();
+
+                switch (sortBy?.ToLower() ?? "")
+                {
+                    case "level":
+                        compiledQuery = sortDirection == SortDirection.Ascending ? compiledQuery.OrderBy(u => u.Level).ThenBy(u => u.Exp) : compiledQuery.OrderByDescending(u => u.Level).ThenByDescending(u => u.Exp);
+                        break;
+                    case "creationdate":
+                        compiledQuery = sortDirection == SortDirection.Ascending ? compiledQuery.OrderBy(u => u.CreationDate) : compiledQuery.OrderByDescending(u => u.CreationDate);
+                        break;
+                    case "playtime":
+                        compiledQuery = sortDirection == SortDirection.Ascending ? compiledQuery.OrderBy(u => u.PlayTimeSeconds) : compiledQuery.OrderByDescending(u => u.PlayTimeSeconds);
+                        break;
+                    case "guildrank":
+                        compiledQuery = sortDirection == SortDirection.Ascending ? compiledQuery.OrderBy(u => u.GuildRank) : compiledQuery.OrderByDescending(u => u.GuildRank);
+                        break;
+                    case "name":
+                    default:
+                        compiledQuery = sortDirection == SortDirection.Ascending ? compiledQuery.OrderBy(u => u.Name.ToUpper()) : compiledQuery.OrderByDescending(u => u.Name.ToUpper());
+                        break;
+                }
+                
+                return compiledQuery.Skip(skip).Take(take).ToList();
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex);
+            total = 0;
+            return null;
+        }
+    }
+
+    public static IEnumerable<Player> Rank(
+        int page,
+        int count,
+        SortDirection sortDirection
+    )
+    {
+        try
+        {
+            using (var context = DbInterface.CreatePlayerContext())
+            {
+                var results = sortDirection == SortDirection.Ascending
+                    ? QueryPlayersWithRankAscending(context, page * count, count)
+                    : QueryPlayersWithRank(context, page * count, count);
+
+                return results?.ToList();
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex);
+            return null;
+        }
+    }
+
+    #endregion
+
+    #region Compiled Queries
+
+    private static readonly Func<PlayerContext, int, int, IEnumerable<Player>> QueryPlayersWithRank =
+        EF.CompileQuery(
+            (PlayerContext context, int offset, int count) => context.Players
+                .OrderByDescending(entity => EF.Property<dynamic>(entity, "Level"))
+                .ThenByDescending(entity => EF.Property<dynamic>(entity, "Exp"))
+                .Skip(offset)
+                .Take(count)
+                .Include(p => p.Bank)
+                .Include(p => p.Hotbar)
+                .Include(p => p.Quests)
+                .Include(p => p.Variables)
+                .Include(p => p.Items)
+                .Include(p => p.Spells)
+                .AsSplitQuery()
+        ) ??
+        throw new InvalidOperationException();
+
+    private static readonly Func<PlayerContext, int, int, IEnumerable<Player>> QueryPlayersWithRankAscending =
+        EF.CompileQuery(
+            (PlayerContext context, int offset, int count) => context.Players
+                .OrderBy(entity => EF.Property<dynamic>(entity, "Level"))
+                .ThenBy(entity => EF.Property<dynamic>(entity, "Exp"))
+                .Skip(offset)
+                .Take(count)
+                .Include(p => p.Bank)
+                .Include(p => p.Hotbar)
+                .Include(p => p.Quests)
+                .Include(p => p.Variables)
+                .Include(p => p.Items)
+                .Include(p => p.Spells)
+                .AsSplitQuery()
+        ) ??
+        throw new InvalidOperationException();
+
+    private static readonly Func<PlayerContext, Guid, Player> QueryPlayerById =
+        EF.CompileQuery(
+            (PlayerContext context, Guid id) => context.Players.Where(p => p.Id == id)
+                .Include(p => p.Bank)
+                .Include(p => p.Hotbar)
+                .Include(p => p.Quests)
+                .Include(p => p.Variables)
+                .Include(p => p.Items)
+                .Include(p => p.Spells)
+                .AsSplitQuery()
+                .FirstOrDefault()
+        ) ??
+        throw new InvalidOperationException();
+
+    private static readonly Func<PlayerContext, string, Player> QueryPlayerByName =
+        EF.CompileQuery(
+            (PlayerContext context, string name) => context.Players
+            .Where(p => p.Name == name)
+                .Include(p => p.Bank)
+                .Include(p => p.Hotbar)
+                .Include(p => p.Quests)
+                .Include(p => p.Variables)
+                .Include(p => p.Items)
+                .Include(p => p.Spells)
+                .AsSplitQuery()
+                .FirstOrDefault()
+        ) ??
+        throw new InvalidOperationException();
+
+    private static readonly Func<PlayerContext, string, bool> AnyPlayerByName =
+        EF.CompileQuery(
+            (PlayerContext context, string name) => context.Players.Where(p => p.Name == name).Any());
+
+    internal static readonly Func<PlayerContext, Guid, Player> QueryPlayerByGuidWithLoading =
+        EF.CompileQuery(
+            // ReSharper disable once SpecifyStringComparison
+            (PlayerContext context, Guid playerId) => context.Players.Where(p => p.Id == playerId)
+                .Include(c => c.Bank)
+                .Include(c => c.Hotbar)
+                .Include(c => c.Items)
+                .Include(c => c.Quests)
+                .Include(c => c.Spells)
+                .Include(c => c.Variables)
+                .AsSplitQuery()
+                .FirstOrDefault()
+        ) ??
+        throw new InvalidOperationException();
+
+    #endregion
+
+    #endregion
 
 }

--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -28,3445 +28,3536 @@ using Newtonsoft.Json;
 using MapAttribute = Intersect.Enums.MapAttribute;
 using Stat = Intersect.Enums.Stat;
 
-namespace Intersect.Server.Entities
+namespace Intersect.Server.Entities;
+
+
+public partial class Player : Entity
 {
+    [NotMapped, JsonIgnore]
+    public Guid PreviousMapInstanceId = Guid.Empty;
 
-    public partial class Player : Entity
+    //Online Players List
+    private static readonly ConcurrentDictionary<Guid, Player> OnlinePlayers = new ConcurrentDictionary<Guid, Player>();
+
+    public static Player[] OnlineList { get; private set; } = new Player[0];
+
+    [NotMapped]
+    public bool Online => OnlinePlayers.ContainsKey(Id);
+
+    #region Chat
+
+    [JsonIgnore][NotMapped] public Player ChatTarget = null;
+
+    #endregion
+
+    [NotMapped, JsonIgnore] public long LastChatTime = -1;
+
+    #region Quests
+
+    [NotMapped, JsonIgnore] public List<Guid> QuestOffers = new List<Guid>();
+
+    #endregion
+
+    #region Event Spawned Npcs
+
+    [JsonIgnore][NotMapped] public List<Npc> SpawnedNpcs = new List<Npc>();
+
+    #endregion
+
+    public static int OnlineCount => OnlinePlayers.Count;
+
+    [JsonProperty("MaxVitals"), NotMapped]
+    public new long[] MaxVitals => GetMaxVitals();
+
+    //Name, X, Y, Dir, Etc all in the base Entity Class
+    public Guid ClassId { get; set; }
+
+    [NotMapped]
+    public string ClassName => ClassBase.GetName(ClassId);
+
+    public Gender Gender { get; set; }
+
+    public long Exp { get; set; }
+
+    public int StatPoints { get; set; }
+
+    [Column("Equipment"), JsonIgnore]
+    public string EquipmentJson
     {
-        [NotMapped, JsonIgnore]
-        public Guid PreviousMapInstanceId = Guid.Empty;
+        get => DatabaseUtils.SaveIntArray(Equipment, Options.EquipmentSlots.Count);
+        set => Equipment = DatabaseUtils.LoadIntArray(value, Options.EquipmentSlots.Count);
+    }
 
-        //Online Players List
-        private static readonly ConcurrentDictionary<Guid, Player> OnlinePlayers = new ConcurrentDictionary<Guid, Player>();
+    [NotMapped]
+    public int[] Equipment { get; set; } = new int[Options.EquipmentSlots.Count];
 
-        public static Player[] OnlineList { get; private set; } = new Player[0];
-
-        [NotMapped]
-        public bool Online => OnlinePlayers.ContainsKey(Id);
-
-        #region Chat
-
-        [JsonIgnore][NotMapped] public Player ChatTarget = null;
-
-        #endregion
-
-        [NotMapped, JsonIgnore] public long LastChatTime = -1;
-
-        #region Quests
-
-        [NotMapped, JsonIgnore] public List<Guid> QuestOffers = new List<Guid>();
-
-        #endregion
-
-        #region Event Spawned Npcs
-
-        [JsonIgnore][NotMapped] public List<Npc> SpawnedNpcs = new List<Npc>();
-
-        #endregion
-
-        public static int OnlineCount => OnlinePlayers.Count;
-
-        [JsonProperty("MaxVitals"), NotMapped]
-        public new long[] MaxVitals => GetMaxVitals();
-
-        //Name, X, Y, Dir, Etc all in the base Entity Class
-        public Guid ClassId { get; set; }
-
-        [NotMapped]
-        public string ClassName => ClassBase.GetName(ClassId);
-
-        public Gender Gender { get; set; }
-
-        public long Exp { get; set; }
-
-        public int StatPoints { get; set; }
-
-        [Column("Equipment"), JsonIgnore]
-        public string EquipmentJson
+    /// <summary>
+    /// Returns a list of all equipped <see cref="Item"/>s
+    /// </summary>
+    [NotMapped, JsonIgnore]
+    public List<Item> EquippedItems
+    {
+        get
         {
-            get => DatabaseUtils.SaveIntArray(Equipment, Options.EquipmentSlots.Count);
-            set => Equipment = DatabaseUtils.LoadIntArray(value, Options.EquipmentSlots.Count);
-        }
-
-        [NotMapped]
-        public int[] Equipment { get; set; } = new int[Options.EquipmentSlots.Count];
-
-        /// <summary>
-        /// Returns a list of all equipped <see cref="Item"/>s
-        /// </summary>
-        [NotMapped, JsonIgnore]
-        public List<Item> EquippedItems
-        {
-            get
+            var equippedItems = new List<Item>();
+            for (var i = 0; i < Options.EquipmentSlots.Count; i++)
             {
-                var equippedItems = new List<Item>();
-                for (var i = 0; i < Options.EquipmentSlots.Count; i++)
-                {
-                    if (!TryGetEquippedItem(i, out var item))
-                    {
-                        continue;
-                    }
-                    equippedItems.Add(item);
-                }
-
-                return equippedItems;
-            }
-        }
-
-        public DateTime? LastOnline { get; set; }
-
-        public DateTime? CreationDate { get; set; } = DateTime.UtcNow;
-
-        private ulong mLoadedPlaytime { get; set; } = 0;
-
-        public ulong PlayTimeSeconds
-        {
-            get
-            {
-                return mLoadedPlaytime + (ulong)(LoginTime != null ? (DateTime.UtcNow - (DateTime)LoginTime) : TimeSpan.Zero).TotalSeconds;
-            }
-
-            set
-            {
-                mLoadedPlaytime = value;
-            }
-        }
-
-        [NotMapped]
-        public TimeSpan OnlineTime => LoginTime != null ? DateTime.UtcNow - (DateTime)LoginTime : TimeSpan.Zero;
-
-        [NotMapped]
-        public DateTime? LoginTime { get; set; }
-
-        //Bank
-        [JsonIgnore]
-        public virtual List<BankSlot> Bank { get; set; } = new List<BankSlot>();
-
-        //Friends -- Not used outside of EF
-        [JsonIgnore]
-        public virtual List<Friend> Friends { get; set; } = new List<Friend>();
-
-        //Local Friends
-        [NotMapped, JsonProperty("Friends")]
-        public virtual Dictionary<Guid, string> CachedFriends { get; set; } = new Dictionary<Guid, string>();
-
-        //HotBar
-        [JsonIgnore]
-        public virtual List<HotbarSlot> Hotbar { get; set; } = new List<HotbarSlot>();
-
-        //Quests
-        [JsonIgnore]
-        public virtual List<Quest> Quests { get; set; } = new List<Quest>();
-
-        //Variables
-        [JsonIgnore]
-        public virtual List<PlayerVariable> Variables { get; set; } = new List<PlayerVariable>();
-
-        [JsonIgnore, NotMapped]
-        public bool IsValidPlayer => !IsDisposed && Client?.Entity == this;
-
-        [NotMapped]
-        public long ExperienceToNextLevel => GetExperienceToNextLevel(Level);
-
-        [NotMapped, JsonIgnore]
-        public long ClientAttackTimer { get; set; }
-
-        [NotMapped, JsonIgnore]
-        public long ClientMoveTimer { get; set; }
-
-        private long mAutorunCommonEventTimer { get; set; }
-
-        [NotMapped, JsonIgnore]
-        public int CommonAutorunEvents { get; private set; }
-
-        [NotMapped, JsonIgnore]
-        public int MapAutorunEvents { get; private set; }
-
-        [NotMapped, JsonIgnore]
-        public bool InOpenInstance => InstanceType != MapInstanceType.Personal && InstanceType != MapInstanceType.Shared;
-
-        /// <summary>
-        /// References the in-memory copy of the guild for this player, reference this instead of the Guild property below.
-        /// </summary>
-        [NotMapped][JsonIgnore] public Guild Guild { get; set; }
-
-        [NotMapped][JsonIgnore] public bool IsInGuild => Guild != null;
-
-        [NotMapped] public Guid GuildId => DbGuild?.Id ?? default;
-
-        /// <summary>
-        /// This field is used for EF database fields only and should never be assigned to or used, instead the guild instance will be assigned to CachedGuild above
-        /// </summary>
-        [JsonIgnore] public Guild DbGuild { get; set; }
-
-        [NotMapped]
-        [JsonIgnore]
-        public Tuple<Player, Guild> GuildInvite { get; set; }
-
-        public int GuildRank { get; set; }
-
-        public DateTime GuildJoinDate { get; set; }
-
-        /// <summary>
-        /// Used to determine whether the player is operating in the guild bank vs player bank
-        /// </summary>
-        [NotMapped] public bool GuildBank;
-
-        /// <summary>
-        /// Used to tell events when to continue when dealing with fade in/out events and knowing when they're complete on the client's end
-        /// </summary>
-        [NotMapped, JsonIgnore]
-        public bool IsFading { get; set; }
-
-        /// <summary>
-        /// Reference stored of the last weapon used for an auto-attack
-        /// </summary>
-        [NotMapped, JsonIgnore]
-        public ItemBase LastAttackingWeapon { get; set; }
-
-        // Instancing
-        public MapInstanceType InstanceType { get; set; } = MapInstanceType.Overworld;
-
-        [NotMapped, JsonIgnore] public MapInstanceType PreviousMapInstanceType { get; set; } = MapInstanceType.Overworld;
-
-        public Guid PersonalMapInstanceId { get; set; } = Guid.Empty;
-
-        /// <summary>
-        /// This instance Id is shared amongst members of a party. Party members will use the shared ID of the party leader.
-        /// </summary>
-        public Guid SharedMapInstanceId { get; set; } = Guid.Empty;
-
-        /* This bundle of columns exists so that we have a "non-instanced" location to reference in case we need
-         * to kick someone out of an instance for any reason */
-        [Column("LastOverworldMapId")]
-        [JsonProperty]
-        public Guid LastOverworldMapId { get; set; }
-        [NotMapped]
-        [JsonIgnore]
-        public MapBase LastOverworldMap
-        {
-            get => MapBase.Get(LastOverworldMapId);
-            set => LastOverworldMapId = value?.Id ?? Guid.Empty;
-        }
-        public int LastOverworldX { get; set; }
-        public int LastOverworldY { get; set; }
-
-        // For respawning in shared instances (configurable option)
-        [Column("SharedInstanceRespawnId")]
-        [JsonProperty]
-        public Guid SharedInstanceRespawnId { get; set; }
-        [NotMapped]
-        [JsonIgnore]
-        public MapBase SharedInstanceRespawn
-        {
-            get => MapBase.Get(SharedInstanceRespawnId);
-            set => SharedInstanceRespawnId = value?.Id ?? Guid.Empty;
-        }
-        public int SharedInstanceRespawnX { get; set; }
-        public int SharedInstanceRespawnY { get; set; }
-        public Direction SharedInstanceRespawnDir { get; set; }
-
-        [NotMapped, JsonIgnore]
-        public int InstanceLives { get; set; }
-
-        private long mStaleCooldownTimer;
-
-        private long mGlobalCooldownTimer;
-
-        [NotMapped, JsonIgnore]
-        public bool IsInParty => Party != null && Party.Count > 1;
-
-        public static Player FindOnline(Guid id)
-        {
-            return OnlinePlayers.ContainsKey(id) ? OnlinePlayers[id] : null;
-        }
-
-        public static Player FindOnline(string charName)
-        {
-            return OnlinePlayers.Values.FirstOrDefault(s => s.Name.ToLower().Trim() == charName.ToLower().Trim());
-        }
-
-        public bool ValidateLists()
-        {
-            var changes = false;
-
-            changes |= SlotHelper.ValidateSlots(Spells, Options.MaxPlayerSkills);
-            changes |= SlotHelper.ValidateSlots(Items, Options.MaxInvItems);
-            changes |= SlotHelper.ValidateSlots(Bank, Options.Instance.PlayerOpts.InitialBankslots);
-
-            if (Hotbar.Count < Options.Instance.PlayerOpts.HotbarSlotCount)
-            {
-                Hotbar.Sort((a, b) => a?.Slot - b?.Slot ?? 0);
-                for (var i = Hotbar.Count; i < Options.Instance.PlayerOpts.HotbarSlotCount; i++)
-                {
-                    Hotbar.Add(new HotbarSlot(i));
-                }
-
-                changes = true;
-            }
-
-            return changes;
-        }
-
-        private long GetExperienceToNextLevel(int level)
-        {
-            if (level >= Options.MaxLevel)
-            {
-                return -1;
-            }
-
-            var classBase = ClassBase.Get(ClassId);
-
-            return classBase?.ExperienceToNextLevel(level) ?? ClassBase.DEFAULT_BASE_EXPERIENCE;
-        }
-
-        public void SetOnline()
-        {
-            IsDisposed = false;
-            mSentMap = false;
-            if (OnlinePlayers.TryGetValue(Id, out var player))
-            {
-                if (player != this)
-                {
-                    throw new InvalidOperationException($@"A player with the id {Id} is already listed as online.");
-                }
-            }
-
-            if (LoginTime == null)
-            {
-                LoginTime = DateTime.UtcNow;
-            }
-
-            if (User != null && User.LoginTime == null)
-            {
-                User.LoginTime = DateTime.UtcNow;
-            }
-
-            LoadFriends();
-            LoadGuild();
-
-            //Upon Sign In Remove Any Items/Spells that have been deleted
-            foreach (var itm in Items)
-            {
-                if (itm.ItemId != Guid.Empty && ItemBase.Get(itm.ItemId) == null)
-                {
-                    itm.Set(Item.None);
-                }
-            }
-
-            foreach (var itm in Bank)
-            {
-                if (itm.ItemId != Guid.Empty && ItemBase.Get(itm.ItemId) == null)
-                {
-                    itm.Set(Item.None);
-                }
-            }
-
-            foreach (var spl in Spells)
-            {
-                if (spl.SpellId != Guid.Empty && SpellBase.Get(spl.SpellId) == null)
-                {
-                    spl.Set(Spell.None);
-                }
-            }
-
-            OnlinePlayers[Id] = this;
-            OnlineList = OnlinePlayers.Values.ToArray();
-
-            //Send guild list update to all members when coming online
-            Guild?.UpdateMemberList();
-
-            // If we are configured to do so, send a notification of us logging in to all online friends.
-            if (Options.Player.EnableFriendLoginNotifications)
-            {
-                foreach (var friend in CachedFriends)
-                {
-                    var onlineFriend = Player.FindOnline(friend.Key);
-                    if (onlineFriend != null)
-                    {
-                        PacketSender.SendChatMsg(onlineFriend, Strings.Friends.LoggedIn.ToString(Name), ChatMessageType.Friend, CustomColors.Alerts.Info, Name);
-                    }
-                }
-            }
-
-            CacheEquipmentTriggers();
-        }
-
-        public void SendPacket(IPacket packet, TransmissionMode mode = TransmissionMode.All)
-        {
-            Client?.Send(packet, mode);
-        }
-
-        public override void Dispose()
-        {
-            if (IsDisposed)
-            {
-                return;
-            }
-
-            base.Dispose();
-        }
-
-        private void RemoveFromInstanceController(Guid mapInstanceId)
-        {
-            if (InstanceProcessor.TryGetInstanceController(mapInstanceId, out var instanceController))
-            {
-                instanceController.RemovePlayer(Id);
-            }
-        }
-
-        public void TryLogout(bool force = false, bool softLogout = false)
-        {
-            LastOnline = DateTime.Now;
-            Client = default;
-
-            if (LoginTime != null)
-            {
-                PlayTimeSeconds += (ulong)(DateTime.UtcNow - (DateTime)LoginTime).TotalSeconds;
-                LoginTime = null;
-            }
-
-            if (CombatTimer < Timing.Global.Milliseconds || force)
-            {
-                Logout(softLogout);
-            }
-        }
-
-        private void Logout(bool softLogout = false)
-        {
-            lock (_savingLock)
-            {
-                _saving = true;
-            }
-
-            if (MapController.TryGetInstanceFromMap(MapId, MapInstanceId, out var instance))
-            {
-                instance.RemoveEntity(this);
-            }
-
-            RemoveFromInstanceController(MapInstanceId);
-
-            //Update parties
-            LeaveParty();
-
-            //Update trade
-            CancelTrade();
-
-            mSentMap = false;
-            ChatTarget = null;
-
-            //Clear all event spawned NPC's
-            var entities = SpawnedNpcs.ToArray();
-            foreach (var t in entities)
-            {
-                if (t == null || t.GetType() != typeof(Npc))
+                if (!TryGetEquippedItem(i, out var item))
                 {
                     continue;
                 }
+                equippedItems.Add(item);
+            }
 
-                if (t.Despawnable)
+            return equippedItems;
+        }
+    }
+
+    public DateTime? LastOnline { get; set; }
+
+    public DateTime? CreationDate { get; set; } = DateTime.UtcNow;
+
+    private ulong mLoadedPlaytime { get; set; } = 0;
+
+    public ulong PlayTimeSeconds
+    {
+        get
+        {
+            return mLoadedPlaytime + (ulong)(LoginTime != null ? (DateTime.UtcNow - (DateTime)LoginTime) : TimeSpan.Zero).TotalSeconds;
+        }
+
+        set
+        {
+            mLoadedPlaytime = value;
+        }
+    }
+
+    [NotMapped]
+    public TimeSpan OnlineTime => LoginTime != null ? DateTime.UtcNow - (DateTime)LoginTime : TimeSpan.Zero;
+
+    [NotMapped]
+    public DateTime? LoginTime { get; set; }
+
+    //Bank
+    [JsonIgnore]
+    public virtual List<BankSlot> Bank { get; set; } = new List<BankSlot>();
+
+    //Friends -- Not used outside of EF
+    [JsonIgnore]
+    public virtual List<Friend> Friends { get; set; } = new List<Friend>();
+
+    //Local Friends
+    [NotMapped, JsonProperty("Friends")]
+    public virtual Dictionary<Guid, string> CachedFriends { get; set; } = new Dictionary<Guid, string>();
+
+    //HotBar
+    [JsonIgnore]
+    public virtual List<HotbarSlot> Hotbar { get; set; } = new List<HotbarSlot>();
+
+    //Quests
+    [JsonIgnore]
+    public virtual List<Quest> Quests { get; set; } = new List<Quest>();
+
+    //Variables
+    [JsonIgnore]
+    public virtual List<PlayerVariable> Variables { get; set; } = new List<PlayerVariable>();
+
+    [JsonIgnore, NotMapped]
+    public bool IsValidPlayer => !IsDisposed && Client?.Entity == this;
+
+    [NotMapped]
+    public long ExperienceToNextLevel => GetExperienceToNextLevel(Level);
+
+    [NotMapped, JsonIgnore]
+    public long ClientAttackTimer { get; set; }
+
+    [NotMapped, JsonIgnore]
+    public long ClientMoveTimer { get; set; }
+
+    private long mAutorunCommonEventTimer { get; set; }
+
+    [NotMapped, JsonIgnore]
+    public int CommonAutorunEvents { get; private set; }
+
+    [NotMapped, JsonIgnore]
+    public int MapAutorunEvents { get; private set; }
+
+    [NotMapped, JsonIgnore]
+    public bool InOpenInstance => InstanceType != MapInstanceType.Personal && InstanceType != MapInstanceType.Shared;
+
+    /// <summary>
+    /// References the in-memory copy of the guild for this player, reference this instead of the Guild property below.
+    /// </summary>
+    [NotMapped][JsonIgnore] public Guild Guild { get; set; }
+
+    [NotMapped][JsonIgnore] public bool IsInGuild => Guild != null;
+
+    [NotMapped] public Guid GuildId => DbGuild?.Id ?? default;
+
+    /// <summary>
+    /// This field is used for EF database fields only and should never be assigned to or used, instead the guild instance will be assigned to CachedGuild above
+    /// </summary>
+    [JsonIgnore] public Guild DbGuild { get; set; }
+
+    [NotMapped]
+    [JsonIgnore]
+    public Tuple<Player, Guild> GuildInvite { get; set; }
+
+    public int GuildRank { get; set; }
+
+    public DateTime GuildJoinDate { get; set; }
+
+    /// <summary>
+    /// Used to determine whether the player is operating in the guild bank vs player bank
+    /// </summary>
+    [NotMapped] public bool GuildBank;
+
+    /// <summary>
+    /// Used to tell events when to continue when dealing with fade in/out events and knowing when they're complete on the client's end
+    /// </summary>
+    [NotMapped, JsonIgnore]
+    public bool IsFading { get; set; }
+
+    /// <summary>
+    /// Reference stored of the last weapon used for an auto-attack
+    /// </summary>
+    [NotMapped, JsonIgnore]
+    public ItemBase LastAttackingWeapon { get; set; }
+
+    // Instancing
+    public MapInstanceType InstanceType { get; set; } = MapInstanceType.Overworld;
+
+    [NotMapped, JsonIgnore] public MapInstanceType PreviousMapInstanceType { get; set; } = MapInstanceType.Overworld;
+
+    public Guid PersonalMapInstanceId { get; set; } = Guid.Empty;
+
+    /// <summary>
+    /// This instance Id is shared amongst members of a party. Party members will use the shared ID of the party leader.
+    /// </summary>
+    public Guid SharedMapInstanceId { get; set; } = Guid.Empty;
+
+    /* This bundle of columns exists so that we have a "non-instanced" location to reference in case we need
+     * to kick someone out of an instance for any reason */
+    [Column("LastOverworldMapId")]
+    [JsonProperty]
+    public Guid LastOverworldMapId { get; set; }
+    [NotMapped]
+    [JsonIgnore]
+    public MapBase LastOverworldMap
+    {
+        get => MapBase.Get(LastOverworldMapId);
+        set => LastOverworldMapId = value?.Id ?? Guid.Empty;
+    }
+    public int LastOverworldX { get; set; }
+    public int LastOverworldY { get; set; }
+
+    // For respawning in shared instances (configurable option)
+    [Column("SharedInstanceRespawnId")]
+    [JsonProperty]
+    public Guid SharedInstanceRespawnId { get; set; }
+    [NotMapped]
+    [JsonIgnore]
+    public MapBase SharedInstanceRespawn
+    {
+        get => MapBase.Get(SharedInstanceRespawnId);
+        set => SharedInstanceRespawnId = value?.Id ?? Guid.Empty;
+    }
+    public int SharedInstanceRespawnX { get; set; }
+    public int SharedInstanceRespawnY { get; set; }
+    public Direction SharedInstanceRespawnDir { get; set; }
+
+    [NotMapped, JsonIgnore]
+    public int InstanceLives { get; set; }
+
+    private long mStaleCooldownTimer;
+
+    private long mGlobalCooldownTimer;
+
+    [NotMapped, JsonIgnore]
+    public bool IsInParty => Party != null && Party.Count > 1;
+
+    public static Player FindOnline(Guid id)
+    {
+        return OnlinePlayers.ContainsKey(id) ? OnlinePlayers[id] : null;
+    }
+
+    public static Player FindOnline(string charName)
+    {
+        return OnlinePlayers.Values.FirstOrDefault(s => s.Name.ToLower().Trim() == charName.ToLower().Trim());
+    }
+
+    public bool ValidateLists()
+    {
+        var changes = false;
+
+        changes |= SlotHelper.ValidateSlots(Spells, Options.MaxPlayerSkills);
+        changes |= SlotHelper.ValidateSlots(Items, Options.MaxInvItems);
+        changes |= SlotHelper.ValidateSlots(Bank, Options.Instance.PlayerOpts.InitialBankslots);
+
+        if (Hotbar.Count < Options.Instance.PlayerOpts.HotbarSlotCount)
+        {
+            Hotbar.Sort((a, b) => a?.Slot - b?.Slot ?? 0);
+            for (var i = Hotbar.Count; i < Options.Instance.PlayerOpts.HotbarSlotCount; i++)
+            {
+                Hotbar.Add(new HotbarSlot(i));
+            }
+
+            changes = true;
+        }
+
+        return changes;
+    }
+
+    private long GetExperienceToNextLevel(int level)
+    {
+        if (level >= Options.MaxLevel)
+        {
+            return -1;
+        }
+
+        var classBase = ClassBase.Get(ClassId);
+
+        return classBase?.ExperienceToNextLevel(level) ?? ClassBase.DEFAULT_BASE_EXPERIENCE;
+    }
+
+    public void SetOnline()
+    {
+        IsDisposed = false;
+        mSentMap = false;
+        if (OnlinePlayers.TryGetValue(Id, out var player))
+        {
+            if (player != this)
+            {
+                throw new InvalidOperationException($@"A player with the id {Id} is already listed as online.");
+            }
+        }
+
+        if (LoginTime == null)
+        {
+            LoginTime = DateTime.UtcNow;
+        }
+
+        if (User != null && User.LoginTime == null)
+        {
+            User.LoginTime = DateTime.UtcNow;
+        }
+
+        LoadFriends();
+        LoadGuild();
+
+        //Upon Sign In Remove Any Items/Spells that have been deleted
+        foreach (var itm in Items)
+        {
+            if (itm.ItemId != Guid.Empty && ItemBase.Get(itm.ItemId) == null)
+            {
+                itm.Set(Item.None);
+            }
+        }
+
+        foreach (var itm in Bank)
+        {
+            if (itm.ItemId != Guid.Empty && ItemBase.Get(itm.ItemId) == null)
+            {
+                itm.Set(Item.None);
+            }
+        }
+
+        foreach (var spl in Spells)
+        {
+            if (spl.SpellId != Guid.Empty && SpellBase.Get(spl.SpellId) == null)
+            {
+                spl.Set(Spell.None);
+            }
+        }
+
+        OnlinePlayers[Id] = this;
+        OnlineList = OnlinePlayers.Values.ToArray();
+
+        //Send guild list update to all members when coming online
+        Guild?.UpdateMemberList();
+
+        // If we are configured to do so, send a notification of us logging in to all online friends.
+        if (Options.Player.EnableFriendLoginNotifications)
+        {
+            foreach (var friend in CachedFriends)
+            {
+                var onlineFriend = Player.FindOnline(friend.Key);
+                if (onlineFriend != null)
                 {
-                    lock (t.EntityLock)
-                    {
-                        t.Die();
-                    }
+                    PacketSender.SendChatMsg(onlineFriend, Strings.Friends.LoggedIn.ToString(Name), ChatMessageType.Friend, CustomColors.Alerts.Info, Name);
                 }
             }
+        }
 
-            SpawnedNpcs.Clear();
+        CacheEquipmentTriggers();
+    }
 
-            lock (mEventLock)
+    public void SendPacket(IPacket packet, TransmissionMode mode = TransmissionMode.All)
+    {
+        Client?.Send(packet, mode);
+    }
+
+    public override void Dispose()
+    {
+        if (IsDisposed)
+        {
+            return;
+        }
+
+        base.Dispose();
+    }
+
+    private void RemoveFromInstanceController(Guid mapInstanceId)
+    {
+        if (InstanceProcessor.TryGetInstanceController(mapInstanceId, out var instanceController))
+        {
+            instanceController.RemovePlayer(Id);
+        }
+    }
+
+    public void TryLogout(bool force = false, bool softLogout = false)
+    {
+        LastOnline = DateTime.Now;
+        Client = default;
+
+        if (LoginTime != null)
+        {
+            PlayTimeSeconds += (ulong)(DateTime.UtcNow - (DateTime)LoginTime).TotalSeconds;
+            LoginTime = null;
+        }
+
+        if (CombatTimer < Timing.Global.Milliseconds || force)
+        {
+            Logout(softLogout);
+        }
+    }
+
+    private void Logout(bool softLogout = false)
+    {
+        lock (_savingLock)
+        {
+            _saving = true;
+        }
+
+        if (MapController.TryGetInstanceFromMap(MapId, MapInstanceId, out var instance))
+        {
+            instance.RemoveEntity(this);
+        }
+
+        RemoveFromInstanceController(MapInstanceId);
+
+        //Update parties
+        LeaveParty();
+
+        //Update trade
+        CancelTrade();
+
+        mSentMap = false;
+        ChatTarget = null;
+
+        //Clear all event spawned NPC's
+        var entities = SpawnedNpcs.ToArray();
+        foreach (var t in entities)
+        {
+            if (t == null || t.GetType() != typeof(Npc))
             {
-                EventLookup.Clear();
-                EventBaseIdLookup.Clear();
-                GlobalPageInstanceLookup.Clear();
-                EventTileLookup.Clear();
+                continue;
             }
 
-            InGame = default;
-            mSentMap = default;
-            mCommonEventLaunches = default;
-            LastMapEntered = default;
-            ChatTarget = default;
-            QuestOffers.Clear();
-            OpenCraftingTableId = default;
-            CraftingState = default;
-            PartyRequester = default;
-            PartyRequests.Clear();
-            FriendRequester = default;
-            FriendRequests.Clear();
-            InBag = default;
-            BankInterface?.Dispose();
-            BankInterface = default;
-            InShop = default;
-
-            // Clear cooldowns that have expired
-            RemoveStaleItemCooldowns();
-            RemoveStaleSpellCooldowns();
-
-            PacketSender.SendEntityLeave(this);
-
-            if (!string.IsNullOrWhiteSpace(Strings.Player.left.ToString()))
+            if (t.Despawnable)
             {
-                PacketSender.SendGlobalMsg(Strings.Player.left.ToString(Name, Options.Instance.GameName));
+                lock (t.EntityLock)
+                {
+                    t.Die();
+                }
             }
+        }
 
-            // Remove this player from the online list
-            if (OnlinePlayers?.ContainsKey(Id) ?? false)
-            {
-                OnlinePlayers.TryRemove(Id, out Player _);
-                OnlineList = OnlinePlayers.Values.ToArray();
-            }
+        SpawnedNpcs.Clear();
 
-            //Send guild update to all members when logging out
-            Guild?.UpdateMemberList();
-            Guild = null;
-            GuildBank = false;
+        lock (mEventLock)
+        {
+            EventLookup.Clear();
+            EventBaseIdLookup.Clear();
+            GlobalPageInstanceLookup.Clear();
+            EventTileLookup.Clear();
+        }
 
-            //If our client has disconnected or logged out but we have kept the user logged in due to being in combat then we should try to logout the user now
-            if (Client == null)
-            {
-                User?.TryLogout(softLogout);
-            }
+        InGame = default;
+        mSentMap = default;
+        mCommonEventLaunches = default;
+        LastMapEntered = default;
+        ChatTarget = default;
+        QuestOffers.Clear();
+        OpenCraftingTableId = default;
+        CraftingState = default;
+        PartyRequester = default;
+        PartyRequests.Clear();
+        FriendRequester = default;
+        FriendRequests.Clear();
+        InBag = default;
+        BankInterface?.Dispose();
+        BankInterface = default;
+        InShop = default;
+
+        // Clear cooldowns that have expired
+        RemoveStaleItemCooldowns();
+        RemoveStaleSpellCooldowns();
+
+        PacketSender.SendEntityLeave(this);
+
+        if (!string.IsNullOrWhiteSpace(Strings.Player.left.ToString()))
+        {
+            PacketSender.SendGlobalMsg(Strings.Player.left.ToString(Name, Options.Instance.GameName));
+        }
+
+        // Remove this player from the online list
+        if (OnlinePlayers?.ContainsKey(Id) ?? false)
+        {
+            OnlinePlayers.TryRemove(Id, out Player _);
+            OnlineList = OnlinePlayers.Values.ToArray();
+        }
+
+        //Send guild update to all members when logging out
+        Guild?.UpdateMemberList();
+        Guild = null;
+        GuildBank = false;
+
+        //If our client has disconnected or logged out but we have kept the user logged in due to being in combat then we should try to logout the user now
+        if (Client == null)
+        {
+            User?.TryLogout(softLogout);
+        }
 
 #if DIAGNOSTIC
-            var stackTrace = Environment.StackTrace;
+        var stackTrace = Environment.StackTrace;
 #else
-            var stackTrace = default(string);
+        var stackTrace = default(string);
 #endif
-            var logoutOperationId = Guid.NewGuid();
-            DbInterface.Pool.QueueWorkItem(CompleteLogout, logoutOperationId, stackTrace);
+        var logoutOperationId = Guid.NewGuid();
+        DbInterface.Pool.QueueWorkItem(CompleteLogout, logoutOperationId, stackTrace);
+    }
+
+#if DIAGNOSTIC
+    private int _logoutCounter = 0;
+#endif
+
+    public void CompleteLogout(Guid logoutOperationId, string? stackTrace = default)
+    {
+        if (logoutOperationId != default)
+        {
+            Log.Debug($"Completing logout {logoutOperationId}");
+        }
+
+        if (stackTrace != default)
+        {
+            Log.Debug(stackTrace);
         }
 
 #if DIAGNOSTIC
-        private int _logoutCounter = 0;
+        var currentExecutionId = _logoutCounter++;
+        Log.Debug($"Started {nameof(CompleteLogout)}() #{currentExecutionId} on {Name} ({User?.Name})");
 #endif
 
-        public void CompleteLogout(Guid logoutOperationId, string? stackTrace = default)
+        try
         {
-            if (logoutOperationId != default)
+            Log.Diagnostic($"Starting save for logout {logoutOperationId}");
+            var saveResult = User?.Save();
+            switch (saveResult)
             {
-                Log.Debug($"Completing logout {logoutOperationId}");
+                case UserSaveResult.Completed:
+                    Log.Diagnostic($"Completed save for logout {logoutOperationId}");
+                    break;
+                case UserSaveResult.SkippedCouldNotTakeLock:
+                    Log.Debug($"Skipped save for logout {logoutOperationId}");
+                    break;
+                case UserSaveResult.Failed:
+                    Log.Warn($"Save failed for logout {logoutOperationId}");
+                    break;
+                case UserSaveResult.DatabaseFailure:
+                    Client?.LogAndDisconnect(Id, stackTrace ?? nameof(CompleteLogout));
+                    break;
+                case null:
+                    Log.Warn($"Skipped save because {nameof(User)} is null.");
+                    break;
+                default:
+                    throw new UnreachableException();
             }
+        }
+        catch
+        {
+            Log.Warn($"Crashed while saving for logout {logoutOperationId}");
+            throw;
+        }
 
-            if (stackTrace != default)
-            {
-                Log.Debug(stackTrace);
-            }
+        lock (_savingLock)
+        {
+            _saving = false;
+        }
+
+        Dispose();
 
 #if DIAGNOSTIC
-            var currentExecutionId = _logoutCounter++;
-            Log.Debug($"Started {nameof(CompleteLogout)}() #{currentExecutionId} on {Name} ({User?.Name})");
+        Log.Debug($"Finished {nameof(CompleteLogout)}() #{currentExecutionId} on {Name} ({User?.Name})");
 #endif
+    }
 
-            try
+    //Update
+    public override void Update(long timeMs)
+    {
+        if (!InGame || MapId == Guid.Empty)
+        {
+            return;
+        }
+
+        var lockObtained = false;
+        try
+        {
+            Monitor.TryEnter(EntityLock, ref lockObtained);
+            if (lockObtained)
             {
-                Log.Diagnostic($"Starting save for logout {logoutOperationId}");
-                var saveResult = User?.Save();
-                switch (saveResult)
+                if (Client == null) //Client logged out
                 {
-                    case UserSaveResult.Completed:
-                        Log.Diagnostic($"Completed save for logout {logoutOperationId}");
-                        break;
-                    case UserSaveResult.SkippedCouldNotTakeLock:
-                        Log.Debug($"Skipped save for logout {logoutOperationId}");
-                        break;
-                    case UserSaveResult.Failed:
-                        Log.Warn($"Save failed for logout {logoutOperationId}");
-                        break;
-                    case UserSaveResult.DatabaseFailure:
-                        Client?.LogAndDisconnect(Id, stackTrace ?? nameof(CompleteLogout));
-                        break;
-                    case null:
-                        Log.Warn($"Skipped save because {nameof(User)} is null.");
-                        break;
-                    default:
-                        throw new UnreachableException();
+                    if (CombatTimer < Timing.Global.Milliseconds)
+                    {
+                        Log.Debug($"Combat timer expired for player {Id}, logging out.");
+                        Logout();
+                        return;
+                    }
                 }
-            }
-            catch
-            {
-                Log.Warn($"Crashed while saving for logout {logoutOperationId}");
-                throw;
-            }
-
-            lock (_savingLock)
-            {
-                _saving = false;
-            }
-
-            Dispose();
-
-#if DIAGNOSTIC
-            Log.Debug($"Finished {nameof(CompleteLogout)}() #{currentExecutionId} on {Name} ({User?.Name})");
-#endif
-        }
-
-        //Update
-        public override void Update(long timeMs)
-        {
-            if (!InGame || MapId == Guid.Empty)
-            {
-                return;
-            }
-
-            var lockObtained = false;
-            try
-            {
-                Monitor.TryEnter(EntityLock, ref lockObtained);
-                if (lockObtained)
+                else
                 {
-                    if (Client == null) //Client logged out
+                    if (SaveTimer < Timing.Global.Milliseconds)
                     {
-                        if (CombatTimer < Timing.Global.Milliseconds)
+                        var user = User;
+                        if (user != null)
                         {
-                            Log.Debug($"Combat timer expired for player {Id}, logging out.");
-                            Logout();
-                            return;
+                            if (Client.IsEditor)
+                            {
+                                Log.Debug($"Editor saving user: {user.Name}");
+                            }
+
+                            DbInterface.Pool.QueueWorkItem(user.Save, false);
                         }
+                        SaveTimer = Timing.Global.Milliseconds + Options.Instance.Processing.PlayerSaveInterval;
                     }
-                    else
+                }
+
+                if (CraftingTableBase.TryGet(OpenCraftingTableId, out var b) && CraftingState?.Id != default)
+                {
+                    if (CraftingState != default && b.Crafts.Contains(CraftingState.Id))
                     {
-                        if (SaveTimer < Timing.Global.Milliseconds)
+                        while (CraftingState?.NextCraftCompletionTime < timeMs)
                         {
-                            var user = User;
-                            if (user != null)
+                            CraftItem();
+
+                            if (CraftingState != default)
                             {
-                                if (Client.IsEditor)
+                                CraftingState.NextCraftCompletionTime += CraftingState.DurationPerCraft;
+
+                                if (CraftingState.RemainingCount < 1)
                                 {
-                                    Log.Debug($"Editor saving user: {user.Name}");
+                                    CraftingState = default;
                                 }
-
-                                DbInterface.Pool.QueueWorkItem(user.Save, false);
                             }
-                            SaveTimer = Timing.Global.Milliseconds + Options.Instance.Processing.PlayerSaveInterval;
+
                         }
-                    }
 
-                    if (CraftingTableBase.TryGet(OpenCraftingTableId, out var b) && CraftingState?.Id != default)
-                    {
-                        if (CraftingState != default && b.Crafts.Contains(CraftingState.Id))
-                        {
-                            while (CraftingState?.NextCraftCompletionTime < timeMs)
-                            {
-                                CraftItem();
-
-                                if (CraftingState != default)
-                                {
-                                    CraftingState.NextCraftCompletionTime += CraftingState.DurationPerCraft;
-
-                                    if (CraftingState.RemainingCount < 1)
-                                    {
-                                        CraftingState = default;
-                                    }
-                                }
-
-                            }
-
-                            if (ShouldCancelCrafting())
-                            {
-                                CraftingState = default;
-                            }
-                        }
-                        else
+                        if (ShouldCancelCrafting())
                         {
                             CraftingState = default;
                         }
                     }
-
-                    // Check for stale cooldown values and remove them
-                    if (mStaleCooldownTimer <= Timing.Global.Milliseconds)
+                    else
                     {
-                        RemoveStaleItemCooldowns();
-                        RemoveStaleSpellCooldowns();
-
-                        // Increment our timer for the next check.
-                        mStaleCooldownTimer = Timing.Global.Milliseconds + Options.Instance.Processing.StaleCooldownRemovalTimer;
+                        CraftingState = default;
                     }
+                }
+
+                // Check for stale cooldown values and remove them
+                if (mStaleCooldownTimer <= Timing.Global.Milliseconds)
+                {
+                    RemoveStaleItemCooldowns();
+                    RemoveStaleSpellCooldowns();
+
+                    // Increment our timer for the next check.
+                    mStaleCooldownTimer = Timing.Global.Milliseconds + Options.Instance.Processing.StaleCooldownRemovalTimer;
+                }
 
 
-                    base.Update(timeMs);
+                base.Update(timeMs);
 
-                    if (mAutorunCommonEventTimer < Timing.Global.Milliseconds)
+                if (mAutorunCommonEventTimer < Timing.Global.Milliseconds)
+                {
+                    var autorunEvents = 0;
+                    //Check for autorun common events and run them
+                    foreach (var obj in EventBase.Lookup)
                     {
-                        var autorunEvents = 0;
-                        //Check for autorun common events and run them
-                        foreach (var obj in EventBase.Lookup)
+                        var evt = obj.Value as EventBase;
+                        if (evt != null && evt.CommonEvent)
                         {
-                            var evt = obj.Value as EventBase;
-                            if (evt != null && evt.CommonEvent)
+                            foreach (var page in evt.Pages)
                             {
-                                foreach (var page in evt.Pages)
+                                if (page.CommonTrigger == CommonEventTrigger.Autorun)
                                 {
-                                    if (page.CommonTrigger == CommonEventTrigger.Autorun)
+                                    if (Options.Instance.Metrics.Enable)
                                     {
-                                        if (Options.Instance.Metrics.Enable)
-                                        {
-                                            autorunEvents += evt.Pages.Count(p => p.CommonTrigger == CommonEventTrigger.Autorun);
-                                        }
-                                        EnqueueStartCommonEvent(evt, CommonEventTrigger.Autorun);
+                                        autorunEvents += evt.Pages.Count(p => p.CommonTrigger == CommonEventTrigger.Autorun);
                                     }
+                                    EnqueueStartCommonEvent(evt, CommonEventTrigger.Autorun);
                                 }
                             }
                         }
-
-                        mAutorunCommonEventTimer = Timing.Global.Milliseconds + Options.Instance.Processing.CommonEventAutorunStartInterval;
-                        CommonAutorunEvents = autorunEvents;
                     }
 
-                    //If we have a move route then let's process it....
-                    if (MoveRoute != null && MoveTimer < timeMs)
+                    mAutorunCommonEventTimer = Timing.Global.Milliseconds + Options.Instance.Processing.CommonEventAutorunStartInterval;
+                    CommonAutorunEvents = autorunEvents;
+                }
+
+                //If we have a move route then let's process it....
+                if (MoveRoute != null && MoveTimer < timeMs)
+                {
+                    //Check to see if the event instance is still active for us... if not then let's remove this route
+                    var foundEvent = false;
+                    foreach (var evt in EventLookup)
                     {
-                        //Check to see if the event instance is still active for us... if not then let's remove this route
-                        var foundEvent = false;
-                        foreach (var evt in EventLookup)
+                        if (evt.Value.PageInstance == MoveRouteSetter)
                         {
-                            if (evt.Value.PageInstance == MoveRouteSetter)
+                            foundEvent = true;
+                            if (MoveRoute.ActionIndex < MoveRoute.Actions.Count)
                             {
-                                foundEvent = true;
-                                if (MoveRoute.ActionIndex < MoveRoute.Actions.Count)
-                                {
-                                    ProcessMoveRoute(this, timeMs);
-                                }
-                                else
-                                {
-                                    if (MoveRoute.Complete && !MoveRoute.RepeatRoute)
-                                    {
-                                        MoveRoute = null;
-                                        MoveRouteSetter = null;
-                                        PacketSender.SendMoveRouteToggle(this, false);
-                                    }
-                                }
-
-                                break;
-                            }
-                        }
-
-                        if (!foundEvent)
-                        {
-                            MoveRoute = null;
-                            MoveRouteSetter = null;
-                            PacketSender.SendMoveRouteToggle(this, false);
-                        }
-                    }
-
-                    //If we switched maps, lets update the maps
-                    if (LastMapEntered != MapId)
-                    {
-                        if (MapController.TryGetInstanceFromMap(LastMapEntered, MapInstanceId, out var oldMapInstance))
-                        {
-                            oldMapInstance.RemoveEntity(this);
-                        }
-
-                        if (MapId != Guid.Empty)
-                        {
-                            if (!MapController.Lookup.Keys.Contains(MapId))
-                            {
-                                WarpToSpawn();
+                                ProcessMoveRoute(this, timeMs);
                             }
                             else
                             {
-                                if (MapController.TryGetInstanceFromMap(MapId, MapInstanceId, out var newMapInstance))
+                                if (MoveRoute.Complete && !MoveRoute.RepeatRoute)
                                 {
-                                    newMapInstance.PlayerEnteredMap(this);
+                                    MoveRoute = null;
+                                    MoveRouteSetter = null;
+                                    PacketSender.SendMoveRouteToggle(this, false);
                                 }
                             }
+
+                            break;
                         }
                     }
 
-                    var map = MapController.Get(MapId);
-                    foreach (var surrMap in map.GetSurroundingMaps(true))
+                    if (!foundEvent)
                     {
-                        if (surrMap == null)
+                        MoveRoute = null;
+                        MoveRouteSetter = null;
+                        PacketSender.SendMoveRouteToggle(this, false);
+                    }
+                }
+
+                //If we switched maps, lets update the maps
+                if (LastMapEntered != MapId)
+                {
+                    if (MapController.TryGetInstanceFromMap(LastMapEntered, MapInstanceId, out var oldMapInstance))
+                    {
+                        oldMapInstance.RemoveEntity(this);
+                    }
+
+                    if (MapId != Guid.Empty)
+                    {
+                        if (!MapController.Lookup.Keys.Contains(MapId))
                         {
-                            continue;
+                            WarpToSpawn();
                         }
-
-                        MapInstance mapInstance;
-                        // If the map does not yet have a MapInstance matching this player's instanceId, create one.
-                        lock (EntityLock)
+                        else
                         {
-                            if (!surrMap.TryGetInstance(MapInstanceId, out mapInstance))
+                            if (MapController.TryGetInstanceFromMap(MapId, MapInstanceId, out var newMapInstance))
                             {
-                                surrMap.TryCreateInstance(MapInstanceId, out mapInstance, this);
-                            }
-                        }
-
-                        //Check to see if we can spawn events, if already spawned.. update them.
-                        lock (mEventLock)
-                        {
-                            var autorunEvents = 0;
-                            foreach (var mapEvent in mapInstance.EventsCache)
-                            {
-                                if (mapEvent != null)
-                                {
-                                    //Look for event
-                                    var loc = new MapTileLoc(surrMap.Id, mapEvent.SpawnX, mapEvent.SpawnY);
-                                    var foundEvent = EventExists(loc);
-                                    if (foundEvent == null)
-                                    {
-                                        var tmpEvent = new Event(Guid.NewGuid(), surrMap, this, mapEvent)
-                                        {
-                                            Global = mapEvent.Global,
-                                            MapId = surrMap.Id,
-                                            SpawnX = mapEvent.SpawnX,
-                                            SpawnY = mapEvent.SpawnY
-                                        };
-
-                                        EventLookup.AddOrUpdate(tmpEvent.Id, tmpEvent, (key, oldValue) => tmpEvent);
-                                        EventBaseIdLookup.AddOrUpdate(mapEvent.Id, tmpEvent, (key, oldvalue) => tmpEvent);
-                                        //var newTileLookup = new Dictionary<MapTileLoc, Event>(EventTileLookup);
-                                        ////If we get a collision here we need to rethink the MapTileLoc struct..
-                                        ////We want a fast lookup through this dictionary and this is hopefully a solution over using a slow Tuple.
-                                        //newTileLookup.Add(loc, tmpEvent);
-                                        //EventTileLookup = newTileLookup;
-
-                                        EventTileLookup.AddOrUpdate(loc, tmpEvent, (key, oldvalue) => tmpEvent);
-                                    }
-                                    else
-                                    {
-                                        foundEvent.Update(timeMs, foundEvent.MapController);
-                                    }
-                                    if (Options.Instance.Metrics.Enable)
-                                    {
-                                        autorunEvents += mapEvent.Pages.Count(p => p.Trigger == EventTrigger.Autorun);
-                                    }
-                                }
-                            }
-                            MapAutorunEvents = autorunEvents;
-
-                            while (_queueStartCommonEvent.TryDequeue(out var startCommonEventMetadata))
-                            {
-                                _ = UnsafeStartCommonEvent(
-                                    startCommonEventMetadata.EventDescriptor,
-                                    startCommonEventMetadata.Trigger,
-                                    startCommonEventMetadata.Command,
-                                    startCommonEventMetadata.Parameter
-                                );
+                                newMapInstance.PlayerEnteredMap(this);
                             }
                         }
                     }
-
-                    map = MapController.Get(MapId);
-
-                    //Check to see if we can spawn events, if already spawned.. update them.
-                    lock (mEventLock)
-                    {
-                        foreach (var evt in EventLookup)
-                        {
-                            if (evt.Value == null)
-                            {
-                                continue;
-                            }
-
-                            var eventFound = false;
-                            var eventMap = map;
-
-                            if (evt.Value.MapId != Guid.Empty)
-                            {
-                                if (evt.Value.MapId != MapId)
-                                {
-                                    eventMap = evt.Value.MapController;
-                                    eventFound = map.SurroundingMapIds.Contains(eventMap.Id);
-                                }
-                                else
-                                {
-                                    eventFound = true;
-                                }
-                            }
-
-
-                            if (evt.Value.MapId == Guid.Empty)
-                            {
-                                evt.Value.Update(timeMs, eventMap);
-                                if (evt.Value.CallStack.Count > 0)
-                                {
-                                    eventFound = true;
-                                }
-                            }
-
-
-                            if (eventFound)
-                            {
-                                continue;
-                            }
-
-                            RemoveEvent(evt.Value.Id);
-                        }
-                    }
-                }
-            }
-            finally
-            {
-                if (lockObtained)
-                {
-                    Monitor.Exit(EntityLock);
-                }
-            }
-        }
-
-        /// <summary>
-        ///     Updates the player's spell cooldown for the specified <paramref name="spellBase"/>.
-        ///     <para> This method is called when a spell is casted by a player. </para>
-        /// </summary>
-        public override void UpdateSpellCooldown(SpellBase spellBase, int spellSlot)
-        {
-            if (spellSlot < 0 || spellSlot >= Options.MaxPlayerSkills)
-            {
-                return;
-            }
-
-            this.UpdateCooldown(spellBase);
-
-            // Trigger the global cooldown, if we're allowed to.
-            if (!spellBase.IgnoreGlobalCooldown)
-            {
-                this.UpdateGlobalCooldown();
-            }
-        }
-        
-        public void RemoveEvent(Guid id, bool sendLeave = true)
-        {
-            Event outInstance;
-            EventLookup.TryRemove(id, out outInstance);
-            if (outInstance != null)
-            {
-                EventBaseIdLookup.TryRemove(outInstance.BaseEvent.Id, out Event evt);
-            }
-            if (outInstance != null && outInstance.MapId != Guid.Empty)
-            {
-                //var newTileLookup = new Dictionary<MapTileLoc, Event>(EventTileLookup);
-                //newTileLookup.Remove(new MapTileLoc(outInstance.MapId, outInstance.SpawnX, outInstance.SpawnY));
-                //EventTileLookup = newTileLookup;
-                EventTileLookup.TryRemove(new MapTileLoc(outInstance.MapId, outInstance.SpawnX, outInstance.SpawnY), out Event val);
-            }
-            if (outInstance?.PageInstance?.GlobalClone != null)
-            {
-                GlobalPageInstanceLookup.TryRemove(outInstance.PageInstance.GlobalClone, out Event val);
-            }
-            if (sendLeave && outInstance != null && outInstance.MapId != Guid.Empty)
-            {
-                PacketSender.SendEntityLeaveTo(this, outInstance);
-            }
-        }
-
-        //Sending Data
-        public override EntityPacket EntityPacket(EntityPacket packet = null, Player forPlayer = null)
-        {
-            if (packet == null)
-            {
-                packet = new PlayerEntityPacket();
-            }
-
-            packet = base.EntityPacket(packet, forPlayer);
-
-            var pkt = (PlayerEntityPacket)packet;
-            pkt.Gender = Gender;
-            pkt.ClassId = ClassId;
-            pkt.Stats = GetStatValues();
-
-            if (Power.IsAdmin)
-            {
-                pkt.AccessLevel = Access.Admin;
-            }
-            else if (Power.IsModerator)
-            {
-                pkt.AccessLevel = Access.Moderator;
-            }
-            else
-            {
-                pkt.AccessLevel = Access.None;
-            }
-
-            if (CombatTimer > Timing.Global.Milliseconds)
-            {
-                pkt.CombatTimeRemaining = CombatTimer - Timing.Global.Milliseconds;
-            }
-
-            if (forPlayer != null && this is Player thisPlayer)
-            {
-                ((PlayerEntityPacket)packet).Equipment =
-                    PacketSender.GenerateEquipmentPacket(forPlayer, thisPlayer);
-            }
-
-            pkt.Guild = Guild?.Name;
-            pkt.GuildRank = GuildRank;
-
-            return pkt;
-        }
-
-        public override EntityType GetEntityType()
-        {
-            return EntityType.Player;
-        }
-
-        //Spawning/Dying
-        private void Respawn()
-        {
-            //Remove any damage over time effects
-            DoT.Clear();
-            CachedDots = new DoT[0];
-            Statuses.Clear();
-            CachedStatuses = new Status[0];
-
-            CombatTimer = 0;
-
-            var cls = ClassBase.Get(ClassId);
-            if (cls != null)
-            {
-                WarpToSpawn();
-            }
-            else
-            {
-                Warp(Guid.Empty, 0, 0, 0);
-            }
-
-            PacketSender.SendEntityDataToProximity(this);
-
-            //Search death common event trigger
-            StartCommonEventsWithTrigger(CommonEventTrigger.OnRespawn);
-        }
-
-        public override void Die(bool dropItems = true, Entity killer = null)
-        {
-            CastTime = 0;
-            CastTarget = null;
-
-            //Flag death to the client
-            PacketSender.SendPlayerDeath(this);
-
-            //Event trigger
-            foreach (var evt in EventLookup)
-            {
-                evt.Value.PlayerHasDied = true;
-            }
-
-            // Remove player from ALL threat lists.
-            foreach (var instance in MapController.GetSurroundingMapInstances(Map.Id, MapInstanceId, true))
-            {
-                foreach (var entity in instance.GetCachedEntities())
-                {
-                    if (entity is Npc npc)
-                    {
-                        npc.RemoveFromDamageMap(this);
-                    }
-                }
-            }
-
-            lock (EntityLock)
-            {
-                base.Die(dropItems, killer);
-            }
-
-
-            // EXP Loss - don't lose in shared instance, or in an Arena zone
-            if (InstanceType != MapInstanceType.Shared || Options.Instance.Instancing.LoseExpOnInstanceDeath)
-            {
-                if (Options.Instance.PlayerOpts.ExpLossOnDeathPercent > 0)
-                {
-                    if (Options.Instance.PlayerOpts.ExpLossFromCurrentExp)
-                    {
-                        var ExpLoss = (this.Exp * (Options.Instance.PlayerOpts.ExpLossOnDeathPercent / 100.0));
-                        TakeExperience((long)ExpLoss);
-                    }
-                    else
-                    {
-                        var ExpLoss = (GetExperienceToNextLevel(this.Level) * (Options.Instance.PlayerOpts.ExpLossOnDeathPercent / 100.0));
-                        TakeExperience((long)ExpLoss);
-                    }
-                }
-            }
-            PacketSender.SendEntityDie(this);
-            Reset();
-            Respawn();
-            PacketSender.SendInventory(this);
-        }
-
-        public override void ProcessRegen()
-        {
-            Debug.Assert(ClassBase.Lookup != null, "ClassBase.Lookup != null");
-
-            var playerClass = ClassBase.Get(ClassId);
-            if (playerClass?.VitalRegen == null)
-            {
-                return;
-            }
-
-            foreach (Vital vital in Enum.GetValues(typeof(Vital)))
-            {
-                if (!Enum.IsDefined(vital))
-                {
-                    continue;
                 }
 
-                var vitalId = (int)vital;
-                var vitalValue = GetVital(vital);
-                var maxVitalValue = GetMaxVital(vital);
-                if (vitalValue >= maxVitalValue)
+                var map = MapController.Get(MapId);
+                foreach (var surrMap in map.GetSurroundingMaps(true))
                 {
-                    continue;
-                }
-
-                var vitalRegenRate = (playerClass.VitalRegen[vitalId] + GetEquipmentVitalRegen(vital)) / 100f;
-                var regenValue = (long)Math.Max(1, maxVitalValue * vitalRegenRate) *
-                                 Math.Abs(Math.Sign(vitalRegenRate));
-
-                AddVital(vital, regenValue);
-            }
-        }
-
-        public override long GetMaxVital(int vital)
-        {
-            var classDescriptor = ClassBase.Get(this.ClassId);
-            long classVital = 20;
-            if (classDescriptor != null)
-            {
-                if (classDescriptor.IncreasePercentage)
-                {
-                    classVital = (long)(classDescriptor.BaseVital[vital] *
-                                        Math.Pow(1 + (double)classDescriptor.VitalIncrease[vital] / 100, Level - 1));
-                }
-                else
-                {
-                    classVital = classDescriptor.BaseVital[vital] + classDescriptor.VitalIncrease[vital] * (Level - 1);
-                }
-            }
-
-            var baseVital = classVital;
-
-            // Loop through equipment and see if any items grant vital buffs
-            foreach (var item in EquippedItems.ToArray())
-            {
-                if (ItemBase.TryGet(item.ItemId, out var descriptor))
-                {
-                    classVital += descriptor.VitalsGiven[vital] + descriptor.PercentageVitalsGiven[vital] * baseVital / 100;
-                }
-            }
-
-            //Must have at least 1 hp and no less than 0 mp
-            if (vital == (int)Vital.Health)
-            {
-                classVital = Math.Max(classVital, 1);
-            }
-            else if (vital == (int)Vital.Mana)
-            {
-                classVital = Math.Max(classVital, 0);
-            }
-
-            return classVital;
-        }
-
-        public override long GetMaxVital(Vital vital)
-        {
-            return GetMaxVital((int)vital);
-        }
-
-        public void FixVitals()
-        {
-            //If add/remove equipment then our vitals might exceed the new max.. this should fix those cases.
-            SetVital(Vital.Health, GetVital(Vital.Health));
-            SetVital(Vital.Mana, GetVital(Vital.Mana));
-        }
-
-        //Leveling
-        public void SetLevel(int level, bool resetExperience = false)
-        {
-            if (level < 1)
-            {
-                return;
-            }
-
-            Level = Math.Min(Options.MaxLevel, level);
-            if (resetExperience)
-            {
-                Exp = 0;
-            }
-
-            RecalculateStatsAndPoints();
-            UnequipInvalidItems();
-            PacketSender.SendEntityDataToProximity(this);
-            PacketSender.SendExperience(this);
-        }
-
-        public void LevelUp(bool resetExperience = true, int levels = 1)
-        {
-            var messages = new List<string>();
-            if (Level < Options.MaxLevel)
-            {
-                for (var i = 0; i < levels; i++)
-                {
-                    SetLevel(Level + 1, resetExperience);
-
-                    //Let's pull up class - leveling info
-                    var classDescriptor = ClassBase.Get(ClassId);
-                    if (classDescriptor?.Spells == null)
+                    if (surrMap == null)
                     {
                         continue;
                     }
 
-                    foreach (var spell in classDescriptor.Spells)
+                    MapInstance mapInstance;
+                    // If the map does not yet have a MapInstance matching this player's instanceId, create one.
+                    lock (EntityLock)
                     {
-                        if (spell.Level != Level)
+                        if (!surrMap.TryGetInstance(MapInstanceId, out mapInstance))
                         {
-                            continue;
+                            surrMap.TryCreateInstance(MapInstanceId, out mapInstance, this);
                         }
+                    }
 
-                        var spellInstance = new Spell(spell.Id);
-                        if (TryTeachSpell(spellInstance, true))
+                    //Check to see if we can spawn events, if already spawned.. update them.
+                    lock (mEventLock)
+                    {
+                        var autorunEvents = 0;
+                        foreach (var mapEvent in mapInstance.EventsCache)
                         {
-                            messages.Add(
-                                Strings.Player.spelltaughtlevelup.ToString(SpellBase.GetName(spellInstance.SpellId))
+                            if (mapEvent != null)
+                            {
+                                //Look for event
+                                var loc = new MapTileLoc(surrMap.Id, mapEvent.SpawnX, mapEvent.SpawnY);
+                                var foundEvent = EventExists(loc);
+                                if (foundEvent == null)
+                                {
+                                    var tmpEvent = new Event(Guid.NewGuid(), surrMap, this, mapEvent)
+                                    {
+                                        Global = mapEvent.Global,
+                                        MapId = surrMap.Id,
+                                        SpawnX = mapEvent.SpawnX,
+                                        SpawnY = mapEvent.SpawnY
+                                    };
+
+                                    EventLookup.AddOrUpdate(tmpEvent.Id, tmpEvent, (key, oldValue) => tmpEvent);
+                                    EventBaseIdLookup.AddOrUpdate(mapEvent.Id, tmpEvent, (key, oldvalue) => tmpEvent);
+                                    //var newTileLookup = new Dictionary<MapTileLoc, Event>(EventTileLookup);
+                                    ////If we get a collision here we need to rethink the MapTileLoc struct..
+                                    ////We want a fast lookup through this dictionary and this is hopefully a solution over using a slow Tuple.
+                                    //newTileLookup.Add(loc, tmpEvent);
+                                    //EventTileLookup = newTileLookup;
+
+                                    EventTileLookup.AddOrUpdate(loc, tmpEvent, (key, oldvalue) => tmpEvent);
+                                }
+                                else
+                                {
+                                    foundEvent.Update(timeMs, foundEvent.MapController);
+                                }
+                                if (Options.Instance.Metrics.Enable)
+                                {
+                                    autorunEvents += mapEvent.Pages.Count(p => p.Trigger == EventTrigger.Autorun);
+                                }
+                            }
+                        }
+                        MapAutorunEvents = autorunEvents;
+
+                        while (_queueStartCommonEvent.TryDequeue(out var startCommonEventMetadata))
+                        {
+                            _ = UnsafeStartCommonEvent(
+                                startCommonEventMetadata.EventDescriptor,
+                                startCommonEventMetadata.Trigger,
+                                startCommonEventMetadata.Command,
+                                startCommonEventMetadata.Parameter
                             );
                         }
                     }
                 }
-            }
 
-            PacketSender.SendChatMsg(this, Strings.Player.levelup.ToString(Level), ChatMessageType.Experience, CustomColors.Combat.LevelUp, Name);
-            PacketSender.SendActionMsg(this, Strings.Combat.levelup, CustomColors.Combat.LevelUp);
-            foreach (var message in messages)
+                map = MapController.Get(MapId);
+
+                //Check to see if we can spawn events, if already spawned.. update them.
+                lock (mEventLock)
+                {
+                    foreach (var evt in EventLookup)
+                    {
+                        if (evt.Value == null)
+                        {
+                            continue;
+                        }
+
+                        var eventFound = false;
+                        var eventMap = map;
+
+                        if (evt.Value.MapId != Guid.Empty)
+                        {
+                            if (evt.Value.MapId != MapId)
+                            {
+                                eventMap = evt.Value.MapController;
+                                eventFound = map.SurroundingMapIds.Contains(eventMap.Id);
+                            }
+                            else
+                            {
+                                eventFound = true;
+                            }
+                        }
+
+
+                        if (evt.Value.MapId == Guid.Empty)
+                        {
+                            evt.Value.Update(timeMs, eventMap);
+                            if (evt.Value.CallStack.Count > 0)
+                            {
+                                eventFound = true;
+                            }
+                        }
+
+
+                        if (eventFound)
+                        {
+                            continue;
+                        }
+
+                        RemoveEvent(evt.Value.Id);
+                    }
+                }
+            }
+        }
+        finally
+        {
+            if (lockObtained)
             {
-                PacketSender.SendChatMsg(this, message, ChatMessageType.Experience, CustomColors.Alerts.Info, Name);
+                Monitor.Exit(EntityLock);
             }
+        }
+    }
 
-            if (StatPoints > 0)
+    /// <summary>
+    ///     Updates the player's spell cooldown for the specified <paramref name="spellBase"/>.
+    ///     <para> This method is called when a spell is casted by a player. </para>
+    /// </summary>
+    public override void UpdateSpellCooldown(SpellBase spellBase, int spellSlot)
+    {
+        if (spellSlot < 0 || spellSlot >= Options.MaxPlayerSkills)
+        {
+            return;
+        }
+
+        this.UpdateCooldown(spellBase);
+
+        // Trigger the global cooldown, if we're allowed to.
+        if (!spellBase.IgnoreGlobalCooldown)
+        {
+            this.UpdateGlobalCooldown();
+        }
+    }
+    
+    public void RemoveEvent(Guid id, bool sendLeave = true)
+    {
+        Event outInstance;
+        EventLookup.TryRemove(id, out outInstance);
+        if (outInstance != null)
+        {
+            EventBaseIdLookup.TryRemove(outInstance.BaseEvent.Id, out Event evt);
+        }
+        if (outInstance != null && outInstance.MapId != Guid.Empty)
+        {
+            //var newTileLookup = new Dictionary<MapTileLoc, Event>(EventTileLookup);
+            //newTileLookup.Remove(new MapTileLoc(outInstance.MapId, outInstance.SpawnX, outInstance.SpawnY));
+            //EventTileLookup = newTileLookup;
+            EventTileLookup.TryRemove(new MapTileLoc(outInstance.MapId, outInstance.SpawnX, outInstance.SpawnY), out Event val);
+        }
+        if (outInstance?.PageInstance?.GlobalClone != null)
+        {
+            GlobalPageInstanceLookup.TryRemove(outInstance.PageInstance.GlobalClone, out Event val);
+        }
+        if (sendLeave && outInstance != null && outInstance.MapId != Guid.Empty)
+        {
+            PacketSender.SendEntityLeaveTo(this, outInstance);
+        }
+    }
+
+    //Sending Data
+    public override EntityPacket EntityPacket(EntityPacket packet = null, Player forPlayer = null)
+    {
+        if (packet == null)
+        {
+            packet = new PlayerEntityPacket();
+        }
+
+        packet = base.EntityPacket(packet, forPlayer);
+
+        var pkt = (PlayerEntityPacket)packet;
+        pkt.Gender = Gender;
+        pkt.ClassId = ClassId;
+        pkt.Stats = GetStatValues();
+
+        if (Power.IsAdmin)
+        {
+            pkt.AccessLevel = Access.Admin;
+        }
+        else if (Power.IsModerator)
+        {
+            pkt.AccessLevel = Access.Moderator;
+        }
+        else
+        {
+            pkt.AccessLevel = Access.None;
+        }
+
+        if (CombatTimer > Timing.Global.Milliseconds)
+        {
+            pkt.CombatTimeRemaining = CombatTimer - Timing.Global.Milliseconds;
+        }
+
+        if (forPlayer != null && this is Player thisPlayer)
+        {
+            ((PlayerEntityPacket)packet).Equipment =
+                PacketSender.GenerateEquipmentPacket(forPlayer, thisPlayer);
+        }
+
+        pkt.Guild = Guild?.Name;
+        pkt.GuildRank = GuildRank;
+
+        return pkt;
+    }
+
+    public override EntityType GetEntityType()
+    {
+        return EntityType.Player;
+    }
+
+    //Spawning/Dying
+    private void Respawn()
+    {
+        //Remove any damage over time effects
+        DoT.Clear();
+        CachedDots = new DoT[0];
+        Statuses.Clear();
+        CachedStatuses = new Status[0];
+
+        CombatTimer = 0;
+
+        var cls = ClassBase.Get(ClassId);
+        if (cls != null)
+        {
+            WarpToSpawn();
+        }
+        else
+        {
+            Warp(Guid.Empty, 0, 0, 0);
+        }
+
+        PacketSender.SendEntityDataToProximity(this);
+
+        //Search death common event trigger
+        StartCommonEventsWithTrigger(CommonEventTrigger.OnRespawn);
+    }
+
+    public override void Die(bool dropItems = true, Entity killer = null)
+    {
+        CastTime = 0;
+        CastTarget = null;
+
+        //Flag death to the client
+        PacketSender.SendPlayerDeath(this);
+
+        //Event trigger
+        foreach (var evt in EventLookup)
+        {
+            evt.Value.PlayerHasDied = true;
+        }
+
+        // Remove player from ALL threat lists.
+        foreach (var instance in MapController.GetSurroundingMapInstances(Map.Id, MapInstanceId, true))
+        {
+            foreach (var entity in instance.GetCachedEntities())
             {
-                PacketSender.SendChatMsg(
-                    this, Strings.Player.statpoints.ToString(StatPoints), ChatMessageType.Experience, CustomColors.Combat.StatPoints, Name
-                );
+                if (entity is Npc npc)
+                {
+                    npc.RemoveFromDamageMap(this);
+                }
+            }
+        }
+
+        lock (EntityLock)
+        {
+            base.Die(dropItems, killer);
+        }
+
+
+        // EXP Loss - don't lose in shared instance, or in an Arena zone
+        if (InstanceType != MapInstanceType.Shared || Options.Instance.Instancing.LoseExpOnInstanceDeath)
+        {
+            if (Options.Instance.PlayerOpts.ExpLossOnDeathPercent > 0)
+            {
+                if (Options.Instance.PlayerOpts.ExpLossFromCurrentExp)
+                {
+                    var ExpLoss = (this.Exp * (Options.Instance.PlayerOpts.ExpLossOnDeathPercent / 100.0));
+                    TakeExperience((long)ExpLoss);
+                }
+                else
+                {
+                    var ExpLoss = (GetExperienceToNextLevel(this.Level) * (Options.Instance.PlayerOpts.ExpLossOnDeathPercent / 100.0));
+                    TakeExperience((long)ExpLoss);
+                }
+            }
+        }
+        PacketSender.SendEntityDie(this);
+        Reset();
+        Respawn();
+        PacketSender.SendInventory(this);
+    }
+
+    public override void ProcessRegen()
+    {
+        Debug.Assert(ClassBase.Lookup != null, "ClassBase.Lookup != null");
+
+        var playerClass = ClassBase.Get(ClassId);
+        if (playerClass?.VitalRegen == null)
+        {
+            return;
+        }
+
+        foreach (Vital vital in Enum.GetValues(typeof(Vital)))
+        {
+            if (!Enum.IsDefined(vital))
+            {
+                continue;
             }
 
-            RecalculateStatsAndPoints();
-            UnequipInvalidItems();
+            var vitalId = (int)vital;
+            var vitalValue = GetVital(vital);
+            var maxVitalValue = GetMaxVital(vital);
+            if (vitalValue >= maxVitalValue)
+            {
+                continue;
+            }
+
+            var vitalRegenRate = (playerClass.VitalRegen[vitalId] + GetEquipmentVitalRegen(vital)) / 100f;
+            var regenValue = (long)Math.Max(1, maxVitalValue * vitalRegenRate) *
+                             Math.Abs(Math.Sign(vitalRegenRate));
+
+            AddVital(vital, regenValue);
+        }
+    }
+
+    public override long GetMaxVital(int vital)
+    {
+        var classDescriptor = ClassBase.Get(this.ClassId);
+        long classVital = 20;
+        if (classDescriptor != null)
+        {
+            if (classDescriptor.IncreasePercentage)
+            {
+                classVital = (long)(classDescriptor.BaseVital[vital] *
+                                    Math.Pow(1 + (double)classDescriptor.VitalIncrease[vital] / 100, Level - 1));
+            }
+            else
+            {
+                classVital = classDescriptor.BaseVital[vital] + classDescriptor.VitalIncrease[vital] * (Level - 1);
+            }
+        }
+
+        var baseVital = classVital;
+
+        // Loop through equipment and see if any items grant vital buffs
+        foreach (var item in EquippedItems.ToArray())
+        {
+            if (ItemBase.TryGet(item.ItemId, out var descriptor))
+            {
+                classVital += descriptor.VitalsGiven[vital] + descriptor.PercentageVitalsGiven[vital] * baseVital / 100;
+            }
+        }
+
+        //Must have at least 1 hp and no less than 0 mp
+        if (vital == (int)Vital.Health)
+        {
+            classVital = Math.Max(classVital, 1);
+        }
+        else if (vital == (int)Vital.Mana)
+        {
+            classVital = Math.Max(classVital, 0);
+        }
+
+        return classVital;
+    }
+
+    public override long GetMaxVital(Vital vital)
+    {
+        return GetMaxVital((int)vital);
+    }
+
+    public void FixVitals()
+    {
+        //If add/remove equipment then our vitals might exceed the new max.. this should fix those cases.
+        SetVital(Vital.Health, GetVital(Vital.Health));
+        SetVital(Vital.Mana, GetVital(Vital.Mana));
+    }
+
+    //Leveling
+    public void SetLevel(int level, bool resetExperience = false)
+    {
+        if (level < 1)
+        {
+            return;
+        }
+
+        Level = Math.Min(Options.MaxLevel, level);
+        if (resetExperience)
+        {
+            Exp = 0;
+        }
+
+        RecalculateStatsAndPoints();
+        UnequipInvalidItems();
+        PacketSender.SendEntityDataToProximity(this);
+        PacketSender.SendExperience(this);
+    }
+
+    public void LevelUp(bool resetExperience = true, int levels = 1)
+    {
+        var messages = new List<string>();
+        if (Level < Options.MaxLevel)
+        {
+            for (var i = 0; i < levels; i++)
+            {
+                SetLevel(Level + 1, resetExperience);
+
+                //Let's pull up class - leveling info
+                var classDescriptor = ClassBase.Get(ClassId);
+                if (classDescriptor?.Spells == null)
+                {
+                    continue;
+                }
+
+                foreach (var spell in classDescriptor.Spells)
+                {
+                    if (spell.Level != Level)
+                    {
+                        continue;
+                    }
+
+                    var spellInstance = new Spell(spell.Id);
+                    if (TryTeachSpell(spellInstance, true))
+                    {
+                        messages.Add(
+                            Strings.Player.spelltaughtlevelup.ToString(SpellBase.GetName(spellInstance.SpellId))
+                        );
+                    }
+                }
+            }
+        }
+
+        PacketSender.SendChatMsg(this, Strings.Player.levelup.ToString(Level), ChatMessageType.Experience, CustomColors.Combat.LevelUp, Name);
+        PacketSender.SendActionMsg(this, Strings.Combat.levelup, CustomColors.Combat.LevelUp);
+        foreach (var message in messages)
+        {
+            PacketSender.SendChatMsg(this, message, ChatMessageType.Experience, CustomColors.Alerts.Info, Name);
+        }
+
+        if (StatPoints > 0)
+        {
+            PacketSender.SendChatMsg(
+                this, Strings.Player.statpoints.ToString(StatPoints), ChatMessageType.Experience, CustomColors.Combat.StatPoints, Name
+            );
+        }
+
+        RecalculateStatsAndPoints();
+        UnequipInvalidItems();
+        PacketSender.SendExperience(this);
+        PacketSender.SendPointsTo(this);
+        PacketSender.SendEntityDataToProximity(this);
+
+        //Search for level up activated events and run them
+        StartCommonEventsWithTrigger(CommonEventTrigger.LevelUp);
+    }
+
+    public void GiveExperience(long amount)
+    {
+        Exp += (int)Math.Round(amount + (amount * (GetEquipmentBonusEffect(ItemEffect.EXP) / 100f)));
+        if (Exp < 0)
+        {
+            Exp = 0;
+        }
+
+        if (!CheckLevelUp())
+        {
             PacketSender.SendExperience(this);
-            PacketSender.SendPointsTo(this);
-            PacketSender.SendEntityDataToProximity(this);
+        }
+    }
 
-            //Search for level up activated events and run them
-            StartCommonEventsWithTrigger(CommonEventTrigger.LevelUp);
+    public void TakeExperience(long amount)
+    {
+        if (this is Player && Options.Instance.MapOpts.DisableExpLossInArenaMaps && Map.ZoneType == MapZone.Arena)
+        {
+            return;
         }
 
-        public void GiveExperience(long amount)
+        Exp -= amount;
+        if (Exp < 0)
         {
-            Exp += (int)Math.Round(amount + (amount * (GetEquipmentBonusEffect(ItemEffect.EXP) / 100f)));
-            if (Exp < 0)
-            {
-                Exp = 0;
-            }
-
-            if (!CheckLevelUp())
-            {
-                PacketSender.SendExperience(this);
-            }
+            Exp = 0;
         }
 
-        public void TakeExperience(long amount)
+        PacketSender.SendExperience(this);
+    }
+
+    private bool CheckLevelUp()
+    {
+        var levelCount = 0;
+        while (Exp >= GetExperienceToNextLevel(Level + levelCount) &&
+               GetExperienceToNextLevel(Level + levelCount) > 0)
         {
-            if (this is Player && Options.Instance.MapOpts.DisableExpLossInArenaMaps && Map.ZoneType == MapZone.Arena)
-            {
-                return;
-            }
-
-            Exp -= amount;
-            if (Exp < 0)
-            {
-                Exp = 0;
-            }
-
-            PacketSender.SendExperience(this);
+            Exp -= GetExperienceToNextLevel(Level + levelCount);
+            levelCount++;
         }
 
-        private bool CheckLevelUp()
+        if (levelCount <= 0)
         {
-            var levelCount = 0;
-            while (Exp >= GetExperienceToNextLevel(Level + levelCount) &&
-                   GetExperienceToNextLevel(Level + levelCount) > 0)
-            {
-                Exp -= GetExperienceToNextLevel(Level + levelCount);
-                levelCount++;
-            }
-
-            if (levelCount <= 0)
-            {
-                return false;
-            }
-
-            LevelUp(false, levelCount);
-
-            return true;
+            return false;
         }
 
-        //Combat
-        public override void KilledEntity(Entity entity)
+        LevelUp(false, levelCount);
+
+        return true;
+    }
+
+    //Combat
+    public override void KilledEntity(Entity entity)
+    {
+        switch (entity)
         {
-            switch (entity)
-            {
-                case Npc npc:
+            case Npc npc:
+                {
+                    var descriptor = npc.Base;
+                    var playerEvent = descriptor.OnDeathEvent;
+                    var partyEvent = descriptor.OnDeathPartyEvent;
+
+                    // If in party, split the exp.
+                    if (Party != null && Party.Count > 0)
                     {
-                        var descriptor = npc.Base;
-                        var playerEvent = descriptor.OnDeathEvent;
-                        var partyEvent = descriptor.OnDeathPartyEvent;
-
-                        // If in party, split the exp.
-                        if (Party != null && Party.Count > 0)
+                        var partyMembersInXpRange = Party.Where(partyMember => partyMember.InRangeOf(this, Options.Party.SharedXpRange)).ToArray();
+                        float bonusExp = Options.Instance.PartyOpts.BonusExperiencePercentPerMember / 100;
+                        var multiplier = 1.0f + (partyMembersInXpRange.Length * bonusExp);
+                        var partyExperience = (int)(descriptor.Experience * multiplier) / partyMembersInXpRange.Length;
+                        foreach (var partyMember in partyMembersInXpRange)
                         {
-                            var partyMembersInXpRange = Party.Where(partyMember => partyMember.InRangeOf(this, Options.Party.SharedXpRange)).ToArray();
-                            float bonusExp = Options.Instance.PartyOpts.BonusExperiencePercentPerMember / 100;
-                            var multiplier = 1.0f + (partyMembersInXpRange.Length * bonusExp);
-                            var partyExperience = (int)(descriptor.Experience * multiplier) / partyMembersInXpRange.Length;
-                            foreach (var partyMember in partyMembersInXpRange)
-                            {
-                                partyMember.GiveExperience(partyExperience);
-                                partyMember.UpdateQuestKillTasks(entity);
-                            }
+                            partyMember.GiveExperience(partyExperience);
+                            partyMember.UpdateQuestKillTasks(entity);
+                        }
 
-                            if (partyEvent != null)
+                        if (partyEvent != null)
+                        {
+                            foreach (var partyMember in Party)
                             {
-                                foreach (var partyMember in Party)
+                                if ((Options.Party.NpcDeathCommonEventStartRange <= 0 || partyMember.InRangeOf(this, Options.Party.NpcDeathCommonEventStartRange)) && !(partyMember == this && playerEvent != null))
                                 {
-                                    if ((Options.Party.NpcDeathCommonEventStartRange <= 0 || partyMember.InRangeOf(this, Options.Party.NpcDeathCommonEventStartRange)) && !(partyMember == this && playerEvent != null))
-                                    {
-                                        partyMember.EnqueueStartCommonEvent(partyEvent);
-                                    }
+                                    partyMember.EnqueueStartCommonEvent(partyEvent);
                                 }
                             }
                         }
-                        else
-                        {
-                            GiveExperience(descriptor.Experience);
-                            UpdateQuestKillTasks(entity);
-                        }
-
-                        if (playerEvent != null)
-                        {
-                            EnqueueStartCommonEvent(playerEvent);
-                        }
-
-                        break;
-                    }
-
-                case Resource resource:
-                    {
-                        var descriptor = resource.Base;
-                        if (descriptor?.Event != null)
-                        {
-                            EnqueueStartCommonEvent(descriptor.Event);
-                        }
-
-                        break;
-                    }
-            }
-        }
-
-        public void UpdateQuestKillTasks(Entity en)
-        {
-            //If any quests demand that this Npc be killed then let's handle it
-            var npc = (Npc)en;
-            foreach (var questProgress in Quests)
-            {
-                var questId = questProgress.QuestId;
-                var quest = QuestBase.Get(questId);
-                if (quest != null)
-                {
-                    if (questProgress.TaskId != Guid.Empty)
-                    {
-                        //Assume this quest is in progress. See if we can find the task in the quest
-                        var questTask = quest.FindTask(questProgress.TaskId);
-                        if (questTask != null)
-                        {
-                            if (questTask.Objective == QuestObjective.KillNpcs && questTask.TargetId == npc.Base.Id)
-                            {
-                                questProgress.TaskProgress++;
-                                if (questProgress.TaskProgress >= questTask.Quantity)
-                                {
-                                    CompleteQuestTask(questId, questProgress.TaskId);
-                                }
-                                else
-                                {
-                                    PacketSender.SendQuestsProgress(this);
-                                    PacketSender.SendChatMsg(
-                                        this,
-                                        Strings.Quests.npctask.ToString(
-                                            quest.Name, questProgress.TaskProgress, questTask.Quantity,
-                                            NpcBase.GetName(questTask.TargetId)
-                                        ),
-                                        ChatMessageType.Quest
-                                    );
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            UnequipInvalidItems();
-        }
-
-        public override void TryAttack(Entity target,
-            ProjectileBase projectile,
-            SpellBase parentSpell,
-            ItemBase parentItem,
-            Direction projectileDir)
-        {
-            if (!CanAttack(target, parentSpell))
-            {
-                return;
-            }
-
-            LastAttackingWeapon = parentItem;
-
-            //If Entity is resource, check for the correct tool and make sure its not a spell cast.
-            if (target is Resource resource)
-            {
-                if (resource.IsDead())
-                {
-                    return;
-                }
-
-                // We don't here deal in them fancy projectile tools o'er in dis town!
-                if (parentSpell != null || projectile != null)
-                {
-                    return;
-                }
-
-                // Check that a resource is actually required.
-                var descriptor = resource.Base;
-
-                //Check Dynamic Requirements
-                if (!Conditions.MeetsConditionLists(descriptor.HarvestingRequirements, this, null))
-                {
-                    if (!string.IsNullOrWhiteSpace(descriptor.CannotHarvestMessage))
-                    {
-                        PacketSender.SendChatMsg(this, descriptor.CannotHarvestMessage, ChatMessageType.Error);
                     }
                     else
                     {
-                        PacketSender.SendChatMsg(this, Strings.Combat.resourcereqs, ChatMessageType.Error);
+                        GiveExperience(descriptor.Experience);
+                        UpdateQuestKillTasks(entity);
                     }
+
+                    if (playerEvent != null)
+                    {
+                        EnqueueStartCommonEvent(playerEvent);
+                    }
+
+                    break;
+                }
+
+            case Resource resource:
+                {
+                    var descriptor = resource.Base;
+                    if (descriptor?.Event != null)
+                    {
+                        EnqueueStartCommonEvent(descriptor.Event);
+                    }
+
+                    break;
+                }
+        }
+    }
+
+    public void UpdateQuestKillTasks(Entity en)
+    {
+        //If any quests demand that this Npc be killed then let's handle it
+        var npc = (Npc)en;
+        foreach (var questProgress in Quests)
+        {
+            var questId = questProgress.QuestId;
+            var quest = QuestBase.Get(questId);
+            if (quest != null)
+            {
+                if (questProgress.TaskId != Guid.Empty)
+                {
+                    //Assume this quest is in progress. See if we can find the task in the quest
+                    var questTask = quest.FindTask(questProgress.TaskId);
+                    if (questTask != null)
+                    {
+                        if (questTask.Objective == QuestObjective.KillNpcs && questTask.TargetId == npc.Base.Id)
+                        {
+                            questProgress.TaskProgress++;
+                            if (questProgress.TaskProgress >= questTask.Quantity)
+                            {
+                                CompleteQuestTask(questId, questProgress.TaskId);
+                            }
+                            else
+                            {
+                                PacketSender.SendQuestsProgress(this);
+                                PacketSender.SendChatMsg(
+                                    this,
+                                    Strings.Quests.npctask.ToString(
+                                        quest.Name, questProgress.TaskProgress, questTask.Quantity,
+                                        NpcBase.GetName(questTask.TargetId)
+                                    ),
+                                    ChatMessageType.Quest
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        UnequipInvalidItems();
+    }
+
+    public override void TryAttack(Entity target,
+        ProjectileBase projectile,
+        SpellBase parentSpell,
+        ItemBase parentItem,
+        Direction projectileDir)
+    {
+        if (!CanAttack(target, parentSpell))
+        {
+            return;
+        }
+
+        LastAttackingWeapon = parentItem;
+
+        //If Entity is resource, check for the correct tool and make sure its not a spell cast.
+        if (target is Resource resource)
+        {
+            if (resource.IsDead())
+            {
+                return;
+            }
+
+            // We don't here deal in them fancy projectile tools o'er in dis town!
+            if (parentSpell != null || projectile != null)
+            {
+                return;
+            }
+
+            // Check that a resource is actually required.
+            var descriptor = resource.Base;
+
+            //Check Dynamic Requirements
+            if (!Conditions.MeetsConditionLists(descriptor.HarvestingRequirements, this, null))
+            {
+                if (!string.IsNullOrWhiteSpace(descriptor.CannotHarvestMessage))
+                {
+                    PacketSender.SendChatMsg(this, descriptor.CannotHarvestMessage, ChatMessageType.Error);
+                }
+                else
+                {
+                    PacketSender.SendChatMsg(this, Strings.Combat.resourcereqs, ChatMessageType.Error);
+                }
+
+                return;
+            }
+
+            if (descriptor.Tool > -1 && descriptor.Tool < Options.ToolTypes.Count)
+            {
+                if (parentItem == null || descriptor.Tool != parentItem.Tool)
+                {
+                    PacketSender.SendChatMsg(
+                        this, Strings.Combat.toolrequired.ToString(Options.ToolTypes[descriptor.Tool]), ChatMessageType.Error
+                    );
 
                     return;
                 }
-
-                if (descriptor.Tool > -1 && descriptor.Tool < Options.ToolTypes.Count)
-                {
-                    if (parentItem == null || descriptor.Tool != parentItem.Tool)
-                    {
-                        PacketSender.SendChatMsg(
-                            this, Strings.Combat.toolrequired.ToString(Options.ToolTypes[descriptor.Tool]), ChatMessageType.Error
-                        );
-
-                        return;
-                    }
-                }
             }
-
-            //Check for taunt status and trying to attack a target that has not taunted you.
-            if (!ValidTauntTarget(target))
-            {
-                return;
-            }
-
-            base.TryAttack(target, projectile, parentSpell, parentItem, projectileDir);
         }
 
-        protected override void ReactToDamage(Vital vital)
+        //Check for taunt status and trying to attack a target that has not taunted you.
+        if (!ValidTauntTarget(target))
         {
-            if (IsDead() || IsDisposed)
-            {
-                base.ReactToDamage(vital);
-                return;
-            }
+            return;
+        }
 
-            if (vital == Vital.Health)
-            {
-                foreach (var trigger in CachedEquipmentOnDamageTriggers)
-                {
-                    EnqueueStartCommonEvent(trigger);
-                }
-            }
+        base.TryAttack(target, projectile, parentSpell, parentItem, projectileDir);
+    }
 
+    protected override void ReactToDamage(Vital vital)
+    {
+        if (IsDead() || IsDisposed)
+        {
             base.ReactToDamage(vital);
+            return;
         }
 
-        protected override void CheckForOnhitAttack(Entity enemy, bool isAutoAttack)
+        if (vital == Vital.Health)
         {
-            if (isAutoAttack)
+            foreach (var trigger in CachedEquipmentOnDamageTriggers)
             {
-                EnqueueStartCommonEvent(LastAttackingWeapon?.GetEventTrigger(ItemEventTriggers.OnHit));
-                foreach (var trigger in CachedEquipmentOnHitTriggers)
-                {
-                    EnqueueStartCommonEvent(trigger);
-                }
+                EnqueueStartCommonEvent(trigger);
             }
-
-            base.CheckForOnhitAttack(enemy, isAutoAttack);
         }
 
-        //Attacking with spell
-        public override void TryAttack(
-            Entity target,
-            SpellBase spellBase,
-            bool onHitTrigger = false,
-            bool trapTrigger = false
-        )
-        {   
-            if (!trapTrigger && !ValidTauntTarget(target)) //Traps ignore taunts.
-            {
-                return;
-            }
+        base.ReactToDamage(vital);
+    }
 
-            base.TryAttack(target, spellBase, onHitTrigger, trapTrigger);
-        }
-
-        /// <summary>
-        /// Check for taunt status and trying to attack a target that has not taunted you.
-        /// </summary>
-        /// <param name="target">The target the player is attempting to attack</param>
-        /// <returns>True if the player can attack that target according to their taunt status</returns>
-        public bool ValidTauntTarget(Entity target)
+    protected override void CheckForOnhitAttack(Entity enemy, bool isAutoAttack)
+    {
+        if (isAutoAttack)
         {
-            if (CachedStatuses?.All(status => status.Type != SpellEffect.Taunt) ?? true)
+            EnqueueStartCommonEvent(LastAttackingWeapon?.GetEventTrigger(ItemEventTriggers.OnHit));
+            foreach (var trigger in CachedEquipmentOnHitTriggers)
             {
-                return true;
+                EnqueueStartCommonEvent(trigger);
             }
+        }
 
-            if (Target != target)
-            {
-                PacketSender.SendActionMsg(this, Strings.Combat.miss, CustomColors.Combat.Missed);
-                return false;
-            }
+        base.CheckForOnhitAttack(enemy, isAutoAttack);
+    }
 
+    //Attacking with spell
+    public override void TryAttack(
+        Entity target,
+        SpellBase spellBase,
+        bool onHitTrigger = false,
+        bool trapTrigger = false
+    )
+    {   
+        if (!trapTrigger && !ValidTauntTarget(target)) //Traps ignore taunts.
+        {
+            return;
+        }
+
+        base.TryAttack(target, spellBase, onHitTrigger, trapTrigger);
+    }
+
+    /// <summary>
+    /// Check for taunt status and trying to attack a target that has not taunted you.
+    /// </summary>
+    /// <param name="target">The target the player is attempting to attack</param>
+    /// <returns>True if the player can attack that target according to their taunt status</returns>
+    public bool ValidTauntTarget(Entity target)
+    {
+        if (CachedStatuses?.All(status => status.Type != SpellEffect.Taunt) ?? true)
+        {
             return true;
         }
 
-        public void TryAttack(Entity target)
+        if (Target != target)
         {
-            if (IsCasting)
+            PacketSender.SendActionMsg(this, Strings.Combat.miss, CustomColors.Combat.Missed);
+            return false;
+        }
+
+        return true;
+    }
+
+    public void TryAttack(Entity target)
+    {
+        if (IsCasting)
+        {
+            if (Options.Combat.EnableCombatChatMessages)
             {
-                if (Options.Combat.EnableCombatChatMessages)
+                PacketSender.SendChatMsg(this, Strings.Combat.channelingnoattack, ChatMessageType.Combat);
+            }
+
+            return;
+        }
+
+        if (!IsOneBlockAway(target))
+        {
+            return;
+        }
+
+        if (!CanAttack(target, null))
+        {
+            return;
+        }
+
+        if (target is EventPage)
+        {
+            return;
+        }
+
+        var weapon = TryGetEquippedItem(Options.WeaponIndex, out var item) ? item.Descriptor : null;
+
+        //If Entity is resource, check for the correct tool and make sure its not a spell cast.
+        if (target is Resource resource)
+        {
+            if (resource.IsDead())
+            {
+                return;
+            }
+
+            // Check that a resource is actually required.
+            var descriptor = resource.Base;
+
+            //Check Dynamic Requirements
+            if (!Conditions.MeetsConditionLists(descriptor.HarvestingRequirements, this, null))
+            {
+                if (!string.IsNullOrWhiteSpace(descriptor.CannotHarvestMessage))
                 {
-                    PacketSender.SendChatMsg(this, Strings.Combat.channelingnoattack, ChatMessageType.Combat);
+                    PacketSender.SendChatMsg(this, descriptor.CannotHarvestMessage, ChatMessageType.Error);
+                }
+                else
+                {
+                    PacketSender.SendChatMsg(this, Strings.Combat.resourcereqs, ChatMessageType.Error);
                 }
 
                 return;
             }
 
-            if (!IsOneBlockAway(target))
+            if (descriptor.Tool > -1 && descriptor.Tool < Options.ToolTypes.Count)
             {
-                return;
-            }
-
-            if (!CanAttack(target, null))
-            {
-                return;
-            }
-
-            if (target is EventPage)
-            {
-                return;
-            }
-
-            var weapon = TryGetEquippedItem(Options.WeaponIndex, out var item) ? item.Descriptor : null;
-
-            //If Entity is resource, check for the correct tool and make sure its not a spell cast.
-            if (target is Resource resource)
-            {
-                if (resource.IsDead())
+                if (weapon == null || descriptor.Tool != weapon.Tool)
                 {
+                    PacketSender.SendChatMsg(
+                        this, Strings.Combat.toolrequired.ToString(Options.ToolTypes[descriptor.Tool]), ChatMessageType.Error
+                    );
+
                     return;
                 }
-
-                // Check that a resource is actually required.
-                var descriptor = resource.Base;
-
-                //Check Dynamic Requirements
-                if (!Conditions.MeetsConditionLists(descriptor.HarvestingRequirements, this, null))
-                {
-                    if (!string.IsNullOrWhiteSpace(descriptor.CannotHarvestMessage))
-                    {
-                        PacketSender.SendChatMsg(this, descriptor.CannotHarvestMessage, ChatMessageType.Error);
-                    }
-                    else
-                    {
-                        PacketSender.SendChatMsg(this, Strings.Combat.resourcereqs, ChatMessageType.Error);
-                    }
-
-                    return;
-                }
-
-                if (descriptor.Tool > -1 && descriptor.Tool < Options.ToolTypes.Count)
-                {
-                    if (weapon == null || descriptor.Tool != weapon.Tool)
-                    {
-                        PacketSender.SendChatMsg(
-                            this, Strings.Combat.toolrequired.ToString(Options.ToolTypes[descriptor.Tool]), ChatMessageType.Error
-                        );
-
-                        return;
-                    }
-                }
             }
+        }
 
-            LastAttackingWeapon = weapon;
+        LastAttackingWeapon = weapon;
 
-            if (weapon != null)
+        if (weapon != null)
+        {
+            base.TryAttack(
+                target, weapon.Damage, (DamageType)weapon.DamageType, (Stat)weapon.ScalingStat, weapon.Scaling,
+                weapon.CritChance, weapon.CritMultiplier, null, null, weapon
+            );
+        }
+        else
+        {
+            var classBase = ClassBase.Get(ClassId);
+            if (classBase != null)
             {
                 base.TryAttack(
-                    target, weapon.Damage, (DamageType)weapon.DamageType, (Stat)weapon.ScalingStat, weapon.Scaling,
-                    weapon.CritChance, weapon.CritMultiplier, null, null, weapon
+                    target, classBase.Damage, (DamageType)classBase.DamageType, (Stat)classBase.ScalingStat,
+                    classBase.Scaling, classBase.CritChance, classBase.CritMultiplier
                 );
             }
             else
             {
-                var classBase = ClassBase.Get(ClassId);
-                if (classBase != null)
-                {
-                    base.TryAttack(
-                        target, classBase.Damage, (DamageType)classBase.DamageType, (Stat)classBase.ScalingStat,
-                        classBase.Scaling, classBase.CritChance, classBase.CritMultiplier
-                    );
-                }
-                else
-                {
-                    base.TryAttack(target, 1, DamageType.Physical, Enums.Stat.Attack, 100, 10, 1.5);
-                }
+                base.TryAttack(target, 1, DamageType.Physical, Enums.Stat.Attack, 100, 10, 1.5);
             }
         }
+    }
 
-        public override bool CanAttack(Entity entity, SpellBase spell)
+    public override bool CanAttack(Entity entity, SpellBase spell)
+    {
+        var npc = entity as Npc;
+        if (npc != default && !npc.CanPlayerAttack(this))
         {
-            var npc = entity as Npc;
-            if (npc != default && !npc.CanPlayerAttack(this))
-            {
-                return false;
-            }
+            return false;
+        }
 
-            if (spell?.Combat?.TargetType == SpellTargetType.Self ||
-                spell?.Combat?.TargetType == SpellTargetType.Projectile ||
-                spell?.SpellType == SpellType.Dash
-                )
-            {
-                return true;
-            }
-
-            if (!base.CanAttack(entity, spell))
-            {
-                return false;
-            }
-
-            if (entity is EventPageInstance)
-            {
-                return false;
-            }
-
-            var friendly = spell?.Combat != null && spell.Combat.Friendly;
-            if (entity is Player player)
-            {
-                if (player.InParty(this) || this == player || (!Options.Instance.Guild.AllowGuildMemberPvp && friendly != (player.Guild != null && player.Guild == this.Guild)))
-                {
-                    return friendly;
-                }
-
-                // Only count safe zones and friendly fire if its a dangerous spell! (If one has been used)
-                // Projectiles are ignored here, because we can always fire those.. Whether they hit or not is a problem for later.
-                if (!friendly && (spell?.Combat?.TargetType != SpellTargetType.Self && spell?.Combat?.TargetType != SpellTargetType.AoE && spell?.SpellType == SpellType.CombatSpell))
-                {
-                    // Check if either the attacker or the defender is in a "safe zone" (Only apply if combat is PVP)
-                    if (MapController.Get(MapId).ZoneType == MapZone.Safe || MapController.Get(player.MapId).ZoneType == MapZone.Safe)
-                    {
-                        return false;
-                    }
-
-                    // Also consider this an issue if either player is in a different map zone type.
-                    if (MapController.Get(MapId).ZoneType != MapController.Get(player.MapId).ZoneType)
-                    {
-                        return false;
-                    }
-
-                }
-            }
-
-            if (entity is Resource)
-            {
-                if (spell != null)
-                {
-                    return false;
-                }
-            }
-
-            if (npc != default)
-            {
-                return !friendly && npc.CanPlayerAttack(this) || friendly && npc.IsAllyOf(this);
-            }
-
+        if (spell?.Combat?.TargetType == SpellTargetType.Self ||
+            spell?.Combat?.TargetType == SpellTargetType.Projectile ||
+            spell?.SpellType == SpellType.Dash
+            )
+        {
             return true;
         }
 
-        public override void NotifySwarm(Entity attacker)
+        if (!base.CanAttack(entity, spell))
         {
-            var mapController = MapController.Get(MapId);
-            if (mapController == null) return;
+            return false;
+        }
 
-            if (MapController.TryGetInstanceFromMap(MapId, MapInstanceId, out var instance))
+        if (entity is EventPageInstance)
+        {
+            return false;
+        }
+
+        var friendly = spell?.Combat != null && spell.Combat.Friendly;
+        if (entity is Player player)
+        {
+            if (player.InParty(this) || this == player || (!Options.Instance.Guild.AllowGuildMemberPvp && friendly != (player.Guild != null && player.Guild == this.Guild)))
             {
-                instance.GetEntities(true).ForEach(
-                    entity =>
-                    {
-                        if (entity is Npc npc &&
-                            npc.Target == null &&
-                            npc.IsAllyOf(this) &&
-                            InRangeOf(npc, npc.Base.SightRange))
-                        {
-                            npc.AssignTarget(attacker);
-                        }
-                    }
-                );
+                return friendly;
+            }
+
+            // Only count safe zones and friendly fire if its a dangerous spell! (If one has been used)
+            // Projectiles are ignored here, because we can always fire those.. Whether they hit or not is a problem for later.
+            if (!friendly && (spell?.Combat?.TargetType != SpellTargetType.Self && spell?.Combat?.TargetType != SpellTargetType.AoE && spell?.SpellType == SpellType.CombatSpell))
+            {
+                // Check if either the attacker or the defender is in a "safe zone" (Only apply if combat is PVP)
+                if (MapController.Get(MapId).ZoneType == MapZone.Safe || MapController.Get(player.MapId).ZoneType == MapZone.Safe)
+                {
+                    return false;
+                }
+
+                // Also consider this an issue if either player is in a different map zone type.
+                if (MapController.Get(MapId).ZoneType != MapController.Get(player.MapId).ZoneType)
+                {
+                    return false;
+                }
+
             }
         }
 
-        public override int CalculateAttackTime()
+        if (entity is Resource)
         {
-            var attackTime = base.CalculateAttackTime();
-
-            var cls = ClassBase.Get(ClassId);
-            if (cls != null && cls.AttackSpeedModifier == 1) //Static
+            if (spell != null)
             {
-                attackTime = cls.AttackSpeedValue;
-            }
-
-            var weapon = TryGetEquippedItem(Options.WeaponIndex, out var item) ? item.Descriptor : null;
-
-            if (weapon != null)
-            {
-                if (weapon.AttackSpeedModifier == 1) // Static
-                {
-                    attackTime = weapon.AttackSpeedValue;
-                }
-                else if (weapon.AttackSpeedModifier == 2) //Percentage
-                {
-                    attackTime = (int)(attackTime * (100f / weapon.AttackSpeedValue));
-                }
-            }
-
-            return
-                attackTime -
-                60; //subtracting 60 to account for a moderate ping to the server so some attacks dont get cancelled.
-        }
-
-        /// <summary>
-        /// Get all StatBuffs for the relevant <see cref="Stat"/>
-        /// </summary>
-        /// <param name="statType">The <see cref="Stat"/> to retrieve the amounts for.</param>
-        /// <returns>Returns a <see cref="Tuple"/> containing the Flat stats on Item1, and Percentage stats on Item2</returns>
-        public Tuple<int, int> GetItemStatBuffs(Stat statType)
-        {
-            var flatStats = 0;
-            var percentageStats = 0;
-
-            //Add up player equipment values
-            foreach (var equippedItem in EquippedItems)
-            {
-                var descriptor = equippedItem.Descriptor;
-                if (descriptor != null)
-                {
-                    flatStats += descriptor.StatsGiven[(int)statType];
-
-                    if (equippedItem.Properties.StatModifiers != null)
-                    {
-                        flatStats += equippedItem.Properties.StatModifiers[(int)statType];
-                    }
-
-                    percentageStats += descriptor.PercentageStatsGiven[(int)statType];
-                }
-            }
-
-            return new Tuple<int, int>(flatStats, percentageStats);
-        }
-
-        public void RecalculateStatsAndPoints()
-        {
-            var playerClass = ClassBase.Get(ClassId);
-
-            if (playerClass != null)
-            {
-                for (var i = 0; i < Enum.GetValues<Stat>().Length; i++)
-                {
-                    var s = playerClass.BaseStat[i];
-
-                    //Add class stat scaling
-                    if (playerClass.IncreasePercentage) //% increase per level
-                    {
-                        s = (int)(s * Math.Pow(1 + (double)playerClass.StatIncrease[i] / 100, Level - 1));
-                    }
-                    else //Static value increase per level
-                    {
-                        s += playerClass.StatIncrease[i] * (Level - 1);
-                    }
-
-                    BaseStats[i] = s;
-                }
-
-                //Handle Changes in Points
-                var currentPoints = StatPoints + StatPointAllocations.Sum();
-                var expectedPoints = playerClass.BasePoints + playerClass.PointIncrease * (Level - 1);
-                if (expectedPoints > currentPoints)
-                {
-                    StatPoints += expectedPoints - currentPoints;
-                }
-                else if (expectedPoints < currentPoints)
-                {
-                    var removePoints = currentPoints - expectedPoints;
-                    StatPoints -= removePoints;
-                    if (StatPoints < 0)
-                    {
-                        removePoints = Math.Abs(StatPoints);
-                        StatPoints = 0;
-                    }
-
-                    var i = 0;
-                    while (removePoints > 0 && StatPointAllocations.Sum() > 0)
-                    {
-                        if (StatPointAllocations[i] > 0)
-                        {
-                            StatPointAllocations[i]--;
-                            removePoints--;
-                        }
-
-                        i++;
-                        if (i >= Enum.GetValues<Stat>().Length)
-                        {
-                            i = 0;
-                        }
-                    }
-                }
+                return false;
             }
         }
 
-        //Warping
-        public override void Warp(Guid newMapId, float newX, float newY, bool adminWarp = false)
+        if (npc != default)
         {
-            Warp(newMapId, newX, newY, Direction.Up, adminWarp, 0, false);
+            return !friendly && npc.CanPlayerAttack(this) || friendly && npc.IsAllyOf(this);
         }
 
-        public void AdminWarp(Guid newMapId, float newX, float newY, Guid newMapInstanceId, MapInstanceType instanceType, bool force)
+        return true;
+    }
+
+    public override void NotifySwarm(Entity attacker)
+    {
+        var mapController = MapController.Get(MapId);
+        if (mapController == null) return;
+
+        if (MapController.TryGetInstanceFromMap(MapId, MapInstanceId, out var instance))
         {
-            PreviousMapInstanceId = MapInstanceId;
-            PreviousMapInstanceType = InstanceType;
-
-            MapInstanceId = newMapInstanceId;
-            InstanceType = instanceType;
-            // If we've warped the player out of their overworld, keep a reference to their overworld just in case.
-            if (PreviousMapInstanceType == MapInstanceType.Overworld)
-            {
-                UpdateLastOverworldLocation(MapId, X, Y);
-            }
-            if (PreviousMapInstanceId != MapInstanceId)
-            {
-                PacketSender.SendChatMsg(this, Strings.Player.InstanceUpdate.ToString(PreviousMapInstanceId.ToString(), MapInstanceId.ToString()), ChatMessageType.Admin, CustomColors.Alerts.Info);
-            }
-
-            Warp(newMapId, newX, newY, Direction.Up, forceInstanceChange: force);
-        }
-
-        public override void Warp(Guid newMapId,
-            float newX,
-            float newY,
-            Direction newDir,
-            bool adminWarp = false,
-            int zOverride = 0,
-            bool mapSave = false,
-            bool fromWarpEvent = false,
-            MapInstanceType? mapInstanceType = null,
-            bool fromLogin = false,
-            bool forceInstanceChange = false)
-        {
-            #region shortcircuit exits
-            // First, deny the warp entirely if we CAN'T, for some reason, warp to the requested instance type. ONly do this if we're not forcing a change
-            if (!forceInstanceChange && !CanChangeToInstanceType(mapInstanceType, fromLogin, newMapId))
-            {
-                return;
-            }
-            #endregion
-
-            // If we are leaving the overworld to go to a new instance, save the overworld location
-            if (!fromLogin && InstanceType == MapInstanceType.Overworld && mapInstanceType != MapInstanceType.Overworld && mapInstanceType != null)
-            {
-                UpdateLastOverworldLocation(MapId, X, Y);
-            }
-            // If we are moving TO a new shared instance, update the shared respawn point (if enabled)
-            if (!fromLogin && mapInstanceType == MapInstanceType.Shared && Options.Instance.Instancing.SharedInstanceRespawnInInstance && MapController.Get(newMapId) != null)
-            {
-                UpdateSharedInstanceRespawnLocation(newMapId, (int)newX, (int)newY, newDir);
-            }
-
-            // Make sure we're heading to a map that exists - otherwise, to spawn you go
-            var newMap = MapController.Get(newMapId);
-            if (newMap == null)
-            {
-                WarpToSpawn();
-
-                return;
-            }
-
-            X = (int)newX;
-            Y = (int)newY;
-            Z = zOverride;
-            Dir = newDir;
-
-            var newSurroundingMaps = newMap.GetSurroundingMapIds(true);
-
-            #region Map instance traversal
-            // Set up player properties if we have changed instance types
-            bool onNewInstance = forceInstanceChange || ProcessMapInstanceChange(mapInstanceType, fromLogin);
-
-            // Ensure there exists a map instance with the Player's InstanceId. A player is the sole entity that can create new map instances
-            MapInstance newMapInstance;
-            lock (EntityLock)
-            {
-                if (!newMap.TryGetInstance(MapInstanceId, out newMapInstance))
+            instance.GetEntities(true).ForEach(
+                entity =>
                 {
-                    // Create a new instance for the map we're on
-                    newMap.TryCreateInstance(MapInstanceId, out newMapInstance, this);
-                    // ...and its surroundings
-                    foreach (var surrMap in newSurroundingMaps)
+                    if (entity is Npc npc &&
+                        npc.Target == null &&
+                        npc.IsAllyOf(this) &&
+                        InRangeOf(npc, npc.Base.SightRange))
                     {
-                        if (!MapController.TryGet(surrMap, out var map))
-                        {
-                            continue;
-                        }
-                        map.TryCreateInstance(MapInstanceId, out _, this);
+                        npc.AssignTarget(attacker);
                     }
                 }
-                else
+            );
+        }
+    }
+
+    public override int CalculateAttackTime()
+    {
+        var attackTime = base.CalculateAttackTime();
+
+        var cls = ClassBase.Get(ClassId);
+        if (cls != null && cls.AttackSpeedModifier == 1) //Static
+        {
+            attackTime = cls.AttackSpeedValue;
+        }
+
+        var weapon = TryGetEquippedItem(Options.WeaponIndex, out var item) ? item.Descriptor : null;
+
+        if (weapon != null)
+        {
+            if (weapon.AttackSpeedModifier == 1) // Static
+            {
+                attackTime = weapon.AttackSpeedValue;
+            }
+            else if (weapon.AttackSpeedModifier == 2) //Percentage
+            {
+                attackTime = (int)(attackTime * (100f / weapon.AttackSpeedValue));
+            }
+        }
+
+        return
+            attackTime -
+            60; //subtracting 60 to account for a moderate ping to the server so some attacks dont get cancelled.
+    }
+
+    /// <summary>
+    /// Get all StatBuffs for the relevant <see cref="Stat"/>
+    /// </summary>
+    /// <param name="statType">The <see cref="Stat"/> to retrieve the amounts for.</param>
+    /// <returns>Returns a <see cref="Tuple"/> containing the Flat stats on Item1, and Percentage stats on Item2</returns>
+    public Tuple<int, int> GetItemStatBuffs(Stat statType)
+    {
+        var flatStats = 0;
+        var percentageStats = 0;
+
+        //Add up player equipment values
+        foreach (var equippedItem in EquippedItems)
+        {
+            var descriptor = equippedItem.Descriptor;
+            if (descriptor != null)
+            {
+                flatStats += descriptor.StatsGiven[(int)statType];
+
+                if (equippedItem.Properties.StatModifiers != null)
                 {
-                    _ = TryAddToInstanceController();
+                    flatStats += equippedItem.Properties.StatModifiers[(int)statType];
+                }
+
+                percentageStats += descriptor.PercentageStatsGiven[(int)statType];
+            }
+        }
+
+        return new Tuple<int, int>(flatStats, percentageStats);
+    }
+
+    public void RecalculateStatsAndPoints()
+    {
+        var playerClass = ClassBase.Get(ClassId);
+
+        if (playerClass != null)
+        {
+            for (var i = 0; i < Enum.GetValues<Stat>().Length; i++)
+            {
+                var s = playerClass.BaseStat[i];
+
+                //Add class stat scaling
+                if (playerClass.IncreasePercentage) //% increase per level
+                {
+                    s = (int)(s * Math.Pow(1 + (double)playerClass.StatIncrease[i] / 100, Level - 1));
+                }
+                else //Static value increase per level
+                {
+                    s += playerClass.StatIncrease[i] * (Level - 1);
+                }
+
+                BaseStats[i] = s;
+            }
+
+            //Handle Changes in Points
+            var currentPoints = StatPoints + StatPointAllocations.Sum();
+            var expectedPoints = playerClass.BasePoints + playerClass.PointIncrease * (Level - 1);
+            if (expectedPoints > currentPoints)
+            {
+                StatPoints += expectedPoints - currentPoints;
+            }
+            else if (expectedPoints < currentPoints)
+            {
+                var removePoints = currentPoints - expectedPoints;
+                StatPoints -= removePoints;
+                if (StatPoints < 0)
+                {
+                    removePoints = Math.Abs(StatPoints);
+                    StatPoints = 0;
+                }
+
+                var i = 0;
+                while (removePoints > 0 && StatPointAllocations.Sum() > 0)
+                {
+                    if (StatPointAllocations[i] > 0)
+                    {
+                        StatPointAllocations[i]--;
+                        removePoints--;
+                    }
+
+                    i++;
+                    if (i >= Enum.GetValues<Stat>().Length)
+                    {
+                        i = 0;
+                    }
                 }
             }
+        }
+    }
 
-            // An instance of the map MUST exist. Otherwise, head to spawn.
-            if (newMapInstance == null)
+    //Warping
+    public override void Warp(Guid newMapId, float newX, float newY, bool adminWarp = false)
+    {
+        Warp(newMapId, newX, newY, Direction.Up, adminWarp, 0, false);
+    }
+
+    public void AdminWarp(Guid newMapId, float newX, float newY, Guid newMapInstanceId, MapInstanceType instanceType, bool force)
+    {
+        PreviousMapInstanceId = MapInstanceId;
+        PreviousMapInstanceType = InstanceType;
+
+        MapInstanceId = newMapInstanceId;
+        InstanceType = instanceType;
+        // If we've warped the player out of their overworld, keep a reference to their overworld just in case.
+        if (PreviousMapInstanceType == MapInstanceType.Overworld)
+        {
+            UpdateLastOverworldLocation(MapId, X, Y);
+        }
+        if (PreviousMapInstanceId != MapInstanceId)
+        {
+            PacketSender.SendChatMsg(this, Strings.Player.InstanceUpdate.ToString(PreviousMapInstanceId.ToString(), MapInstanceId.ToString()), ChatMessageType.Admin, CustomColors.Alerts.Info);
+        }
+
+        Warp(newMapId, newX, newY, Direction.Up, forceInstanceChange: force);
+    }
+
+    public override void Warp(Guid newMapId,
+        float newX,
+        float newY,
+        Direction newDir,
+        bool adminWarp = false,
+        int zOverride = 0,
+        bool mapSave = false,
+        bool fromWarpEvent = false,
+        MapInstanceType? mapInstanceType = null,
+        bool fromLogin = false,
+        bool forceInstanceChange = false)
+    {
+        #region shortcircuit exits
+        // First, deny the warp entirely if we CAN'T, for some reason, warp to the requested instance type. ONly do this if we're not forcing a change
+        if (!forceInstanceChange && !CanChangeToInstanceType(mapInstanceType, fromLogin, newMapId))
+        {
+            return;
+        }
+        #endregion
+
+        // If we are leaving the overworld to go to a new instance, save the overworld location
+        if (!fromLogin && InstanceType == MapInstanceType.Overworld && mapInstanceType != MapInstanceType.Overworld && mapInstanceType != null)
+        {
+            UpdateLastOverworldLocation(MapId, X, Y);
+        }
+        // If we are moving TO a new shared instance, update the shared respawn point (if enabled)
+        if (!fromLogin && mapInstanceType == MapInstanceType.Shared && Options.Instance.Instancing.SharedInstanceRespawnInInstance && MapController.Get(newMapId) != null)
+        {
+            UpdateSharedInstanceRespawnLocation(newMapId, (int)newX, (int)newY, newDir);
+        }
+
+        // Make sure we're heading to a map that exists - otherwise, to spawn you go
+        var newMap = MapController.Get(newMapId);
+        if (newMap == null)
+        {
+            WarpToSpawn();
+
+            return;
+        }
+
+        X = (int)newX;
+        Y = (int)newY;
+        Z = zOverride;
+        Dir = newDir;
+
+        var newSurroundingMaps = newMap.GetSurroundingMapIds(true);
+
+        #region Map instance traversal
+        // Set up player properties if we have changed instance types
+        bool onNewInstance = forceInstanceChange || ProcessMapInstanceChange(mapInstanceType, fromLogin);
+
+        // Ensure there exists a map instance with the Player's InstanceId. A player is the sole entity that can create new map instances
+        MapInstance newMapInstance;
+        lock (EntityLock)
+        {
+            if (!newMap.TryGetInstance(MapInstanceId, out newMapInstance))
             {
-                Log.Error($"Player {Name} requested a new map Instance with ID {MapInstanceId} and failed to get it.");
-                WarpToSpawn();
-
-                return;
+                // Create a new instance for the map we're on
+                newMap.TryCreateInstance(MapInstanceId, out newMapInstance, this);
+                // ...and its surroundings
+                foreach (var surrMap in newSurroundingMaps)
+                {
+                    if (!MapController.TryGet(surrMap, out var map))
+                    {
+                        continue;
+                    }
+                    map.TryCreateInstance(MapInstanceId, out _, this);
+                }
             }
-
-            // If we've changed instances, send data to instance entities/entities to player
-            if (onNewInstance || forceInstanceChange)
+            else
             {
-                SendToNewMapInstance(newMap);
-                // Clear all events - get fresh ones from the new instance to re-fresh event locations
-                foreach (var evt in EventLookup)
+                _ = TryAddToInstanceController();
+            }
+        }
+
+        // An instance of the map MUST exist. Otherwise, head to spawn.
+        if (newMapInstance == null)
+        {
+            Log.Error($"Player {Name} requested a new map Instance with ID {MapInstanceId} and failed to get it.");
+            WarpToSpawn();
+
+            return;
+        }
+
+        // If we've changed instances, send data to instance entities/entities to player
+        if (onNewInstance || forceInstanceChange)
+        {
+            SendToNewMapInstance(newMap);
+            // Clear all events - get fresh ones from the new instance to re-fresh event locations
+            foreach (var evt in EventLookup)
+            {
+                RemoveEvent(evt.Value.Id, false);
+            }
+        }
+        else
+        {
+            // Clear events that are no longer on a surrounding map.
+            foreach (var evt in EventLookup)
+            {
+                // Remove events that aren't relevant (on a surrounding map) anymore
+                if (evt.Value.MapId != Guid.Empty && (!newSurroundingMaps.Contains(evt.Value.MapId) || mapSave))
                 {
                     RemoveEvent(evt.Value.Id, false);
                 }
             }
-            else
+        }
+        #endregion
+
+        if (newMapId != MapId || mSentMap == false) // Player warped to a new map?
+        {
+            // Remove the entity from the old map instance
+            var oldMap = MapController.Get(MapId);
+            if (oldMap != null && oldMap.TryGetInstance(PreviousMapInstanceId, out var oldMapInstance))
             {
-                // Clear events that are no longer on a surrounding map.
-                foreach (var evt in EventLookup)
-                {
-                    // Remove events that aren't relevant (on a surrounding map) anymore
-                    if (evt.Value.MapId != Guid.Empty && (!newSurroundingMaps.Contains(evt.Value.MapId) || mapSave))
-                    {
-                        RemoveEvent(evt.Value.Id, false);
-                    }
-                }
+                oldMapInstance.RemoveEntity(this);
             }
-            #endregion
 
-            if (newMapId != MapId || mSentMap == false) // Player warped to a new map?
+            PacketSender.SendEntityLeave(this); // We simply changed maps - leave the old one
+            MapId = newMapId;
+            newMapInstance.PlayerEnteredMap(this);
+            PacketSender.SendEntityPositionToAll(this);
+
+            //If map grid changed then send the new map grid
+            if (!adminWarp && (oldMap == null || !oldMap.SurroundingMapIds.Contains(newMapId)) || fromLogin)
             {
-                // Remove the entity from the old map instance
-                var oldMap = MapController.Get(MapId);
-                if (oldMap != null && oldMap.TryGetInstance(PreviousMapInstanceId, out var oldMapInstance))
-                {
-                    oldMapInstance.RemoveEntity(this);
-                }
+                PacketSender.SendMapGrid(this.Client, newMap.MapGrid, true);
+            }
 
-                PacketSender.SendEntityLeave(this); // We simply changed maps - leave the old one
-                MapId = newMapId;
+            mSentMap = true;
+
+            StartCommonEventsWithTrigger(CommonEventTrigger.MapChanged);
+        }
+        else // Player moved on same map?
+        {
+            if (onNewInstance)
+            {
+                // But instance changed? Add player to the new instance (will also send stats thru SendEntityDataToProximity)
                 newMapInstance.PlayerEnteredMap(this);
-                PacketSender.SendEntityPositionToAll(this);
-
-                //If map grid changed then send the new map grid
-                if (!adminWarp && (oldMap == null || !oldMap.SurroundingMapIds.Contains(newMapId)) || fromLogin)
-                {
-                    PacketSender.SendMapGrid(this.Client, newMap.MapGrid, true);
-                }
-
-                mSentMap = true;
-
-                StartCommonEventsWithTrigger(CommonEventTrigger.MapChanged);
-            }
-            else // Player moved on same map?
-            {
-                if (onNewInstance)
-                {
-                    // But instance changed? Add player to the new instance (will also send stats thru SendEntityDataToProximity)
-                    newMapInstance.PlayerEnteredMap(this);
-                }
-                else
-                {
-                    PacketSender.SendEntityStats(this);
-                }
-                PacketSender.SendEntityPositionToAll(this);
-            }
-
-            UnequipInvalidItems();
-        }
-
-        /// <summary>
-        /// Warps the player on login, taking care of instance management depending on the instance type the player
-        /// is attempting to login to.
-        /// </summary>
-        public void LoginWarp()
-        {
-            if (MapId == null || MapId == Guid.Empty)
-            {
-                WarpToSpawn();
             }
             else
             {
-                if (!CanChangeToInstanceType(InstanceType, true, MapId))
-                {
-                    WarpToLastOverworldLocation(true);
-                }
-                else
-                {
-                    // Will warp to spawn if we fail to create an instance for the relevant map
-                    Warp(
-                        MapId, X, Y, Dir, false, Z, false, false, InstanceType, true
-                    );
-                }
+                PacketSender.SendEntityStats(this);
+            }
+            PacketSender.SendEntityPositionToAll(this);
+        }
+
+        UnequipInvalidItems();
+    }
+
+    /// <summary>
+    /// Warps the player on login, taking care of instance management depending on the instance type the player
+    /// is attempting to login to.
+    /// </summary>
+    public void LoginWarp()
+    {
+        if (MapId == null || MapId == Guid.Empty)
+        {
+            WarpToSpawn();
+        }
+        else
+        {
+            if (!CanChangeToInstanceType(InstanceType, true, MapId))
+            {
+                WarpToLastOverworldLocation(true);
+            }
+            else
+            {
+                // Will warp to spawn if we fail to create an instance for the relevant map
+                Warp(
+                    MapId, X, Y, Dir, false, Z, false, false, InstanceType, true
+                );
             }
         }
+    }
 
-        /// <summary>
-        /// Warps the player to the last location they were at on the "Overworld" (empty Guid) map instance. Useful for kicking out of
-        /// instances in a variety of situations.
-        /// </summary>
-        /// <param name="fromLogin">Whether or not we're coming to this method via the player login/join game flow</param>
-        public void WarpToLastOverworldLocation(bool fromLogin)
+    /// <summary>
+    /// Warps the player to the last location they were at on the "Overworld" (empty Guid) map instance. Useful for kicking out of
+    /// instances in a variety of situations.
+    /// </summary>
+    /// <param name="fromLogin">Whether or not we're coming to this method via the player login/join game flow</param>
+    public void WarpToLastOverworldLocation(bool fromLogin)
+    {
+        Warp(
+            LastOverworldMapId, (byte)LastOverworldX, (byte)LastOverworldY, Dir, zOverride: (byte)Z, mapInstanceType: MapInstanceType.Overworld, fromLogin: fromLogin
+        );
+    }
+
+    public void SendLivesRemainingMessage()
+    {
+        if (InstanceLives > 0)
         {
-            Warp(
-                LastOverworldMapId, (byte)LastOverworldX, (byte)LastOverworldY, Dir, zOverride: (byte)Z, mapInstanceType: MapInstanceType.Overworld, fromLogin: fromLogin
-            );
+            PacketSender.SendChatMsg(this, Strings.Parties.InstanceLivesRemaining.ToString(InstanceLives), ChatMessageType.Party, CustomColors.Chat.PartyChat);
         }
-
-        public void SendLivesRemainingMessage()
+        else
         {
+            PacketSender.SendChatMsg(this, Strings.Parties.NoMoreLivesRemaining, ChatMessageType.Party, CustomColors.Chat.PartyChat);
+        }
+    }
+
+    public void WarpToSpawn(bool forceClassRespawn = false)
+    {
+        var mapId = Guid.Empty;
+        byte x = 0;
+        byte y = 0;
+        Direction dir = 0;
+
+        if (Options.Instance.Instancing.SharedInstanceRespawnInInstance && InstanceType == MapInstanceType.Shared && !forceClassRespawn)
+        {
+            if (SharedInstanceRespawn == null)
+            {
+                // invalid map - try overworld (which will throw to class spawn if itself is invalid)
+                WarpToLastOverworldLocation(false);
+                return;
+            }
+
+            if (Options.Instance.Instancing.MaxSharedInstanceLives <= 0) // User has not configured shared instances to have lives
+            {
+                // Warp to the start of the shared instance - no concern for life total
+                Warp(SharedInstanceRespawnId, SharedInstanceRespawnX, SharedInstanceRespawnY, SharedInstanceRespawnDir);
+                return;
+            }
+
+            // Check if the player/party have enough lives to spawn in-instance
             if (InstanceLives > 0)
             {
-                PacketSender.SendChatMsg(this, Strings.Parties.InstanceLivesRemaining.ToString(InstanceLives), ChatMessageType.Party, CustomColors.Chat.PartyChat);
-            }
-            else
-            {
-                PacketSender.SendChatMsg(this, Strings.Parties.NoMoreLivesRemaining, ChatMessageType.Party, CustomColors.Chat.PartyChat);
-            }
-        }
-
-        public void WarpToSpawn(bool forceClassRespawn = false)
-        {
-            var mapId = Guid.Empty;
-            byte x = 0;
-            byte y = 0;
-            Direction dir = 0;
-
-            if (Options.Instance.Instancing.SharedInstanceRespawnInInstance && InstanceType == MapInstanceType.Shared && !forceClassRespawn)
-            {
-                if (SharedInstanceRespawn == null)
+                // If they do, subtract from this player's life total...
+                InstanceLives--;
+                SendLivesRemainingMessage();
+                // And the totals from any party members
+                if (Party != null && Party.Count > 1)
                 {
-                    // invalid map - try overworld (which will throw to class spawn if itself is invalid)
-                    WarpToLastOverworldLocation(false);
-                    return;
-                }
-
-                if (Options.Instance.Instancing.MaxSharedInstanceLives <= 0) // User has not configured shared instances to have lives
-                {
-                    // Warp to the start of the shared instance - no concern for life total
-                    Warp(SharedInstanceRespawnId, SharedInstanceRespawnX, SharedInstanceRespawnY, SharedInstanceRespawnDir);
-                    return;
-                }
-
-                // Check if the player/party have enough lives to spawn in-instance
-                if (InstanceLives > 0)
-                {
-                    // If they do, subtract from this player's life total...
-                    InstanceLives--;
-                    SendLivesRemainingMessage();
-                    // And the totals from any party members
-                    if (Party != null && Party.Count > 1)
+                    foreach (Player member in Party)
                     {
-                        foreach (Player member in Party)
+                        if (member.Id != Id)
                         {
-                            if (member.Id != Id)
+                            // Keep party member instance lives in sync
+                            member.InstanceLives--;
+                            if (member.InstanceType == MapInstanceType.Shared)
                             {
-                                // Keep party member instance lives in sync
-                                member.InstanceLives--;
-                                if (member.InstanceType == MapInstanceType.Shared)
-                                {
-                                    member.SendLivesRemainingMessage();
-                                }
+                                member.SendLivesRemainingMessage();
                             }
                         }
                     }
+                }
 
-                    // And warp to the instance start
-                    Warp(SharedInstanceRespawnId, SharedInstanceRespawnX, SharedInstanceRespawnY, SharedInstanceRespawnDir);
+                // And warp to the instance start
+                Warp(SharedInstanceRespawnId, SharedInstanceRespawnX, SharedInstanceRespawnY, SharedInstanceRespawnDir);
+            }
+            else
+            {
+                // The player has ran out of lives - too bad, back to instance entrance you go.
+                if (!Options.Instance.Instancing.BootAllFromInstanceWhenOutOfLives || Party == null || Party.Count < 2)
+                {
+                    WarpToLastOverworldLocation(false);
                 }
                 else
                 {
-                    // The player has ran out of lives - too bad, back to instance entrance you go.
-                    if (!Options.Instance.Instancing.BootAllFromInstanceWhenOutOfLives || Party == null || Party.Count < 2)
+                    // Oh shit, hard mode enabled - boot ALL party members out of instance. No more lives.
+                    foreach (Player member in Party)
                     {
-                        WarpToLastOverworldLocation(false);
+                        // Only warp players in the instance
+                        if (member.InstanceType == MapInstanceType.Shared)
+                        {
+                            lock (EntityLock)
+                            {
+                                member.WarpToLastOverworldLocation(false);
+                                PacketSender.SendChatMsg(member, Strings.Parties.InstanceFailed, ChatMessageType.Party, CustomColors.Chat.PartyChat);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        else
+        {
+            var cls = ClassBase.Get(ClassId);
+            if (cls != null)
+            {
+                if (MapController.Lookup.Keys.Contains(cls.SpawnMapId))
+                {
+                    mapId = cls.SpawnMapId;
+                }
+
+                x = (byte)cls.SpawnX;
+                y = (byte)cls.SpawnY;
+                dir = (Direction)cls.SpawnDir;
+            }
+
+            if (mapId == Guid.Empty)
+            {
+                using (var mapenum = MapController.Lookup.GetEnumerator())
+                {
+                    mapenum.MoveNext();
+                    mapId = mapenum.Current.Value.Id;
+                }
+            }
+
+            Warp(mapId, x, y, dir, false, 0, false, false, MapInstanceType.Overworld);
+        }
+    }
+
+    // Instancing
+
+    /// <summary>
+    /// Checks to see if we CAN go to the requested instance type
+    /// </summary>
+    /// <param name="instanceType">The instance type we're requesting a warp to</param>
+    /// <param name="fromLogin">Whether or not this is from the login flow</param>
+    /// <param name="newMapId">The map ID we will be warping to</param>
+    /// <returns></returns>
+    public bool CanChangeToInstanceType(MapInstanceType? instanceType, bool fromLogin, Guid newMapId)
+    {
+        bool isValid = true;
+
+        switch (instanceType)
+        {
+            case MapInstanceType.Guild:
+                if (Guild == null)
+                {
+                    isValid = false;
+
+                    if (fromLogin)
+                    {
+                        PacketSender.SendChatMsg(this, Strings.Guilds.NoLongerAllowedInInstance, ChatMessageType.Guild, CustomColors.Alerts.Error);
                     }
                     else
                     {
-                        // Oh shit, hard mode enabled - boot ALL party members out of instance. No more lives.
-                        foreach (Player member in Party)
-                        {
-                            // Only warp players in the instance
-                            if (member.InstanceType == MapInstanceType.Shared)
-                            {
-                                lock (EntityLock)
-                                {
-                                    member.WarpToLastOverworldLocation(false);
-                                    PacketSender.SendChatMsg(member, Strings.Parties.InstanceFailed, ChatMessageType.Party, CustomColors.Chat.PartyChat);
-                                }
-                            }
-                        }
+                        PacketSender.SendChatMsg(this, Strings.Guilds.NotAllowedInInstance, ChatMessageType.Guild, CustomColors.Alerts.Error);
                     }
                 }
-            }
-            else
-            {
-                var cls = ClassBase.Get(ClassId);
-                if (cls != null)
+                break;
+            case MapInstanceType.Shared:
+                if (fromLogin)
                 {
-                    if (MapController.Lookup.Keys.Contains(cls.SpawnMapId))
+                    // Check to see if the instance still exists & is populated
+                    if (!InstanceProcessor.TryGetInstanceController(SharedMapInstanceId, out var sharedController) || sharedController.Players.Count == 0)
                     {
-                        mapId = cls.SpawnMapId;
+                        return false;
                     }
 
-                    x = (byte)cls.SpawnX;
-                    y = (byte)cls.SpawnY;
-                    dir = (Direction)cls.SpawnDir;
-                }
-
-                if (mapId == Guid.Empty)
-                {
-                    using (var mapenum = MapController.Lookup.GetEnumerator())
+                    // If it does, get the party leader from it...
+                    var partyMember = sharedController.Players.FirstOrDefault();
+                    if (partyMember == default)
                     {
-                        mapenum.MoveNext();
-                        mapId = mapenum.Current.Value.Id;
+                        return false;
                     }
-                }
 
-                Warp(mapId, x, y, dir, false, 0, false, false, MapInstanceType.Overworld);
-            }
-        }
-
-        // Instancing
-
-        /// <summary>
-        /// Checks to see if we CAN go to the requested instance type
-        /// </summary>
-        /// <param name="instanceType">The instance type we're requesting a warp to</param>
-        /// <param name="fromLogin">Whether or not this is from the login flow</param>
-        /// <param name="newMapId">The map ID we will be warping to</param>
-        /// <returns></returns>
-        public bool CanChangeToInstanceType(MapInstanceType? instanceType, bool fromLogin, Guid newMapId)
-        {
-            bool isValid = true;
-
-            switch (instanceType)
-            {
-                case MapInstanceType.Guild:
-                    if (Guild == null)
-                    {
-                        isValid = false;
-
-                        if (fromLogin)
-                        {
-                            PacketSender.SendChatMsg(this, Strings.Guilds.NoLongerAllowedInInstance, ChatMessageType.Guild, CustomColors.Alerts.Error);
-                        }
-                        else
-                        {
-                            PacketSender.SendChatMsg(this, Strings.Guilds.NotAllowedInInstance, ChatMessageType.Guild, CustomColors.Alerts.Error);
-                        }
-                    }
-                    break;
-                case MapInstanceType.Shared:
-                    if (fromLogin)
-                    {
-                        // Check to see if the instance still exists & is populated
-                        if (!InstanceProcessor.TryGetInstanceController(SharedMapInstanceId, out var sharedController) || sharedController.Players.Count == 0)
-                        {
-                            return false;
-                        }
-
-                        // If it does, get the party leader from it...
-                        var partyMember = sharedController.Players.FirstOrDefault();
-                        if (partyMember == default)
-                        {
-                            return false;
-                        }
-
-                        // are we in the party?
-                        if (partyMember.Party?.Contains(this) ?? false)
-                        {
-                            return true;
-                        }
-                        // If the party was disbanded during the disconnect...
-                        if (partyMember.PartyLeader == default)
-                        {
-                            // Rekindle the party members
-                            return partyMember.TryAddParty(this);
-                        }
-                        else // otherwise, add the player back using the party leader
-                        {
-                            return partyMember.PartyLeader.TryAddParty(this);
-                        }
-                    }
-                    // else here because we don't want someone logging on to an abandoned instance -- that could result in things
-                    // like boss-kill abuse, etc.
-                    else if (Options.Instance.Instancing.RejoinableSharedInstances)
+                    // are we in the party?
+                    if (partyMember.Party?.Contains(this) ?? false)
                     {
                         return true;
                     }
-
-                    if (Party != null && Party.Count > 0)
+                    // If the party was disbanded during the disconnect...
+                    if (partyMember.PartyLeader == default)
                     {
-                        if (PartyLeader.Id == Id) // if we are the party leader
-                        {
-                            // And other players are using our shared instance, deny creation of a new instance until they are finished.
-                            if (Party.FindAll((Player member) => member.Id != Id && member.InstanceType == MapInstanceType.Shared).Count > 0)
-                            {
-                                isValid = false;
-                                PacketSender.SendChatMsg(this, Strings.Parties.InstanceInUse, ChatMessageType.Party, CustomColors.Alerts.Error);
-                            }
-                        }
-                        else
-                        {
-                            // Otherwise, if the party leader hasn't yet created a shared instance, deny creation of a new one.
-                            if (PartyLeader.InstanceType != MapInstanceType.Shared)
-                            {
-                                isValid = false;
-                                PacketSender.SendChatMsg(this, Strings.Parties.CannotCreateInstance, ChatMessageType.Party, CustomColors.Alerts.Error);
-                            }
-                            else if (PartyLeader.SharedMapInstanceId != SharedMapInstanceId)
-                            {
-                                isValid = false;
-                                PacketSender.SendChatMsg(this, Strings.Parties.InstanceInProgress, ChatMessageType.Party, CustomColors.Alerts.Error);
-                            }
-                            else if (newMapId != Party[0].SharedInstanceRespawn.Id)
-                            {
-                                isValid = false;
-                                PacketSender.SendChatMsg(this, Strings.Parties.WrongInstance, ChatMessageType.Party, CustomColors.Alerts.Error);
-                            }
-                        }
+                        // Rekindle the party members
+                        return partyMember.TryAddParty(this);
                     }
-                    break;
-            }
-
-            return isValid;
-        }
-
-        /// <summary>
-        /// In charge of sending the necessary packet information on an instance change
-        /// </summary>
-        /// <param name="newMap">The <see cref="MapController"/> we are warping to</param>
-        private void SendToNewMapInstance(MapController newMap)
-        {
-            // Refresh the client's entity list
-            var oldMap = MapController.Get(MapId);
-            // Get the entities from the old map - we need to clear them off the player's global entities on their client
-            if (oldMap != null && oldMap.TryGetInstance(PreviousMapInstanceId, out var oldMapInstance))
-            {
-                PacketSender.SendMapInstanceChangedPacket(this, oldMap, PreviousMapInstanceId);
-                oldMapInstance.ClearEntityTargetsOf(this); // Remove targets of this entity
-                RemoveFromInstanceController(PreviousMapInstanceId);
-            }
-            // Clear events - we'll get them again from the map instance's event cache
-            EventTileLookup.Clear();
-            EventLookup.Clear();
-            EventBaseIdLookup.Clear();
-            Log.Debug($"Player {Name} has joined instance {MapInstanceId} of map: {newMap.Name}");
-            Log.Info($"Previous instance was {PreviousMapInstanceId}");
-            // We changed maps AND instance layers - remove from the old instance
-            PacketSender.SendEntityLeaveInstanceOfMap(this, oldMap?.Id ?? MapId, PreviousMapInstanceId);
-            // Remove any trace of our player from the old instance's processing
-            newMap.RemoveEntityFromAllSurroundingMapsInInstance(this, PreviousMapInstanceId);
-        }
-
-        /// <summary>
-        /// Checks to see if the <see cref="MapInstanceType"/> we're warping to is different than what type we are currently
-        /// on, and, if so, takes care of updating our instance settings.
-        /// </summary>
-        /// <param name="mapInstanceType">The <see cref="MapInstanceType"/> the player is currently on</param>
-        /// <param name="fromLogin">Whether or not we're coming to this method via a login warp.</param>
-        /// <returns></returns>
-        public bool ProcessMapInstanceChange(MapInstanceType? mapInstanceType, bool fromLogin)
-        {
-            // Save values before change for reference/emergency recall
-            PreviousMapInstanceId = MapInstanceId;
-            PreviousMapInstanceType = InstanceType;
-            if (mapInstanceType != null) // If we're requesting an instance type change
-            {
-                // Update our saved instance type - this helps us determine what to do on login, warps, etc
-                InstanceType = (MapInstanceType)mapInstanceType;
-                // Requests a new instance id, using the type of instance to determine creation logic
-                MapInstanceId = CreateNewInstanceIdFromType(mapInstanceType, fromLogin);
-            }
-            return MapInstanceId != PreviousMapInstanceId;
-        }
-
-        /// <summary>
-        /// Creates an instance id based on the type of instance we are heading to, and whether or not we should generate a fresh id or use a saved id.
-        /// </summary>
-        /// <remarks>
-        /// Note that if we are coming to this method, we have already checked to see whether or not we CAN go to the requested instance.
-        /// </remarks>
-        /// <param name="mapInstanceType">The <see cref="MapInstanceType"/> we are switching to</param>
-        /// <param name="fromLogin">Whether or not we are coming to this method via player login. We may prefer to use saved values instead of generate new
-        /// values if this is the case.</param>
-        /// <returns></returns>
-        public Guid CreateNewInstanceIdFromType(MapInstanceType? mapInstanceType, bool fromLogin)
-        {
-            Guid newMapLayerId = MapInstanceId;
-            switch (mapInstanceType)
-            {
-                case MapInstanceType.Overworld:
-                    ResetSavedInstanceIds();
-                    newMapLayerId = Guid.Empty;
-                    break;
-                case MapInstanceType.Personal:
-                    if (!fromLogin) // If we're logging into a personal instance, we want to login to the SAME instance.
+                    else // otherwise, add the player back using the party leader
                     {
-                        PersonalMapInstanceId = Guid.NewGuid();
+                        return partyMember.PartyLeader.TryAddParty(this);
                     }
-                    newMapLayerId = PersonalMapInstanceId;
-                    break;
-                case MapInstanceType.Guild:
-                    if (Guild != null)
+                }
+                // else here because we don't want someone logging on to an abandoned instance -- that could result in things
+                // like boss-kill abuse, etc.
+                else if (Options.Instance.Instancing.RejoinableSharedInstances)
+                {
+                    return true;
+                }
+
+                if (Party != null && Party.Count > 0)
+                {
+                    if (PartyLeader.Id == Id) // if we are the party leader
                     {
-                        newMapLayerId = Guild.GuildInstanceId;
+                        // And other players are using our shared instance, deny creation of a new instance until they are finished.
+                        if (Party.FindAll((Player member) => member.Id != Id && member.InstanceType == MapInstanceType.Shared).Count > 0)
+                        {
+                            isValid = false;
+                            PacketSender.SendChatMsg(this, Strings.Parties.InstanceInUse, ChatMessageType.Party, CustomColors.Alerts.Error);
+                        }
                     }
                     else
                     {
-                        Log.Error($"Player {Name} requested a guild warp with no guild, and proceeded to warp to map anyway");
-                        newMapLayerId = Guid.Empty;
-                    }
-                    break;
-                case MapInstanceType.Shared:
-                    bool isSolo = Party == null || Party.Count < 2;
-                    bool isPartyLeader = Party != null && Party.Count > 0 && Party[0].Id == Id;
-
-                    if (isSolo) // Solo instance initialization
-                    {
-                        if (Options.Instance.Instancing.MaxSharedInstanceLives > 0)
+                        // Otherwise, if the party leader hasn't yet created a shared instance, deny creation of a new one.
+                        if (PartyLeader.InstanceType != MapInstanceType.Shared)
                         {
-                            InstanceLives = Options.Instance.Instancing.MaxSharedInstanceLives;
+                            isValid = false;
+                            PacketSender.SendChatMsg(this, Strings.Parties.CannotCreateInstance, ChatMessageType.Party, CustomColors.Alerts.Error);
                         }
-                        SharedMapInstanceId = Guid.NewGuid();
-                        newMapLayerId = SharedMapInstanceId;
+                        else if (PartyLeader.SharedMapInstanceId != SharedMapInstanceId)
+                        {
+                            isValid = false;
+                            PacketSender.SendChatMsg(this, Strings.Parties.InstanceInProgress, ChatMessageType.Party, CustomColors.Alerts.Error);
+                        }
+                        else if (newMapId != Party[0].SharedInstanceRespawn.Id)
+                        {
+                            isValid = false;
+                            PacketSender.SendChatMsg(this, Strings.Parties.WrongInstance, ChatMessageType.Party, CustomColors.Alerts.Error);
+                        }
                     }
-                    else if (!Options.Instance.Instancing.RejoinableSharedInstances && isPartyLeader) // Non-rejoinable instance initialization
+                }
+                break;
+        }
+
+        return isValid;
+    }
+
+    /// <summary>
+    /// In charge of sending the necessary packet information on an instance change
+    /// </summary>
+    /// <param name="newMap">The <see cref="MapController"/> we are warping to</param>
+    private void SendToNewMapInstance(MapController newMap)
+    {
+        // Refresh the client's entity list
+        var oldMap = MapController.Get(MapId);
+        // Get the entities from the old map - we need to clear them off the player's global entities on their client
+        if (oldMap != null && oldMap.TryGetInstance(PreviousMapInstanceId, out var oldMapInstance))
+        {
+            PacketSender.SendMapInstanceChangedPacket(this, oldMap, PreviousMapInstanceId);
+            oldMapInstance.ClearEntityTargetsOf(this); // Remove targets of this entity
+            RemoveFromInstanceController(PreviousMapInstanceId);
+        }
+        // Clear events - we'll get them again from the map instance's event cache
+        EventTileLookup.Clear();
+        EventLookup.Clear();
+        EventBaseIdLookup.Clear();
+        Log.Debug($"Player {Name} has joined instance {MapInstanceId} of map: {newMap.Name}");
+        Log.Info($"Previous instance was {PreviousMapInstanceId}");
+        // We changed maps AND instance layers - remove from the old instance
+        PacketSender.SendEntityLeaveInstanceOfMap(this, oldMap?.Id ?? MapId, PreviousMapInstanceId);
+        // Remove any trace of our player from the old instance's processing
+        newMap.RemoveEntityFromAllSurroundingMapsInInstance(this, PreviousMapInstanceId);
+    }
+
+    /// <summary>
+    /// Checks to see if the <see cref="MapInstanceType"/> we're warping to is different than what type we are currently
+    /// on, and, if so, takes care of updating our instance settings.
+    /// </summary>
+    /// <param name="mapInstanceType">The <see cref="MapInstanceType"/> the player is currently on</param>
+    /// <param name="fromLogin">Whether or not we're coming to this method via a login warp.</param>
+    /// <returns></returns>
+    public bool ProcessMapInstanceChange(MapInstanceType? mapInstanceType, bool fromLogin)
+    {
+        // Save values before change for reference/emergency recall
+        PreviousMapInstanceId = MapInstanceId;
+        PreviousMapInstanceType = InstanceType;
+        if (mapInstanceType != null) // If we're requesting an instance type change
+        {
+            // Update our saved instance type - this helps us determine what to do on login, warps, etc
+            InstanceType = (MapInstanceType)mapInstanceType;
+            // Requests a new instance id, using the type of instance to determine creation logic
+            MapInstanceId = CreateNewInstanceIdFromType(mapInstanceType, fromLogin);
+        }
+        return MapInstanceId != PreviousMapInstanceId;
+    }
+
+    /// <summary>
+    /// Creates an instance id based on the type of instance we are heading to, and whether or not we should generate a fresh id or use a saved id.
+    /// </summary>
+    /// <remarks>
+    /// Note that if we are coming to this method, we have already checked to see whether or not we CAN go to the requested instance.
+    /// </remarks>
+    /// <param name="mapInstanceType">The <see cref="MapInstanceType"/> we are switching to</param>
+    /// <param name="fromLogin">Whether or not we are coming to this method via player login. We may prefer to use saved values instead of generate new
+    /// values if this is the case.</param>
+    /// <returns></returns>
+    public Guid CreateNewInstanceIdFromType(MapInstanceType? mapInstanceType, bool fromLogin)
+    {
+        Guid newMapLayerId = MapInstanceId;
+        switch (mapInstanceType)
+        {
+            case MapInstanceType.Overworld:
+                ResetSavedInstanceIds();
+                newMapLayerId = Guid.Empty;
+                break;
+            case MapInstanceType.Personal:
+                if (!fromLogin) // If we're logging into a personal instance, we want to login to the SAME instance.
+                {
+                    PersonalMapInstanceId = Guid.NewGuid();
+                }
+                newMapLayerId = PersonalMapInstanceId;
+                break;
+            case MapInstanceType.Guild:
+                if (Guild != null)
+                {
+                    newMapLayerId = Guild.GuildInstanceId;
+                }
+                else
+                {
+                    Log.Error($"Player {Name} requested a guild warp with no guild, and proceeded to warp to map anyway");
+                    newMapLayerId = Guid.Empty;
+                }
+                break;
+            case MapInstanceType.Shared:
+                bool isSolo = Party == null || Party.Count < 2;
+                bool isPartyLeader = Party != null && Party.Count > 0 && Party[0].Id == Id;
+
+                if (isSolo) // Solo instance initialization
+                {
+                    if (Options.Instance.Instancing.MaxSharedInstanceLives > 0)
                     {
-                        // Generate a new instance
+                        InstanceLives = Options.Instance.Instancing.MaxSharedInstanceLives;
+                    }
+                    SharedMapInstanceId = Guid.NewGuid();
+                    newMapLayerId = SharedMapInstanceId;
+                }
+                else if (!Options.Instance.Instancing.RejoinableSharedInstances && isPartyLeader) // Non-rejoinable instance initialization
+                {
+                    // Generate a new instance
+                    SharedMapInstanceId = Guid.NewGuid();
+                    // If we are the leader, propogate your shared instance ID to all current members of the party.
+                    if (isPartyLeader && !Options.Instance.Instancing.RejoinableSharedInstances)
+                    {
+                        foreach (Player member in Party)
+                        {
+                            member.SharedMapInstanceId = SharedMapInstanceId;
+                            if (Options.Instance.Instancing.MaxSharedInstanceLives > 0)
+                            {
+                                member.InstanceLives = Options.Instance.Instancing.MaxSharedInstanceLives;
+                            }
+                        }
+                    }
+                }
+                else if (Party != null && Party.Count > 0 && Options.Instance.Instancing.RejoinableSharedInstances) // Joinable instance initialization
+                {
+                    // Scan party members for an active shared instance - if one is found, use it
+                    var memberInInstance = Party.Find((Player member) => member.SharedMapInstanceId != Guid.Empty);
+                    if (memberInInstance != null)
+                    {
+                        SharedMapInstanceId = memberInInstance.SharedMapInstanceId;
+                    }
+                    else
+                    {
+                        // Otherwise, if no one is on an instance, create a new instance
                         SharedMapInstanceId = Guid.NewGuid();
-                        // If we are the leader, propogate your shared instance ID to all current members of the party.
-                        if (isPartyLeader && !Options.Instance.Instancing.RejoinableSharedInstances)
+
+                        // And give your party members their instance lives - though this can be exploited when instances are rejoinable, so you'd really
+                        // have to be a freak to have both options on
+                        if (Options.Instance.Instancing.MaxSharedInstanceLives > 0)
                         {
                             foreach (Player member in Party)
                             {
-                                member.SharedMapInstanceId = SharedMapInstanceId;
-                                if (Options.Instance.Instancing.MaxSharedInstanceLives > 0)
-                                {
-                                    member.InstanceLives = Options.Instance.Instancing.MaxSharedInstanceLives;
-                                }
+                                member.InstanceLives = Options.Instance.Instancing.MaxSharedInstanceLives;
                             }
                         }
                     }
-                    else if (Party != null && Party.Count > 0 && Options.Instance.Instancing.RejoinableSharedInstances) // Joinable instance initialization
-                    {
-                        // Scan party members for an active shared instance - if one is found, use it
-                        var memberInInstance = Party.Find((Player member) => member.SharedMapInstanceId != Guid.Empty);
-                        if (memberInInstance != null)
-                        {
-                            SharedMapInstanceId = memberInInstance.SharedMapInstanceId;
-                        }
-                        else
-                        {
-                            // Otherwise, if no one is on an instance, create a new instance
-                            SharedMapInstanceId = Guid.NewGuid();
-
-                            // And give your party members their instance lives - though this can be exploited when instances are rejoinable, so you'd really
-                            // have to be a freak to have both options on
-                            if (Options.Instance.Instancing.MaxSharedInstanceLives > 0)
-                            {
-                                foreach (Player member in Party)
-                                {
-                                    member.InstanceLives = Options.Instance.Instancing.MaxSharedInstanceLives;
-                                }
-                            }
-                        }
-                    }
-                    // Use whatever your shared instance id is for the warp
-                    newMapLayerId = SharedMapInstanceId;
-
-                    break;
-                default:
-                    Log.Error($"Player {Name} requested an instance type that is not supported. Their map instance settings will not change.");
-                    break;
-            }
-
-            return newMapLayerId;
-        }
-
-        /// <summary>
-        /// /// Updates the player's last overworld location. Useful for warping out of instances if need be.
-        /// </summary>
-        /// <param name="overworldMapId">Which map we were on before the instance change</param>
-        /// <param name="overworldX">X before instance change</param>
-        /// <param name="overworldY">Y before instance change</param>
-        public void UpdateLastOverworldLocation(Guid overworldMapId, int overworldX, int overworldY)
-        {
-            LastOverworldMapId = overworldMapId;
-            LastOverworldX = overworldX;
-            LastOverworldY = overworldY;
-        }
-
-        /// <summary>
-        /// Updates the shared instance respawn location - for respawning on death in a shared instance (when this is enabled)
-        /// </summary>
-        /// <param name="respawnMapId"></param>
-        /// <param name="x"></param>
-        /// <param name="y"></param>
-        /// <param name="dir"></param>
-        public void UpdateSharedInstanceRespawnLocation(Guid respawnMapId, int x, int y, Direction dir)
-        {
-            SharedInstanceRespawnId = respawnMapId;
-            SharedInstanceRespawnX = x;
-            SharedInstanceRespawnY = y;
-            SharedInstanceRespawnDir = dir;
-        }
-
-        /// <summary>
-        /// Resets instance ids we've saved on the player. Generally called when going back to the overworld.
-        /// </summary>
-        public void ResetSavedInstanceIds()
-        {
-            PersonalMapInstanceId = Guid.Empty;
-            SharedMapInstanceId = Guid.Empty;
-        }
-
-        /// <summary>
-        /// Checks whether a player can or can not receive the specified item and its quantity.
-        /// </summary>
-        /// <param name="itemId">The item Id to check if the player can receive.</param>
-        /// <param name="quantity">The amount of this item to check if the player can receive.</param>
-        /// <param name="slot">The inventory slot to check against.</param>
-        /// <returns></returns>
-        public bool CanGiveItem(Guid itemId, int quantity, int slot) => CanGiveItem(new Item(itemId, quantity), slot);
-
-        /// <summary>
-        /// Checks whether a player can or can not receive the specified item and its quantity.
-        /// </summary>
-        /// <param name="item">The <see cref="Item"/> to check if this player can receive.</param>
-        /// /// <param name="slot">The inventory slot to check against.</param>
-        /// <returns></returns>
-        public bool CanGiveItem(Item item, int slot)
-        {
-            // Is this a valid item and slot?
-            if (slot >= 0 && slot < Items.Count)
-            {
-                // Is this slot empty?
-                if (Items[slot] != null && Items[slot].ItemId == Guid.Empty)
-                {
-                    // It is! Can we store the full quantity of this item though?
-                    return CanGiveItem(item, out _);
                 }
-            }
-            else
+                // Use whatever your shared instance id is for the warp
+                newMapLayerId = SharedMapInstanceId;
+
+                break;
+            default:
+                Log.Error($"Player {Name} requested an instance type that is not supported. Their map instance settings will not change.");
+                break;
+        }
+
+        return newMapLayerId;
+    }
+
+    /// <summary>
+    /// /// Updates the player's last overworld location. Useful for warping out of instances if need be.
+    /// </summary>
+    /// <param name="overworldMapId">Which map we were on before the instance change</param>
+    /// <param name="overworldX">X before instance change</param>
+    /// <param name="overworldY">Y before instance change</param>
+    public void UpdateLastOverworldLocation(Guid overworldMapId, int overworldX, int overworldY)
+    {
+        LastOverworldMapId = overworldMapId;
+        LastOverworldX = overworldX;
+        LastOverworldY = overworldY;
+    }
+
+    /// <summary>
+    /// Updates the shared instance respawn location - for respawning on death in a shared instance (when this is enabled)
+    /// </summary>
+    /// <param name="respawnMapId"></param>
+    /// <param name="x"></param>
+    /// <param name="y"></param>
+    /// <param name="dir"></param>
+    public void UpdateSharedInstanceRespawnLocation(Guid respawnMapId, int x, int y, Direction dir)
+    {
+        SharedInstanceRespawnId = respawnMapId;
+        SharedInstanceRespawnX = x;
+        SharedInstanceRespawnY = y;
+        SharedInstanceRespawnDir = dir;
+    }
+
+    /// <summary>
+    /// Resets instance ids we've saved on the player. Generally called when going back to the overworld.
+    /// </summary>
+    public void ResetSavedInstanceIds()
+    {
+        PersonalMapInstanceId = Guid.Empty;
+        SharedMapInstanceId = Guid.Empty;
+    }
+
+    /// <summary>
+    /// Checks whether a player can or can not receive the specified item and its quantity.
+    /// </summary>
+    /// <param name="itemId">The item Id to check if the player can receive.</param>
+    /// <param name="quantity">The amount of this item to check if the player can receive.</param>
+    /// <param name="slot">The inventory slot to check against.</param>
+    /// <returns></returns>
+    public bool CanGiveItem(Guid itemId, int quantity, int slot) => CanGiveItem(new Item(itemId, quantity), slot);
+
+    /// <summary>
+    /// Checks whether a player can or can not receive the specified item and its quantity.
+    /// </summary>
+    /// <param name="item">The <see cref="Item"/> to check if this player can receive.</param>
+    /// /// <param name="slot">The inventory slot to check against.</param>
+    /// <returns></returns>
+    public bool CanGiveItem(Item item, int slot)
+    {
+        // Is this a valid item and slot?
+        if (slot >= 0 && slot < Items.Count)
+        {
+            // Is this slot empty?
+            if (Items[slot] != null && Items[slot].ItemId == Guid.Empty)
             {
-                // Not a valid slot, just treat it as a normal query.
+                // It is! Can we store the full quantity of this item though?
                 return CanGiveItem(item, out _);
             }
+        }
+        else
+        {
+            // Not a valid slot, just treat it as a normal query.
+            return CanGiveItem(item, out _);
+        }
 
+        return false;
+    }
+
+    /// <summary>
+    /// Checks whether a player can or can not receive the specified item and its quantity.
+    /// </summary>
+    /// <param name="itemId">The item Id to check if the player can receive.</param>
+    /// <param name="quantity">The amount of this item to check if the player can receive.</param>
+    /// <returns></returns>
+    public bool CanGiveItem(Guid itemId, int quantity) => CanGiveItem(new Item(itemId, quantity), out _);
+
+    private BagSlot[] FindCompatibleBagSlots(ItemBase itemDescriptor, int quantityHint, out int remainingQuantity)
+    {
+        var items = Items;
+        if (items == default || items.Count < 1)
+        {
+            remainingQuantity = quantityHint;
+            return Array.Empty<BagSlot>();
+        }
+
+        List<BagSlot> compatibleBagSlots = new();
+        remainingQuantity = quantityHint;
+        foreach (var inventorySlot in items)
+        {
+            if (remainingQuantity < 1)
+            {
+                break;
+            }
+
+            if (inventorySlot.BagId == default)
+            {
+                continue;
+            }
+
+            if (!inventorySlot.TryGetBag(out var bagInSlot))
+            {
+                continue;
+            }
+
+            var compatibleSlotsInBag = Item.FindCompatibleSlotsForItem(
+                itemDescriptor,
+                itemDescriptor.MaxInventoryStack,
+                -1,
+                remainingQuantity,
+                bagInSlot.Slots.ToArray(),
+                excludeEmpty: true
+            );
+
+            var totalAvailableQuantity = compatibleSlotsInBag.Aggregate(
+                0,
+                (current, compatibleSlotInBag) =>
+                    current + (itemDescriptor.MaxInventoryStack - compatibleSlotInBag.Quantity)
+            );
+            remainingQuantity -= totalAvailableQuantity;
+            compatibleBagSlots.AddRange(compatibleSlotsInBag);
+        }
+
+        return compatibleBagSlots.ToArray();
+    }
+
+    //Inventory
+    /// <summary>
+    /// Checks whether a player can or can not receive the specified item and its quantity.
+    /// </summary>
+    /// <param name="item">The <see cref="Item"/> to check if this player can receive.</param>
+    /// <returns></returns>
+    public bool CanGiveItem(Item item, out BagSlot[] bagSlots)
+    {
+        if (item.Descriptor == default)
+        {
+            bagSlots = Array.Empty<BagSlot>();
             return false;
         }
 
-        /// <summary>
-        /// Checks whether a player can or can not receive the specified item and its quantity.
-        /// </summary>
-        /// <param name="itemId">The item Id to check if the player can receive.</param>
-        /// <param name="quantity">The amount of this item to check if the player can receive.</param>
-        /// <returns></returns>
-        public bool CanGiveItem(Guid itemId, int quantity) => CanGiveItem(new Item(itemId, quantity), out _);
-
-        private BagSlot[] FindCompatibleBagSlots(ItemBase itemDescriptor, int quantityHint, out int remainingQuantity)
+        // Is the item stackable?
+        if (!item.Descriptor.IsStackable)
         {
-            var items = Items;
-            if (items == default || items.Count < 1)
-            {
-                remainingQuantity = quantityHint;
-                return Array.Empty<BagSlot>();
-            }
+            bagSlots = Array.Empty<BagSlot>();
+            // Not a stacking item, so can we contain the amount we want to give them?
+            return FindOpenInventorySlots().Count >= item.Quantity;
+        }
 
-            List<BagSlot> compatibleBagSlots = new();
-            remainingQuantity = quantityHint;
-            foreach (var inventorySlot in items)
+        bagSlots = FindCompatibleBagSlots(item.Descriptor, item.Quantity, out var remainingQuantity);
+
+        if (remainingQuantity < 0)
+        {
+            return true;
+        }
+
+        // Does the user have this item already?
+        var existingItemSlots = FindInventoryItemSlots(item.ItemId);
+        var slotsRequired = Math.Ceiling((double)remainingQuantity / item.Descriptor.MaxInventoryStack);
+
+        // User doesn't have this item yet.
+        if (existingItemSlots.Count == 0)
+        {
+            // Does the user have enough free space for these stacks?
+            return FindOpenInventorySlots().Count >= slotsRequired;
+        }
+
+        // We need to check to see how much space we'd have if we first filled all possible stacks
+
+        // For each stack while we still have items to give
+        for (var i = 0; i < existingItemSlots.Count && remainingQuantity > 0; i++)
+        {
+            // Give as much as possible to this stack
+            remainingQuantity -= item.Descriptor.MaxInventoryStack - existingItemSlots[i].Quantity;
+        }
+
+        // We don't have anymore stuff to give after filling up our available stacks - we good
+        if (remainingQuantity < 1)
+        {
+            return true;
+        }
+
+        // We still have leftover even after maxing each of our current stacks. See if we have empty slots in the inventory.
+        return Math.Ceiling((double)remainingQuantity / item.Descriptor.MaxInventoryStack) <=
+               FindOpenInventorySlots().Count;
+    }
+
+    /// <summary>
+    /// Checks whether or not a player has enough items in their inventory to be taken.
+    /// </summary>
+    /// <param name="itemId">The ItemId to see if it can be taken away from the player.</param>
+    /// <param name="quantity">The quantity of above item to see if we can take away from the player.</param>
+    /// <returns>Whether or not the item can be taken away from the player in the requested quantity.</returns>
+    public bool CanTakeItem(Guid itemId, int quantity) => FindInventoryItemQuantity(itemId) >= quantity;
+
+    /// <summary>
+    /// Checks whether or not a player has enough items in their inventory to be taken.
+    /// </summary>
+    /// <param name="item">The <see cref="Item"/> to see if it can be taken away from the player.</param>
+    /// <returns>Whether or not the item can be taken away from the player.</returns>
+    public bool CanTakeItem(Item item) => CanTakeItem(item.ItemId, item.Quantity);
+
+    /// <summary>
+    /// Gets the item at <paramref name="slotIndex"/> and stores it in <paramref name="slot"/>.
+    /// </summary>
+    /// <param name="slotIndex">the slot to load the <see cref="Item"/> from</param>
+    /// <param name="slot">the <see cref="Item"/> at <paramref name="slotIndex"/></param>
+    /// <param name="createSlotIfNull">if the slot is in an invalid state (<see langword="null"/>), set it</param>
+    /// <returns>returns <see langword="false"/> if <paramref name="slot"/> is set to <see langword="null"/></returns>
+    public bool TryGetSlot(int slotIndex, out InventorySlot slot, bool createSlotIfNull = false)
+    {
+        // ReSharper disable once AssignNullToNotNullAttribute Justification: slot is never null when this returns true.
+        slot = Items[slotIndex];
+
+        // ReSharper disable once InvertIf
+        if (default == slot && createSlotIfNull)
+        {
+            var createdSlot = new InventorySlot(slotIndex);
+            Log.Error("Creating inventory slot " + slotIndex + " for player " + Name + Environment.NewLine + Environment.StackTrace);
+            Items[slotIndex] = createdSlot;
+            slot = createdSlot;
+        }
+
+        return default != slot;
+    }
+
+    /// <summary>
+    /// Gets the item at <paramref name="slotIndex"/> and stores it in <paramref name="item"/>.
+    /// </summary>
+    /// <param name="slotIndex">the slot to load the <see cref="Item"/> from</param>
+    /// <param name="item">the <see cref="Item"/> at <paramref name="slotIndex"/></param>
+    /// <returns>returns <see langword="false"/> if <paramref name="item"/> is set to <see langword="null"/></returns>
+    public bool TryGetItemAt(int slotIndex, out Item item)
+    {
+        TryGetSlot(slotIndex, out var slot);
+        item = slot;
+        return default != item;
+    }
+
+    /// <summary>
+    /// Attempts to give the player an item. Returns whether or not it succeeds.
+    /// </summary>
+    /// <param name="item">The <see cref="Item"/> to give to the player.</param>
+    /// <param name="slot">The inventory slot to put this item into.</param>
+    /// <returns>Whether the player received the item or not.</returns>
+    public bool TryGiveItem(Item item, int slot = -1) => TryGiveItem(item, ItemHandling.Normal, false, slot, true);
+
+    /// <summary>
+    /// Attempts to give the player an item. Returns whether or not it succeeds.
+    /// </summary>
+    /// <param name="item">The <see cref="Item"/> to give to the player.</param>
+    /// <param name="handler">The way to handle handing out this item.</param>
+    /// <returns>Whether the player received the item or not.</returns>
+    public bool TryGiveItem(Item item, ItemHandling handler) => TryGiveItem(item, handler, false, -1, true);
+
+    /// <summary>
+    /// Attempts to give the player an item. Returns whether or not it succeeds.
+    /// </summary>
+    /// <param name="itemId">The Id for the item to be handed out to the player.</param>
+    /// <param name="quantity">The quantity of items to be handed out to the player.</param>
+    /// <returns>Whether the player received the item or not.</returns>
+    public bool TryGiveItem(Guid itemId, int quantity) => TryGiveItem(new Item(itemId, quantity), ItemHandling.Normal, false, -1, true);
+
+    /// <summary>
+    /// Attempts to give the player an item. Returns whether or not it succeeds.
+    /// </summary>
+    /// <param name="itemId">The Id for the item to be handed out to the player.</param>
+    /// <param name="quantity">The quantity of items to be handed out to the player.</param>
+    /// <param name="handler">The way to handle handing out this item.</param>
+    /// <returns>Whether the player received the item or not.</returns>
+    public bool TryGiveItem(Guid itemId, int quantity, ItemHandling handler) => TryGiveItem(new Item(itemId, quantity), handler, false, -1, true);
+
+    /// <summary>
+    /// Attempts to give the player an item. Returns whether or not it succeeds.
+    /// </summary>
+    /// <param name="itemId">The Id for the item to be handed out to the player.</param>
+    /// <param name="quantity">The quantity of items to be handed out to the player.</param>
+    /// <param name="handler">The way to handle handing out this item.</param>
+    /// <param name="bankOverflow">Should we allow the items to overflow into the player's bank when their inventory is full.</param>
+    /// <param name="slot">The inventory slot to put this item into.</param>
+    /// <param name="sendUpdate">Should we send an inventory update when we are done changing the player's items.</param>
+    /// <returns>Whether the player received the item or not.</returns>
+    public bool TryGiveItem(Guid itemId, int quantity, ItemHandling handler, bool bankOverflow = false, int slot = -1, bool sendUpdate = true) => TryGiveItem(new Item(itemId, quantity), handler, bankOverflow, slot, sendUpdate);
+
+    /// <summary>
+    /// Attempts to give the player an item. Returns whether or not it succeeds.
+    /// </summary>
+    /// <param name="item">The <see cref="Item"/> to give to the player.</param>
+    /// <param name="handler">The way to handle handing out this item.</param>
+    /// <param name="bankOverflow">Should we allow the items to overflow into the player's bank when their inventory is full.</param>
+    /// <param name="slot">The inventory slot to put this item into.</param>
+    /// <param name="sendUpdate">Should we send an inventory update when we are done changing the player's items.</param>
+    /// <param name="overflowTileX">The x coordinate of the tile in which overflow should spawn on, if the player cannot hold the full amount.</param>
+    /// <param name="overflowTileY">The y coordinate of the tile in which overflow should spawn on, if the player cannot hold the full amount.</param>
+    /// <returns>Whether the player received the item or not.</returns>
+    public bool TryGiveItem(Item item, ItemHandling handler = ItemHandling.Normal, bool bankOverflow = false, int slot = -1, bool sendUpdate = true, int overflowTileX = -1, int overflowTileY = -1)
+    {
+        // Is this a valid item?
+        if (item.Descriptor == null)
+        {
+            return false;
+        }
+
+        if (item.Quantity <= 0)
+        {
+            return true;
+        }
+
+        // Get this information so we can use it later.
+        var openSlots = FindOpenInventorySlots().Count;
+        var slotsRequired = (int)Math.Ceiling(item.Quantity / (double)item.Descriptor.MaxInventoryStack);
+
+        // How are we going to be handling this?
+        var success = false;
+        switch (handler)
+        {
+            // Handle this item like normal, there's no special rules attached to this method.
+            case ItemHandling.Normal:
+                if (CanGiveItem(item, slot)) // Can receive item under regular rules.
+                {
+                    GiveItem(item, slot, sendUpdate);
+                    success = true;
+                }
+                break;
+
+            case ItemHandling.Overflow:
+                {
+                    int spawnAmount;
+                    if (CanGiveItem(item, out var bagSlots)) // Can receive item under regular rules.
+                    {
+                        GiveItem(item, slot, sendUpdate, bagSlots);
+                        success = true;
+                        break;
+                    }
+
+                    if (item.Descriptor.Stackable && openSlots < slotsRequired) // Is stackable, but no inventory space.
+                    {
+                        spawnAmount = item.Quantity;
+                    }
+                    else // Time to give them as much as they can take, and spawn the rest on the map!
+                    {
+                        spawnAmount = item.Quantity - openSlots;
+                        if (openSlots > 0)
+                        {
+                            item.Quantity = openSlots;
+                            GiveItem(item, slot, sendUpdate);
+                        }
+                    }
+
+                    // Do we have any items to spawn to the map?
+                    if (spawnAmount > 0 && MapController.TryGetInstanceFromMap(Map.Id, MapInstanceId, out var instance))
+                    {
+                        instance.SpawnItem(overflowTileX > -1 ? overflowTileX : X, overflowTileY > -1 ? overflowTileY : Y, item, spawnAmount, Id);
+                        return spawnAmount != item.Quantity;
+                    }
+
+                    break;
+                }
+
+            case ItemHandling.UpTo:
+                if (CanGiveItem(item, slot)) // Can receive item under regular rules.
+                {
+                    GiveItem(item, slot, sendUpdate);
+                    success = true;
+                }
+                else if (!item.Descriptor.Stackable && openSlots >= slotsRequired) // Is not stackable, has space for some.
+                {
+                    item.Quantity = openSlots;
+                    GiveItem(item, slot, sendUpdate);
+                    success = true;
+                }
+                break;
+
+            // Did you forget to change this method when you added something? ;)
+            default:
+                throw new NotImplementedException();
+        }
+
+        if (success)
+        {
+            // Start common events related to inventory changes.
+            EnqueueStartCommonEvent(item.Descriptor?.GetEventTrigger(ItemEventTriggers.OnPickup));
+            StartCommonEventsWithTrigger(CommonEventTrigger.InventoryChanged);
+            UnequipInvalidItems();
+
+            return true;
+        }
+
+        var bankInterface = new BankInterface(this, ((IEnumerable<Item>)Bank).ToList(), new object(), null, Options.Instance.Bank.MaxSlots);
+        return bankOverflow && bankInterface.TryDepositItem(item, sendUpdate);
+    }
+
+
+    /// <summary>
+    /// Gives the player an item. NOTE: This method MAKES ZERO CHECKS to see if this is possible!
+    /// Use TryGiveItem where possible!
+    /// </summary>
+    /// <param name="item"></param>
+    /// <param name="sendUpdate"></param>
+    private void GiveItem(Item item, int destSlot, bool sendUpdate, BagSlot[]? bagSlots = default)
+    {
+        var remainingQuantity = item.Quantity;
+        if (bagSlots != default && destSlot < 0)
+        {
+            List<Bag> bagsUpdated = new List<Bag>();
+
+            foreach (var bagSlot in bagSlots)
             {
                 if (remainingQuantity < 1)
                 {
                     break;
                 }
 
-                if (inventorySlot.BagId == default)
-                {
-                    continue;
-                }
-
-                if (!inventorySlot.TryGetBag(out var bagInSlot))
-                {
-                    continue;
-                }
-
-                var compatibleSlotsInBag = Item.FindCompatibleSlotsForItem(
-                    itemDescriptor,
-                    itemDescriptor.MaxInventoryStack,
-                    -1,
+                var insertableQuantity = Math.Min(
                     remainingQuantity,
-                    bagInSlot.Slots.ToArray(),
-                    excludeEmpty: true
+                    item.Descriptor.MaxInventoryStack - bagSlot.Quantity
                 );
+                bagSlot.Quantity += insertableQuantity;
+                remainingQuantity -= insertableQuantity;
 
-                var totalAvailableQuantity = compatibleSlotsInBag.Aggregate(
-                    0,
-                    (current, compatibleSlotInBag) =>
-                        current + (itemDescriptor.MaxInventoryStack - compatibleSlotInBag.Quantity)
-                );
-                remainingQuantity -= totalAvailableQuantity;
-                compatibleBagSlots.AddRange(compatibleSlotsInBag);
+                if (!bagsUpdated.Contains(bagSlot.ParentBag))
+                {
+                    bagsUpdated.Add(bagSlot.ParentBag);
+                }
             }
 
-            return compatibleBagSlots.ToArray();
+            foreach (var bagUpdated in bagsUpdated)
+            {
+                // Save the bag changes
+                bagUpdated.Save();
+                if (IsInBag && InBag.Id == bagUpdated.Id)
+                {
+                    // Refresh the player's UI if they had the bag opened.
+                    PacketSender.SendOpenBag(this, bagUpdated.SlotCount, bagUpdated);
+                }
+            }
         }
 
-        //Inventory
-        /// <summary>
-        /// Checks whether a player can or can not receive the specified item and its quantity.
-        /// </summary>
-        /// <param name="item">The <see cref="Item"/> to check if this player can receive.</param>
-        /// <returns></returns>
-        public bool CanGiveItem(Item item, out BagSlot[] bagSlots)
+        // Did placing stacks in the bags take care of business?
+        if (remainingQuantity < 1)
         {
-            if (item.Descriptor == default)
-            {
-                bagSlots = Array.Empty<BagSlot>();
-                return false;
-            }
-
-            // Is the item stackable?
-            if (!item.Descriptor.IsStackable)
-            {
-                bagSlots = Array.Empty<BagSlot>();
-                // Not a stacking item, so can we contain the amount we want to give them?
-                return FindOpenInventorySlots().Count >= item.Quantity;
-            }
-
-            bagSlots = FindCompatibleBagSlots(item.Descriptor, item.Quantity, out var remainingQuantity);
-
-            if (remainingQuantity < 0)
-            {
-                return true;
-            }
-
-            // Does the user have this item already?
-            var existingItemSlots = FindInventoryItemSlots(item.ItemId);
-            var slotsRequired = Math.Ceiling((double)remainingQuantity / item.Descriptor.MaxInventoryStack);
-
-            // User doesn't have this item yet.
-            if (existingItemSlots.Count == 0)
-            {
-                // Does the user have enough free space for these stacks?
-                return FindOpenInventorySlots().Count >= slotsRequired;
-            }
-
-            // We need to check to see how much space we'd have if we first filled all possible stacks
-
-            // For each stack while we still have items to give
-            for (var i = 0; i < existingItemSlots.Count && remainingQuantity > 0; i++)
-            {
-                // Give as much as possible to this stack
-                remainingQuantity -= item.Descriptor.MaxInventoryStack - existingItemSlots[i].Quantity;
-            }
-
-            // We don't have anymore stuff to give after filling up our available stacks - we good
-            if (remainingQuantity < 1)
-            {
-                return true;
-            }
-
-            // We still have leftover even after maxing each of our current stacks. See if we have empty slots in the inventory.
-            return Math.Ceiling((double)remainingQuantity / item.Descriptor.MaxInventoryStack) <=
-                   FindOpenInventorySlots().Count;
+            return;
         }
 
-        /// <summary>
-        /// Checks whether or not a player has enough items in their inventory to be taken.
-        /// </summary>
-        /// <param name="itemId">The ItemId to see if it can be taken away from the player.</param>
-        /// <param name="quantity">The quantity of above item to see if we can take away from the player.</param>
-        /// <returns>Whether or not the item can be taken away from the player in the requested quantity.</returns>
-        public bool CanTakeItem(Guid itemId, int quantity) => FindInventoryItemQuantity(itemId) >= quantity;
-
-        /// <summary>
-        /// Checks whether or not a player has enough items in their inventory to be taken.
-        /// </summary>
-        /// <param name="item">The <see cref="Item"/> to see if it can be taken away from the player.</param>
-        /// <returns>Whether or not the item can be taken away from the player.</returns>
-        public bool CanTakeItem(Item item) => CanTakeItem(item.ItemId, item.Quantity);
-
-        /// <summary>
-        /// Gets the item at <paramref name="slotIndex"/> and stores it in <paramref name="slot"/>.
-        /// </summary>
-        /// <param name="slotIndex">the slot to load the <see cref="Item"/> from</param>
-        /// <param name="slot">the <see cref="Item"/> at <paramref name="slotIndex"/></param>
-        /// <param name="createSlotIfNull">if the slot is in an invalid state (<see langword="null"/>), set it</param>
-        /// <returns>returns <see langword="false"/> if <paramref name="slot"/> is set to <see langword="null"/></returns>
-        public bool TryGetSlot(int slotIndex, out InventorySlot slot, bool createSlotIfNull = false)
+        // Decide how we're going to handle this item.
+        var existingSlots = FindInventoryItemSlots(item.Descriptor.Id);
+        var updateSlots = new List<int>();
+        if (item.Descriptor.Stackable && existingSlots.Count > 0) // Stackable, but already exists in the inventory.
         {
-            // ReSharper disable once AssignNullToNotNullAttribute Justification: slot is never null when this returns true.
-            slot = Items[slotIndex];
-
-            // ReSharper disable once InvertIf
-            if (default == slot && createSlotIfNull)
+            // So this gets complicated.. First let's hand out the quantity we can hand out before we hit a stack limit.
+            foreach (var slot in existingSlots)
             {
-                var createdSlot = new InventorySlot(slotIndex);
-                Log.Error("Creating inventory slot " + slotIndex + " for player " + Name + Environment.NewLine + Environment.StackTrace);
-                Items[slotIndex] = createdSlot;
-                slot = createdSlot;
-            }
-
-            return default != slot;
-        }
-
-        /// <summary>
-        /// Gets the item at <paramref name="slotIndex"/> and stores it in <paramref name="item"/>.
-        /// </summary>
-        /// <param name="slotIndex">the slot to load the <see cref="Item"/> from</param>
-        /// <param name="item">the <see cref="Item"/> at <paramref name="slotIndex"/></param>
-        /// <returns>returns <see langword="false"/> if <paramref name="item"/> is set to <see langword="null"/></returns>
-        public bool TryGetItemAt(int slotIndex, out Item item)
-        {
-            TryGetSlot(slotIndex, out var slot);
-            item = slot;
-            return default != item;
-        }
-
-        /// <summary>
-        /// Attempts to give the player an item. Returns whether or not it succeeds.
-        /// </summary>
-        /// <param name="item">The <see cref="Item"/> to give to the player.</param>
-        /// <param name="slot">The inventory slot to put this item into.</param>
-        /// <returns>Whether the player received the item or not.</returns>
-        public bool TryGiveItem(Item item, int slot = -1) => TryGiveItem(item, ItemHandling.Normal, false, slot, true);
-
-        /// <summary>
-        /// Attempts to give the player an item. Returns whether or not it succeeds.
-        /// </summary>
-        /// <param name="item">The <see cref="Item"/> to give to the player.</param>
-        /// <param name="handler">The way to handle handing out this item.</param>
-        /// <returns>Whether the player received the item or not.</returns>
-        public bool TryGiveItem(Item item, ItemHandling handler) => TryGiveItem(item, handler, false, -1, true);
-
-        /// <summary>
-        /// Attempts to give the player an item. Returns whether or not it succeeds.
-        /// </summary>
-        /// <param name="itemId">The Id for the item to be handed out to the player.</param>
-        /// <param name="quantity">The quantity of items to be handed out to the player.</param>
-        /// <returns>Whether the player received the item or not.</returns>
-        public bool TryGiveItem(Guid itemId, int quantity) => TryGiveItem(new Item(itemId, quantity), ItemHandling.Normal, false, -1, true);
-
-        /// <summary>
-        /// Attempts to give the player an item. Returns whether or not it succeeds.
-        /// </summary>
-        /// <param name="itemId">The Id for the item to be handed out to the player.</param>
-        /// <param name="quantity">The quantity of items to be handed out to the player.</param>
-        /// <param name="handler">The way to handle handing out this item.</param>
-        /// <returns>Whether the player received the item or not.</returns>
-        public bool TryGiveItem(Guid itemId, int quantity, ItemHandling handler) => TryGiveItem(new Item(itemId, quantity), handler, false, -1, true);
-
-        /// <summary>
-        /// Attempts to give the player an item. Returns whether or not it succeeds.
-        /// </summary>
-        /// <param name="itemId">The Id for the item to be handed out to the player.</param>
-        /// <param name="quantity">The quantity of items to be handed out to the player.</param>
-        /// <param name="handler">The way to handle handing out this item.</param>
-        /// <param name="bankOverflow">Should we allow the items to overflow into the player's bank when their inventory is full.</param>
-        /// <param name="slot">The inventory slot to put this item into.</param>
-        /// <param name="sendUpdate">Should we send an inventory update when we are done changing the player's items.</param>
-        /// <returns>Whether the player received the item or not.</returns>
-        public bool TryGiveItem(Guid itemId, int quantity, ItemHandling handler, bool bankOverflow = false, int slot = -1, bool sendUpdate = true) => TryGiveItem(new Item(itemId, quantity), handler, bankOverflow, slot, sendUpdate);
-
-        /// <summary>
-        /// Attempts to give the player an item. Returns whether or not it succeeds.
-        /// </summary>
-        /// <param name="item">The <see cref="Item"/> to give to the player.</param>
-        /// <param name="handler">The way to handle handing out this item.</param>
-        /// <param name="bankOverflow">Should we allow the items to overflow into the player's bank when their inventory is full.</param>
-        /// <param name="slot">The inventory slot to put this item into.</param>
-        /// <param name="sendUpdate">Should we send an inventory update when we are done changing the player's items.</param>
-        /// <param name="overflowTileX">The x coordinate of the tile in which overflow should spawn on, if the player cannot hold the full amount.</param>
-        /// <param name="overflowTileY">The y coordinate of the tile in which overflow should spawn on, if the player cannot hold the full amount.</param>
-        /// <returns>Whether the player received the item or not.</returns>
-        public bool TryGiveItem(Item item, ItemHandling handler = ItemHandling.Normal, bool bankOverflow = false, int slot = -1, bool sendUpdate = true, int overflowTileX = -1, int overflowTileY = -1)
-        {
-            // Is this a valid item?
-            if (item.Descriptor == null)
-            {
-                return false;
-            }
-
-            if (item.Quantity <= 0)
-            {
-                return true;
-            }
-
-            // Get this information so we can use it later.
-            var openSlots = FindOpenInventorySlots().Count;
-            var slotsRequired = (int)Math.Ceiling(item.Quantity / (double)item.Descriptor.MaxInventoryStack);
-
-            // How are we going to be handling this?
-            var success = false;
-            switch (handler)
-            {
-                // Handle this item like normal, there's no special rules attached to this method.
-                case ItemHandling.Normal:
-                    if (CanGiveItem(item, slot)) // Can receive item under regular rules.
-                    {
-                        GiveItem(item, slot, sendUpdate);
-                        success = true;
-                    }
+                if (remainingQuantity == 0)
+                {
                     break;
-
-                case ItemHandling.Overflow:
-                    {
-                        int spawnAmount;
-                        if (CanGiveItem(item, out var bagSlots)) // Can receive item under regular rules.
-                        {
-                            GiveItem(item, slot, sendUpdate, bagSlots);
-                            success = true;
-                            break;
-                        }
-
-                        if (item.Descriptor.Stackable && openSlots < slotsRequired) // Is stackable, but no inventory space.
-                        {
-                            spawnAmount = item.Quantity;
-                        }
-                        else // Time to give them as much as they can take, and spawn the rest on the map!
-                        {
-                            spawnAmount = item.Quantity - openSlots;
-                            if (openSlots > 0)
-                            {
-                                item.Quantity = openSlots;
-                                GiveItem(item, slot, sendUpdate);
-                            }
-                        }
-
-                        // Do we have any items to spawn to the map?
-                        if (spawnAmount > 0 && MapController.TryGetInstanceFromMap(Map.Id, MapInstanceId, out var instance))
-                        {
-                            instance.SpawnItem(overflowTileX > -1 ? overflowTileX : X, overflowTileY > -1 ? overflowTileY : Y, item, spawnAmount, Id);
-                            return spawnAmount != item.Quantity;
-                        }
-
-                        break;
-                    }
-
-                case ItemHandling.UpTo:
-                    if (CanGiveItem(item, slot)) // Can receive item under regular rules.
-                    {
-                        GiveItem(item, slot, sendUpdate);
-                        success = true;
-                    }
-                    else if (!item.Descriptor.Stackable && openSlots >= slotsRequired) // Is not stackable, has space for some.
-                    {
-                        item.Quantity = openSlots;
-                        GiveItem(item, slot, sendUpdate);
-                        success = true;
-                    }
-                    break;
-
-                // Did you forget to change this method when you added something? ;)
-                default:
-                    throw new NotImplementedException();
-            }
-
-            if (success)
-            {
-                // Start common events related to inventory changes.
-                EnqueueStartCommonEvent(item.Descriptor?.GetEventTrigger(ItemEventTriggers.OnPickup));
-                StartCommonEventsWithTrigger(CommonEventTrigger.InventoryChanged);
-                UnequipInvalidItems();
-
-                return true;
-            }
-
-            var bankInterface = new BankInterface(this, ((IEnumerable<Item>)Bank).ToList(), new object(), null, Options.Instance.Bank.MaxSlots);
-            return bankOverflow && bankInterface.TryDepositItem(item, sendUpdate);
-        }
-
-
-        /// <summary>
-        /// Gives the player an item. NOTE: This method MAKES ZERO CHECKS to see if this is possible!
-        /// Use TryGiveItem where possible!
-        /// </summary>
-        /// <param name="item"></param>
-        /// <param name="sendUpdate"></param>
-        private void GiveItem(Item item, int destSlot, bool sendUpdate, BagSlot[]? bagSlots = default)
-        {
-            var remainingQuantity = item.Quantity;
-            if (bagSlots != default && destSlot < 0)
-            {
-                List<Bag> bagsUpdated = new List<Bag>();
-
-                foreach (var bagSlot in bagSlots)
-                {
-                    if (remainingQuantity < 1)
-                    {
-                        break;
-                    }
-
-                    var insertableQuantity = Math.Min(
-                        remainingQuantity,
-                        item.Descriptor.MaxInventoryStack - bagSlot.Quantity
-                    );
-                    bagSlot.Quantity += insertableQuantity;
-                    remainingQuantity -= insertableQuantity;
-
-                    if (!bagsUpdated.Contains(bagSlot.ParentBag))
-                    {
-                        bagsUpdated.Add(bagSlot.ParentBag);
-                    }
                 }
 
-                foreach (var bagUpdated in bagsUpdated)
+                if (slot.Quantity >= item.Descriptor.MaxInventoryStack)
                 {
-                    // Save the bag changes
-                    bagUpdated.Save();
-                    if (IsInBag && InBag.Id == bagUpdated.Id)
-                    {
-                        // Refresh the player's UI if they had the bag opened.
-                        PacketSender.SendOpenBag(this, bagUpdated.SlotCount, bagUpdated);
-                    }
-                }
-            }
-
-            // Did placing stacks in the bags take care of business?
-            if (remainingQuantity < 1)
-            {
-                return;
-            }
-
-            // Decide how we're going to handle this item.
-            var existingSlots = FindInventoryItemSlots(item.Descriptor.Id);
-            var updateSlots = new List<int>();
-            if (item.Descriptor.Stackable && existingSlots.Count > 0) // Stackable, but already exists in the inventory.
-            {
-                // So this gets complicated.. First let's hand out the quantity we can hand out before we hit a stack limit.
-                foreach (var slot in existingSlots)
-                {
-                    if (remainingQuantity == 0)
-                    {
-                        break;
-                    }
-
-                    if (slot.Quantity >= item.Descriptor.MaxInventoryStack)
-                    {
-                        continue;
-                    }
-
-                    var canAdd = item.Descriptor.MaxInventoryStack - slot.Quantity;
-                    if (canAdd > remainingQuantity)
-                    {
-                        slot.Quantity += remainingQuantity;
-                        updateSlots.Add(slot.Slot);
-                        remainingQuantity = 0;
-                    }
-                    else
-                    {
-                        slot.Quantity += canAdd;
-                        updateSlots.Add(slot.Slot);
-                        remainingQuantity -= canAdd;
-                    }
+                    continue;
                 }
 
-                // Is there anything left to hand out? If so, hand out max stacks and what remains until we run out!
-                if (remainingQuantity > 0)
+                var canAdd = item.Descriptor.MaxInventoryStack - slot.Quantity;
+                if (canAdd > remainingQuantity)
                 {
-                    // Are we trying to put the item into a specific slot? If so, put as much in as possible!
-                    if (destSlot != -1)
-                    {
-                        if (remainingQuantity > item.Descriptor.MaxInventoryStack)
-                        {
-                            Items[destSlot].Set(new Item(item.ItemId, item.Descriptor.MaxInventoryStack));
-                            updateSlots.Add(destSlot);
-                            remainingQuantity -= item.Descriptor.MaxInventoryStack;
-                        }
-                        else
-                        {
-                            Items[destSlot].Set(new Item(item.ItemId, remainingQuantity));
-                            updateSlots.Add(destSlot);
-                            remainingQuantity = 0;
-                        }
-                    }
-
-                    var openSlots = FindOpenInventorySlots();
-                    var total = remainingQuantity; // Copy this as we're going to be editing toGive.
-                    for (var slot = 0; slot < Math.Ceiling((double)total / item.Descriptor.MaxInventoryStack); slot++)
-                    {
-                        var quantity = item.Descriptor.MaxInventoryStack <= remainingQuantity ?
-                            item.Descriptor.MaxInventoryStack :
-                            remainingQuantity;
-
-                        remainingQuantity -= quantity;
-                        openSlots[slot].Set(new Item(item.ItemId, quantity));
-                        updateSlots.Add(openSlots[slot].Slot);
-                    }
+                    slot.Quantity += remainingQuantity;
+                    updateSlots.Add(slot.Slot);
+                    remainingQuantity = 0;
                 }
-            }
-            else if (!item.Descriptor.Stackable && remainingQuantity > 1) // Not stackable, but multiple items.
-            {
-                if (destSlot != -1)
-                {
-                    Items[destSlot].Set(new Item(item.ItemId, 1));
-                    updateSlots.Add(destSlot);
-                    remainingQuantity -= 1;
-                }
-
-                var openSlots = FindOpenInventorySlots();
-                for (var slot = 0; slot < remainingQuantity; slot++)
-                {
-                    openSlots[slot].Set(new Item(item.ItemId, 1));
-                    updateSlots.Add(openSlots[slot].Slot);
-                }
-            }
-            else // Hand out without any special treatment. Either a single item or a stackable item we don't have yet.
-            {
-                // If the item is not stackable, or the amount is below our stack cap just blindly hand it out.
-                if (!item.Descriptor.Stackable || remainingQuantity < item.Descriptor.MaxInventoryStack)
-                {
-                    if (destSlot != -1)
-                    {
-                        Items[destSlot].Set(item);
-                        updateSlots.Add(destSlot);
-                    }
-                    else
-                    {
-                        var newSlot = FindOpenInventorySlot();
-                        newSlot.Set(new Item(item.ItemId, remainingQuantity, item.Properties));
-                        updateSlots.Add(newSlot.Slot);
-                    }
-                }
-                // The item is above our stack cap.. Let's start handing them phat stacks out!
                 else
                 {
-                    if (destSlot != -1)
+                    slot.Quantity += canAdd;
+                    updateSlots.Add(slot.Slot);
+                    remainingQuantity -= canAdd;
+                }
+            }
+
+            // Is there anything left to hand out? If so, hand out max stacks and what remains until we run out!
+            if (remainingQuantity > 0)
+            {
+                // Are we trying to put the item into a specific slot? If so, put as much in as possible!
+                if (destSlot != -1)
+                {
+                    if (remainingQuantity > item.Descriptor.MaxInventoryStack)
                     {
                         Items[destSlot].Set(new Item(item.ItemId, item.Descriptor.MaxInventoryStack));
                         updateSlots.Add(destSlot);
                         remainingQuantity -= item.Descriptor.MaxInventoryStack;
                     }
-
-                    var openSlots = FindOpenInventorySlots();
-                    var maxSlot = Math.Ceiling((double)remainingQuantity / item.Descriptor.MaxInventoryStack);
-                    for (var slot = 0; remainingQuantity > 0 && slot < maxSlot; slot++)
+                    else
                     {
-                        var quantity = item.Descriptor.MaxInventoryStack <= remainingQuantity ?
-                            item.Descriptor.MaxInventoryStack :
-                            remainingQuantity;
-
-                        remainingQuantity -= quantity;
-                        openSlots[slot].Set(new Item(item.ItemId, quantity));
-                        updateSlots.Add(openSlots[slot].Slot);
+                        Items[destSlot].Set(new Item(item.ItemId, remainingQuantity));
+                        updateSlots.Add(destSlot);
+                        remainingQuantity = 0;
                     }
                 }
 
-            }
-
-            // Do we need to update the player's inventory?
-            if (sendUpdate)
-            {
-                foreach (var slot in updateSlots)
+                var openSlots = FindOpenInventorySlots();
+                var total = remainingQuantity; // Copy this as we're going to be editing toGive.
+                for (var slot = 0; slot < Math.Ceiling((double)total / item.Descriptor.MaxInventoryStack); slot++)
                 {
-                    PacketSender.SendInventoryItemUpdate(this, slot);
+                    var quantity = item.Descriptor.MaxInventoryStack <= remainingQuantity ?
+                        item.Descriptor.MaxInventoryStack :
+                        remainingQuantity;
+
+                    remainingQuantity -= quantity;
+                    openSlots[slot].Set(new Item(item.ItemId, quantity));
+                    updateSlots.Add(openSlots[slot].Slot);
                 }
             }
-
-            // Update quests for this item.
-            UpdateGatherItemQuests(item.ItemId);
-
         }
-
-        /// <summary>
-        /// Retrieves a list of open inventory slots for this player.
-        /// </summary>
-        /// <returns>A list of <see cref="InventorySlot"/></returns>
-        public List<InventorySlot> FindOpenInventorySlots()
+        else if (!item.Descriptor.Stackable && remainingQuantity > 1) // Not stackable, but multiple items.
         {
-            var slots = new List<InventorySlot>();
-            for (var i = 0; i < Options.MaxInvItems; i++)
+            if (destSlot != -1)
             {
-                var inventorySlot = Items[i];
-
-                if (inventorySlot != null && inventorySlot.ItemId == Guid.Empty)
-                {
-                    slots.Add(inventorySlot);
-                }
+                Items[destSlot].Set(new Item(item.ItemId, 1));
+                updateSlots.Add(destSlot);
+                remainingQuantity -= 1;
             }
-            return slots;
+
+            var openSlots = FindOpenInventorySlots();
+            for (var slot = 0; slot < remainingQuantity; slot++)
+            {
+                openSlots[slot].Set(new Item(item.ItemId, 1));
+                updateSlots.Add(openSlots[slot].Slot);
+            }
         }
-
-        /// <summary>
-        /// Finds the first open inventory slot this player has.
-        /// </summary>
-        /// <returns>An <see cref="InventorySlot"/> instance, or null if none are found.</returns>
-        public InventorySlot FindOpenInventorySlot() => FindOpenInventorySlots().FirstOrDefault();
-
-        /// <summary>
-        /// Swap items between <paramref name="fromSlotIndex"/> and <paramref name="toSlotIndex"/>.
-        /// </summary>
-        /// <param name="fromSlotIndex">the slot index to swap from</param>
-        /// <param name="toSlotIndex">the slot index to swap to</param>
-        public void SwapItems(int fromSlotIndex, int toSlotIndex)
+        else // Hand out without any special treatment. Either a single item or a stackable item we don't have yet.
         {
-            TryGetSlot(fromSlotIndex, out var fromSlot, true);
-            TryGetSlot(toSlotIndex, out var toSlot, true);
-
-            if (
-                fromSlot.ItemId == toSlot.ItemId
-                && ItemBase.TryGet(toSlot.ItemId, out var itemInSlot)
-                && itemInSlot.IsStackable
-                && fromSlot.Quantity < itemInSlot.MaxInventoryStack
-                && toSlot.Quantity < itemInSlot.MaxInventoryStack
-            )
+            // If the item is not stackable, or the amount is below our stack cap just blindly hand it out.
+            if (!item.Descriptor.Stackable || remainingQuantity < item.Descriptor.MaxInventoryStack)
             {
-                var combinedQuantity = fromSlot.Quantity + toSlot.Quantity;
-                var toQuantity = Math.Min(itemInSlot.MaxInventoryStack, combinedQuantity);
-                var fromQuantity = combinedQuantity - toQuantity;
-                toSlot.Quantity = toQuantity;
-                fromSlot.Quantity = fromQuantity;
-                if (fromQuantity < 1)
+                if (destSlot != -1)
                 {
-                    fromSlot.Set(new InventorySlot());
+                    Items[destSlot].Set(item);
+                    updateSlots.Add(destSlot);
+                }
+                else
+                {
+                    var newSlot = FindOpenInventorySlot();
+                    newSlot.Set(new Item(item.ItemId, remainingQuantity, item.Properties));
+                    updateSlots.Add(newSlot.Slot);
                 }
             }
+            // The item is above our stack cap.. Let's start handing them phat stacks out!
             else
             {
-                var toSlotClone = toSlot.Clone();
-                toSlot.Set(fromSlot);
-                fromSlot.Set(toSlotClone);
-            }
-
-            // TODO(0.8-beta): combine into 1 batch packet
-            PacketSender.SendInventoryItemUpdate(this, fromSlotIndex);
-            PacketSender.SendInventoryItemUpdate(this, toSlotIndex);
-            EquipmentProcessItemSwap(fromSlotIndex, toSlotIndex);
-        }
-
-        /// <summary>
-        /// Attempt to drop <paramref name="amount"/> of the item in the slot
-        /// identified by <paramref name="slotIndex"/>, returning false if it
-        /// is unable to drop the item for any reason.
-        /// </summary>
-        /// <param name="slotIndex">the slot to drop from</param>
-        /// <param name="amount">the amount to drop</param>
-        /// <returns>if an item was dropped</returns>
-        public bool TryDropItemFrom(int slotIndex, int amount)
-        {
-            if (!TryGetItemAt(slotIndex, out var itemInSlot))
-            {
-                return false;
-            }
-
-            amount = Math.Min(amount, itemInSlot.Quantity);
-            if (amount < 1)
-            {
-                // Abort if the amount we are trying to drop is below 1.
-                return false;
-            }
-
-            if (Equipment?.Any(equipmentSlotIndex => equipmentSlotIndex == slotIndex) ?? false)
-            {
-                PacketSender.SendChatMsg(this, Strings.Items.equipped, ChatMessageType.Inventory, CustomColors.Items.Bound);
-                return false;
-            }
-
-            var itemDescriptor = itemInSlot.Descriptor;
-            if (itemDescriptor == null)
-            {
-                return false;
-            }
-
-            if (!itemDescriptor.CanDrop)
-            {
-                PacketSender.SendChatMsg(this, Strings.Items.bound, ChatMessageType.Inventory, CustomColors.Items.Bound);
-                return false;
-            }
-
-            if (itemInSlot.TryGetBag(out var bag) && !bag.IsEmpty)
-            {
-                PacketSender.SendChatMsg(this, Strings.Bags.dropnotempty, ChatMessageType.Inventory, CustomColors.Alerts.Error);
-                return false;
-            }
-
-            if (!MapController.TryGetInstanceFromMap(MapId, MapInstanceId, out var mapInstance))
-            {
-                Log.Error(
-                    Map == default
-                        ? $"Could not find map {MapId} for player '{Name}'."
-                        : $"Could not find map instance {MapInstanceId} for player '{Name}' on map {Map.Name}."
-                );
-                return false;
-            }
-
-            mapInstance.SpawnItem(X, Y, itemInSlot, itemDescriptor.IsStackable ? amount : 1, Id);
-
-            itemInSlot.Quantity = Math.Max(0, itemInSlot.Quantity - amount);
-
-            if (itemInSlot.Quantity == 0)
-            {
-                itemInSlot.Set(Item.None);
-                EquipmentProcessItemLoss(slotIndex);
-            }
-
-            EnqueueStartCommonEvent(itemDescriptor.GetEventTrigger(ItemEventTriggers.OnDrop));
-            UnequipInvalidItems();
-            StartCommonEventsWithTrigger(CommonEventTrigger.InventoryChanged);
-            UpdateGatherItemQuests(itemDescriptor.Id);
-            PacketSender.SendInventoryItemUpdate(this, slotIndex);
-            return true;
-        }
-
-        /// <summary>
-        /// Drops <paramref name="amount"/> of the item in the slot identified by <paramref name="slotIndex"/>.
-        /// </summary>
-        /// <param name="slotIndex">the slot to drop from</param>
-        /// <param name="amount">the amount to drop</param>
-        /// <see cref="TryDropItemFrom(int, int)"/>
-        [Obsolete("Use TryDropItemFrom(int, int).")]
-        public void DropItemFrom(int slotIndex, int amount) => TryDropItemFrom(slotIndex, amount);
-
-        protected override bool ShouldDropItem(Entity killer, ItemBase itemDescriptor, Item item, float dropRateModifier, out Guid lootOwner)
-        {
-            lootOwner = (killer as Player)?.Id ?? Id;
-
-            if (itemDescriptor.DropChanceOnDeath == 0)
-            {
-                return false;
-            }
-
-            var dropRate = itemDescriptor.DropChanceOnDeath * dropRateModifier;
-            var dropResult = Randomization.Next(1, 101);
-            return dropResult < dropRate;
-        }
-
-        protected override void OnDropItem(InventorySlot slot, Item drop)
-        {
-            _ = TryTakeItem(slot, drop.Quantity);
-        }
-
-        public void UseItem(int slot, Entity target = null)
-        {
-            var equipped = false;
-            var Item = Items[slot];
-            var itemBase = ItemBase.Get(Item.ItemId);
-            if (itemBase != null && Item.Quantity > 0)
-            {
-
-                //Check if the user is silenced or stunned
-                foreach (var status in CachedStatuses)
+                if (destSlot != -1)
                 {
-                    if (status.Type == SpellEffect.Stun)
-                    {
-                        PacketSender.SendChatMsg(this, Strings.Items.stunned, ChatMessageType.Error);
-
-                        return;
-                    }
-
-                    if (status.Type == SpellEffect.Sleep)
-                    {
-                        PacketSender.SendChatMsg(this, Strings.Items.sleep, ChatMessageType.Error);
-
-                        return;
-                    }
+                    Items[destSlot].Set(new Item(item.ItemId, item.Descriptor.MaxInventoryStack));
+                    updateSlots.Add(destSlot);
+                    remainingQuantity -= item.Descriptor.MaxInventoryStack;
                 }
 
-                // Unequip items even if you do not meet the requirements.
-                // (Need this for silly devs who give people items and then later add restrictions...)
-                if (itemBase.ItemType == ItemType.Equipment && SlotIsEquipped(slot, out var equippedSlot))
+                var openSlots = FindOpenInventorySlots();
+                var maxSlot = Math.Ceiling((double)remainingQuantity / item.Descriptor.MaxInventoryStack);
+                for (var slot = 0; remainingQuantity > 0 && slot < maxSlot; slot++)
                 {
-                    UnequipItem(equippedSlot, true);
+                    var quantity = item.Descriptor.MaxInventoryStack <= remainingQuantity ?
+                        item.Descriptor.MaxInventoryStack :
+                        remainingQuantity;
+
+                    remainingQuantity -= quantity;
+                    openSlots[slot].Set(new Item(item.ItemId, quantity));
+                    updateSlots.Add(openSlots[slot].Slot);
+                }
+            }
+
+        }
+
+        // Do we need to update the player's inventory?
+        if (sendUpdate)
+        {
+            foreach (var slot in updateSlots)
+            {
+                PacketSender.SendInventoryItemUpdate(this, slot);
+            }
+        }
+
+        // Update quests for this item.
+        UpdateGatherItemQuests(item.ItemId);
+
+    }
+
+    /// <summary>
+    /// Retrieves a list of open inventory slots for this player.
+    /// </summary>
+    /// <returns>A list of <see cref="InventorySlot"/></returns>
+    public List<InventorySlot> FindOpenInventorySlots()
+    {
+        var slots = new List<InventorySlot>();
+        for (var i = 0; i < Options.MaxInvItems; i++)
+        {
+            var inventorySlot = Items[i];
+
+            if (inventorySlot != null && inventorySlot.ItemId == Guid.Empty)
+            {
+                slots.Add(inventorySlot);
+            }
+        }
+        return slots;
+    }
+
+    /// <summary>
+    /// Finds the first open inventory slot this player has.
+    /// </summary>
+    /// <returns>An <see cref="InventorySlot"/> instance, or null if none are found.</returns>
+    public InventorySlot FindOpenInventorySlot() => FindOpenInventorySlots().FirstOrDefault();
+
+    /// <summary>
+    /// Swap items between <paramref name="fromSlotIndex"/> and <paramref name="toSlotIndex"/>.
+    /// </summary>
+    /// <param name="fromSlotIndex">the slot index to swap from</param>
+    /// <param name="toSlotIndex">the slot index to swap to</param>
+    public void SwapItems(int fromSlotIndex, int toSlotIndex)
+    {
+        TryGetSlot(fromSlotIndex, out var fromSlot, true);
+        TryGetSlot(toSlotIndex, out var toSlot, true);
+
+        if (
+            fromSlot.ItemId == toSlot.ItemId
+            && ItemBase.TryGet(toSlot.ItemId, out var itemInSlot)
+            && itemInSlot.IsStackable
+            && fromSlot.Quantity < itemInSlot.MaxInventoryStack
+            && toSlot.Quantity < itemInSlot.MaxInventoryStack
+        )
+        {
+            var combinedQuantity = fromSlot.Quantity + toSlot.Quantity;
+            var toQuantity = Math.Min(itemInSlot.MaxInventoryStack, combinedQuantity);
+            var fromQuantity = combinedQuantity - toQuantity;
+            toSlot.Quantity = toQuantity;
+            fromSlot.Quantity = fromQuantity;
+            if (fromQuantity < 1)
+            {
+                fromSlot.Set(new InventorySlot());
+            }
+        }
+        else
+        {
+            var toSlotClone = toSlot.Clone();
+            toSlot.Set(fromSlot);
+            fromSlot.Set(toSlotClone);
+        }
+
+        // TODO(0.8-beta): combine into 1 batch packet
+        PacketSender.SendInventoryItemUpdate(this, fromSlotIndex);
+        PacketSender.SendInventoryItemUpdate(this, toSlotIndex);
+        EquipmentProcessItemSwap(fromSlotIndex, toSlotIndex);
+    }
+
+    /// <summary>
+    /// Attempt to drop <paramref name="amount"/> of the item in the slot
+    /// identified by <paramref name="slotIndex"/>, returning false if it
+    /// is unable to drop the item for any reason.
+    /// </summary>
+    /// <param name="slotIndex">the slot to drop from</param>
+    /// <param name="amount">the amount to drop</param>
+    /// <returns>if an item was dropped</returns>
+    public bool TryDropItemFrom(int slotIndex, int amount)
+    {
+        if (!TryGetItemAt(slotIndex, out var itemInSlot))
+        {
+            return false;
+        }
+
+        amount = Math.Min(amount, itemInSlot.Quantity);
+        if (amount < 1)
+        {
+            // Abort if the amount we are trying to drop is below 1.
+            return false;
+        }
+
+        if (Equipment?.Any(equipmentSlotIndex => equipmentSlotIndex == slotIndex) ?? false)
+        {
+            PacketSender.SendChatMsg(this, Strings.Items.equipped, ChatMessageType.Inventory, CustomColors.Items.Bound);
+            return false;
+        }
+
+        var itemDescriptor = itemInSlot.Descriptor;
+        if (itemDescriptor == null)
+        {
+            return false;
+        }
+
+        if (!itemDescriptor.CanDrop)
+        {
+            PacketSender.SendChatMsg(this, Strings.Items.bound, ChatMessageType.Inventory, CustomColors.Items.Bound);
+            return false;
+        }
+
+        if (itemInSlot.TryGetBag(out var bag) && !bag.IsEmpty)
+        {
+            PacketSender.SendChatMsg(this, Strings.Bags.dropnotempty, ChatMessageType.Inventory, CustomColors.Alerts.Error);
+            return false;
+        }
+
+        if (!MapController.TryGetInstanceFromMap(MapId, MapInstanceId, out var mapInstance))
+        {
+            Log.Error(
+                Map == default
+                    ? $"Could not find map {MapId} for player '{Name}'."
+                    : $"Could not find map instance {MapInstanceId} for player '{Name}' on map {Map.Name}."
+            );
+            return false;
+        }
+
+        mapInstance.SpawnItem(X, Y, itemInSlot, itemDescriptor.IsStackable ? amount : 1, Id);
+
+        itemInSlot.Quantity = Math.Max(0, itemInSlot.Quantity - amount);
+
+        if (itemInSlot.Quantity == 0)
+        {
+            itemInSlot.Set(Item.None);
+            EquipmentProcessItemLoss(slotIndex);
+        }
+
+        EnqueueStartCommonEvent(itemDescriptor.GetEventTrigger(ItemEventTriggers.OnDrop));
+        UnequipInvalidItems();
+        StartCommonEventsWithTrigger(CommonEventTrigger.InventoryChanged);
+        UpdateGatherItemQuests(itemDescriptor.Id);
+        PacketSender.SendInventoryItemUpdate(this, slotIndex);
+        return true;
+    }
+
+    /// <summary>
+    /// Drops <paramref name="amount"/> of the item in the slot identified by <paramref name="slotIndex"/>.
+    /// </summary>
+    /// <param name="slotIndex">the slot to drop from</param>
+    /// <param name="amount">the amount to drop</param>
+    /// <see cref="TryDropItemFrom(int, int)"/>
+    [Obsolete("Use TryDropItemFrom(int, int).")]
+    public void DropItemFrom(int slotIndex, int amount) => TryDropItemFrom(slotIndex, amount);
+
+    protected override bool ShouldDropItem(Entity killer, ItemBase itemDescriptor, Item item, float dropRateModifier, out Guid lootOwner)
+    {
+        lootOwner = (killer as Player)?.Id ?? Id;
+
+        if (itemDescriptor.DropChanceOnDeath == 0)
+        {
+            return false;
+        }
+
+        var dropRate = itemDescriptor.DropChanceOnDeath * dropRateModifier;
+        var dropResult = Randomization.Next(1, 101);
+        return dropResult < dropRate;
+    }
+
+    protected override void OnDropItem(InventorySlot slot, Item drop)
+    {
+        _ = TryTakeItem(slot, drop.Quantity);
+    }
+
+    public void UseItem(int slot, Entity target = null)
+    {
+        var equipped = false;
+        var Item = Items[slot];
+        var itemBase = ItemBase.Get(Item.ItemId);
+        if (itemBase != null && Item.Quantity > 0)
+        {
+
+            //Check if the user is silenced or stunned
+            foreach (var status in CachedStatuses)
+            {
+                if (status.Type == SpellEffect.Stun)
+                {
+                    PacketSender.SendChatMsg(this, Strings.Items.stunned, ChatMessageType.Error);
+
                     return;
                 }
 
-                if (!Conditions.MeetsConditionLists(itemBase.UsageRequirements, this, null))
+                if (status.Type == SpellEffect.Sleep)
                 {
-                    if (!string.IsNullOrWhiteSpace(itemBase.CannotUseMessage))
+                    PacketSender.SendChatMsg(this, Strings.Items.sleep, ChatMessageType.Error);
+
+                    return;
+                }
+            }
+
+            // Unequip items even if you do not meet the requirements.
+            // (Need this for silly devs who give people items and then later add restrictions...)
+            if (itemBase.ItemType == ItemType.Equipment && SlotIsEquipped(slot, out var equippedSlot))
+            {
+                UnequipItem(equippedSlot, true);
+                return;
+            }
+
+            if (!Conditions.MeetsConditionLists(itemBase.UsageRequirements, this, null))
+            {
+                if (!string.IsNullOrWhiteSpace(itemBase.CannotUseMessage))
+                {
+                    PacketSender.SendChatMsg(this, itemBase.CannotUseMessage, ChatMessageType.Error);
+                }
+                else
+                {
+                    PacketSender.SendChatMsg(this, Strings.Items.dynamicreq, ChatMessageType.Error);
+                }
+
+                return;
+            }
+
+            // Check if there's a global cooldown blocking our action.
+            if (!itemBase.IgnoreGlobalCooldown && mGlobalCooldownTimer > Timing.Global.MillisecondsUtc)
+            {
+                //Cooldown warning!
+                PacketSender.SendChatMsg(this, Strings.Items.cooldown, ChatMessageType.Error);
+
+                return;
+            }
+
+            if (ItemCooldowns.ContainsKey(itemBase.Id) && ItemCooldowns[itemBase.Id] > Timing.Global.MillisecondsUtc)
+            {
+                //Cooldown warning!
+                PacketSender.SendChatMsg(this, Strings.Items.cooldown, ChatMessageType.Error);
+
+                return;
+            }
+
+            var useEvent = itemBase.GetEventTrigger(ItemEventTriggers.OnUse);
+
+            switch (itemBase.ItemType)
+            {
+                case ItemType.None:
+                case ItemType.Currency:
+                    if (useEvent != default)
                     {
-                        PacketSender.SendChatMsg(this, itemBase.CannotUseMessage, ChatMessageType.Error);
+                        EnqueueStartCommonEvent(useEvent);
                     }
                     else
                     {
-                        PacketSender.SendChatMsg(this, Strings.Items.dynamicreq, ChatMessageType.Error);
+                        PacketSender.SendChatMsg(this, Strings.Items.cannotuse, ChatMessageType.Error);
                     }
 
                     return;
-                }
+                case ItemType.Consumable:
+                    var color = CustomColors.Items.ConsumeHp;
+                    var die = false;
+                    long value;
 
-                // Check if there's a global cooldown blocking our action.
-                if (!itemBase.IgnoreGlobalCooldown && mGlobalCooldownTimer > Timing.Global.MillisecondsUtc)
-                {
-                    //Cooldown warning!
-                    PacketSender.SendChatMsg(this, Strings.Items.cooldown, ChatMessageType.Error);
+                    switch (itemBase.Consumable.Type)
+                    {
+                        case ConsumableType.Health:
+                            value = itemBase.Consumable.Value +
+                                    GetMaxVital((int)itemBase.Consumable.Type) *
+                                    itemBase.Consumable.Percentage /
+                                    100;
+
+                            AddVital(Vital.Health, value);
+                            if (value < 0)
+                            {
+                                color = CustomColors.Items.ConsumePoison;
+
+                                //Add a death handler for poison.
+                                die = !HasVital(Vital.Health);
+                            }
+
+                            break;
+
+                        case ConsumableType.Mana:
+                            value = itemBase.Consumable.Value +
+                                    GetMaxVital((int)itemBase.Consumable.Type) *
+                                    itemBase.Consumable.Percentage /
+                                    100;
+
+                            AddVital(Vital.Mana, value);
+                            color = CustomColors.Items.ConsumeMp;
+
+                            break;
+
+                        case ConsumableType.Experience:
+                            value = itemBase.Consumable.Value +
+                                    (GetExperienceToNextLevel(Level) * itemBase.Consumable.Percentage / 100);
+
+                            GiveExperience(value);
+                            color = CustomColors.Items.ConsumeExp;
+
+                            break;
+
+                        default:
+                            throw new IndexOutOfRangeException();
+                    }
+
+                    var symbol = value < 0 ? Strings.Combat.removesymbol : Strings.Combat.addsymbol;
+                    var number = $"{symbol}{Math.Abs(value)}";
+                    PacketSender.SendActionMsg(this, number, color);
+
+                    if (die)
+                    {
+                        lock (EntityLock)
+                        {
+                            Die(true, this);
+                        }
+                    }
+
+                    if (TryTakeItem(Items[slot], 1) && useEvent != default)
+                    {
+                        EnqueueStartCommonEvent(useEvent);
+                    }
+
+                    break;
+                case ItemType.Equipment:
+                    if (SlotIsEquipped(slot, out var eqpSlot))
+                    {
+                        UnequipItem(eqpSlot, true);
+                        return;
+                    }
+
+                    EquipItem(itemBase, slot);
+                    EnqueueStartCommonEvent(useEvent);
+
+                    break;
+                case ItemType.Spell:
+                    if (itemBase.SpellId == Guid.Empty)
+                    {
+                        return;
+                    }
+
+                    if (itemBase.QuickCast)
+                    {
+                        if (!CanCastSpell(itemBase.Spell, target, false, out var _))
+                        {
+                            return;
+                        }
+
+                        CastTarget = target;
+                        CastSpell(itemBase.SpellId);
+                    }
+                    else if (!TryTeachSpell(new Spell(itemBase.SpellId)))
+                    {
+                        return;
+                    }
+
+                    if (itemBase.SingleUse)
+                    {
+                        if (TryTakeItem(Items[slot], 1))
+                        {
+                            EnqueueStartCommonEvent(useEvent);
+                        }
+                    }
+                    else
+                    {
+                        EnqueueStartCommonEvent(useEvent);
+                    }
+
+                    break;
+                case ItemType.Event:
+                    var evt = EventBase.Get(itemBase.EventId);
+                    if (evt == null || !UnsafeStartCommonEvent(evt))
+                    {
+                        return;
+                    }
+
+                    if (itemBase.SingleUse)
+                    {
+                        TryTakeItem(Items[slot], 1);
+                    }
+
+                    break;
+                case ItemType.Bag:
+                    OpenBag(Item, itemBase);
+                    EnqueueStartCommonEvent(useEvent);
+
+                    break;
+                default:
+                    PacketSender.SendChatMsg(this, Strings.Items.notimplemented, ChatMessageType.Error);
 
                     return;
-                }
+            }
 
-                if (ItemCooldowns.ContainsKey(itemBase.Id) && ItemCooldowns[itemBase.Id] > Timing.Global.MillisecondsUtc)
-                {
-                    //Cooldown warning!
-                    PacketSender.SendChatMsg(this, Strings.Items.cooldown, ChatMessageType.Error);
+            if (itemBase.Animation != null)
+            {
+                PacketSender.SendAnimationToProximity(
+                    itemBase.Animation.Id, 1, base.Id, MapId, 0, 0, Dir, MapInstanceId
+                ); //Target Type 1 will be global entity
+            }
 
-                    return;
-                }
+            // Does this item have a cooldown to process of its own?
+            if (itemBase.Cooldown > 0)
+            {
+                UpdateCooldown(itemBase);
+            }
 
-                var useEvent = itemBase.GetEventTrigger(ItemEventTriggers.OnUse);
-
-                switch (itemBase.ItemType)
-                {
-                    case ItemType.None:
-                    case ItemType.Currency:
-                        if (useEvent != default)
-                        {
-                            EnqueueStartCommonEvent(useEvent);
-                        }
-                        else
-                        {
-                            PacketSender.SendChatMsg(this, Strings.Items.cannotuse, ChatMessageType.Error);
-                        }
-
-                        return;
-                    case ItemType.Consumable:
-                        var color = CustomColors.Items.ConsumeHp;
-                        var die = false;
-                        long value;
-
-                        switch (itemBase.Consumable.Type)
-                        {
-                            case ConsumableType.Health:
-                                value = itemBase.Consumable.Value +
-                                        GetMaxVital((int)itemBase.Consumable.Type) *
-                                        itemBase.Consumable.Percentage /
-                                        100;
-
-                                AddVital(Vital.Health, value);
-                                if (value < 0)
-                                {
-                                    color = CustomColors.Items.ConsumePoison;
-
-                                    //Add a death handler for poison.
-                                    die = !HasVital(Vital.Health);
-                                }
-
-                                break;
-
-                            case ConsumableType.Mana:
-                                value = itemBase.Consumable.Value +
-                                        GetMaxVital((int)itemBase.Consumable.Type) *
-                                        itemBase.Consumable.Percentage /
-                                        100;
-
-                                AddVital(Vital.Mana, value);
-                                color = CustomColors.Items.ConsumeMp;
-
-                                break;
-
-                            case ConsumableType.Experience:
-                                value = itemBase.Consumable.Value +
-                                        (GetExperienceToNextLevel(Level) * itemBase.Consumable.Percentage / 100);
-
-                                GiveExperience(value);
-                                color = CustomColors.Items.ConsumeExp;
-
-                                break;
-
-                            default:
-                                throw new IndexOutOfRangeException();
-                        }
-
-                        var symbol = value < 0 ? Strings.Combat.removesymbol : Strings.Combat.addsymbol;
-                        var number = $"{symbol}{Math.Abs(value)}";
-                        PacketSender.SendActionMsg(this, number, color);
-
-                        if (die)
-                        {
-                            lock (EntityLock)
-                            {
-                                Die(true, this);
-                            }
-                        }
-
-                        if (TryTakeItem(Items[slot], 1) && useEvent != default)
-                        {
-                            EnqueueStartCommonEvent(useEvent);
-                        }
-
-                        break;
-                    case ItemType.Equipment:
-                        if (SlotIsEquipped(slot, out var eqpSlot))
-                        {
-                            UnequipItem(eqpSlot, true);
-                            return;
-                        }
-
-                        EquipItem(itemBase, slot);
-                        EnqueueStartCommonEvent(useEvent);
-
-                        break;
-                    case ItemType.Spell:
-                        if (itemBase.SpellId == Guid.Empty)
-                        {
-                            return;
-                        }
-
-                        if (itemBase.QuickCast)
-                        {
-                            if (!CanCastSpell(itemBase.Spell, target, false, out var _))
-                            {
-                                return;
-                            }
-
-                            CastTarget = target;
-                            CastSpell(itemBase.SpellId);
-                        }
-                        else if (!TryTeachSpell(new Spell(itemBase.SpellId)))
-                        {
-                            return;
-                        }
-
-                        if (itemBase.SingleUse)
-                        {
-                            if (TryTakeItem(Items[slot], 1))
-                            {
-                                EnqueueStartCommonEvent(useEvent);
-                            }
-                        }
-                        else
-                        {
-                            EnqueueStartCommonEvent(useEvent);
-                        }
-
-                        break;
-                    case ItemType.Event:
-                        var evt = EventBase.Get(itemBase.EventId);
-                        if (evt == null || !UnsafeStartCommonEvent(evt))
-                        {
-                            return;
-                        }
-
-                        if (itemBase.SingleUse)
-                        {
-                            TryTakeItem(Items[slot], 1);
-                        }
-
-                        break;
-                    case ItemType.Bag:
-                        OpenBag(Item, itemBase);
-                        EnqueueStartCommonEvent(useEvent);
-
-                        break;
-                    default:
-                        PacketSender.SendChatMsg(this, Strings.Items.notimplemented, ChatMessageType.Error);
-
-                        return;
-                }
-
-                if (itemBase.Animation != null)
-                {
-                    PacketSender.SendAnimationToProximity(
-                        itemBase.Animation.Id, 1, base.Id, MapId, 0, 0, Dir, MapInstanceId
-                    ); //Target Type 1 will be global entity
-                }
-
-                // Does this item have a cooldown to process of its own?
-                if (itemBase.Cooldown > 0)
-                {
-                    UpdateCooldown(itemBase);
-                }
-
-                // Update the global cooldown, if we can trigger it here.
-                if (!itemBase.IgnoreGlobalCooldown)
-                {
-                    UpdateGlobalCooldown();
-                }
+            // Update the global cooldown, if we can trigger it here.
+            if (!itemBase.IgnoreGlobalCooldown)
+            {
+                UpdateGlobalCooldown();
             }
         }
+    }
 
-        /// <summary>
-        /// Try to take an item away from the player by slot.
-        /// </summary>
-        /// <param name="slot">The inventory slot to take the item away from.</param>
-        /// <param name="amount">The amount of this item we intend to take away from the player.</param>
-        /// <param name="handler">The method in which we intend to handle taking away the item from our player.</param>
-        /// <param name="sendUpdate">Do we need to send an inventory update after taking away the item.</param>
-        /// <returns></returns>
-        public bool TryTakeItem(InventorySlot slot, int amount, ItemHandling handler = ItemHandling.Normal, bool sendUpdate = true)
+    /// <summary>
+    /// Try to take an item away from the player by slot.
+    /// </summary>
+    /// <param name="slot">The inventory slot to take the item away from.</param>
+    /// <param name="amount">The amount of this item we intend to take away from the player.</param>
+    /// <param name="handler">The method in which we intend to handle taking away the item from our player.</param>
+    /// <param name="sendUpdate">Do we need to send an inventory update after taking away the item.</param>
+    /// <returns></returns>
+    public bool TryTakeItem(InventorySlot slot, int amount, ItemHandling handler = ItemHandling.Normal, bool sendUpdate = true)
+    {
+        if (Items == null || slot == Item.None || slot == null)
         {
-            if (Items == null || slot == Item.None || slot == null)
+            return false;
+        }
+
+        // Figure out how many we can take!
+        var toTake = 0;
+        switch (handler)
+        {
+            case ItemHandling.Normal:
+            case ItemHandling.Overflow: // We can't overflow a take command, so process it as if it's a normal one.
+                if (slot.Quantity < amount) // Cancel out if we don't have enough items to cover for this.
+                {
+                    return false;
+                }
+
+                // We can take all of the items we need!
+                toTake = amount;
+
+                break;
+            case ItemHandling.UpTo:
+                // Can we take all our items or just some?
+                toTake = slot.Quantity >= amount ? amount : slot.Quantity;
+
+                break;
+
+            // Did you forget something? ;)
+            default:
+                throw new NotImplementedException();
+        }
+
+        // Can we actually take any?
+        if (toTake == 0)
+        {
+            return false;
+        }
+
+        // Figure out what we're dealing with here.
+        var itemDescriptor = slot.Descriptor;
+
+        // is this stackable? if so try to take as many as we can each time.
+        if (itemDescriptor.Stackable)
+        {
+            if (slot.Quantity >= toTake)
             {
-                return false;
+                TakeItem(slot, toTake, sendUpdate);
+                toTake = 0;
             }
-
-            // Figure out how many we can take!
-            var toTake = 0;
-            switch (handler)
+            else // Take away the entire quantity of the item and lower our items that we still need to take!
             {
-                case ItemHandling.Normal:
-                case ItemHandling.Overflow: // We can't overflow a take command, so process it as if it's a normal one.
-                    if (slot.Quantity < amount) // Cancel out if we don't have enough items to cover for this.
-                    {
-                        return false;
-                    }
-
-                    // We can take all of the items we need!
-                    toTake = amount;
-
-                    break;
-                case ItemHandling.UpTo:
-                    // Can we take all our items or just some?
-                    toTake = slot.Quantity >= amount ? amount : slot.Quantity;
-
-                    break;
-
-                // Did you forget something? ;)
-                default:
-                    throw new NotImplementedException();
+                toTake -= slot.Quantity;
+                TakeItem(slot, slot.Quantity, sendUpdate);
             }
+        }
+        else // Not stackable, so just take one item away.
+        {
+            toTake -= 1;
+            TakeItem(slot, 1, sendUpdate);
+        }
 
-            // Can we actually take any?
+        // Update quest progress and we're done!
+        UpdateGatherItemQuests(slot.ItemId);
+
+        // Start common events related to inventory changes.
+        StartCommonEventsWithTrigger(CommonEventTrigger.InventoryChanged);
+        UnequipInvalidItems();
+
+        return true;
+
+    }
+
+    /// <summary>
+    /// Try to take away an item from the player by Id.
+    /// </summary>
+    /// <param name="itemId">The Id of the item we're trying to take away from the player.</param>
+    /// <param name="amount">The amount of this item we intend to take away from the player.</param>
+    /// <param name="handler">The method in which we intend to handle taking away the item from our player.</param>
+    /// <param name="sendUpdate">Do we need to send an inventory update after taking away the item.</param>
+    /// <returns>Whether the item was taken away successfully or not.</returns>
+    public bool TryTakeItem(Guid itemId, int amount, ItemHandling handler = ItemHandling.Normal, bool sendUpdate = true)
+    {
+        if (Items == null)
+        {
+            return false;
+        }
+
+        // Figure out how many we can take!
+        var toTake = 0;
+        switch (handler)
+        {
+            case ItemHandling.Normal:
+            case ItemHandling.Overflow: // We can't overflow a take command, so process it as if it's a normal one.
+                if (!CanTakeItem(itemId, amount)) // Cancel out if we don't have enough items to cover for this.
+                {
+                    return false;
+                }
+
+                // We can take all of the items we need!
+                toTake = amount;
+
+                break;
+            case ItemHandling.UpTo:
+                // Can we take all our items or just some?
+                var itemCount = FindInventoryItemQuantity(itemId);
+                toTake = itemCount >= amount ? amount : itemCount;
+
+                break;
+
+            // Did you forget something? ;)
+            default:
+                throw new NotImplementedException();
+        }
+
+        // Can we actually take any?
+        if (toTake == 0)
+        {
+            return false;
+        }
+
+        // Figure out what we're dealing with here.
+        var itemDescriptor = ItemBase.Get(itemId);
+
+        // Go through our inventory and take what we need!
+        foreach (var slot in FindInventoryItemSlots(itemId))
+        {
+            // Do we still have items to take? If not leave the loop!
             if (toTake == 0)
             {
-                return false;
+                break;
             }
-
-            // Figure out what we're dealing with here.
-            var itemDescriptor = slot.Descriptor;
 
             // is this stackable? if so try to take as many as we can each time.
             if (itemDescriptor.Stackable)
@@ -3487,361 +3578,252 @@ namespace Intersect.Server.Entities
                 toTake -= 1;
                 TakeItem(slot, 1, sendUpdate);
             }
-
-            // Update quest progress and we're done!
-            UpdateGatherItemQuests(slot.ItemId);
-
-            // Start common events related to inventory changes.
-            StartCommonEventsWithTrigger(CommonEventTrigger.InventoryChanged);
-            UnequipInvalidItems();
-
-            return true;
-
         }
 
-        /// <summary>
-        /// Try to take away an item from the player by Id.
-        /// </summary>
-        /// <param name="itemId">The Id of the item we're trying to take away from the player.</param>
-        /// <param name="amount">The amount of this item we intend to take away from the player.</param>
-        /// <param name="handler">The method in which we intend to handle taking away the item from our player.</param>
-        /// <param name="sendUpdate">Do we need to send an inventory update after taking away the item.</param>
-        /// <returns>Whether the item was taken away successfully or not.</returns>
-        public bool TryTakeItem(Guid itemId, int amount, ItemHandling handler = ItemHandling.Normal, bool sendUpdate = true)
+        // Update quest progress and we're done!
+        UpdateGatherItemQuests(itemId);
+
+        // Start common events related to inventory changes.
+        StartCommonEventsWithTrigger(CommonEventTrigger.InventoryChanged);
+        UnequipInvalidItems();
+
+        return true;
+    }
+
+    /// <summary>
+    /// Take an item away from the player, or an amount of it if they have more. NOTE: This method MAKES ZERO CHECKS to see if this is possible!
+    /// Use TryTakeItem where possible!
+    /// </summary>
+    /// <param name="slot"></param>
+    /// <param name="amount"></param>
+    /// <param name="sendUpdate"></param>
+    private void TakeItem(InventorySlot slot, int amount, bool sendUpdate = true)
+    {
+        if (slot.Quantity > amount) // This slot contains more than what we're trying to take away here. Update the quantity.
         {
-            if (Items == null)
-            {
-                return false;
-            }
-
-            // Figure out how many we can take!
-            var toTake = 0;
-            switch (handler)
-            {
-                case ItemHandling.Normal:
-                case ItemHandling.Overflow: // We can't overflow a take command, so process it as if it's a normal one.
-                    if (!CanTakeItem(itemId, amount)) // Cancel out if we don't have enough items to cover for this.
-                    {
-                        return false;
-                    }
-
-                    // We can take all of the items we need!
-                    toTake = amount;
-
-                    break;
-                case ItemHandling.UpTo:
-                    // Can we take all our items or just some?
-                    var itemCount = FindInventoryItemQuantity(itemId);
-                    toTake = itemCount >= amount ? amount : itemCount;
-
-                    break;
-
-                // Did you forget something? ;)
-                default:
-                    throw new NotImplementedException();
-            }
-
-            // Can we actually take any?
-            if (toTake == 0)
-            {
-                return false;
-            }
-
-            // Figure out what we're dealing with here.
-            var itemDescriptor = ItemBase.Get(itemId);
-
-            // Go through our inventory and take what we need!
-            foreach (var slot in FindInventoryItemSlots(itemId))
-            {
-                // Do we still have items to take? If not leave the loop!
-                if (toTake == 0)
-                {
-                    break;
-                }
-
-                // is this stackable? if so try to take as many as we can each time.
-                if (itemDescriptor.Stackable)
-                {
-                    if (slot.Quantity >= toTake)
-                    {
-                        TakeItem(slot, toTake, sendUpdate);
-                        toTake = 0;
-                    }
-                    else // Take away the entire quantity of the item and lower our items that we still need to take!
-                    {
-                        toTake -= slot.Quantity;
-                        TakeItem(slot, slot.Quantity, sendUpdate);
-                    }
-                }
-                else // Not stackable, so just take one item away.
-                {
-                    toTake -= 1;
-                    TakeItem(slot, 1, sendUpdate);
-                }
-            }
-
-            // Update quest progress and we're done!
-            UpdateGatherItemQuests(itemId);
-
-            // Start common events related to inventory changes.
-            StartCommonEventsWithTrigger(CommonEventTrigger.InventoryChanged);
-            UnequipInvalidItems();
-
-            return true;
+            slot.Quantity -= amount;
+        }
+        else // Take the entire thing away!
+        {
+            slot.Set(Item.None);
+            EquipmentProcessItemLoss(slot.Slot);
         }
 
-        /// <summary>
-        /// Take an item away from the player, or an amount of it if they have more. NOTE: This method MAKES ZERO CHECKS to see if this is possible!
-        /// Use TryTakeItem where possible!
-        /// </summary>
-        /// <param name="slot"></param>
-        /// <param name="amount"></param>
-        /// <param name="sendUpdate"></param>
-        private void TakeItem(InventorySlot slot, int amount, bool sendUpdate = true)
+        if (sendUpdate)
         {
-            if (slot.Quantity > amount) // This slot contains more than what we're trying to take away here. Update the quantity.
-            {
-                slot.Quantity -= amount;
-            }
-            else // Take the entire thing away!
-            {
-                slot.Set(Item.None);
-                EquipmentProcessItemLoss(slot.Slot);
-            }
+            PacketSender.SendInventoryItemUpdate(this, slot.Slot);
+        }
+    }
 
-            if (sendUpdate)
+    /// <summary>
+    /// Find the amount of a specific item a player has.
+    /// </summary>
+    /// <param name="itemId">The item Id to look for.</param>
+    /// <returns>The amount of the requested item the player has on them.</returns>
+    public int FindInventoryItemQuantity(Guid itemId)
+    {
+        if (Items == null)
+        {
+            return 0;
+        }
+
+        long itemCount = 0;
+        for (var i = 0; i < Options.MaxInvItems; i++)
+        {
+            var item = Items[i];
+            if (item.ItemId == itemId)
             {
-                PacketSender.SendInventoryItemUpdate(this, slot.Slot);
+                itemCount = item.Descriptor.Stackable ? itemCount += item.Quantity : itemCount += 1;
             }
         }
 
-        /// <summary>
-        /// Find the amount of a specific item a player has.
-        /// </summary>
-        /// <param name="itemId">The item Id to look for.</param>
-        /// <returns>The amount of the requested item the player has on them.</returns>
-        public int FindInventoryItemQuantity(Guid itemId)
+        // TODO: Stop using Int32 for item quantities
+        return itemCount >= Int32.MaxValue ? Int32.MaxValue : (int)itemCount;
+    }
+
+    /// <summary>
+    /// Finds an inventory slot matching the desired item and quantity.
+    /// </summary>
+    /// <param name="itemId">The item Id to look for.</param>
+    /// <param name="quantity">The quantity of the item to look for.</param>
+    /// <returns>An <see cref="InventorySlot"/> that contains the item, or null if none are found.</returns>
+    public InventorySlot FindInventoryItemSlot(Guid itemId, int quantity = 1) => FindInventoryItemSlots(itemId, quantity).FirstOrDefault();
+
+    /// <summary>
+    /// Finds the index of a given inventory slot
+    /// </summary>
+    /// <param name="slot">The <see cref="InventorySlot"/> to find</param>
+    /// <returns>An <see cref="int"/>containing the relevant index, or -1 if not found</returns>
+    public int FindInventoryItemSlotIndex(InventorySlot slot)
+    {
+        return Items.FindIndex(sl => sl.Id == slot.Id);
+    }
+
+    /// <summary>
+    /// Finds all inventory slots matching the desired item and quantity.
+    /// </summary>
+    /// <param name="itemId">The item Id to look for.</param>
+    /// <param name="quantity">The quantity of the item to look for.</param>
+    /// <returns>A list of <see cref="InventorySlot"/> containing the requested item.</returns>
+    public List<InventorySlot> FindInventoryItemSlots(Guid itemId, int quantity = 1)
+    {
+        var slots = new List<InventorySlot>();
+        if (Items == null)
         {
-            if (Items == null)
-            {
-                return 0;
-            }
-
-            long itemCount = 0;
-            for (var i = 0; i < Options.MaxInvItems; i++)
-            {
-                var item = Items[i];
-                if (item.ItemId == itemId)
-                {
-                    itemCount = item.Descriptor.Stackable ? itemCount += item.Quantity : itemCount += 1;
-                }
-            }
-
-            // TODO: Stop using Int32 for item quantities
-            return itemCount >= Int32.MaxValue ? Int32.MaxValue : (int)itemCount;
-        }
-
-        /// <summary>
-        /// Finds an inventory slot matching the desired item and quantity.
-        /// </summary>
-        /// <param name="itemId">The item Id to look for.</param>
-        /// <param name="quantity">The quantity of the item to look for.</param>
-        /// <returns>An <see cref="InventorySlot"/> that contains the item, or null if none are found.</returns>
-        public InventorySlot FindInventoryItemSlot(Guid itemId, int quantity = 1) => FindInventoryItemSlots(itemId, quantity).FirstOrDefault();
-
-        /// <summary>
-        /// Finds the index of a given inventory slot
-        /// </summary>
-        /// <param name="slot">The <see cref="InventorySlot"/> to find</param>
-        /// <returns>An <see cref="int"/>containing the relevant index, or -1 if not found</returns>
-        public int FindInventoryItemSlotIndex(InventorySlot slot)
-        {
-            return Items.FindIndex(sl => sl.Id == slot.Id);
-        }
-
-        /// <summary>
-        /// Finds all inventory slots matching the desired item and quantity.
-        /// </summary>
-        /// <param name="itemId">The item Id to look for.</param>
-        /// <param name="quantity">The quantity of the item to look for.</param>
-        /// <returns>A list of <see cref="InventorySlot"/> containing the requested item.</returns>
-        public List<InventorySlot> FindInventoryItemSlots(Guid itemId, int quantity = 1)
-        {
-            var slots = new List<InventorySlot>();
-            if (Items == null)
-            {
-                return slots;
-            }
-
-            for (var i = 0; i < Options.MaxInvItems; i++)
-            {
-                var item = Items[i];
-                if (item?.ItemId != itemId)
-                {
-                    continue;
-                }
-
-                if (item.Quantity >= quantity)
-                {
-                    slots.Add(Items[i]);
-                }
-            }
-
             return slots;
         }
 
-        public int CountItems(Guid itemId, bool inInventory = true, bool inBank = false)
+        for (var i = 0; i < Options.MaxInvItems; i++)
         {
-            if (inInventory == false && inBank == false)
+            var item = Items[i];
+            if (item?.ItemId != itemId)
             {
-                throw new ArgumentException(
-                    $@"At least one of either {nameof(inInventory)} or {nameof(inBank)} must be true to count items."
-                );
+                continue;
             }
 
-            var count = 0;
-
-            int QuantityFromSlot(Item item)
+            if (item.Quantity >= quantity)
             {
-                return item?.ItemId == itemId ? Math.Max(1, item.Quantity) : 0;
+                slots.Add(Items[i]);
             }
-
-            if (inInventory)
-            {
-                count += Items.Sum(QuantityFromSlot);
-            }
-
-            if (inBank)
-            {
-                count += Bank.Sum(QuantityFromSlot);
-            }
-
-            return count;
         }
 
-        public override int GetWeaponDamage()
-        {
-            if (!TryGetEquippedItem(Options.WeaponIndex, out var item))
-            {
-                return 0;
-            }
+        return slots;
+    }
 
-            return item.Descriptor.Damage;
+    public int CountItems(Guid itemId, bool inInventory = true, bool inBank = false)
+    {
+        if (inInventory == false && inBank == false)
+        {
+            throw new ArgumentException(
+                $@"At least one of either {nameof(inInventory)} or {nameof(inBank)} must be true to count items."
+            );
         }
 
-        /// <summary>
-        /// Gets the percentage value of a bonus effect as granted by the currently equipped gear.
-        /// </summary>
-        /// <param name="effect">The <see cref="ItemEffect"/> to retrieve the amount for.</param>
-        /// <returns></returns>
-        public int GetEquipmentBonusEffect(ItemEffect effect)
-        {
-            var value = 0;
+        var count = 0;
 
-            foreach (var item in EquippedItems)
+        int QuantityFromSlot(Item item)
+        {
+            return item?.ItemId == itemId ? Math.Max(1, item.Quantity) : 0;
+        }
+
+        if (inInventory)
+        {
+            count += Items.Sum(QuantityFromSlot);
+        }
+
+        if (inBank)
+        {
+            count += Bank.Sum(QuantityFromSlot);
+        }
+
+        return count;
+    }
+
+    public override int GetWeaponDamage()
+    {
+        if (!TryGetEquippedItem(Options.WeaponIndex, out var item))
+        {
+            return 0;
+        }
+
+        return item.Descriptor.Damage;
+    }
+
+    /// <summary>
+    /// Gets the percentage value of a bonus effect as granted by the currently equipped gear.
+    /// </summary>
+    /// <param name="effect">The <see cref="ItemEffect"/> to retrieve the amount for.</param>
+    /// <returns></returns>
+    public int GetEquipmentBonusEffect(ItemEffect effect)
+    {
+        var value = 0;
+
+        foreach (var item in EquippedItems)
+        {
+            if (!item.Descriptor.EffectsEnabled.Contains(effect))
             {
-                if (!item.Descriptor.EffectsEnabled.Contains(effect))
+                continue;
+            }
+            value += item.Descriptor.GetEffectPercentage(effect);
+        }
+
+        return value;
+    }
+
+    public long GetEquipmentVitalRegen(Vital vital)
+    {
+        long regen = 0;
+
+        foreach (var item in EquippedItems)
+        {
+            regen += item.Descriptor.VitalsRegen[(int)vital];
+        }
+
+        return regen;
+    }
+
+    //Shop
+    public bool OpenShop(ShopBase shop)
+    {
+        if (IsBusy())
+        {
+            return false;
+        }
+
+        InShop = shop;
+        PacketSender.SendOpenShop(this, shop);
+
+        return true;
+    }
+
+    public void CloseShop()
+    {
+        if (InShop != null)
+        {
+            InShop = null;
+            PacketSender.SendCloseShop(this);
+        }
+    }
+
+    public void SellItem(int slot, int amount)
+    {
+        var canSellItem = true;
+        var rewardItemId = Guid.Empty;
+        var rewardItemVal = 0;
+
+        TryGetSlot(slot, out var itemInSlot, true);
+        var sellItemNum = itemInSlot.ItemId;
+        var shop = InShop;
+        if (shop != null)
+        {
+            var itemDescriptor = Items[slot].Descriptor;
+            if (itemDescriptor != null)
+            {
+                if (!itemDescriptor.CanSell)
                 {
-                    continue;
+                    PacketSender.SendChatMsg(this, Strings.Shops.bound, ChatMessageType.Inventory, CustomColors.Items.Bound);
+
+                    return;
                 }
-                value += item.Descriptor.GetEffectPercentage(effect);
-            }
 
-            return value;
-        }
-
-        public long GetEquipmentVitalRegen(Vital vital)
-        {
-            long regen = 0;
-
-            foreach (var item in EquippedItems)
-            {
-                regen += item.Descriptor.VitalsRegen[(int)vital];
-            }
-
-            return regen;
-        }
-
-        //Shop
-        public bool OpenShop(ShopBase shop)
-        {
-            if (IsBusy())
-            {
-                return false;
-            }
-
-            InShop = shop;
-            PacketSender.SendOpenShop(this, shop);
-
-            return true;
-        }
-
-        public void CloseShop()
-        {
-            if (InShop != null)
-            {
-                InShop = null;
-                PacketSender.SendCloseShop(this);
-            }
-        }
-
-        public void SellItem(int slot, int amount)
-        {
-            var canSellItem = true;
-            var rewardItemId = Guid.Empty;
-            var rewardItemVal = 0;
-
-            TryGetSlot(slot, out var itemInSlot, true);
-            var sellItemNum = itemInSlot.ItemId;
-            var shop = InShop;
-            if (shop != null)
-            {
-                var itemDescriptor = Items[slot].Descriptor;
-                if (itemDescriptor != null)
+                //Check if this is a bag with items.. if so don't allow sale
+                if (itemDescriptor.ItemType == ItemType.Bag)
                 {
-                    if (!itemDescriptor.CanSell)
+                    if (itemInSlot.TryGetBag(out var bag))
                     {
-                        PacketSender.SendChatMsg(this, Strings.Shops.bound, ChatMessageType.Inventory, CustomColors.Items.Bound);
-
-                        return;
-                    }
-
-                    //Check if this is a bag with items.. if so don't allow sale
-                    if (itemDescriptor.ItemType == ItemType.Bag)
-                    {
-                        if (itemInSlot.TryGetBag(out var bag))
+                        if (!bag.IsEmpty)
                         {
-                            if (!bag.IsEmpty)
-                            {
-                                PacketSender.SendChatMsg(this, Strings.Bags.onlysellempty, ChatMessageType.Inventory, CustomColors.Alerts.Error);
-                                return;
-                            }
+                            PacketSender.SendChatMsg(this, Strings.Bags.onlysellempty, ChatMessageType.Inventory, CustomColors.Alerts.Error);
+                            return;
                         }
                     }
+                }
 
-                    for (var i = 0; i < shop.BuyingItems.Count; i++)
+                for (var i = 0; i < shop.BuyingItems.Count; i++)
+                {
+                    if (shop.BuyingItems[i].ItemId == sellItemNum)
                     {
-                        if (shop.BuyingItems[i].ItemId == sellItemNum)
-                        {
-                            if (!shop.BuyingWhitelist)
-                            {
-                                PacketSender.SendChatMsg(this, Strings.Shops.doesnotaccept, ChatMessageType.Inventory, CustomColors.Alerts.Error);
-
-                                return;
-                            }
-                            else
-                            {
-                                rewardItemId = shop.BuyingItems[i].CostItemId;
-                                rewardItemVal = shop.BuyingItems[i].CostItemQuantity;
-
-                                break;
-                            }
-                        }
-                    }
-
-                    if (rewardItemId == Guid.Empty)
-                    {
-                        if (shop.BuyingWhitelist)
+                        if (!shop.BuyingWhitelist)
                         {
                             PacketSender.SendChatMsg(this, Strings.Shops.doesnotaccept, ChatMessageType.Inventory, CustomColors.Alerts.Error);
 
@@ -3849,251 +3831,239 @@ namespace Intersect.Server.Entities
                         }
                         else
                         {
-                            rewardItemId = shop.DefaultCurrencyId;
-                            rewardItemVal = itemDescriptor.Price;
+                            rewardItemId = shop.BuyingItems[i].CostItemId;
+                            rewardItemVal = shop.BuyingItems[i].CostItemQuantity;
+
+                            break;
                         }
                     }
+                }
 
-                    var amountInInventory = FindInventoryItemQuantity(itemInSlot.ItemId);
-
-                    var amountRemaining = Math.Min(amountInInventory, amount);
-                    var currentSlot = itemInSlot;
-                    var currentSlotIndex = slot;
-                    while (currentSlot != default && amountRemaining > 0)
+                if (rewardItemId == Guid.Empty)
+                {
+                    if (shop.BuyingWhitelist)
                     {
-                        var amountFromSlot = Math.Min(currentSlot.Quantity, amountRemaining);
-                        if (amountFromSlot < currentSlot.Quantity)
+                        PacketSender.SendChatMsg(this, Strings.Shops.doesnotaccept, ChatMessageType.Inventory, CustomColors.Alerts.Error);
+
+                        return;
+                    }
+                    else
+                    {
+                        rewardItemId = shop.DefaultCurrencyId;
+                        rewardItemVal = itemDescriptor.Price;
+                    }
+                }
+
+                var amountInInventory = FindInventoryItemQuantity(itemInSlot.ItemId);
+
+                var amountRemaining = Math.Min(amountInInventory, amount);
+                var currentSlot = itemInSlot;
+                var currentSlotIndex = slot;
+                while (currentSlot != default && amountRemaining > 0)
+                {
+                    var amountFromSlot = Math.Min(currentSlot.Quantity, amountRemaining);
+                    if (amountFromSlot < currentSlot.Quantity)
+                    {
+                        //check if can get reward
+                        if (!CanGiveItem(rewardItemId, rewardItemVal))
                         {
-                            //check if can get reward
-                            if (!CanGiveItem(rewardItemId, rewardItemVal))
-                            {
-                                canSellItem = false;
-                            }
-                            else
-                            {
-                                currentSlot.Quantity -= amountFromSlot;
-                            }
+                            canSellItem = false;
                         }
                         else
                         {
-                            // Definitely can get reward.
-                            currentSlot.Set(Item.None);
-                            EquipmentProcessItemLoss(currentSlotIndex);
-                        }
-
-                        if (canSellItem)
-                        {
-                            TryGiveItem(rewardItemId, rewardItemVal * amountFromSlot);
-
-                            if (!TextUtils.IsNone(shop.SellSound))
-                            {
-                                PacketSender.SendPlaySound(this, shop.SellSound);
-                            }
-                        }
-
-                        PacketSender.SendInventoryItemUpdate(this, currentSlotIndex);
-
-                        amountRemaining -= amountFromSlot;
-                        if (amountRemaining > 0)
-                        {
-                            currentSlot = FindInventoryItemSlot(sellItemNum);
-                            currentSlotIndex = FindInventoryItemSlotIndex(currentSlot);
+                            currentSlot.Quantity -= amountFromSlot;
                         }
                     }
-
-                }
-            }
-        }
-
-        public void BuyItem(int slot, int amount)
-        {
-            if (InShop == default)
-            {
-                PacketSender.SendChatMsg(this, Strings.Shops.TransactionFailed, ChatMessageType.Inventory, CustomColors.Alerts.Error, Name);
-                return;
-            }
-
-            if (slot < 0 || slot >= InShop.SellingItems.Count)
-            {
-                PacketSender.SendChatMsg(this, Strings.Shops.TransactionFailed, ChatMessageType.Inventory, CustomColors.Alerts.Error, Name);
-                return;
-            }
-
-            var boughtItem = InShop.SellingItems[slot];
-            var boughtItemBase = ItemBase.Get(boughtItem.ItemId);
-            if (boughtItemBase == default)
-            {
-                PacketSender.SendChatMsg(this, Strings.Shops.TransactionFailed, ChatMessageType.Inventory, CustomColors.Alerts.Error, Name);
-                return;
-            }
-
-            var currencyBase = ItemBase.Get(boughtItem.CostItemId);
-            if (currencyBase == default)
-            {
-                PacketSender.SendChatMsg(this, Strings.Shops.TransactionFailed, ChatMessageType.Inventory, CustomColors.Alerts.Error, Name);
-                return;
-            }
-
-            var boughtItemAmount = 1;
-            if (boughtItemBase.IsStackable)
-            {
-                boughtItemAmount = Math.Max(1, amount);
-            }
-
-            var currencyAmount = FindInventoryItemQuantity(currencyBase.Id);
-            var itemCostTotal = boughtItem.CostItemQuantity * boughtItemAmount;
-            if (currencyAmount < itemCostTotal)
-            {
-                PacketSender.SendChatMsg(this, Strings.Shops.cantafford, ChatMessageType.Inventory, CustomColors.Alerts.Error, Name);
-                return;
-            }
-
-            if (!CanGiveItem(boughtItemBase.Id, boughtItemAmount))
-            {
-                PacketSender.SendChatMsg(this, Strings.Shops.inventoryfull, ChatMessageType.Inventory, CustomColors.Alerts.Error, Name);
-                return;
-            }
-
-            bool success = true;
-            Dictionary<Guid, int> removedItems = new Dictionary<Guid, int>();
-
-            if (itemCostTotal > 0)
-            {
-                var currencySlots = FindInventoryItemSlots(currencyBase.Id);
-                int remainingCost = itemCostTotal;
-
-                foreach (var itemSlot in currencySlots)
-                {
-                    int quantityToRemove = Math.Min(remainingCost, itemSlot.Quantity);
-                    if (!TryTakeItem(itemSlot, quantityToRemove))
+                    else
                     {
-                        success = false;
-                        Log.Warn(Strings.Shops.FailedRemovedItem.ToString(itemSlot, Id, quantityToRemove, "BuyItem(int slot, int amount)"));
-                        break;
+                        // Definitely can get reward.
+                        currentSlot.Set(Item.None);
+                        EquipmentProcessItemLoss(currentSlotIndex);
                     }
 
-                    removedItems.Add(itemSlot.Id, quantityToRemove);
-                    Log.Warn(Strings.Shops.SuccessfullyRemovedItem.ToString(quantityToRemove, itemSlot, Id, "BuyItem(int slot, int amount)"));
-                    remainingCost -= quantityToRemove;
-
-                    if (remainingCost <= 0)
+                    if (canSellItem)
                     {
-                        break;
-                    }
-                }
-            }
+                        TryGiveItem(rewardItemId, rewardItemVal * amountFromSlot);
 
-            if (!success)
-            {
-                //return all removed items because we failed to remove the rest
-                foreach (var removedItem in removedItems)
-                {
-                    TryGiveItem(removedItem.Key, removedItem.Value);
-                }
-
-                PacketSender.SendChatMsg(this, Strings.Shops.TransactionFailed, ChatMessageType.Inventory, CustomColors.Alerts.Error, Name);
-                return;
-            }
-
-            TryGiveItem(boughtItemBase.Id, boughtItemAmount);
-
-            if (!TextUtils.IsNone(InShop.BuySound))
-            {
-                PacketSender.SendPlaySound(this, InShop.BuySound);
-            }
-        }
-
-        //Crafting
-        public bool OpenCraftingTable(CraftingTableBase table, bool journalMode)
-        {
-            if (IsBusy())
-            {
-                return false;
-            }
-
-            if (table != null)
-            {
-                OpenCraftingTableId = table.Id;
-                CraftJournalMode = journalMode;
-                PacketSender.SendOpenCraftingTable(this, table, journalMode);
-            }
-
-            return true;
-        }
-
-        public void CloseCraftingTable()
-        {
-            OpenCraftingTableId = default;
-            CraftingState = default;
-            PacketSender.SendCloseCraftingTable(this);
-        }
-
-        //Craft a new item
-        public void CraftItem()
-        {
-            if (ShouldCancelCrafting() || CraftingState == default)
-            {
-                return;
-            }
-
-            if (!CraftBase.TryGet(CraftingState?.Id ?? default, out var craftDescriptor))
-            {
-                return;
-            }
-
-            var backupItems = new List<Item>();
-            foreach (var backupItem in Items)
-            {
-                backupItems.Add(backupItem.Clone());
-            }
-
-            if (!ItemBase.TryGet(craftDescriptor.ItemId, out var craftItem) && CraftingState != default)
-            {
-                CraftingState.RemainingCount--;
-                return;
-            }
-
-            lock (EntityLock)
-            {
-                var craftRoll = Randomization.Next(0, 101);
-                var failedCraft = craftRoll < craftDescriptor.FailureChance;
-                if (failedCraft)
-                {
-                    var message = Strings.Crafting.CraftFailure;
-
-                    var itemLossRoll = Randomization.Next(0, 101);
-                    var itemLost = itemLossRoll < craftDescriptor.ItemLossChance;
-                    if (itemLost)
-                    {
-                        //Take the items
-                        foreach (var ingredient in craftDescriptor.Ingredients)
+                        if (!TextUtils.IsNone(shop.SellSound))
                         {
-                            if (TryTakeItem(ingredient.ItemId, ingredient.Quantity))
-                            {
-                                continue;
-                            }
-
-                            for (var i = 0; i < backupItems.Count; i++)
-                            {
-                                Items[i].Set(backupItems[i]);
-                            }
-
-                            PacketSender.SendInventory(this);
-                            if (CraftingState != default)
-                            {
-                                CraftingState.RemainingCount--;
-                            }
-
-                            return;
+                            PacketSender.SendPlaySound(this, shop.SellSound);
                         }
-
-                        message = Strings.Crafting.CraftFailureLostItems;
                     }
 
-                    PacketSender.SendInventory(this);
-                    PacketSender.SendChatMsg(this, message.ToString(craftItem.Name), ChatMessageType.Crafting, CustomColors.Alerts.Error);
+                    PacketSender.SendInventoryItemUpdate(this, currentSlotIndex);
+
+                    amountRemaining -= amountFromSlot;
+                    if (amountRemaining > 0)
+                    {
+                        currentSlot = FindInventoryItemSlot(sellItemNum);
+                        currentSlotIndex = FindInventoryItemSlotIndex(currentSlot);
+                    }
                 }
-                else
+
+            }
+        }
+    }
+
+    public void BuyItem(int slot, int amount)
+    {
+        if (InShop == default)
+        {
+            PacketSender.SendChatMsg(this, Strings.Shops.TransactionFailed, ChatMessageType.Inventory, CustomColors.Alerts.Error, Name);
+            return;
+        }
+
+        if (slot < 0 || slot >= InShop.SellingItems.Count)
+        {
+            PacketSender.SendChatMsg(this, Strings.Shops.TransactionFailed, ChatMessageType.Inventory, CustomColors.Alerts.Error, Name);
+            return;
+        }
+
+        var boughtItem = InShop.SellingItems[slot];
+        var boughtItemBase = ItemBase.Get(boughtItem.ItemId);
+        if (boughtItemBase == default)
+        {
+            PacketSender.SendChatMsg(this, Strings.Shops.TransactionFailed, ChatMessageType.Inventory, CustomColors.Alerts.Error, Name);
+            return;
+        }
+
+        var currencyBase = ItemBase.Get(boughtItem.CostItemId);
+        if (currencyBase == default)
+        {
+            PacketSender.SendChatMsg(this, Strings.Shops.TransactionFailed, ChatMessageType.Inventory, CustomColors.Alerts.Error, Name);
+            return;
+        }
+
+        var boughtItemAmount = 1;
+        if (boughtItemBase.IsStackable)
+        {
+            boughtItemAmount = Math.Max(1, amount);
+        }
+
+        var currencyAmount = FindInventoryItemQuantity(currencyBase.Id);
+        var itemCostTotal = boughtItem.CostItemQuantity * boughtItemAmount;
+        if (currencyAmount < itemCostTotal)
+        {
+            PacketSender.SendChatMsg(this, Strings.Shops.cantafford, ChatMessageType.Inventory, CustomColors.Alerts.Error, Name);
+            return;
+        }
+
+        if (!CanGiveItem(boughtItemBase.Id, boughtItemAmount))
+        {
+            PacketSender.SendChatMsg(this, Strings.Shops.inventoryfull, ChatMessageType.Inventory, CustomColors.Alerts.Error, Name);
+            return;
+        }
+
+        bool success = true;
+        Dictionary<Guid, int> removedItems = new Dictionary<Guid, int>();
+
+        if (itemCostTotal > 0)
+        {
+            var currencySlots = FindInventoryItemSlots(currencyBase.Id);
+            int remainingCost = itemCostTotal;
+
+            foreach (var itemSlot in currencySlots)
+            {
+                int quantityToRemove = Math.Min(remainingCost, itemSlot.Quantity);
+                if (!TryTakeItem(itemSlot, quantityToRemove))
+                {
+                    success = false;
+                    Log.Warn(Strings.Shops.FailedRemovedItem.ToString(itemSlot, Id, quantityToRemove, "BuyItem(int slot, int amount)"));
+                    break;
+                }
+
+                removedItems.Add(itemSlot.Id, quantityToRemove);
+                Log.Warn(Strings.Shops.SuccessfullyRemovedItem.ToString(quantityToRemove, itemSlot, Id, "BuyItem(int slot, int amount)"));
+                remainingCost -= quantityToRemove;
+
+                if (remainingCost <= 0)
+                {
+                    break;
+                }
+            }
+        }
+
+        if (!success)
+        {
+            //return all removed items because we failed to remove the rest
+            foreach (var removedItem in removedItems)
+            {
+                TryGiveItem(removedItem.Key, removedItem.Value);
+            }
+
+            PacketSender.SendChatMsg(this, Strings.Shops.TransactionFailed, ChatMessageType.Inventory, CustomColors.Alerts.Error, Name);
+            return;
+        }
+
+        TryGiveItem(boughtItemBase.Id, boughtItemAmount);
+
+        if (!TextUtils.IsNone(InShop.BuySound))
+        {
+            PacketSender.SendPlaySound(this, InShop.BuySound);
+        }
+    }
+
+    //Crafting
+    public bool OpenCraftingTable(CraftingTableBase table, bool journalMode)
+    {
+        if (IsBusy())
+        {
+            return false;
+        }
+
+        if (table != null)
+        {
+            OpenCraftingTableId = table.Id;
+            CraftJournalMode = journalMode;
+            PacketSender.SendOpenCraftingTable(this, table, journalMode);
+        }
+
+        return true;
+    }
+
+    public void CloseCraftingTable()
+    {
+        OpenCraftingTableId = default;
+        CraftingState = default;
+        PacketSender.SendCloseCraftingTable(this);
+    }
+
+    //Craft a new item
+    public void CraftItem()
+    {
+        if (ShouldCancelCrafting() || CraftingState == default)
+        {
+            return;
+        }
+
+        if (!CraftBase.TryGet(CraftingState?.Id ?? default, out var craftDescriptor))
+        {
+            return;
+        }
+
+        var backupItems = new List<Item>();
+        foreach (var backupItem in Items)
+        {
+            backupItems.Add(backupItem.Clone());
+        }
+
+        if (!ItemBase.TryGet(craftDescriptor.ItemId, out var craftItem) && CraftingState != default)
+        {
+            CraftingState.RemainingCount--;
+            return;
+        }
+
+        lock (EntityLock)
+        {
+            var craftRoll = Randomization.Next(0, 101);
+            var failedCraft = craftRoll < craftDescriptor.FailureChance;
+            if (failedCraft)
+            {
+                var message = Strings.Crafting.CraftFailure;
+
+                var itemLossRoll = Randomization.Next(0, 101);
+                var itemLost = itemLossRoll < craftDescriptor.ItemLossChance;
+                if (itemLost)
                 {
                     //Take the items
                     foreach (var ingredient in craftDescriptor.Ingredients)
@@ -4103,9 +4073,9 @@ namespace Intersect.Server.Entities
                             continue;
                         }
 
-                        for (var slotIndex = 0; slotIndex < backupItems.Count; slotIndex++)
+                        for (var i = 0; i < backupItems.Count; i++)
                         {
-                            Items[slotIndex].Set(backupItems[slotIndex]);
+                            Items[i].Set(backupItems[i]);
                         }
 
                         PacketSender.SendInventory(this);
@@ -4117,757 +4087,759 @@ namespace Intersect.Server.Entities
                         return;
                     }
 
-                    //Give them the craft
-                    var quantity = Math.Max(craftDescriptor.Quantity, 1);
-                    if (!craftItem.IsStackable)
-                    {
-                        quantity = 1;
-                    }
-
-                    if (TryGiveItem(craftItem.Id, quantity))
-                    {
-                        PacketSender.SendChatMsg(
-                            this, Strings.Crafting.crafted.ToString(craftItem.Name), ChatMessageType.Crafting,
-                            CustomColors.Alerts.Success
-                        );
-
-                        if (craftDescriptor.Event != default)
-                        {
-                            EnqueueStartCommonEvent(craftDescriptor.Event);
-                        }
-                    }
-                    else
-                    {
-                        for (var i = 0; i < backupItems.Count; i++)
-                        {
-                            Items[i].Set(backupItems[i]);
-                        }
-
-                        PacketSender.SendInventory(this);
-                        PacketSender.SendChatMsg(
-                            this, Strings.Crafting.nospace.ToString(craftItem.Name), ChatMessageType.Crafting,
-                            CustomColors.Alerts.Error
-                        );
-                    }
+                    message = Strings.Crafting.CraftFailureLostItems;
                 }
 
-                if (CraftingState != default)
-                {
-                    CraftingState.RemainingCount--;
-                }
-            }
-        }
-
-        public bool ShouldCancelCrafting()
-        {
-            if (OpenCraftingTableId == default)
-            {
-                return true;
-            }
-
-            if (CraftingState == null)
-            {
-                return true;
-            }
-
-            if (CraftingState.RemainingCount <= 0)
-            {
-                return true;
-            }
-
-            if (!CraftingTableBase.TryGet(OpenCraftingTableId, out var table))
-            {
-                return true;
-            }
-
-            var craftingStateId = CraftingState?.Id;
-
-            if (craftingStateId == null || !table.Crafts.Contains(craftingStateId.Value))
-            {
-                return true;
-            }
-
-            if (!CraftBase.TryGet(craftingStateId.Value, out var craftDescriptor))
-            {
-                return true;
-            }
-
-            if (!Conditions.MeetsConditionLists(craftDescriptor.CraftingRequirements, this, null))
-            {
-                PacketSender.SendChatMsg(this, Strings.Crafting.RequirementsNotMet.ToString(), ChatMessageType.Error);
-                return true;
-            }
-
-            if (!ItemBase.TryGet(craftDescriptor.ItemId, out var craftItem))
-            {
-                PacketSender.SendChatMsg(this, Strings.Errors.UnknownErrorTryAgain, ChatMessageType.Error, CustomColors.Alerts.Error);
-                Log.Error($"Unable to find item descriptor {craftItem?.Id} for craft {craftDescriptor?.Id}.");
-                return true;
-            }
-
-            //Quickly Look through the inventory and create a catalog of what items we have, and how many
-            var inventoryItems = new Dictionary<Guid, int>();
-            foreach (var inventoryItem in Items)
-            {
-                if (inventoryItem == null)
-                {
-                    continue;
-                }
-
-                var quantity = inventoryItem.Quantity;
-                if (inventoryItems.TryGetValue(inventoryItem.ItemId, out var currentQuantitySum))
-                {
-                    quantity += currentQuantitySum;
-                }
-                inventoryItems[inventoryItem.ItemId] = quantity;
-            }
-
-            //Check the player actually has the items
-            foreach (var ingredient in craftDescriptor.Ingredients)
-            {
-                var qSearch = inventoryItems.TryGetValue(ingredient.ItemId, out var currentQuantity);
-                if (CraftingState != default && !qSearch)
-                {
-                    CraftingState.Id = Guid.Empty;
-                    return true;
-                }
-
-                if (CraftingState != default && currentQuantity < ingredient.Quantity)
-                {
-                    CraftingState.Id = Guid.Empty;
-                    return true;
-                }
-
-                inventoryItems[ingredient.ItemId] = currentQuantity - ingredient.Quantity;
-            }
-
-            return false;
-        }
-
-        //Business
-        private bool IsBusy() =>
-            InShop != default ||
-            InBank ||
-            OpenCraftingTableId != default ||
-            Trading.Counterparty != default ||
-            Trading.Requester != default ||
-            PartyRequester != default ||
-            FriendRequester != default;
-
-        //Bank
-        public bool OpenBank(bool guild = false)
-        {
-            if (IsBusy())
-            {
-                return false;
-            }
-
-            if (guild && Guild == null)
-            {
-                return false;
-            }
-
-            var bankItems = ((IEnumerable<Item>)Bank).ToList();
-
-            if (guild)
-            {
-                bankItems = ((IEnumerable<Item>)Guild.Bank).ToList();
-            }
-
-            BankInterface = new BankInterface(this, bankItems, guild ? Guild.Lock : new object(), guild ? Guild : null, guild ? Guild.BankSlotsCount : Options.Instance.PlayerOpts.InitialBankslots);
-
-            GuildBank = guild;
-            BankInterface.SendOpenBank();
-
-            return true;
-        }
-
-        public void CloseBank()
-        {
-            if (InBank)
-            {
-                BankInterface.Dispose();
-            }
-        }
-
-        // TODO: Document this. The TODO on bagItem == null needs to be resolved before this is.
-        public bool OpenBag(Item bagItem, ItemBase itemDescriptor)
-        {
-            if (IsBusy())
-            {
-                return false;
-            }
-
-            // TODO: Figure out what to return in the event of a bad argument. An NRE would have happened anyway, and I don't have enough awareness of the bag feature to do this differently.
-            if (bagItem == null)
-            {
-                throw new ArgumentNullException(nameof(bagItem));
-            }
-
-            // If the bag does not exist, create one.
-            if (!bagItem.TryGetBag(out var bag))
-            {
-                var slotCount = itemDescriptor.SlotCount;
-                if (slotCount < 1)
-                {
-                    slotCount = 1;
-                }
-
-                bag = new Bag(slotCount);
-                bagItem.Bag = bag;
-            }
-
-            //Send the bag to the player (this will make it appear on screen)
-            InBag = bag;
-            PacketSender.SendOpenBag(this, bag.SlotCount, bag);
-
-            return true;
-        }
-
-        public bool HasBag(Bag bag)
-        {
-            for (var i = 0; i < Items.Count; i++)
-            {
-                if (Items[i] != null && Items[i].Bag == bag)
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        public Bag GetBag()
-        {
-            if (InBag != null)
-            {
-                return InBag;
-            }
-
-            return null;
-        }
-
-        public void CloseBag()
-        {
-            if (InBag != null)
-            {
-                InBag = null;
-                PacketSender.SendCloseBag(this);
-            }
-        }
-
-        private bool TryFillInventoryStacksOfItemForTradeOffer(Item tradeItem, int offerIdx, List<InventorySlot> inventorySlots, ItemBase itemDescriptor, int amountToGive = 1)
-        {
-            int amountRemainder = amountToGive;
-            foreach (var invItem in inventorySlots)
-            {
-                // If we've fulfilled our stacking desires, we're done
-                if (amountRemainder <= 0 || FindOpenInventorySlots().Count <= 0)
-                {
-                    return amountRemainder <= 0;
-                }
-                var currSlot = FindInventoryItemSlotIndex(invItem);
-
-                // Otherwise, first update how many of our item we still need to put in this current slot
-                amountToGive = amountRemainder;
-                var maxDiff = itemDescriptor.MaxInventoryStack - invItem.Quantity;
-                amountRemainder = amountToGive - maxDiff;
-                amountToGive = MathHelper.Clamp(amountToGive, 0, maxDiff);
-
-                // Then, determine what the slots _new_ quantity should be
-                var newQuantity = MathHelper.Clamp(invItem.Quantity + amountToGive, 0, itemDescriptor.MaxInventoryStack);
-                // If the slot we're going to fill is empty, give it the item from the inventory
-                if (invItem.ItemId == default)
-                {
-                    invItem.Set(tradeItem);
-                }
-                invItem.Quantity = newQuantity;
-
-                // If we drained the inventory item's stack with that transaction, remove the inventory item from the inventory
-                if (amountToGive >= tradeItem.Quantity)
-                {
-                    tradeItem.Set(Item.None);
-                }
-                // Otherwise, just reduce its quantity
-                else
-                {
-                    tradeItem.Quantity -= amountToGive;
-                }
-
-                // Aaaand tell the client, provided any amount got given
-                if (amountToGive > 0)
-                {
-                    PacketSender.SendInventoryItemUpdate(this, invItem.Slot);
-                    PacketSender.SendTradeUpdate(this, this, offerIdx);
-                    PacketSender.SendTradeUpdate(Trading.Counterparty, this, offerIdx);
-                }
-            } // repeat until we've either filled the bag or fulfilled our stack requirements
-
-            return amountRemainder <= 0;
-        }
-
-        /// <summary>
-        /// Fills an inventory with items from a <see cref="BagSlot"/>, mostly making sure stacks play along correctly
-        /// </summary>
-        /// <param name="bag">The <see cref="Bag"/> we're pulling from</param>
-        /// <param name="bagSlotIdx">The index of the bag that we're choosing to withrdaw</param>
-        /// <param name="inventorySlots">A list of inventory slots that are valid locations for the withdrawal</param>
-        /// <param name="itemDescriptor">The <see cref="ItemBase"/> of the item that is getting moved around.</param>
-        /// <param name="amountToGive">How many of the item that we're moving, if stackable.</param>
-        /// <returns>A <see cref="bool"/> saying whether or not we successfully deposited ALL the items</returns>
-        private bool TryFillInventoryStacksOfItemFromBagSlot(Bag bag, int bagSlotIdx, List<InventorySlot> inventorySlots, ItemBase itemDescriptor, int amountToGive = 1)
-        {
-            int amountRemainder = amountToGive;
-            var bagSlots = bag.Slots;
-            foreach (var inventorySlotsWithItem in inventorySlots)
-            {
-                // If we've fulfilled our stacking desires, we're done
-                if (amountRemainder < 1 || FindOpenInventorySlots().Count < 1)
-                {
-                    return amountRemainder < 1;
-                }
-                var currSlot = FindInventoryItemSlotIndex(inventorySlotsWithItem);
-
-                // Otherwise, first update how many of our item we still need to put in this current slot
-                amountToGive = amountRemainder;
-                var maxDiff = itemDescriptor.MaxInventoryStack - inventorySlotsWithItem.Quantity;
-                amountRemainder = amountToGive - maxDiff;
-                amountToGive = MathHelper.Clamp(amountToGive, 0, maxDiff);
-
-                // Then, determine what the slots _new_ quantity should be
-                var newQuantity = MathHelper.Clamp(inventorySlotsWithItem.Quantity + amountToGive, 0, itemDescriptor.MaxInventoryStack);
-                // If the slot we're going to fill is empty, give it the item from the inventory
-                if (inventorySlotsWithItem.ItemId == default)
-                {
-                    inventorySlotsWithItem.Set(bagSlots[bagSlotIdx]);
-                }
-                inventorySlotsWithItem.Quantity = newQuantity;
-
-                // If we drained the inventory item's stack with that transaction, remove the inventory item from the inventory
-                if (amountToGive >= bagSlots[bagSlotIdx].Quantity)
-                {
-                    bagSlots[bagSlotIdx].Set(Item.None);
-                }
-                // Otherwise, just reduce its quantity
-                else
-                {
-                    bagSlots[bagSlotIdx].Quantity -= amountToGive;
-                }
-
-                // Aaaand tell the client (if we actually dumped any amount of the item)
-                if (amountToGive > 0)
-                {
-                    PacketSender.SendInventoryItemUpdate(this, currSlot);
-                    PacketSender.SendBagUpdate(this, bagSlotIdx, bagSlots[bagSlotIdx]);
-                }
-            } // repeat until we've either filled the bag or fulfilled our stack requirements
-
-            return amountRemainder < 1;
-        }
-
-        /// <summary>
-        /// Fills a bag with items from a <see cref="InventorySlot"/>, mostly making sure stacks play along correctly
-        /// </summary>
-        /// <param name="bag">The <see cref="Bag"/> we're putting items into from</param>
-        /// <param name="inventorySlotIdx">The index of the players inventory that we're withrdawing from</param>
-        /// <param name="bagSlots">A list of valid bag slots that could ccontain the item</param>
-        /// <param name="itemDescriptor">The <see cref="ItemBase"/> of the item that is getting moved around.</param>
-        /// <param name="amountToGive">How many of the item that we're moving, if stackable.</param>
-        /// <returns>A <see cref="bool"/> saying whether or not we successfully deposited ALL the items</returns>
-        private bool TryFillBagStacksOfItemFromInventorySlot(Bag bag, int inventorySlotIdx, List<BagSlot> bagSlots, ItemBase itemDescriptor, int amountToGive = 1)
-        {
-            int amountRemainder = amountToGive;
-            foreach (var bagSlotWithItem in bagSlots)
-            {
-                if (amountRemainder < 1 || bag.FindOpenBagSlots().Count < 1)
-                {
-                    return amountRemainder < 1;
-                }
-                var currSlot = bag.FindSlotIndex(bagSlotWithItem);
-
-                amountToGive = amountRemainder;
-                var maxDiff = itemDescriptor.MaxInventoryStack - bagSlotWithItem.Quantity;
-                amountRemainder = amountToGive - maxDiff;
-                amountToGive = MathHelper.Clamp(amountToGive, 0, maxDiff);
-
-                var newQuantity = MathHelper.Clamp(bagSlotWithItem.Quantity + amountToGive, 0, itemDescriptor.MaxInventoryStack);
-                if (bagSlotWithItem.ItemId == default)
-                {
-                    bagSlotWithItem.Set(Items[inventorySlotIdx]);
-                }
-                bagSlotWithItem.Quantity = newQuantity;
-
-                if (amountToGive >= Items[inventorySlotIdx].Quantity)
-                {
-                    Items[inventorySlotIdx].Set(Item.None);
-                    EquipmentProcessItemLoss(inventorySlotIdx);
-                }
-                else
-                {
-                    Items[inventorySlotIdx].Quantity -= amountToGive;
-                }
-
-                if (amountToGive > 0)
-                {
-                    PacketSender.SendInventoryItemUpdate(this, inventorySlotIdx);
-                    PacketSender.SendBagUpdate(this, currSlot, bagSlotWithItem);
-                }
-            }
-
-            return amountRemainder < 1;
-        }
-
-        public void StoreBagItem(int inventorySlotIndex, int amount, int bagSlotIndex)
-        {
-            if (InBag == null || !HasBag(InBag))
-            {
-                return;
-            }
-
-            var inventorySlot = Items[inventorySlotIndex];
-            var itemDescriptor = inventorySlot.Descriptor;
-            var bag = GetBag();
-
-            if (itemDescriptor == default || bag == default || inventorySlot.ItemId == default)
-            {
-                return;
-            }
-
-            if (!itemDescriptor.CanBag)
-            {
-                PacketSender.SendChatMsg(this, Strings.Items.nobag, ChatMessageType.Inventory, CustomColors.Items.Bound);
-                return;
-            }
-
-            // Make Sure we are not Storing a Bag inside of itself
-            if (inventorySlot.Bag == InBag)
-            {
-                PacketSender.SendChatMsg(this, Strings.Bags.baginself, ChatMessageType.Inventory, CustomColors.Alerts.Error);
-                return;
-            }
-
-            if (itemDescriptor.ItemType == ItemType.Bag)
-            {
-                PacketSender.SendChatMsg(this, Strings.Bags.baginbag, ChatMessageType.Inventory, CustomColors.Alerts.Error);
-                return;
-            }
-
-            bool specificSlot = bagSlotIndex != -1;
-            // Sanitize amount
-            if (itemDescriptor.IsStackable)
-            {
-                if (amount >= inventorySlot.Quantity)
-                {
-                    amount = Math.Min(inventorySlot.Quantity, inventorySlot.Descriptor.MaxInventoryStack);
-                }
+                PacketSender.SendInventory(this);
+                PacketSender.SendChatMsg(this, message.ToString(craftItem.Name), ChatMessageType.Crafting, CustomColors.Alerts.Error);
             }
             else
             {
-                amount = 1;
-            }
-
-            // Sanitize currSlot - this is the slot we want to fill
-            int currSlot = 0;
-            // First, we'll get our slots in the order we wish to fill them - prioritizing the user's requested slot, otherwise going from the first instance of the item found
-            var relevantSlots = new List<BagSlot>();
-            if (specificSlot)
-            {
-                currSlot = bagSlotIndex;
-                var requestedSlot = bag.Slots[currSlot];
-                // If the slot we're trying to fill is occupied...
-                if (requestedSlot.ItemId != default && (!itemDescriptor.IsStackable || requestedSlot.ItemId != itemDescriptor.Id))
+                //Take the items
+                foreach (var ingredient in craftDescriptor.Ingredients)
                 {
-                    // Alert the user
-                    PacketSender.SendChatMsg(this, Strings.Bags.SlotOccupied, ChatMessageType.Inventory, CustomColors.Alerts.Error);
+                    if (TryTakeItem(ingredient.ItemId, ingredient.Quantity))
+                    {
+                        continue;
+                    }
+
+                    for (var slotIndex = 0; slotIndex < backupItems.Count; slotIndex++)
+                    {
+                        Items[slotIndex].Set(backupItems[slotIndex]);
+                    }
+
+                    PacketSender.SendInventory(this);
+                    if (CraftingState != default)
+                    {
+                        CraftingState.RemainingCount--;
+                    }
+
                     return;
                 }
 
-                relevantSlots.Add(requestedSlot);
+                //Give them the craft
+                var quantity = Math.Max(craftDescriptor.Quantity, 1);
+                if (!craftItem.IsStackable)
+                {
+                    quantity = 1;
+                }
+
+                if (TryGiveItem(craftItem.Id, quantity))
+                {
+                    PacketSender.SendChatMsg(
+                        this, Strings.Crafting.crafted.ToString(craftItem.Name), ChatMessageType.Crafting,
+                        CustomColors.Alerts.Success
+                    );
+
+                    if (craftDescriptor.Event != default)
+                    {
+                        EnqueueStartCommonEvent(craftDescriptor.Event);
+                    }
+                }
+                else
+                {
+                    for (var i = 0; i < backupItems.Count; i++)
+                    {
+                        Items[i].Set(backupItems[i]);
+                    }
+
+                    PacketSender.SendInventory(this);
+                    PacketSender.SendChatMsg(
+                        this, Strings.Crafting.nospace.ToString(craftItem.Name), ChatMessageType.Crafting,
+                        CustomColors.Alerts.Error
+                    );
+                }
             }
 
-            // If the item is stackable, add slots that contain that item into the mix
-            if (itemDescriptor.IsStackable)
+            if (CraftingState != default)
             {
-                relevantSlots.AddRange(bag.FindBagItemSlots(itemDescriptor.Id));
+                CraftingState.RemainingCount--;
             }
-            // And last, add any and all open slots as valid locations for this item, if need be
-            relevantSlots.AddRange(bag.FindOpenBagSlots());
-            relevantSlots.Select(sl => sl).Distinct();
+        }
+    }
 
-            // Otherwise, fill in the empty slots as much as possible
-            if (!TryFillBagStacksOfItemFromInventorySlot(bag, inventorySlotIndex, relevantSlots, itemDescriptor, amount))
+    public bool ShouldCancelCrafting()
+    {
+        if (OpenCraftingTableId == default)
+        {
+            return true;
+        }
+
+        if (CraftingState == null)
+        {
+            return true;
+        }
+
+        if (CraftingState.RemainingCount <= 0)
+        {
+            return true;
+        }
+
+        if (!CraftingTableBase.TryGet(OpenCraftingTableId, out var table))
+        {
+            return true;
+        }
+
+        var craftingStateId = CraftingState?.Id;
+
+        if (craftingStateId == null || !table.Crafts.Contains(craftingStateId.Value))
+        {
+            return true;
+        }
+
+        if (!CraftBase.TryGet(craftingStateId.Value, out var craftDescriptor))
+        {
+            return true;
+        }
+
+        if (!Conditions.MeetsConditionLists(craftDescriptor.CraftingRequirements, this, null))
+        {
+            PacketSender.SendChatMsg(this, Strings.Crafting.RequirementsNotMet.ToString(), ChatMessageType.Error);
+            return true;
+        }
+
+        if (!ItemBase.TryGet(craftDescriptor.ItemId, out var craftItem))
+        {
+            PacketSender.SendChatMsg(this, Strings.Errors.UnknownErrorTryAgain, ChatMessageType.Error, CustomColors.Alerts.Error);
+            Log.Error($"Unable to find item descriptor {craftItem?.Id} for craft {craftDescriptor?.Id}.");
+            return true;
+        }
+
+        //Quickly Look through the inventory and create a catalog of what items we have, and how many
+        var inventoryItems = new Dictionary<Guid, int>();
+        foreach (var inventoryItem in Items)
+        {
+            if (inventoryItem == null)
             {
-                // If we're STILL not done, alert the user that we didn't have enough slots
-                PacketSender.SendChatMsg(this, Strings.Bags.bagnospace, ChatMessageType.Inventory, CustomColors.Alerts.Error);
+                continue;
+            }
+
+            var quantity = inventoryItem.Quantity;
+            if (inventoryItems.TryGetValue(inventoryItem.ItemId, out var currentQuantitySum))
+            {
+                quantity += currentQuantitySum;
+            }
+            inventoryItems[inventoryItem.ItemId] = quantity;
+        }
+
+        //Check the player actually has the items
+        foreach (var ingredient in craftDescriptor.Ingredients)
+        {
+            var qSearch = inventoryItems.TryGetValue(ingredient.ItemId, out var currentQuantity);
+            if (CraftingState != default && !qSearch)
+            {
+                CraftingState.Id = Guid.Empty;
+                return true;
+            }
+
+            if (CraftingState != default && currentQuantity < ingredient.Quantity)
+            {
+                CraftingState.Id = Guid.Empty;
+                return true;
+            }
+
+            inventoryItems[ingredient.ItemId] = currentQuantity - ingredient.Quantity;
+        }
+
+        return false;
+    }
+
+    //Business
+    private bool IsBusy() =>
+        InShop != default ||
+        InBank ||
+        OpenCraftingTableId != default ||
+        Trading.Counterparty != default ||
+        Trading.Requester != default ||
+        PartyRequester != default ||
+        FriendRequester != default;
+
+    //Bank
+    public bool OpenBank(bool guild = false)
+    {
+        if (IsBusy())
+        {
+            return false;
+        }
+
+        if (guild && Guild == null)
+        {
+            return false;
+        }
+
+        var bankItems = ((IEnumerable<Item>)Bank).ToList();
+
+        if (guild)
+        {
+            bankItems = ((IEnumerable<Item>)Guild.Bank).ToList();
+        }
+
+        BankInterface = new BankInterface(this, bankItems, guild ? Guild.Lock : new object(), guild ? Guild : null, guild ? Guild.BankSlotsCount : Options.Instance.PlayerOpts.InitialBankslots);
+
+        GuildBank = guild;
+        BankInterface.SendOpenBank();
+
+        return true;
+    }
+
+    public void CloseBank()
+    {
+        if (InBank)
+        {
+            BankInterface.Dispose();
+        }
+    }
+
+    // TODO: Document this. The TODO on bagItem == null needs to be resolved before this is.
+    public bool OpenBag(Item bagItem, ItemBase itemDescriptor)
+    {
+        if (IsBusy())
+        {
+            return false;
+        }
+
+        // TODO: Figure out what to return in the event of a bad argument. An NRE would have happened anyway, and I don't have enough awareness of the bag feature to do this differently.
+        if (bagItem == null)
+        {
+            throw new ArgumentNullException(nameof(bagItem));
+        }
+
+        // If the bag does not exist, create one.
+        if (!bagItem.TryGetBag(out var bag))
+        {
+            var slotCount = itemDescriptor.SlotCount;
+            if (slotCount < 1)
+            {
+                slotCount = 1;
+            }
+
+            bag = new Bag(slotCount);
+            bagItem.Bag = bag;
+        }
+
+        //Send the bag to the player (this will make it appear on screen)
+        InBag = bag;
+        PacketSender.SendOpenBag(this, bag.SlotCount, bag);
+
+        return true;
+    }
+
+    public bool HasBag(Bag bag)
+    {
+        for (var i = 0; i < Items.Count; i++)
+        {
+            if (Items[i] != null && Items[i].Bag == bag)
+            {
+                return true;
             }
         }
 
-        public void RetrieveBagItem(int slot, int amount, int invSlot)
+        return false;
+    }
+
+    public Bag GetBag()
+    {
+        if (InBag != null)
         {
-            if (InBag == null || !HasBag(InBag))
+            return InBag;
+        }
+
+        return null;
+    }
+
+    public void CloseBag()
+    {
+        if (InBag != null)
+        {
+            InBag = null;
+            PacketSender.SendCloseBag(this);
+        }
+    }
+
+    private bool TryFillInventoryStacksOfItemForTradeOffer(Item tradeItem, int offerIdx, List<InventorySlot> inventorySlots, ItemBase itemDescriptor, int amountToGive = 1)
+    {
+        int amountRemainder = amountToGive;
+        foreach (var invItem in inventorySlots)
+        {
+            // If we've fulfilled our stacking desires, we're done
+            if (amountRemainder <= 0 || FindOpenInventorySlots().Count <= 0)
             {
-                return;
+                return amountRemainder <= 0;
+            }
+            var currSlot = FindInventoryItemSlotIndex(invItem);
+
+            // Otherwise, first update how many of our item we still need to put in this current slot
+            amountToGive = amountRemainder;
+            var maxDiff = itemDescriptor.MaxInventoryStack - invItem.Quantity;
+            amountRemainder = amountToGive - maxDiff;
+            amountToGive = MathHelper.Clamp(amountToGive, 0, maxDiff);
+
+            // Then, determine what the slots _new_ quantity should be
+            var newQuantity = MathHelper.Clamp(invItem.Quantity + amountToGive, 0, itemDescriptor.MaxInventoryStack);
+            // If the slot we're going to fill is empty, give it the item from the inventory
+            if (invItem.ItemId == default)
+            {
+                invItem.Set(tradeItem);
+            }
+            invItem.Quantity = newQuantity;
+
+            // If we drained the inventory item's stack with that transaction, remove the inventory item from the inventory
+            if (amountToGive >= tradeItem.Quantity)
+            {
+                tradeItem.Set(Item.None);
+            }
+            // Otherwise, just reduce its quantity
+            else
+            {
+                tradeItem.Quantity -= amountToGive;
             }
 
-            var bag = GetBag();
-            if (bag == null || slot > bag.Slots.Count || bag.Slots[slot] == null)
+            // Aaaand tell the client, provided any amount got given
+            if (amountToGive > 0)
             {
-                return;
+                PacketSender.SendInventoryItemUpdate(this, invItem.Slot);
+                PacketSender.SendTradeUpdate(this, this, offerIdx);
+                PacketSender.SendTradeUpdate(Trading.Counterparty, this, offerIdx);
+            }
+        } // repeat until we've either filled the bag or fulfilled our stack requirements
+
+        return amountRemainder <= 0;
+    }
+
+    /// <summary>
+    /// Fills an inventory with items from a <see cref="BagSlot"/>, mostly making sure stacks play along correctly
+    /// </summary>
+    /// <param name="bag">The <see cref="Bag"/> we're pulling from</param>
+    /// <param name="bagSlotIdx">The index of the bag that we're choosing to withrdaw</param>
+    /// <param name="inventorySlots">A list of inventory slots that are valid locations for the withdrawal</param>
+    /// <param name="itemDescriptor">The <see cref="ItemBase"/> of the item that is getting moved around.</param>
+    /// <param name="amountToGive">How many of the item that we're moving, if stackable.</param>
+    /// <returns>A <see cref="bool"/> saying whether or not we successfully deposited ALL the items</returns>
+    private bool TryFillInventoryStacksOfItemFromBagSlot(Bag bag, int bagSlotIdx, List<InventorySlot> inventorySlots, ItemBase itemDescriptor, int amountToGive = 1)
+    {
+        int amountRemainder = amountToGive;
+        var bagSlots = bag.Slots;
+        foreach (var inventorySlotsWithItem in inventorySlots)
+        {
+            // If we've fulfilled our stacking desires, we're done
+            if (amountRemainder < 1 || FindOpenInventorySlots().Count < 1)
+            {
+                return amountRemainder < 1;
+            }
+            var currSlot = FindInventoryItemSlotIndex(inventorySlotsWithItem);
+
+            // Otherwise, first update how many of our item we still need to put in this current slot
+            amountToGive = amountRemainder;
+            var maxDiff = itemDescriptor.MaxInventoryStack - inventorySlotsWithItem.Quantity;
+            amountRemainder = amountToGive - maxDiff;
+            amountToGive = MathHelper.Clamp(amountToGive, 0, maxDiff);
+
+            // Then, determine what the slots _new_ quantity should be
+            var newQuantity = MathHelper.Clamp(inventorySlotsWithItem.Quantity + amountToGive, 0, itemDescriptor.MaxInventoryStack);
+            // If the slot we're going to fill is empty, give it the item from the inventory
+            if (inventorySlotsWithItem.ItemId == default)
+            {
+                inventorySlotsWithItem.Set(bagSlots[bagSlotIdx]);
+            }
+            inventorySlotsWithItem.Quantity = newQuantity;
+
+            // If we drained the inventory item's stack with that transaction, remove the inventory item from the inventory
+            if (amountToGive >= bagSlots[bagSlotIdx].Quantity)
+            {
+                bagSlots[bagSlotIdx].Set(Item.None);
+            }
+            // Otherwise, just reduce its quantity
+            else
+            {
+                bagSlots[bagSlotIdx].Quantity -= amountToGive;
             }
 
-            var itemBase = bag.Slots[slot].Descriptor;
-            var inventorySlot = -1;
-            if (itemBase == null || bag.Slots[slot] == null || bag.Slots[slot].ItemId == Guid.Empty)
+            // Aaaand tell the client (if we actually dumped any amount of the item)
+            if (amountToGive > 0)
             {
-                return;
+                PacketSender.SendInventoryItemUpdate(this, currSlot);
+                PacketSender.SendBagUpdate(this, bagSlotIdx, bagSlots[bagSlotIdx]);
             }
+        } // repeat until we've either filled the bag or fulfilled our stack requirements
 
-            // Sanitize amounts
-            if (itemBase.IsStackable)
+        return amountRemainder < 1;
+    }
+
+    /// <summary>
+    /// Fills a bag with items from a <see cref="InventorySlot"/>, mostly making sure stacks play along correctly
+    /// </summary>
+    /// <param name="bag">The <see cref="Bag"/> we're putting items into from</param>
+    /// <param name="inventorySlotIdx">The index of the players inventory that we're withrdawing from</param>
+    /// <param name="bagSlots">A list of valid bag slots that could ccontain the item</param>
+    /// <param name="itemDescriptor">The <see cref="ItemBase"/> of the item that is getting moved around.</param>
+    /// <param name="amountToGive">How many of the item that we're moving, if stackable.</param>
+    /// <returns>A <see cref="bool"/> saying whether or not we successfully deposited ALL the items</returns>
+    private bool TryFillBagStacksOfItemFromInventorySlot(Bag bag, int inventorySlotIdx, List<BagSlot> bagSlots, ItemBase itemDescriptor, int amountToGive = 1)
+    {
+        int amountRemainder = amountToGive;
+        foreach (var bagSlotWithItem in bagSlots)
+        {
+            if (amountRemainder < 1 || bag.FindOpenBagSlots().Count < 1)
             {
-                if (amount >= bag.Slots[slot].Quantity)
-                {
-                    amount = bag.Slots[slot].Quantity;
-                }
+                return amountRemainder < 1;
+            }
+            var currSlot = bag.FindSlotIndex(bagSlotWithItem);
+
+            amountToGive = amountRemainder;
+            var maxDiff = itemDescriptor.MaxInventoryStack - bagSlotWithItem.Quantity;
+            amountRemainder = amountToGive - maxDiff;
+            amountToGive = MathHelper.Clamp(amountToGive, 0, maxDiff);
+
+            var newQuantity = MathHelper.Clamp(bagSlotWithItem.Quantity + amountToGive, 0, itemDescriptor.MaxInventoryStack);
+            if (bagSlotWithItem.ItemId == default)
+            {
+                bagSlotWithItem.Set(Items[inventorySlotIdx]);
+            }
+            bagSlotWithItem.Quantity = newQuantity;
+
+            if (amountToGive >= Items[inventorySlotIdx].Quantity)
+            {
+                Items[inventorySlotIdx].Set(Item.None);
+                EquipmentProcessItemLoss(inventorySlotIdx);
             }
             else
             {
-                amount = 1;
+                Items[inventorySlotIdx].Quantity -= amountToGive;
             }
 
-            // Sanitize currSlot - this is the slot we want to fill
-            int currSlot = 0;
-            // First, we'll get our slots in the order we wish to fill them - prioritizing the user's requested slot, otherwise going from the first instance of the item found
-            var relevantSlots = new List<InventorySlot>();
-            bool specificSlot = invSlot != -1;
-            if (specificSlot)
+            if (amountToGive > 0)
             {
-                currSlot = invSlot;
-                var requestedSlot = Items[currSlot];
-                // If the slot we're trying to fill is occupied...
-                if (requestedSlot.ItemId != default && (!itemBase.IsStackable || requestedSlot.ItemId != itemBase.Id))
+                PacketSender.SendInventoryItemUpdate(this, inventorySlotIdx);
+                PacketSender.SendBagUpdate(this, currSlot, bagSlotWithItem);
+            }
+        }
+
+        return amountRemainder < 1;
+    }
+
+    public void StoreBagItem(int inventorySlotIndex, int amount, int bagSlotIndex)
+    {
+        if (InBag == null || !HasBag(InBag))
+        {
+            return;
+        }
+
+        var inventorySlot = Items[inventorySlotIndex];
+        var itemDescriptor = inventorySlot.Descriptor;
+        var bag = GetBag();
+
+        if (itemDescriptor == default || bag == default || inventorySlot.ItemId == default)
+        {
+            return;
+        }
+
+        if (!itemDescriptor.CanBag)
+        {
+            PacketSender.SendChatMsg(this, Strings.Items.nobag, ChatMessageType.Inventory, CustomColors.Items.Bound);
+            return;
+        }
+
+        // Make Sure we are not Storing a Bag inside of itself
+        if (inventorySlot.Bag == InBag)
+        {
+            PacketSender.SendChatMsg(this, Strings.Bags.baginself, ChatMessageType.Inventory, CustomColors.Alerts.Error);
+            return;
+        }
+
+        if (itemDescriptor.ItemType == ItemType.Bag)
+        {
+            PacketSender.SendChatMsg(this, Strings.Bags.baginbag, ChatMessageType.Inventory, CustomColors.Alerts.Error);
+            return;
+        }
+
+        bool specificSlot = bagSlotIndex != -1;
+        // Sanitize amount
+        if (itemDescriptor.IsStackable)
+        {
+            if (amount >= inventorySlot.Quantity)
+            {
+                amount = Math.Min(inventorySlot.Quantity, inventorySlot.Descriptor.MaxInventoryStack);
+            }
+        }
+        else
+        {
+            amount = 1;
+        }
+
+        // Sanitize currSlot - this is the slot we want to fill
+        int currSlot = 0;
+        // First, we'll get our slots in the order we wish to fill them - prioritizing the user's requested slot, otherwise going from the first instance of the item found
+        var relevantSlots = new List<BagSlot>();
+        if (specificSlot)
+        {
+            currSlot = bagSlotIndex;
+            var requestedSlot = bag.Slots[currSlot];
+            // If the slot we're trying to fill is occupied...
+            if (requestedSlot.ItemId != default && (!itemDescriptor.IsStackable || requestedSlot.ItemId != itemDescriptor.Id))
+            {
+                // Alert the user
+                PacketSender.SendChatMsg(this, Strings.Bags.SlotOccupied, ChatMessageType.Inventory, CustomColors.Alerts.Error);
+                return;
+            }
+
+            relevantSlots.Add(requestedSlot);
+        }
+
+        // If the item is stackable, add slots that contain that item into the mix
+        if (itemDescriptor.IsStackable)
+        {
+            relevantSlots.AddRange(bag.FindBagItemSlots(itemDescriptor.Id));
+        }
+        // And last, add any and all open slots as valid locations for this item, if need be
+        relevantSlots.AddRange(bag.FindOpenBagSlots());
+        relevantSlots.Select(sl => sl).Distinct();
+
+        // Otherwise, fill in the empty slots as much as possible
+        if (!TryFillBagStacksOfItemFromInventorySlot(bag, inventorySlotIndex, relevantSlots, itemDescriptor, amount))
+        {
+            // If we're STILL not done, alert the user that we didn't have enough slots
+            PacketSender.SendChatMsg(this, Strings.Bags.bagnospace, ChatMessageType.Inventory, CustomColors.Alerts.Error);
+        }
+    }
+
+    public void RetrieveBagItem(int slot, int amount, int invSlot)
+    {
+        if (InBag == null || !HasBag(InBag))
+        {
+            return;
+        }
+
+        var bag = GetBag();
+        if (bag == null || slot > bag.Slots.Count || bag.Slots[slot] == null)
+        {
+            return;
+        }
+
+        var itemBase = bag.Slots[slot].Descriptor;
+        var inventorySlot = -1;
+        if (itemBase == null || bag.Slots[slot] == null || bag.Slots[slot].ItemId == Guid.Empty)
+        {
+            return;
+        }
+
+        // Sanitize amounts
+        if (itemBase.IsStackable)
+        {
+            if (amount >= bag.Slots[slot].Quantity)
+            {
+                amount = bag.Slots[slot].Quantity;
+            }
+        }
+        else
+        {
+            amount = 1;
+        }
+
+        // Sanitize currSlot - this is the slot we want to fill
+        int currSlot = 0;
+        // First, we'll get our slots in the order we wish to fill them - prioritizing the user's requested slot, otherwise going from the first instance of the item found
+        var relevantSlots = new List<InventorySlot>();
+        bool specificSlot = invSlot != -1;
+        if (specificSlot)
+        {
+            currSlot = invSlot;
+            var requestedSlot = Items[currSlot];
+            // If the slot we're trying to fill is occupied...
+            if (requestedSlot.ItemId != default && (!itemBase.IsStackable || requestedSlot.ItemId != itemBase.Id))
+            {
+                // Alert the user
+                PacketSender.SendChatMsg(this, Strings.Bags.SlotOccupied, ChatMessageType.Inventory, CustomColors.Alerts.Error);
+                return;
+            }
+
+            relevantSlots.Add(requestedSlot);
+        }
+        // If the item is stackable, add slots that contain that item into the mix
+        if (itemBase.IsStackable)
+        {
+            relevantSlots.AddRange(FindInventoryItemSlots(itemBase.Id));
+        }
+        // And last, add any and all open slots as valid locations for this item, if need be
+        relevantSlots.AddRange(FindOpenInventorySlots());
+        relevantSlots.Select(sl => sl).Distinct();
+
+        // Otherwise, fill in the empty slots as much as possible
+        if (!TryFillInventoryStacksOfItemFromBagSlot(bag, slot, relevantSlots, itemBase, amount))
+        {
+            // If we're STILL not done, alert the user that we didn't have enough slots
+            PacketSender.SendChatMsg(this, Strings.Bags.withdrawinvalid, ChatMessageType.Inventory, CustomColors.Alerts.Error);
+        }
+    }
+
+    public void SwapBagItems(int item1, int item2)
+    {
+        if (InBag == null || !HasBag(InBag))
+        {
+            return;
+        }
+
+        var bag = GetBag();
+        Item tmpInstance = null;
+        if (bag.Slots[item2] != null)
+        {
+            tmpInstance = bag.Slots[item2].Clone();
+        }
+
+        if (bag.Slots[item1] != null)
+        {
+            bag.Slots[item2].Set(bag.Slots[item1]);
+        }
+        else
+        {
+            bag.Slots[item2].Set(Item.None);
+        }
+
+        if (tmpInstance != null)
+        {
+            bag.Slots[item1].Set(tmpInstance);
+        }
+        else
+        {
+            bag.Slots[item1].Set(Item.None);
+        }
+
+        PacketSender.SendBagUpdate(this, item1, bag.Slots[item1]);
+        PacketSender.SendBagUpdate(this, item2, bag.Slots[item2]);
+    }
+
+    //Friends
+    public void FriendRequest(Player fromPlayer)
+    {
+        if (fromPlayer.FriendRequests.ContainsKey(this))
+        {
+            fromPlayer.FriendRequests.Remove(this);
+        }
+
+        if (!FriendRequests.ContainsKey(fromPlayer) || !(FriendRequests[fromPlayer] > Timing.Global.Milliseconds))
+        {
+            if (!IsBusy())
+            {
+                FriendRequester = fromPlayer;
+                PacketSender.SendFriendRequest(this, fromPlayer);
+                PacketSender.SendChatMsg(fromPlayer, Strings.Friends.sent, ChatMessageType.Friend, CustomColors.Alerts.RequestSent);
+            }
+            else
+            {
+                PacketSender.SendChatMsg(
+                    fromPlayer, Strings.Friends.busy.ToString(Name), ChatMessageType.Friend, CustomColors.Alerts.Error
+                );
+            }
+        }
+    }
+
+    public bool HasFriend(string name)
+    {
+        return CachedFriends.Values.Any(f => string.Equals(f, name, StringComparison.OrdinalIgnoreCase));
+    }
+
+    public Guid GetFriendId(string name)
+    {
+        var friend = CachedFriends.FirstOrDefault(f => string.Equals(f.Value, name, StringComparison.OrdinalIgnoreCase));
+        if (friend.Value != null)
+        {
+            return friend.Key;
+        }
+        return Guid.Empty;
+    }
+
+    //Trading
+    public void InviteToTrade(Player fromPlayer)
+    {
+        if (Trading.Requests == null)
+        {
+            Trading = new Trading(this);
+        }
+
+        if (fromPlayer.Trading.Requests == null)
+        {
+            fromPlayer.Trading = new Trading(fromPlayer);
+        }
+
+        if (fromPlayer.Trading.Requests.ContainsKey(this))
+        {
+            fromPlayer.Trading.Requests.Remove(this);
+        }
+
+        if (Trading.Requests.ContainsKey(fromPlayer) && Trading.Requests[fromPlayer] > Timing.Global.Milliseconds)
+        {
+            PacketSender.SendChatMsg(fromPlayer, Strings.Trading.alreadydenied, ChatMessageType.Trading, CustomColors.Alerts.Error);
+        }
+        else
+        {
+            if (!IsBusy())
+            {
+                Trading.Requester = fromPlayer;
+                PacketSender.SendTradeRequest(this, fromPlayer);
+            }
+            else
+            {
+                PacketSender.SendChatMsg(
+                    fromPlayer, Strings.Trading.busy.ToString(Name), ChatMessageType.Trading, CustomColors.Alerts.Error
+                );
+            }
+        }
+    }
+
+    public void OfferItem(int slot, int amount)
+    {
+        // TODO: Accessor cleanup
+        if (Trading.Counterparty == null)
+        {
+            return;
+        }
+
+        var itemBase = Items[slot].Descriptor;
+        if (itemBase != null)
+        {
+            if (Items[slot].ItemId != Guid.Empty)
+            {
+                if (itemBase.IsStackable)
                 {
-                    // Alert the user
-                    PacketSender.SendChatMsg(this, Strings.Bags.SlotOccupied, ChatMessageType.Inventory, CustomColors.Alerts.Error);
+                    if (amount >= Items[slot].Quantity)
+                    {
+                        amount = Items[slot].Quantity;
+                    }
+                }
+                else
+                {
+                    amount = 1;
+                }
+
+                //Check if the item is bound.. if so don't allow trade
+                if (!itemBase.CanTrade)
+                {
+                    PacketSender.SendChatMsg(this, Strings.Bags.tradebound, ChatMessageType.Trading, CustomColors.Items.Bound);
+
                     return;
                 }
 
-                relevantSlots.Add(requestedSlot);
-            }
-            // If the item is stackable, add slots that contain that item into the mix
-            if (itemBase.IsStackable)
-            {
-                relevantSlots.AddRange(FindInventoryItemSlots(itemBase.Id));
-            }
-            // And last, add any and all open slots as valid locations for this item, if need be
-            relevantSlots.AddRange(FindOpenInventorySlots());
-            relevantSlots.Select(sl => sl).Distinct();
-
-            // Otherwise, fill in the empty slots as much as possible
-            if (!TryFillInventoryStacksOfItemFromBagSlot(bag, slot, relevantSlots, itemBase, amount))
-            {
-                // If we're STILL not done, alert the user that we didn't have enough slots
-                PacketSender.SendChatMsg(this, Strings.Bags.withdrawinvalid, ChatMessageType.Inventory, CustomColors.Alerts.Error);
-            }
-        }
-
-        public void SwapBagItems(int item1, int item2)
-        {
-            if (InBag == null || !HasBag(InBag))
-            {
-                return;
-            }
-
-            var bag = GetBag();
-            Item tmpInstance = null;
-            if (bag.Slots[item2] != null)
-            {
-                tmpInstance = bag.Slots[item2].Clone();
-            }
-
-            if (bag.Slots[item1] != null)
-            {
-                bag.Slots[item2].Set(bag.Slots[item1]);
-            }
-            else
-            {
-                bag.Slots[item2].Set(Item.None);
-            }
-
-            if (tmpInstance != null)
-            {
-                bag.Slots[item1].Set(tmpInstance);
-            }
-            else
-            {
-                bag.Slots[item1].Set(Item.None);
-            }
-
-            PacketSender.SendBagUpdate(this, item1, bag.Slots[item1]);
-            PacketSender.SendBagUpdate(this, item2, bag.Slots[item2]);
-        }
-
-        //Friends
-        public void FriendRequest(Player fromPlayer)
-        {
-            if (fromPlayer.FriendRequests.ContainsKey(this))
-            {
-                fromPlayer.FriendRequests.Remove(this);
-            }
-
-            if (!FriendRequests.ContainsKey(fromPlayer) || !(FriendRequests[fromPlayer] > Timing.Global.Milliseconds))
-            {
-                if (!IsBusy())
+                //Check if this is a bag with items.. if so don't allow sale
+                if (itemBase.ItemType == ItemType.Bag)
                 {
-                    FriendRequester = fromPlayer;
-                    PacketSender.SendFriendRequest(this, fromPlayer);
-                    PacketSender.SendChatMsg(fromPlayer, Strings.Friends.sent, ChatMessageType.Friend, CustomColors.Alerts.RequestSent);
-                }
-                else
-                {
-                    PacketSender.SendChatMsg(
-                        fromPlayer, Strings.Friends.busy.ToString(Name), ChatMessageType.Friend, CustomColors.Alerts.Error
-                    );
-                }
-            }
-        }
-
-        public bool HasFriend(string name)
-        {
-            return CachedFriends.Values.Any(f => string.Equals(f, name, StringComparison.OrdinalIgnoreCase));
-        }
-
-        public Guid GetFriendId(string name)
-        {
-            var friend = CachedFriends.FirstOrDefault(f => string.Equals(f.Value, name, StringComparison.OrdinalIgnoreCase));
-            if (friend.Value != null)
-            {
-                return friend.Key;
-            }
-            return Guid.Empty;
-        }
-
-        //Trading
-        public void InviteToTrade(Player fromPlayer)
-        {
-            if (Trading.Requests == null)
-            {
-                Trading = new Trading(this);
-            }
-
-            if (fromPlayer.Trading.Requests == null)
-            {
-                fromPlayer.Trading = new Trading(fromPlayer);
-            }
-
-            if (fromPlayer.Trading.Requests.ContainsKey(this))
-            {
-                fromPlayer.Trading.Requests.Remove(this);
-            }
-
-            if (Trading.Requests.ContainsKey(fromPlayer) && Trading.Requests[fromPlayer] > Timing.Global.Milliseconds)
-            {
-                PacketSender.SendChatMsg(fromPlayer, Strings.Trading.alreadydenied, ChatMessageType.Trading, CustomColors.Alerts.Error);
-            }
-            else
-            {
-                if (!IsBusy())
-                {
-                    Trading.Requester = fromPlayer;
-                    PacketSender.SendTradeRequest(this, fromPlayer);
-                }
-                else
-                {
-                    PacketSender.SendChatMsg(
-                        fromPlayer, Strings.Trading.busy.ToString(Name), ChatMessageType.Trading, CustomColors.Alerts.Error
-                    );
-                }
-            }
-        }
-
-        public void OfferItem(int slot, int amount)
-        {
-            // TODO: Accessor cleanup
-            if (Trading.Counterparty == null)
-            {
-                return;
-            }
-
-            var itemBase = Items[slot].Descriptor;
-            if (itemBase != null)
-            {
-                if (Items[slot].ItemId != Guid.Empty)
-                {
-                    if (itemBase.IsStackable)
+                    if (Items[slot].TryGetBag(out var bag))
                     {
-                        if (amount >= Items[slot].Quantity)
+                        if (!bag.IsEmpty)
                         {
-                            amount = Items[slot].Quantity;
+                            PacketSender.SendChatMsg(this, Strings.Bags.onlytradeempty, ChatMessageType.Trading, CustomColors.Alerts.Error);
+                            return;
                         }
                     }
-                    else
-                    {
-                        amount = 1;
-                    }
+                }
 
-                    //Check if the item is bound.. if so don't allow trade
-                    if (!itemBase.CanTrade)
-                    {
-                        PacketSender.SendChatMsg(this, Strings.Bags.tradebound, ChatMessageType.Trading, CustomColors.Items.Bound);
-
-                        return;
-                    }
-
-                    //Check if this is a bag with items.. if so don't allow sale
-                    if (itemBase.ItemType == ItemType.Bag)
-                    {
-                        if (Items[slot].TryGetBag(out var bag))
-                        {
-                            if (!bag.IsEmpty)
-                            {
-                                PacketSender.SendChatMsg(this, Strings.Bags.onlytradeempty, ChatMessageType.Trading, CustomColors.Alerts.Error);
-                                return;
-                            }
-                        }
-                    }
-
-                    //Find a spot in the trade for it!
-                    if (itemBase.IsStackable)
-                    {
-                        for (var i = 0; i < Options.MaxInvItems; i++)
-                        {
-                            if (Trading.Offer[i] != null && Trading.Offer[i].ItemId == Items[slot].ItemId)
-                            {
-                                amount = Math.Min(amount, int.MaxValue - Trading.Offer[i].Quantity);
-                                Trading.Offer[i].Quantity += amount;
-
-                                //Remove Items from inventory send updates
-                                if (amount >= Items[slot].Quantity)
-                                {
-                                    Items[slot].Set(Item.None);
-                                    EquipmentProcessItemLoss(slot);
-                                }
-                                else
-                                {
-                                    Items[slot].Quantity -= amount;
-                                }
-
-                                PacketSender.SendInventoryItemUpdate(this, slot);
-                                PacketSender.SendTradeUpdate(this, this, i);
-                                PacketSender.SendTradeUpdate(Trading.Counterparty, this, i);
-
-                                return;
-                            }
-                        }
-                    }
-
-                    //Either a non stacking item, or we couldn't find the item already existing in the players inventory
+                //Find a spot in the trade for it!
+                if (itemBase.IsStackable)
+                {
                     for (var i = 0; i < Options.MaxInvItems; i++)
                     {
-                        if (Trading.Offer[i] == null || Trading.Offer[i].ItemId == Guid.Empty)
+                        if (Trading.Offer[i] != null && Trading.Offer[i].ItemId == Items[slot].ItemId)
                         {
-                            Trading.Offer[i] = Items[slot].Clone();
-                            Trading.Offer[i].Quantity = amount;
+                            amount = Math.Min(amount, int.MaxValue - Trading.Offer[i].Quantity);
+                            Trading.Offer[i].Quantity += amount;
 
                             //Remove Items from inventory send updates
                             if (amount >= Items[slot].Quantity)
@@ -4887,1278 +4859,1270 @@ namespace Intersect.Server.Entities
                             return;
                         }
                     }
-
-                    PacketSender.SendChatMsg(this, Strings.Trading.tradenospace, ChatMessageType.Trading, CustomColors.Alerts.Error);
                 }
-                else
+
+                //Either a non stacking item, or we couldn't find the item already existing in the players inventory
+                for (var i = 0; i < Options.MaxInvItems; i++)
                 {
-                    PacketSender.SendChatMsg(this, Strings.Trading.offerinvalid, ChatMessageType.Trading, CustomColors.Alerts.Error);
+                    if (Trading.Offer[i] == null || Trading.Offer[i].ItemId == Guid.Empty)
+                    {
+                        Trading.Offer[i] = Items[slot].Clone();
+                        Trading.Offer[i].Quantity = amount;
+
+                        //Remove Items from inventory send updates
+                        if (amount >= Items[slot].Quantity)
+                        {
+                            Items[slot].Set(Item.None);
+                            EquipmentProcessItemLoss(slot);
+                        }
+                        else
+                        {
+                            Items[slot].Quantity -= amount;
+                        }
+
+                        PacketSender.SendInventoryItemUpdate(this, slot);
+                        PacketSender.SendTradeUpdate(this, this, i);
+                        PacketSender.SendTradeUpdate(Trading.Counterparty, this, i);
+
+                        return;
+                    }
                 }
-            }
-        }
 
-        public void RevokeItem(int slot, int amount)
-        {
-            if (Trading.Counterparty == null)
-            {
-                return;
-            }
-
-            if (slot < 0 || slot >= Trading.Offer.Length || Trading.Offer[slot] == null)
-            {
-                return;
-            }
-
-            var itemBase = Trading.Offer[slot].Descriptor;
-            if (itemBase == null)
-            {
-                return;
-            }
-
-            if (Trading.Offer[slot] == null || Trading.Offer[slot].ItemId == Guid.Empty)
-            {
-                PacketSender.SendChatMsg(this, Strings.Trading.revokeinvalid, ChatMessageType.Trading, CustomColors.Alerts.Error);
-
-                return;
-            }
-
-            // Sanitize amounts
-            var inventorySlot = -1;
-            var stackable = itemBase.IsStackable;
-            var tradeItem = Trading.Offer[slot];
-            if (stackable)
-            {
-                if (amount >= tradeItem.Quantity)
-                {
-                    amount = tradeItem.Quantity;
-                }
+                PacketSender.SendChatMsg(this, Strings.Trading.tradenospace, ChatMessageType.Trading, CustomColors.Alerts.Error);
             }
             else
             {
-                amount = 1;
-            }
-
-            if (Trading.Counterparty.Trading.Accepted || Trading.Accepted)
-            {
-                PacketSender.SendChatMsg(this, Strings.Trading.RevokeNotAllowed, ChatMessageType.Trading, CustomColors.Alerts.Error);
-
-                return;
-            }
-
-            // Sanitize currSlot - this is the slot we want to fill
-            int currSlot = 0;
-            // First, we'll get our slots in the order we wish to fill them - prioritizing the user's requested slot, otherwise going from the first instance of the item found
-            var relevantSlots = new List<InventorySlot>();
-            // If the item is stackable, add slots that contain that item into the mix
-            if (itemBase.IsStackable)
-            {
-                relevantSlots.AddRange(FindInventoryItemSlots(itemBase.Id));
-            }
-            // And last, add any and all open slots as valid locations for this item, if need be
-            relevantSlots.AddRange(FindOpenInventorySlots());
-            relevantSlots.Select(sl => sl).Distinct();
-
-            // Otherwise, fill in the empty slots as much as possible
-            if (!TryFillInventoryStacksOfItemForTradeOffer(tradeItem, slot, relevantSlots, itemBase, amount))
-            {
-                // If we're STILL not done, alert the user that we didn't have enough slots
-                PacketSender.SendChatMsg(this, Strings.Bags.withdrawinvalid, ChatMessageType.Inventory, CustomColors.Alerts.Error);
+                PacketSender.SendChatMsg(this, Strings.Trading.offerinvalid, ChatMessageType.Trading, CustomColors.Alerts.Error);
             }
         }
+    }
 
-        public void ReturnTradeItems()
+    public void RevokeItem(int slot, int amount)
+    {
+        if (Trading.Counterparty == null)
         {
-            if (Trading.Counterparty == null)
-            {
-                return;
-            }
-
-            foreach (var offer in Trading.Offer)
-            {
-                if (offer == null || offer.ItemId == Guid.Empty)
-                {
-                    continue;
-                }
-
-                if (!TryGiveItem(offer, -1) && MapController.TryGetInstanceFromMap(MapId, MapInstanceId, out var instance))
-                {
-                    instance.SpawnItem(X, Y, offer, offer.Quantity, Id);
-                    PacketSender.SendChatMsg(this, Strings.Trading.itemsdropped, ChatMessageType.Inventory, CustomColors.Alerts.Error);
-                }
-
-                offer.ItemId = Guid.Empty;
-                offer.Quantity = 0;
-            }
-
-            PacketSender.SendInventory(this);
+            return;
         }
 
-        public void CancelTrade()
+        if (slot < 0 || slot >= Trading.Offer.Length || Trading.Offer[slot] == null)
         {
-            if (Trading.Counterparty == null)
-            {
-                return;
-            }
-
-            Trading.Counterparty.ReturnTradeItems();
-            PacketSender.SendChatMsg(Trading.Counterparty, Strings.Trading.declined, ChatMessageType.Trading, CustomColors.Alerts.Error);
-            PacketSender.SendTradeClose(Trading.Counterparty);
-            Trading.Counterparty.Trading.Counterparty = null;
-
-            ReturnTradeItems();
-            PacketSender.SendChatMsg(this, Strings.Trading.declined, ChatMessageType.Trading, CustomColors.Alerts.Error);
-            PacketSender.SendTradeClose(this);
-            Trading.Counterparty = null;
+            return;
         }
 
-        //Parties
-        public void InviteToParty(Player fromPlayer)
+        var itemBase = Trading.Offer[slot].Descriptor;
+        if (itemBase == null)
         {
-            if (fromPlayer == null)
+            return;
+        }
+
+        if (Trading.Offer[slot] == null || Trading.Offer[slot].ItemId == Guid.Empty)
+        {
+            PacketSender.SendChatMsg(this, Strings.Trading.revokeinvalid, ChatMessageType.Trading, CustomColors.Alerts.Error);
+
+            return;
+        }
+
+        // Sanitize amounts
+        var inventorySlot = -1;
+        var stackable = itemBase.IsStackable;
+        var tradeItem = Trading.Offer[slot];
+        if (stackable)
+        {
+            if (amount >= tradeItem.Quantity)
             {
-                return;
+                amount = tradeItem.Quantity;
+            }
+        }
+        else
+        {
+            amount = 1;
+        }
+
+        if (Trading.Counterparty.Trading.Accepted || Trading.Accepted)
+        {
+            PacketSender.SendChatMsg(this, Strings.Trading.RevokeNotAllowed, ChatMessageType.Trading, CustomColors.Alerts.Error);
+
+            return;
+        }
+
+        // Sanitize currSlot - this is the slot we want to fill
+        int currSlot = 0;
+        // First, we'll get our slots in the order we wish to fill them - prioritizing the user's requested slot, otherwise going from the first instance of the item found
+        var relevantSlots = new List<InventorySlot>();
+        // If the item is stackable, add slots that contain that item into the mix
+        if (itemBase.IsStackable)
+        {
+            relevantSlots.AddRange(FindInventoryItemSlots(itemBase.Id));
+        }
+        // And last, add any and all open slots as valid locations for this item, if need be
+        relevantSlots.AddRange(FindOpenInventorySlots());
+        relevantSlots.Select(sl => sl).Distinct();
+
+        // Otherwise, fill in the empty slots as much as possible
+        if (!TryFillInventoryStacksOfItemForTradeOffer(tradeItem, slot, relevantSlots, itemBase, amount))
+        {
+            // If we're STILL not done, alert the user that we didn't have enough slots
+            PacketSender.SendChatMsg(this, Strings.Bags.withdrawinvalid, ChatMessageType.Inventory, CustomColors.Alerts.Error);
+        }
+    }
+
+    public void ReturnTradeItems()
+    {
+        if (Trading.Counterparty == null)
+        {
+            return;
+        }
+
+        foreach (var offer in Trading.Offer)
+        {
+            if (offer == null || offer.ItemId == Guid.Empty)
+            {
+                continue;
             }
 
-            if (Party.Count != 0)
+            if (!TryGiveItem(offer, -1) && MapController.TryGetInstanceFromMap(MapId, MapInstanceId, out var instance))
             {
-                PacketSender.SendChatMsg(fromPlayer, Strings.Parties.inparty.ToString(Name), ChatMessageType.Party, CustomColors.Alerts.Error);
-
-                return;
+                instance.SpawnItem(X, Y, offer, offer.Quantity, Id);
+                PacketSender.SendChatMsg(this, Strings.Trading.itemsdropped, ChatMessageType.Inventory, CustomColors.Alerts.Error);
             }
 
-            if (Options.Instance.Instancing.BlockPartyInvitesInInstance && (!InOpenInstance || !fromPlayer.InOpenInstance))
-            {
-                PacketSender.SendChatMsg(fromPlayer, Strings.Parties.InInstance, ChatMessageType.Party, CustomColors.Alerts.Error);
+            offer.ItemId = Guid.Empty;
+            offer.Quantity = 0;
+        }
 
-                return;
-            }
+        PacketSender.SendInventory(this);
+    }
 
-            if (fromPlayer.PartyRequests.ContainsKey(this))
-            {
-                fromPlayer.PartyRequests.Remove(this);
-            }
+    public void CancelTrade()
+    {
+        if (Trading.Counterparty == null)
+        {
+            return;
+        }
 
-            if (PartyRequests.ContainsKey(fromPlayer) && PartyRequests[fromPlayer] > Timing.Global.Milliseconds)
+        Trading.Counterparty.ReturnTradeItems();
+        PacketSender.SendChatMsg(Trading.Counterparty, Strings.Trading.declined, ChatMessageType.Trading, CustomColors.Alerts.Error);
+        PacketSender.SendTradeClose(Trading.Counterparty);
+        Trading.Counterparty.Trading.Counterparty = null;
+
+        ReturnTradeItems();
+        PacketSender.SendChatMsg(this, Strings.Trading.declined, ChatMessageType.Trading, CustomColors.Alerts.Error);
+        PacketSender.SendTradeClose(this);
+        Trading.Counterparty = null;
+    }
+
+    //Parties
+    public void InviteToParty(Player fromPlayer)
+    {
+        if (fromPlayer == null)
+        {
+            return;
+        }
+
+        if (Party.Count != 0)
+        {
+            PacketSender.SendChatMsg(fromPlayer, Strings.Parties.inparty.ToString(Name), ChatMessageType.Party, CustomColors.Alerts.Error);
+
+            return;
+        }
+
+        if (Options.Instance.Instancing.BlockPartyInvitesInInstance && (!InOpenInstance || !fromPlayer.InOpenInstance))
+        {
+            PacketSender.SendChatMsg(fromPlayer, Strings.Parties.InInstance, ChatMessageType.Party, CustomColors.Alerts.Error);
+
+            return;
+        }
+
+        if (fromPlayer.PartyRequests.ContainsKey(this))
+        {
+            fromPlayer.PartyRequests.Remove(this);
+        }
+
+        if (PartyRequests.ContainsKey(fromPlayer) && PartyRequests[fromPlayer] > Timing.Global.Milliseconds)
+        {
+            PacketSender.SendChatMsg(fromPlayer, Strings.Parties.alreadydenied, ChatMessageType.Party, CustomColors.Alerts.Error);
+        }
+        else
+        {
+            if (!IsBusy())
             {
-                PacketSender.SendChatMsg(fromPlayer, Strings.Parties.alreadydenied, ChatMessageType.Party, CustomColors.Alerts.Error);
+                PartyRequester = fromPlayer;
+                PacketSender.SendPartyInvite(this, fromPlayer);
             }
             else
             {
-                if (!IsBusy())
-                {
-                    PartyRequester = fromPlayer;
-                    PacketSender.SendPartyInvite(this, fromPlayer);
-                }
-                else
-                {
-                    PacketSender.SendChatMsg(
-                        fromPlayer, Strings.Parties.busy.ToString(Name), ChatMessageType.Party, CustomColors.Alerts.Error
-                    );
-                }
+                PacketSender.SendChatMsg(
+                    fromPlayer, Strings.Parties.busy.ToString(Name), ChatMessageType.Party, CustomColors.Alerts.Error
+                );
             }
         }
+    }
 
-        public bool TryAddParty(Player target)
+    public bool TryAddParty(Player target)
+    {
+        //If a new party, make yourself the leader
+        if (Party.Count == 0)
         {
-            //If a new party, make yourself the leader
-            if (Party.Count == 0)
+            Party.Add(this);
+        }
+        else
+        {
+            if (PartyLeader != this)
             {
-                Party.Add(this);
-            }
-            else
-            {
-                if (PartyLeader != this)
-                {
-                    PacketSender.SendChatMsg(this, Strings.Parties.leaderinvonly, ChatMessageType.Party, CustomColors.Alerts.Error);
+                PacketSender.SendChatMsg(this, Strings.Parties.leaderinvonly, ChatMessageType.Party, CustomColors.Alerts.Error);
 
+                return false;
+            }
+
+            //Check for member being already in the party, if so cancel
+            for (var i = 0; i < Party.Count; i++)
+            {
+                if (Party[i] == target)
+                {
                     return false;
                 }
-
-                //Check for member being already in the party, if so cancel
-                for (var i = 0; i < Party.Count; i++)
-                {
-                    if (Party[i] == target)
-                    {
-                        return false;
-                    }
-                }
-            }
-
-            if (Party.Count >= Options.Party.MaximumMembers)
-            {
-                PacketSender.SendChatMsg(this, Strings.Parties.limitreached, ChatMessageType.Party, CustomColors.Alerts.Error);
-                return false;
-            }
-
-            target.LeaveParty();
-            Party.Add(target);
-
-            //Update all members of the party with the new list
-            var cachedParty = Party.ToList();
-            foreach (var member in cachedParty)
-            {
-                member.Party = cachedParty;
-                PacketSender.SendParty(member);
-                PacketSender.SendChatMsg(
-                    member, Strings.Parties.joined.ToString(target.Name), ChatMessageType.Party, CustomColors.Alerts.Accepted
-                );
-            }
-            return true;
-        }
-
-        public void KickParty(Guid target)
-        {
-            if (Party.Count > 0 && Party[0] == this)
-            {
-                if (target != Guid.Empty)
-                {
-                    var oldMember = Party.Where(p => p.Id == target).FirstOrDefault();
-                    if (oldMember != null)
-                    {
-                        oldMember.Party = new List<Player>();
-                        PacketSender.SendParty(oldMember);
-                        PacketSender.SendChatMsg(oldMember, Strings.Parties.kicked, ChatMessageType.Party, CustomColors.Alerts.Error);
-
-                        // Kick the player out of your shared instance!
-                        if (Options.Instance.Instancing.KickPartyMembersOnKick && oldMember.InstanceType == MapInstanceType.Shared)
-                        {
-                            oldMember.WarpToLastOverworldLocation(false);
-                        }
-
-                        Party.Remove(oldMember);
-
-                        if (Party.Count > 1) //Need atleast 2 party members to function
-                        {
-                            //Update all members of the party with the new list
-                            for (var i = 0; i < Party.Count; i++)
-                            {
-                                Party[i].Party = Party;
-                                PacketSender.SendParty(Party[i]);
-                                PacketSender.SendChatMsg(
-                                    Party[i], Strings.Parties.memberkicked.ToString(oldMember.Name),
-                                    ChatMessageType.Party,
-                                    CustomColors.Alerts.Error
-                                );
-                            }
-                        }
-                        else if (Party.Count > 0) //Check if anyone is left on their own
-                        {
-                            var remainder = Party[0];
-                            remainder.Party.Clear();
-                            PacketSender.SendParty(remainder);
-                            PacketSender.SendChatMsg(remainder, Strings.Parties.disbanded, ChatMessageType.Party, CustomColors.Alerts.Error);
-                        }
-                    }
-                }
             }
         }
 
-        public void LeaveParty()
+        if (Party.Count >= Options.Party.MaximumMembers)
         {
-            if (Options.Instance.Instancing.KickPartyMembersOnKick && InstanceType == MapInstanceType.Shared)
-            {
-                WarpToLastOverworldLocation(false);
-            }
-
-            Party ??= new List<Player>();
-            if (Party.Count < 1 || !Party.Contains(this))
-            {
-                return;
-            }
-
-            var currentParty = Party.ToList();
-            currentParty.Remove(this);
-
-            string partyMessage = currentParty.Count > 1
-                ? Strings.Parties.memberleft.ToString(Name)
-                : Strings.Parties.disbanded;
-
-            // Update all members of the party with the new list
-            foreach (var partyMember in currentParty)
-            {
-                partyMember.Party = currentParty.ToList();
-                PacketSender.SendParty(partyMember);
-                PacketSender.SendChatMsg(
-                    partyMember,
-                    partyMessage,
-                    ChatMessageType.Party,
-                    CustomColors.Alerts.Error
-                );
-            }
-
-            Party = new List<Player>();
-            PacketSender.SendParty(this);
-            PacketSender.SendChatMsg(this, Strings.Parties.left, ChatMessageType.Party, CustomColors.Alerts.Error);
-        }
-
-        public bool InParty(Player member)
-        {
-            return Party.Contains(member);
-        }
-
-        public void StartTrade(Player target)
-        {
-            if (target?.Trading.Counterparty != null)
-            {
-                return;
-            }
-
-            // Set the status of both players to be in a trade
-            Trading.Counterparty = target;
-            target.Trading.Counterparty = this;
-            Trading.Accepted = false;
-            target.Trading.Accepted = false;
-            Trading.Offer = new Item[Options.MaxInvItems];
-            target.Trading.Offer = new Item[Options.MaxInvItems];
-
-            for (var i = 0; i < Options.MaxInvItems; i++)
-            {
-                Trading.Offer[i] = new Item();
-                target.Trading.Offer[i] = new Item();
-            }
-
-            //Send the trade confirmation to both players
-            PacketSender.StartTrade(target, this);
-            PacketSender.StartTrade(this, target);
-        }
-
-        //Spells
-        public bool TryTeachSpell(Spell spell, bool sendUpdate = true)
-        {
-            if (spell == null || spell.SpellId == Guid.Empty)
-            {
-                return false;
-            }
-
-            if (KnowsSpell(spell.SpellId))
-            {
-                return false;
-            }
-
-            if (SpellBase.Get(spell.SpellId) == null)
-            {
-                return false;
-            }
-
-            for (var i = 0; i < Options.MaxPlayerSkills; i++)
-            {
-                if (Spells[i].SpellId == Guid.Empty)
-                {
-                    Spells[i].Set(spell);
-                    if (sendUpdate)
-                    {
-                        PacketSender.SendPlayerSpellUpdate(this, i);
-                        PacketSender.SendChatMsg(this,
-                            Strings.Player.spelltaughtlevelup.ToString(SpellBase.GetName(spell.SpellId)),
-                            ChatMessageType.Experience, CustomColors.Alerts.Info, Name);
-                    }
-
-                    return true;
-                }
-            }
-
+            PacketSender.SendChatMsg(this, Strings.Parties.limitreached, ChatMessageType.Party, CustomColors.Alerts.Error);
             return false;
         }
 
-        public bool KnowsSpell(Guid spellId)
+        target.LeaveParty();
+        Party.Add(target);
+
+        //Update all members of the party with the new list
+        var cachedParty = Party.ToList();
+        foreach (var member in cachedParty)
         {
-            for (var i = 0; i < Options.MaxPlayerSkills; i++)
+            member.Party = cachedParty;
+            PacketSender.SendParty(member);
+            PacketSender.SendChatMsg(
+                member, Strings.Parties.joined.ToString(target.Name), ChatMessageType.Party, CustomColors.Alerts.Accepted
+            );
+        }
+        return true;
+    }
+
+    public void KickParty(Guid target)
+    {
+        if (Party.Count > 0 && Party[0] == this)
+        {
+            if (target != Guid.Empty)
             {
-                if (Spells[i].SpellId == spellId)
+                var oldMember = Party.Where(p => p.Id == target).FirstOrDefault();
+                if (oldMember != null)
                 {
-                    return true;
-                }
-            }
+                    oldMember.Party = new List<Player>();
+                    PacketSender.SendParty(oldMember);
+                    PacketSender.SendChatMsg(oldMember, Strings.Parties.kicked, ChatMessageType.Party, CustomColors.Alerts.Error);
 
-            return false;
-        }
-
-        public int FindSpell(Guid spellId)
-        {
-            for (var i = 0; i < Options.MaxPlayerSkills; i++)
-            {
-                if (Spells[i].SpellId == spellId)
-                {
-                    return i;
-                }
-            }
-
-            return -1;
-        }
-
-        public void SwapSpells(int spell1, int spell2)
-        {
-            var tmpInstance = Spells[spell2].Clone();
-            Spells[spell2].Set(Spells[spell1]);
-            Spells[spell1].Set(tmpInstance);
-            PacketSender.SendPlayerSpellUpdate(this, spell1);
-            PacketSender.SendPlayerSpellUpdate(this, spell2);
-        }
-
-        public void ForgetSpell(int spellSlot, bool removeBoundSpell = false)
-        {
-            if (!SpellBase.Get(Spells[spellSlot].SpellId).Bound || removeBoundSpell)
-            {
-                Spells[spellSlot].Set(Spell.None);
-                PacketSender.SendPlayerSpellUpdate(this, spellSlot);
-                UnequipInvalidItems();
-            }
-            else
-            {
-                PacketSender.SendChatMsg(this, Strings.Combat.tryforgetboundspell, ChatMessageType.Spells);
-            }
-        }
-
-        public bool TryForgetSpell(Spell spell, bool sendUpdate = true)
-        {
-            Spell slot = null;
-            var slotIndex = -1;
-
-            for (var index = 0; index < Spells.Count; ++index)
-            {
-                var spellSlot = Spells[index];
-
-                // Avoid continue;
-                // ReSharper disable once InvertIf
-                if (spellSlot?.SpellId == spell.SpellId)
-                {
-                    slot = spellSlot;
-                    slotIndex = index;
-
-                    break;
-                }
-            }
-
-            if (slot == null)
-            {
-                return false;
-            }
-
-            var spellBase = SpellBase.Get(spell.SpellId);
-            if (spellBase == null)
-            {
-                return false;
-            }
-
-            if (spellBase.Bound)
-            {
-                PacketSender.SendChatMsg(this, Strings.Combat.tryforgetboundspell, ChatMessageType.Spells);
-
-                return false;
-            }
-
-            slot.Set(Spell.None);
-            PacketSender.SendPlayerSpellUpdate(this, slotIndex);
-            UnequipInvalidItems();
-
-            return true;
-        }
-
-        public override bool IsAllyOf(Entity otherEntity)
-        {
-            switch (otherEntity)
-            {
-                case Player otherPlayer:
-                    return IsAllyOf(otherPlayer);
-                case Npc otherNpc:
-                    return otherNpc.IsAllyOf(this);
-                default:
-                    return base.IsAllyOf(otherEntity);
-            }
-        }
-
-        public virtual bool IsAllyOf(Player otherPlayer)
-        {
-            if (Id == otherPlayer.Id)
-            {
-                return true;
-            }
-
-            if (InParty(otherPlayer))
-            {
-                return true;
-            }
-
-            if (IsInGuild && otherPlayer?.Guild?.Id == Guild.Id)
-            {
-                return true;
-            }
-
-            return Map?.ZoneType == MapZone.Safe && Options.Instance.CombatOpts.EnableAllPlayersFriendlyInSafeZone;
-        }
-
-        public override bool CanCastSpell(SpellBase spell, Entity target, bool checkVitalReqs, out SpellCastFailureReason reason)
-        {
-            // Do we fail our base class check? If so cancel out with a reason!
-            if (!base.CanCastSpell(spell, target, checkVitalReqs, out reason))
-            {
-                // Let our user know the reason if configured.
-                if (Options.Combat.EnableCombatChatMessages)
-                {
-                    switch (reason)
+                    // Kick the player out of your shared instance!
+                    if (Options.Instance.Instancing.KickPartyMembersOnKick && oldMember.InstanceType == MapInstanceType.Shared)
                     {
-                        case SpellCastFailureReason.InsufficientMP:
-                            PacketSender.SendChatMsg(this, Strings.Combat.lowmana, ChatMessageType.Combat);
-                            break;
-                        case SpellCastFailureReason.InsufficientHP:
-                            PacketSender.SendChatMsg(this, Strings.Combat.lowhealth, ChatMessageType.Combat);
-                            break;
-                        case SpellCastFailureReason.InvalidTarget:
-                            PacketSender.SendChatMsg(this, Strings.Combat.InvalidTarget, ChatMessageType.Combat);
-                            break;
-                        case SpellCastFailureReason.Silenced:
-                            PacketSender.SendChatMsg(this, Strings.Combat.silenced, ChatMessageType.Combat);
-                            break;
-                        case SpellCastFailureReason.Stunned:
-                            PacketSender.SendChatMsg(this, Strings.Combat.stunned, ChatMessageType.Combat);
-                            break;
-                        case SpellCastFailureReason.Asleep:
-                            PacketSender.SendChatMsg(this, Strings.Combat.sleep, ChatMessageType.Combat);
-                            break;
-                        case SpellCastFailureReason.Snared:
-                            PacketSender.SendChatMsg(this, Strings.Combat.Snared, ChatMessageType.Combat);
-                            break;
-                        case SpellCastFailureReason.OutOfRange:
-                            PacketSender.SendChatMsg(this, Strings.Combat.targetoutsiderange, ChatMessageType.Combat);
-                            break;
-                        case SpellCastFailureReason.OnCooldown:
-                            PacketSender.SendChatMsg(this, Strings.Combat.cooldown, ChatMessageType.Combat);
-                            break;
+                        oldMember.WarpToLastOverworldLocation(false);
                     }
-                }
-                return false;
-            }
 
-            // Check if out action is blocked by the global cooldown
-            if (!spell.IgnoreGlobalCooldown && mGlobalCooldownTimer > Timing.Global.MillisecondsUtc)
-            {
-                // Notify our user!
-                PacketSender.SendChatMsg(this, Strings.Combat.cooldown, ChatMessageType.Combat);
-                return false;
-            }
+                    Party.Remove(oldMember);
 
-            // Check for dynamic conditions.
-            if (!Conditions.MeetsConditionLists(spell.CastingRequirements, this, null))
-            {
-                if (!string.IsNullOrWhiteSpace(spell.CannotCastMessage))
-                {
-                    PacketSender.SendChatMsg(this, spell.CannotCastMessage, ChatMessageType.Error);
-                }
-                else
-                {
-                    PacketSender.SendChatMsg(this, Strings.Combat.dynamicreq, ChatMessageType.Spells);
-                }
-
-                reason = SpellCastFailureReason.ConditionsNotMet;
-                return false;
-            }
-
-            // If this is a projectile, check if the user has the corresponding item.
-            if (spell.SpellType == SpellType.CombatSpell &&
-                spell.Combat.TargetType == SpellTargetType.Projectile &&
-                spell.Combat.ProjectileId != Guid.Empty)
-            {
-                var projectileBase = spell.Combat.Projectile;
-                if (projectileBase == null)
-                {
-                    reason = SpellCastFailureReason.InvalidProjectile;
-                    return false;
-                }
-
-                if (projectileBase.AmmoItemId != Guid.Empty)
-                {
-                    if (FindInventoryItemSlot(projectileBase.AmmoItemId, projectileBase.AmmoRequired) == null)
+                    if (Party.Count > 1) //Need atleast 2 party members to function
                     {
-                        if (Options.Combat.EnableCombatChatMessages)
+                        //Update all members of the party with the new list
+                        for (var i = 0; i < Party.Count; i++)
                         {
+                            Party[i].Party = Party;
+                            PacketSender.SendParty(Party[i]);
                             PacketSender.SendChatMsg(
-                                this, Strings.Items.notenough.ToString(ItemBase.GetName(projectileBase.AmmoItemId)),
-                                ChatMessageType.Inventory,
+                                Party[i], Strings.Parties.memberkicked.ToString(oldMember.Name),
+                                ChatMessageType.Party,
                                 CustomColors.Alerts.Error
                             );
                         }
-
-                        reason = SpellCastFailureReason.InsufficientItems;
-                        return false;
+                    }
+                    else if (Party.Count > 0) //Check if anyone is left on their own
+                    {
+                        var remainder = Party[0];
+                        remainder.Party.Clear();
+                        PacketSender.SendParty(remainder);
+                        PacketSender.SendChatMsg(remainder, Strings.Parties.disbanded, ChatMessageType.Party, CustomColors.Alerts.Error);
                     }
                 }
             }
+        }
+    }
 
-            // We have no reason to stop this player from casting!
+    public void LeaveParty()
+    {
+        if (Options.Instance.Instancing.KickPartyMembersOnKick && InstanceType == MapInstanceType.Shared)
+        {
+            WarpToLastOverworldLocation(false);
+        }
+
+        Party ??= new List<Player>();
+        if (Party.Count < 1 || !Party.Contains(this))
+        {
+            return;
+        }
+
+        var currentParty = Party.ToList();
+        currentParty.Remove(this);
+
+        string partyMessage = currentParty.Count > 1
+            ? Strings.Parties.memberleft.ToString(Name)
+            : Strings.Parties.disbanded;
+
+        // Update all members of the party with the new list
+        foreach (var partyMember in currentParty)
+        {
+            partyMember.Party = currentParty.ToList();
+            PacketSender.SendParty(partyMember);
+            PacketSender.SendChatMsg(
+                partyMember,
+                partyMessage,
+                ChatMessageType.Party,
+                CustomColors.Alerts.Error
+            );
+        }
+
+        Party = new List<Player>();
+        PacketSender.SendParty(this);
+        PacketSender.SendChatMsg(this, Strings.Parties.left, ChatMessageType.Party, CustomColors.Alerts.Error);
+    }
+
+    public bool InParty(Player member)
+    {
+        return Party.Contains(member);
+    }
+
+    public void StartTrade(Player target)
+    {
+        if (target?.Trading.Counterparty != null)
+        {
+            return;
+        }
+
+        // Set the status of both players to be in a trade
+        Trading.Counterparty = target;
+        target.Trading.Counterparty = this;
+        Trading.Accepted = false;
+        target.Trading.Accepted = false;
+        Trading.Offer = new Item[Options.MaxInvItems];
+        target.Trading.Offer = new Item[Options.MaxInvItems];
+
+        for (var i = 0; i < Options.MaxInvItems; i++)
+        {
+            Trading.Offer[i] = new Item();
+            target.Trading.Offer[i] = new Item();
+        }
+
+        //Send the trade confirmation to both players
+        PacketSender.StartTrade(target, this);
+        PacketSender.StartTrade(this, target);
+    }
+
+    //Spells
+    public bool TryTeachSpell(Spell spell, bool sendUpdate = true)
+    {
+        if (spell == null || spell.SpellId == Guid.Empty)
+        {
+            return false;
+        }
+
+        if (KnowsSpell(spell.SpellId))
+        {
+            return false;
+        }
+
+        if (SpellBase.Get(spell.SpellId) == null)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < Options.MaxPlayerSkills; i++)
+        {
+            if (Spells[i].SpellId == Guid.Empty)
+            {
+                Spells[i].Set(spell);
+                if (sendUpdate)
+                {
+                    PacketSender.SendPlayerSpellUpdate(this, i);
+                    PacketSender.SendChatMsg(this,
+                        Strings.Player.spelltaughtlevelup.ToString(SpellBase.GetName(spell.SpellId)),
+                        ChatMessageType.Experience, CustomColors.Alerts.Info, Name);
+                }
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public bool KnowsSpell(Guid spellId)
+    {
+        for (var i = 0; i < Options.MaxPlayerSkills; i++)
+        {
+            if (Spells[i].SpellId == spellId)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public int FindSpell(Guid spellId)
+    {
+        for (var i = 0; i < Options.MaxPlayerSkills; i++)
+        {
+            if (Spells[i].SpellId == spellId)
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    public void SwapSpells(int spell1, int spell2)
+    {
+        var tmpInstance = Spells[spell2].Clone();
+        Spells[spell2].Set(Spells[spell1]);
+        Spells[spell1].Set(tmpInstance);
+        PacketSender.SendPlayerSpellUpdate(this, spell1);
+        PacketSender.SendPlayerSpellUpdate(this, spell2);
+    }
+
+    public void ForgetSpell(int spellSlot, bool removeBoundSpell = false)
+    {
+        if (!SpellBase.Get(Spells[spellSlot].SpellId).Bound || removeBoundSpell)
+        {
+            Spells[spellSlot].Set(Spell.None);
+            PacketSender.SendPlayerSpellUpdate(this, spellSlot);
+            UnequipInvalidItems();
+        }
+        else
+        {
+            PacketSender.SendChatMsg(this, Strings.Combat.tryforgetboundspell, ChatMessageType.Spells);
+        }
+    }
+
+    public bool TryForgetSpell(Spell spell, bool sendUpdate = true)
+    {
+        Spell slot = null;
+        var slotIndex = -1;
+
+        for (var index = 0; index < Spells.Count; ++index)
+        {
+            var spellSlot = Spells[index];
+
+            // Avoid continue;
+            // ReSharper disable once InvertIf
+            if (spellSlot?.SpellId == spell.SpellId)
+            {
+                slot = spellSlot;
+                slotIndex = index;
+
+                break;
+            }
+        }
+
+        if (slot == null)
+        {
+            return false;
+        }
+
+        var spellBase = SpellBase.Get(spell.SpellId);
+        if (spellBase == null)
+        {
+            return false;
+        }
+
+        if (spellBase.Bound)
+        {
+            PacketSender.SendChatMsg(this, Strings.Combat.tryforgetboundspell, ChatMessageType.Spells);
+
+            return false;
+        }
+
+        slot.Set(Spell.None);
+        PacketSender.SendPlayerSpellUpdate(this, slotIndex);
+        UnequipInvalidItems();
+
+        return true;
+    }
+
+    public override bool IsAllyOf(Entity otherEntity)
+    {
+        switch (otherEntity)
+        {
+            case Player otherPlayer:
+                return IsAllyOf(otherPlayer);
+            case Npc otherNpc:
+                return otherNpc.IsAllyOf(this);
+            default:
+                return base.IsAllyOf(otherEntity);
+        }
+    }
+
+    public virtual bool IsAllyOf(Player otherPlayer)
+    {
+        if (Id == otherPlayer.Id)
+        {
             return true;
         }
 
-        public void UseSpell(int spellSlot, Entity target)
+        if (InParty(otherPlayer))
         {
-            var spellNum = Spells[spellSlot].SpellId;
-            Target = target;
-            var spell = SpellBase.Get(spellNum);
-            if (spell == null)
+            return true;
+        }
+
+        if (IsInGuild && otherPlayer?.Guild?.Id == Guild.Id)
+        {
+            return true;
+        }
+
+        return Map?.ZoneType == MapZone.Safe && Options.Instance.CombatOpts.EnableAllPlayersFriendlyInSafeZone;
+    }
+
+    public override bool CanCastSpell(SpellBase spell, Entity target, bool checkVitalReqs, out SpellCastFailureReason reason)
+    {
+        // Do we fail our base class check? If so cancel out with a reason!
+        if (!base.CanCastSpell(spell, target, checkVitalReqs, out reason))
+        {
+            // Let our user know the reason if configured.
+            if (Options.Combat.EnableCombatChatMessages)
             {
-                return;
+                switch (reason)
+                {
+                    case SpellCastFailureReason.InsufficientMP:
+                        PacketSender.SendChatMsg(this, Strings.Combat.lowmana, ChatMessageType.Combat);
+                        break;
+                    case SpellCastFailureReason.InsufficientHP:
+                        PacketSender.SendChatMsg(this, Strings.Combat.lowhealth, ChatMessageType.Combat);
+                        break;
+                    case SpellCastFailureReason.InvalidTarget:
+                        PacketSender.SendChatMsg(this, Strings.Combat.InvalidTarget, ChatMessageType.Combat);
+                        break;
+                    case SpellCastFailureReason.Silenced:
+                        PacketSender.SendChatMsg(this, Strings.Combat.silenced, ChatMessageType.Combat);
+                        break;
+                    case SpellCastFailureReason.Stunned:
+                        PacketSender.SendChatMsg(this, Strings.Combat.stunned, ChatMessageType.Combat);
+                        break;
+                    case SpellCastFailureReason.Asleep:
+                        PacketSender.SendChatMsg(this, Strings.Combat.sleep, ChatMessageType.Combat);
+                        break;
+                    case SpellCastFailureReason.Snared:
+                        PacketSender.SendChatMsg(this, Strings.Combat.Snared, ChatMessageType.Combat);
+                        break;
+                    case SpellCastFailureReason.OutOfRange:
+                        PacketSender.SendChatMsg(this, Strings.Combat.targetoutsiderange, ChatMessageType.Combat);
+                        break;
+                    case SpellCastFailureReason.OnCooldown:
+                        PacketSender.SendChatMsg(this, Strings.Combat.cooldown, ChatMessageType.Combat);
+                        break;
+                }
             }
+            return false;
+        }
 
-            if (!CanCastSpell(spell, target, true, out _))
+        // Check if out action is blocked by the global cooldown
+        if (!spell.IgnoreGlobalCooldown && mGlobalCooldownTimer > Timing.Global.MillisecondsUtc)
+        {
+            // Notify our user!
+            PacketSender.SendChatMsg(this, Strings.Combat.cooldown, ChatMessageType.Combat);
+            return false;
+        }
+
+        // Check for dynamic conditions.
+        if (!Conditions.MeetsConditionLists(spell.CastingRequirements, this, null))
+        {
+            if (!string.IsNullOrWhiteSpace(spell.CannotCastMessage))
             {
-                if (!spell.Combat.Friendly)
-                {
-                    return;
-                }
-
-                if (!Options.Instance.CombatOpts.EnableAutoSelfCastFriendlySpellsWhenTargetingHostile)
-                {
-                    return;
-                }
-
-                if (target == this)
-                {
-                    return;
-                }
-
-                // Since it's a friendly spell and we have auto-retarget enabled,
-                // check if we can cast the spell on ourselves
-                if (!CanCastSpell(spell, this, true, out _))
-                {
-                    return;
-                }
-
-                // If we can, soft-change the target to ourselves (we will use this to set CastTarget
-                target = this;
-            }
-
-            if (CastTime == 0)
-            {
-                CastTime = Timing.Global.Milliseconds + spell.CastDuration;
-
-                //Remove stealth status.
-                foreach (var status in CachedStatuses)
-                {
-                    if (status.Type == SpellEffect.Stealth)
-                    {
-                        status.RemoveStatus();
-                    }
-                }
-
-                SpellCastSlot = spellSlot;
-
-                // Set to lower case target instead of Target to facilitate soft
-                // retargeting for auto self-cast on friendly when targeting hostile
-                CastTarget = target;
-
-                if (spell.CastAnimationId != Guid.Empty)
-                {
-                    PacketSender.SendAnimationToProximity(
-                        spell.CastAnimationId, 1, base.Id, MapId, 0, 0, Dir, MapInstanceId
-                    ); //Target Type 1 will be global entity
-                }
-
-                //Tell the client we are channeling the spell
-                if (IsCasting)
-                {
-                    PacketSender.SendEntityCastTime(this, spellNum);
-                }
+                PacketSender.SendChatMsg(this, spell.CannotCastMessage, ChatMessageType.Error);
             }
             else
             {
-                if (Options.Combat.EnableCombatChatMessages)
-                {
-                    PacketSender.SendChatMsg(this, Strings.Combat.channeling, ChatMessageType.Combat);
-                }
-            }
-        }
-
-        public override void CastSpell(Guid spellId, int spellSlot = -1)
-        {
-            var spellBase = SpellBase.Get(spellId);
-            if (spellBase == null)
-            {
-                return;
+                PacketSender.SendChatMsg(this, Strings.Combat.dynamicreq, ChatMessageType.Spells);
             }
 
-            switch (spellBase.SpellType)
-            {
-                case SpellType.Event:
-                    var evt = spellBase.Event;
-                    if (evt != null)
-                    {
-                        EnqueueStartCommonEvent(evt);
-                    }
-
-                    base.CastSpell(spellId, spellSlot); //To get cooldown :P
-
-                    break;
-                default:
-                    base.CastSpell(spellId, spellSlot);
-
-                    break;
-            }
-
-            UpdateSpellCooldown(spellBase, spellSlot);
-
-            ConsumeSpellProjectile(spellBase);
-        }
-
-        /// <summary>
-        /// Checks if the caster has the required projectile(s) for the spell and tries to take them.
-        /// This method is used when a spell that requires projectile is casted.
-        /// If the spell has a valid ProjectileId, it retrieves the projectile and checks if it has a valid AmmoItemId.
-        /// If it does, it attempts to take the required amount of ammo from the player's inventory.
-        /// </summary>
-        /// <param name="spellBase">The spell that is being cast.</param>
-        private void ConsumeSpellProjectile(SpellBase spellBase)
-        {
-            // Check if the caster has the required projectile(s) for the spell and try to take it/them.
-            if (spellBase.SpellType == SpellType.CombatSpell &&
-                spellBase.Combat.TargetType == SpellTargetType.Projectile &&
-                spellBase.Combat.ProjectileId != Guid.Empty)
-            {
-                var projectileBase = spellBase.Combat.Projectile;
-                if (projectileBase != null && projectileBase.AmmoItemId != Guid.Empty)
-                {
-                    TryTakeItem(projectileBase.AmmoItemId, projectileBase.AmmoRequired);
-                }
-            }
-        }
-
-        public bool TryGetEquipmentSlot(int equipmentSlot, out int inventorySlot)
-        {
-            inventorySlot = -1;
-            if (equipmentSlot > -1 && equipmentSlot < Equipment.Length)
-            {
-                inventorySlot = Equipment.ElementAtOrDefault(equipmentSlot);
-            }
-
-            return inventorySlot > -1;
-        }
-
-        /// <summary>
-        /// Safely sets an equipment slot, if valid
-        /// </summary>
-        /// <param name="equipmentSlot">The slot in <see cref="Equipment"/> to set</param>
-        /// <param name="inventorySlot">The inventory slot of the item</param>
-        private void SetEquipmentSlot(int equipmentSlot, int inventorySlot)
-        {
-            if (equipmentSlot < 0 || equipmentSlot > Equipment.Length)
-            {
-                return;
-            }
-
-            Equipment[equipmentSlot] = inventorySlot;
-        }
-
-        /// <summary>
-        /// Returns an equipped item from some equipment slot
-        /// </summary>
-        /// <param name="equipmentSlot">The slot in <see cref="Equipment"/> that we're checking for</param>
-        /// <param name="equippedItem">The equipped <see cref="Item"/>, if found</param>
-        /// <returns></returns>
-        public bool TryGetEquippedItem(int equipmentSlot, out Item equippedItem)
-        {
-            equippedItem = null;
-            if (equipmentSlot < -1 || equipmentSlot > Equipment.Length)
-            {
-                return false;
-            }
-
-            var itm = Items.ElementAtOrDefault(Equipment[equipmentSlot]);
-            if (itm?.Descriptor == null)
-            {
-                return false;
-            }
-
-            equippedItem = itm;
-            return true;
-        }
-
-        /// <summary>
-        /// Determines whether or not a given inventory slot is currently equipped
-        /// </summary>
-        /// <param name="slot">The iventory slot of the item</param>
-        /// <param name="equippedSlot">The equipment slot found, if any</param>
-        /// <returns></returns>
-        public bool SlotIsEquipped(int slot, out int equippedSlot)
-        {
-            equippedSlot = 0;
-            foreach (var equipmentSlot in Equipment)
-            {
-                if (equipmentSlot == slot)
-                {
-                    return true;
-                }
-                equippedSlot++;
-            }
-
-            equippedSlot = -1;
+            reason = SpellCastFailureReason.ConditionsNotMet;
             return false;
         }
 
-        //Equipment
-        public void EquipItem(ItemBase itemBase, int slot = -1, bool updateCooldown = false)
+        // If this is a projectile, check if the user has the corresponding item.
+        if (spell.SpellType == SpellType.CombatSpell &&
+            spell.Combat.TargetType == SpellTargetType.Projectile &&
+            spell.Combat.ProjectileId != Guid.Empty)
         {
-            if (itemBase == null || itemBase.ItemType != ItemType.Equipment)
+            var projectileBase = spell.Combat.Projectile;
+            if (projectileBase == null)
+            {
+                reason = SpellCastFailureReason.InvalidProjectile;
+                return false;
+            }
+
+            if (projectileBase.AmmoItemId != Guid.Empty)
+            {
+                if (FindInventoryItemSlot(projectileBase.AmmoItemId, projectileBase.AmmoRequired) == null)
+                {
+                    if (Options.Combat.EnableCombatChatMessages)
+                    {
+                        PacketSender.SendChatMsg(
+                            this, Strings.Items.notenough.ToString(ItemBase.GetName(projectileBase.AmmoItemId)),
+                            ChatMessageType.Inventory,
+                            CustomColors.Alerts.Error
+                        );
+                    }
+
+                    reason = SpellCastFailureReason.InsufficientItems;
+                    return false;
+                }
+            }
+        }
+
+        // We have no reason to stop this player from casting!
+        return true;
+    }
+
+    public void UseSpell(int spellSlot, Entity target)
+    {
+        var spellNum = Spells[spellSlot].SpellId;
+        Target = target;
+        var spell = SpellBase.Get(spellNum);
+        if (spell == null)
+        {
+            return;
+        }
+
+        if (!CanCastSpell(spell, target, true, out _))
+        {
+            if (!spell.Combat.Friendly)
             {
                 return;
             }
 
-            // Find the appropriate slot if not passed in
-            if (slot == -1)
+            if (!Options.Instance.CombatOpts.EnableAutoSelfCastFriendlySpellsWhenTargetingHostile)
             {
-                for (var i = 0; i < Options.MaxInvItems; i++)
+                return;
+            }
+
+            if (target == this)
+            {
+                return;
+            }
+
+            // Since it's a friendly spell and we have auto-retarget enabled,
+            // check if we can cast the spell on ourselves
+            if (!CanCastSpell(spell, this, true, out _))
+            {
+                return;
+            }
+
+            // If we can, soft-change the target to ourselves (we will use this to set CastTarget
+            target = this;
+        }
+
+        if (CastTime == 0)
+        {
+            CastTime = Timing.Global.Milliseconds + spell.CastDuration;
+
+            //Remove stealth status.
+            foreach (var status in CachedStatuses)
+            {
+                if (status.Type == SpellEffect.Stealth)
                 {
-                    if (itemBase == Items[i].Descriptor)
-                    {
-                        slot = i;
-                        break;
-                    }
+                    status.RemoveStatus();
                 }
             }
 
-            if (slot != -1)
+            SpellCastSlot = spellSlot;
+
+            // Set to lower case target instead of Target to facilitate soft
+            // retargeting for auto self-cast on friendly when targeting hostile
+            CastTarget = target;
+
+            if (spell.CastAnimationId != Guid.Empty)
             {
-                if (itemBase.EquipmentSlot == Options.WeaponIndex)
+                PacketSender.SendAnimationToProximity(
+                    spell.CastAnimationId, 1, base.Id, MapId, 0, 0, Dir, MapInstanceId
+                ); //Target Type 1 will be global entity
+            }
+
+            //Tell the client we are channeling the spell
+            if (IsCasting)
+            {
+                PacketSender.SendEntityCastTime(this, spellNum);
+            }
+        }
+        else
+        {
+            if (Options.Combat.EnableCombatChatMessages)
+            {
+                PacketSender.SendChatMsg(this, Strings.Combat.channeling, ChatMessageType.Combat);
+            }
+        }
+    }
+
+    public override void CastSpell(Guid spellId, int spellSlot = -1)
+    {
+        var spellBase = SpellBase.Get(spellId);
+        if (spellBase == null)
+        {
+            return;
+        }
+
+        switch (spellBase.SpellType)
+        {
+            case SpellType.Event:
+                var evt = spellBase.Event;
+                if (evt != null)
                 {
-                    //If we are equipping a 2hand weapon, remove the shield
-                    if (itemBase.TwoHanded)
-                    {
-                        UnequipItem(Options.ShieldIndex, false);
-                    }
-                }
-                else if (itemBase.EquipmentSlot == Options.ShieldIndex)
-                {
-                    // If we are equipping a shield, remove any 2-handed weapon
-                    if (TryGetEquippedItem(Options.WeaponIndex, out Item weapon) && weapon.Descriptor.TwoHanded)
-                    {
-                        UnequipItem(Options.WeaponIndex, false);
-                    }
+                    EnqueueStartCommonEvent(evt);
                 }
 
-                SetEquipmentSlot(itemBase.EquipmentSlot, slot);
+                base.CastSpell(spellId, spellSlot); //To get cooldown :P
 
-                if (updateCooldown)
+                break;
+            default:
+                base.CastSpell(spellId, spellSlot);
+
+                break;
+        }
+
+        UpdateSpellCooldown(spellBase, spellSlot);
+
+        ConsumeSpellProjectile(spellBase);
+    }
+
+    /// <summary>
+    /// Checks if the caster has the required projectile(s) for the spell and tries to take them.
+    /// This method is used when a spell that requires projectile is casted.
+    /// If the spell has a valid ProjectileId, it retrieves the projectile and checks if it has a valid AmmoItemId.
+    /// If it does, it attempts to take the required amount of ammo from the player's inventory.
+    /// </summary>
+    /// <param name="spellBase">The spell that is being cast.</param>
+    private void ConsumeSpellProjectile(SpellBase spellBase)
+    {
+        // Check if the caster has the required projectile(s) for the spell and try to take it/them.
+        if (spellBase.SpellType == SpellType.CombatSpell &&
+            spellBase.Combat.TargetType == SpellTargetType.Projectile &&
+            spellBase.Combat.ProjectileId != Guid.Empty)
+        {
+            var projectileBase = spellBase.Combat.Projectile;
+            if (projectileBase != null && projectileBase.AmmoItemId != Guid.Empty)
+            {
+                TryTakeItem(projectileBase.AmmoItemId, projectileBase.AmmoRequired);
+            }
+        }
+    }
+
+    public bool TryGetEquipmentSlot(int equipmentSlot, out int inventorySlot)
+    {
+        inventorySlot = -1;
+        if (equipmentSlot > -1 && equipmentSlot < Equipment.Length)
+        {
+            inventorySlot = Equipment.ElementAtOrDefault(equipmentSlot);
+        }
+
+        return inventorySlot > -1;
+    }
+
+    /// <summary>
+    /// Safely sets an equipment slot, if valid
+    /// </summary>
+    /// <param name="equipmentSlot">The slot in <see cref="Equipment"/> to set</param>
+    /// <param name="inventorySlot">The inventory slot of the item</param>
+    private void SetEquipmentSlot(int equipmentSlot, int inventorySlot)
+    {
+        if (equipmentSlot < 0 || equipmentSlot > Equipment.Length)
+        {
+            return;
+        }
+
+        Equipment[equipmentSlot] = inventorySlot;
+    }
+
+    /// <summary>
+    /// Returns an equipped item from some equipment slot
+    /// </summary>
+    /// <param name="equipmentSlot">The slot in <see cref="Equipment"/> that we're checking for</param>
+    /// <param name="equippedItem">The equipped <see cref="Item"/>, if found</param>
+    /// <returns></returns>
+    public bool TryGetEquippedItem(int equipmentSlot, out Item equippedItem)
+    {
+        equippedItem = null;
+        if (equipmentSlot < -1 || equipmentSlot > Equipment.Length)
+        {
+            return false;
+        }
+
+        var itm = Items.ElementAtOrDefault(Equipment[equipmentSlot]);
+        if (itm?.Descriptor == null)
+        {
+            return false;
+        }
+
+        equippedItem = itm;
+        return true;
+    }
+
+    /// <summary>
+    /// Determines whether or not a given inventory slot is currently equipped
+    /// </summary>
+    /// <param name="slot">The iventory slot of the item</param>
+    /// <param name="equippedSlot">The equipment slot found, if any</param>
+    /// <returns></returns>
+    public bool SlotIsEquipped(int slot, out int equippedSlot)
+    {
+        equippedSlot = 0;
+        foreach (var equipmentSlot in Equipment)
+        {
+            if (equipmentSlot == slot)
+            {
+                return true;
+            }
+            equippedSlot++;
+        }
+
+        equippedSlot = -1;
+        return false;
+    }
+
+    //Equipment
+    public void EquipItem(ItemBase itemBase, int slot = -1, bool updateCooldown = false)
+    {
+        if (itemBase == null || itemBase.ItemType != ItemType.Equipment)
+        {
+            return;
+        }
+
+        // Find the appropriate slot if not passed in
+        if (slot == -1)
+        {
+            for (var i = 0; i < Options.MaxInvItems; i++)
+            {
+                if (itemBase == Items[i].Descriptor)
                 {
-                    UpdateCooldown(itemBase);
+                    slot = i;
+                    break;
+                }
+            }
+        }
+
+        if (slot != -1)
+        {
+            if (itemBase.EquipmentSlot == Options.WeaponIndex)
+            {
+                //If we are equipping a 2hand weapon, remove the shield
+                if (itemBase.TwoHanded)
+                {
+                    UnequipItem(Options.ShieldIndex, false);
+                }
+            }
+            else if (itemBase.EquipmentSlot == Options.ShieldIndex)
+            {
+                // If we are equipping a shield, remove any 2-handed weapon
+                if (TryGetEquippedItem(Options.WeaponIndex, out Item weapon) && weapon.Descriptor.TwoHanded)
+                {
+                    UnequipItem(Options.WeaponIndex, false);
                 }
             }
 
-            EnqueueStartCommonEvent(itemBase.GetEventTrigger(ItemEventTriggers.OnEquip));
+            SetEquipmentSlot(itemBase.EquipmentSlot, slot);
 
+            if (updateCooldown)
+            {
+                UpdateCooldown(itemBase);
+            }
+        }
+
+        EnqueueStartCommonEvent(itemBase.GetEventTrigger(ItemEventTriggers.OnEquip));
+
+        ProcessEquipmentUpdated(true);
+    }
+
+    public void UnequipItem(Guid itemId, bool sendUpdate = true)
+    {
+        var updated = false;
+        for (int i = 0; i < Options.EquipmentSlots.Count; i++)
+        {
+            var itemSlot = Equipment[i];
+            if (Items.ElementAtOrDefault(itemSlot)?.ItemId == itemId)
+            {
+                UnequipItem(i, false);
+                updated = true;
+            }
+        }
+        if (!updated)
+        {
+            return;
+        }
+
+        ProcessEquipmentUpdated(sendUpdate);
+    }
+
+    public void UnequipItem(int equipmentSlot, bool sendUpdate = true)
+    {
+        if (equipmentSlot < 0 || equipmentSlot > Equipment.Length)
+        {
+            return;
+        }
+
+        if (TryGetEquippedItem(equipmentSlot, out var prevEquipped))
+        {
+            EnqueueStartCommonEvent(prevEquipped.Descriptor?.GetEventTrigger(ItemEventTriggers.OnUnequip));
+        }
+
+        Equipment[equipmentSlot] = -1;
+        ProcessEquipmentUpdated(sendUpdate);
+    }
+
+    public void ProcessEquipmentUpdated(bool sendPackets, bool ignoreEvents = false)
+    {
+        FixVitals();
+        if (!ignoreEvents)
+        {
+            StartCommonEventsWithTrigger(CommonEventTrigger.EquipChange);
+        }
+
+        if (sendPackets)
+        {
+            PacketSender.SendPlayerEquipmentToProximity(this);
+            PacketSender.SendEntityStats(this);
+        }
+        
+        CacheEquipmentTriggers();
+        UnequipInvalidItems();
+    }
+
+    [NotMapped, JsonIgnore]
+    private List<EventBase> CachedEquipmentOnHitTriggers { get; set; } = new List<EventBase>();
+    
+    [NotMapped, JsonIgnore]
+    private List<EventBase> CachedEquipmentOnDamageTriggers { get; set; } = new List<EventBase>();
+
+    public void CacheEquipmentTriggers()
+    {
+        CachedEquipmentOnHitTriggers.Clear();
+        CachedEquipmentOnDamageTriggers.Clear();
+
+        for (var slot = 0; slot < Options.EquipmentSlots.Count; slot++)
+        {
+            if (!TryGetEquippedItem(slot, out var equippedItem) || equippedItem == null || equippedItem.Descriptor == null)
+            {
+                continue;
+            }
+
+            var onHit = equippedItem.Descriptor.GetEventTrigger(ItemEventTriggers.OnHit);
+            var onDamaged = equippedItem.Descriptor.GetEventTrigger(ItemEventTriggers.OnDamageReceived);
+
+            // We have special logic for handling weapons, so the player can't hot-swap their weapon and get a different on-hit event to proc
+            // As a result, don't cache them, instead use property "LastAttackingWeapon"
+            if (onHit != null && slot != Options.WeaponIndex)
+            {
+                CachedEquipmentOnHitTriggers.Add(onHit);
+            }
+
+            if (onDamaged != null)
+            {
+                CachedEquipmentOnDamageTriggers.Add(onDamaged);
+            }
+        }
+    }
+
+    public void EquipmentProcessItemSwap(int item1, int item2)
+    {
+        for (var i = 0; i < Options.EquipmentSlots.Count; i++)
+        {
+            if (Equipment[i] == item1)
+            {
+                Equipment[i] = item2;
+            }
+            else if (Equipment[i] == item2)
+            {
+                Equipment[i] = item1;
+            }
+        }
+
+        ProcessEquipmentUpdated(true, true);
+    }
+
+    public void EquipmentProcessItemLoss(int slot)
+    {
+        if (SlotIsEquipped(slot, out var equippedSlot))
+        {
+            UnequipItem(equippedSlot, true);
+        }
+    }
+
+    /// <summary>
+    /// Unequips any items that the player is currently wearing in which they no longer meet the conditions for
+    /// Also unequips any items that are not actually equipment anymore
+    /// </summary>
+    public void UnequipInvalidItems()
+    {
+        var updated = false;
+
+        foreach (var item in EquippedItems)
+        {
+            var descriptor = item.Descriptor;
+            if (descriptor == default ||
+                descriptor.ItemType != ItemType.Equipment ||
+                !Conditions.MeetsConditionLists(descriptor.UsageRequirements, this, null))
+            {
+                UnequipItem(item.ItemId);
+            }
+        }
+
+        if (updated)
+        {
             ProcessEquipmentUpdated(true);
         }
+    }
 
-        public void UnequipItem(Guid itemId, bool sendUpdate = true)
+    public void StartCommonEventsWithTrigger(CommonEventTrigger trigger, string command = "", string param = "")
+    {
+        foreach (var value in EventBase.Lookup.Values)
         {
-            var updated = false;
-            for (int i = 0; i < Options.EquipmentSlots.Count; i++)
+            if (value is EventBase eventDescriptor && eventDescriptor.Pages.Any(p => p.CommonTrigger == trigger))
             {
-                var itemSlot = Equipment[i];
-                if (Items.ElementAtOrDefault(itemSlot)?.ItemId == itemId)
+                EnqueueStartCommonEvent(eventDescriptor, trigger, command, param);
+            }
+        }
+    }
+
+    public static void StartCommonEventsWithTriggerForAll(CommonEventTrigger trigger, string command = "", string param = "")
+    {
+        var players = Player.OnlineList;
+        foreach (var value in EventBase.Lookup.Values)
+        {
+            if (value is EventBase eventDescriptor && eventDescriptor.Pages.Any(p => p.CommonTrigger == trigger))
+            {
+                foreach (var player in players)
                 {
-                    UnequipItem(i, false);
-                    updated = true;
+                    player.EnqueueStartCommonEvent(eventDescriptor, trigger, command, param);
                 }
             }
-            if (!updated)
-            {
-                return;
-            }
-
-            ProcessEquipmentUpdated(sendUpdate);
         }
+    }
 
-        public void UnequipItem(int equipmentSlot, bool sendUpdate = true)
+    //Stats
+    public void UpgradeStat(int statIndex)
+    {
+        if (Stat[statIndex].BaseStat + StatPointAllocations[statIndex] < Options.MaxStatValue && StatPoints > 0)
         {
-            if (equipmentSlot < 0 || equipmentSlot > Equipment.Length)
-            {
-                return;
-            }
-
-            if (TryGetEquippedItem(equipmentSlot, out var prevEquipped))
-            {
-                EnqueueStartCommonEvent(prevEquipped.Descriptor?.GetEventTrigger(ItemEventTriggers.OnUnequip));
-            }
-
-            Equipment[equipmentSlot] = -1;
-            ProcessEquipmentUpdated(sendUpdate);
-        }
-
-        public void ProcessEquipmentUpdated(bool sendPackets, bool ignoreEvents = false)
-        {
-            FixVitals();
-            if (!ignoreEvents)
-            {
-                StartCommonEventsWithTrigger(CommonEventTrigger.EquipChange);
-            }
-
-            if (sendPackets)
-            {
-                PacketSender.SendPlayerEquipmentToProximity(this);
-                PacketSender.SendEntityStats(this);
-            }
-            
-            CacheEquipmentTriggers();
+            StatPointAllocations[statIndex]++;
+            StatPoints--;
+            PacketSender.SendEntityStats(this);
+            PacketSender.SendPointsTo(this);
             UnequipInvalidItems();
         }
+    }
 
-        [NotMapped, JsonIgnore]
-        private List<EventBase> CachedEquipmentOnHitTriggers { get; set; } = new List<EventBase>();
-        
-        [NotMapped, JsonIgnore]
-        private List<EventBase> CachedEquipmentOnDamageTriggers { get; set; } = new List<EventBase>();
-
-        public void CacheEquipmentTriggers()
+    //HotbarSlot
+    public void HotbarChange(int index, int type, int slot)
+    {
+        Hotbar[index].ItemOrSpellId = Guid.Empty;
+        Hotbar[index].BagId = Guid.Empty;
+        Hotbar[index].PreferredStatBuffs = new int[Enum.GetValues<Stat>().Length];
+        if (type == 0) //Item
         {
-            CachedEquipmentOnHitTriggers.Clear();
-            CachedEquipmentOnDamageTriggers.Clear();
-
-            for (var slot = 0; slot < Options.EquipmentSlots.Count; slot++)
+            var item = Items[slot];
+            if (item != null)
             {
-                if (!TryGetEquippedItem(slot, out var equippedItem) || equippedItem == null || equippedItem.Descriptor == null)
-                {
-                    continue;
-                }
+                Hotbar[index].ItemOrSpellId = item.ItemId;
+                Hotbar[index].BagId = item.BagId ?? Guid.Empty;
+                Hotbar[index].PreferredStatBuffs = item.Properties.StatModifiers;
+            }
+        }
+        else if (type == 1) //Spell
+        {
+            var spell = Spells[slot];
+            if (spell != null)
+            {
+                Hotbar[index].ItemOrSpellId = spell.SpellId;
+            }
+        }
+    }
 
-                var onHit = equippedItem.Descriptor.GetEventTrigger(ItemEventTriggers.OnHit);
-                var onDamaged = equippedItem.Descriptor.GetEventTrigger(ItemEventTriggers.OnDamageReceived);
+    public void HotbarSwap(int index, int swapIndex)
+    {
+        var itemId = Hotbar[index].ItemOrSpellId;
+        var bagId = Hotbar[index].BagId;
+        var stats = Hotbar[index].PreferredStatBuffs;
 
-                // We have special logic for handling weapons, so the player can't hot-swap their weapon and get a different on-hit event to proc
-                // As a result, don't cache them, instead use property "LastAttackingWeapon"
-                if (onHit != null && slot != Options.WeaponIndex)
-                {
-                    CachedEquipmentOnHitTriggers.Add(onHit);
-                }
+        Hotbar[index].ItemOrSpellId = Hotbar[swapIndex].ItemOrSpellId;
+        Hotbar[index].BagId = Hotbar[swapIndex].BagId;
+        Hotbar[index].PreferredStatBuffs = Hotbar[swapIndex].PreferredStatBuffs;
 
-                if (onDamaged != null)
-                {
-                    CachedEquipmentOnDamageTriggers.Add(onDamaged);
-                }
+        Hotbar[swapIndex].ItemOrSpellId = itemId;
+        Hotbar[swapIndex].BagId = bagId;
+        Hotbar[swapIndex].PreferredStatBuffs = stats;
+    }
+
+    //Quests
+    public bool CanStartQuest(QuestBase quest)
+    {
+        //Check and see if the quest is already in progress, or if it has already been completed and cannot be repeated.
+        var questProgress = FindQuest(quest.Id);
+        if (questProgress != null)
+        {
+            if (questProgress.TaskId != Guid.Empty && quest.GetTaskIndex(questProgress.TaskId) != -1)
+            {
+                return false;
+            }
+
+            if (questProgress.Completed && !quest.Repeatable)
+            {
+                return false;
             }
         }
 
-        public void EquipmentProcessItemSwap(int item1, int item2)
+        //So the quest isn't started or we can repeat it.. let's make sure that we meet requirements.
+        if (!Conditions.MeetsConditionLists(quest.Requirements, this, null, true, quest))
         {
-            for (var i = 0; i < Options.EquipmentSlots.Count; i++)
-            {
-                if (Equipment[i] == item1)
-                {
-                    Equipment[i] = item2;
-                }
-                else if (Equipment[i] == item2)
-                {
-                    Equipment[i] = item1;
-                }
-            }
-
-            ProcessEquipmentUpdated(true, true);
+            return false;
         }
 
-        public void EquipmentProcessItemLoss(int slot)
+        if (quest.Tasks.Count == 0)
         {
-            if (SlotIsEquipped(slot, out var equippedSlot))
-            {
-                UnequipItem(equippedSlot, true);
-            }
+            return false;
         }
 
-        /// <summary>
-        /// Unequips any items that the player is currently wearing in which they no longer meet the conditions for
-        /// Also unequips any items that are not actually equipment anymore
-        /// </summary>
-        public void UnequipInvalidItems()
+        return true;
+    }
+
+    public bool QuestCompleted(Guid questId)
+    {
+        var questProgress = FindQuest(questId);
+        if (questProgress != null)
         {
-            var updated = false;
-
-            foreach (var item in EquippedItems)
+            if (questProgress.Completed)
             {
-                var descriptor = item.Descriptor;
-                if (descriptor == default ||
-                    descriptor.ItemType != ItemType.Equipment ||
-                    !Conditions.MeetsConditionLists(descriptor.UsageRequirements, this, null))
-                {
-                    UnequipItem(item.ItemId);
-                }
-            }
-
-            if (updated)
-            {
-                ProcessEquipmentUpdated(true);
+                return true;
             }
         }
 
-        public void StartCommonEventsWithTrigger(CommonEventTrigger trigger, string command = "", string param = "")
+        return false;
+    }
+
+    public bool QuestInProgress(Guid questId, QuestProgressState progress, Guid taskId)
+    {
+        var questProgress = FindQuest(questId);
+        if (questProgress != null)
         {
-            foreach (var value in EventBase.Lookup.Values)
-            {
-                if (value is EventBase eventDescriptor && eventDescriptor.Pages.Any(p => p.CommonTrigger == trigger))
-                {
-                    EnqueueStartCommonEvent(eventDescriptor, trigger, command, param);
-                }
-            }
-        }
-
-        public static void StartCommonEventsWithTriggerForAll(CommonEventTrigger trigger, string command = "", string param = "")
-        {
-            var players = Player.OnlineList;
-            foreach (var value in EventBase.Lookup.Values)
-            {
-                if (value is EventBase eventDescriptor && eventDescriptor.Pages.Any(p => p.CommonTrigger == trigger))
-                {
-                    foreach (var player in players)
-                    {
-                        player.EnqueueStartCommonEvent(eventDescriptor, trigger, command, param);
-                    }
-                }
-            }
-        }
-
-        //Stats
-        public void UpgradeStat(int statIndex)
-        {
-            if (Stat[statIndex].BaseStat + StatPointAllocations[statIndex] < Options.MaxStatValue && StatPoints > 0)
-            {
-                StatPointAllocations[statIndex]++;
-                StatPoints--;
-                PacketSender.SendEntityStats(this);
-                PacketSender.SendPointsTo(this);
-                UnequipInvalidItems();
-            }
-        }
-
-        //HotbarSlot
-        public void HotbarChange(int index, int type, int slot)
-        {
-            Hotbar[index].ItemOrSpellId = Guid.Empty;
-            Hotbar[index].BagId = Guid.Empty;
-            Hotbar[index].PreferredStatBuffs = new int[Enum.GetValues<Stat>().Length];
-            if (type == 0) //Item
-            {
-                var item = Items[slot];
-                if (item != null)
-                {
-                    Hotbar[index].ItemOrSpellId = item.ItemId;
-                    Hotbar[index].BagId = item.BagId ?? Guid.Empty;
-                    Hotbar[index].PreferredStatBuffs = item.Properties.StatModifiers;
-                }
-            }
-            else if (type == 1) //Spell
-            {
-                var spell = Spells[slot];
-                if (spell != null)
-                {
-                    Hotbar[index].ItemOrSpellId = spell.SpellId;
-                }
-            }
-        }
-
-        public void HotbarSwap(int index, int swapIndex)
-        {
-            var itemId = Hotbar[index].ItemOrSpellId;
-            var bagId = Hotbar[index].BagId;
-            var stats = Hotbar[index].PreferredStatBuffs;
-
-            Hotbar[index].ItemOrSpellId = Hotbar[swapIndex].ItemOrSpellId;
-            Hotbar[index].BagId = Hotbar[swapIndex].BagId;
-            Hotbar[index].PreferredStatBuffs = Hotbar[swapIndex].PreferredStatBuffs;
-
-            Hotbar[swapIndex].ItemOrSpellId = itemId;
-            Hotbar[swapIndex].BagId = bagId;
-            Hotbar[swapIndex].PreferredStatBuffs = stats;
-        }
-
-        //Quests
-        public bool CanStartQuest(QuestBase quest)
-        {
-            //Check and see if the quest is already in progress, or if it has already been completed and cannot be repeated.
-            var questProgress = FindQuest(quest.Id);
-            if (questProgress != null)
+            var quest = QuestBase.Get(questId);
+            if (quest != null)
             {
                 if (questProgress.TaskId != Guid.Empty && quest.GetTaskIndex(questProgress.TaskId) != -1)
                 {
-                    return false;
+                    switch (progress)
+                    {
+                        case QuestProgressState.OnAnyTask:
+                            return true;
+                        case QuestProgressState.BeforeTask:
+                            if (quest.GetTaskIndex(taskId) != -1)
+                            {
+                                return quest.GetTaskIndex(taskId) > quest.GetTaskIndex(questProgress.TaskId);
+                            }
+
+                            break;
+                        case QuestProgressState.OnTask:
+                            if (quest.GetTaskIndex(taskId) != -1)
+                            {
+                                return quest.GetTaskIndex(taskId) == quest.GetTaskIndex(questProgress.TaskId);
+                            }
+
+                            break;
+                        case QuestProgressState.AfterTask:
+                            if (quest.GetTaskIndex(taskId) != -1)
+                            {
+                                return quest.GetTaskIndex(taskId) < quest.GetTaskIndex(questProgress.TaskId);
+                            }
+
+                            break;
+                        default:
+                            throw new ArgumentOutOfRangeException(nameof(progress), progress, null);
+                    }
                 }
-
-                if (questProgress.Completed && !quest.Repeatable)
-                {
-                    return false;
-                }
             }
-
-            //So the quest isn't started or we can repeat it.. let's make sure that we meet requirements.
-            if (!Conditions.MeetsConditionLists(quest.Requirements, this, null, true, quest))
-            {
-                return false;
-            }
-
-            if (quest.Tasks.Count == 0)
-            {
-                return false;
-            }
-
-            return true;
         }
 
-        public bool QuestCompleted(Guid questId)
-        {
-            var questProgress = FindQuest(questId);
-            if (questProgress != null)
-            {
-                if (questProgress.Completed)
-                {
-                    return true;
-                }
-            }
+        return false;
+    }
 
-            return false;
+    public void OfferQuest(QuestBase quest)
+    {
+        if (CanStartQuest(quest))
+        {
+            QuestOffers.Add(quest.Id);
+            PacketSender.SendQuestOffer(this, quest.Id);
+        }
+    }
+
+    public Quest FindQuest(Guid questId)
+    {
+        foreach (var quest in Quests)
+        {
+            if (quest.QuestId == questId)
+            {
+                return quest;
+            }
         }
 
-        public bool QuestInProgress(Guid questId, QuestProgressState progress, Guid taskId)
+        return null;
+    }
+
+    public void StartQuest(QuestBase quest)
+    {
+        if (CanStartQuest(quest))
         {
-            var questProgress = FindQuest(questId);
+            var questProgress = FindQuest(quest.Id);
             if (questProgress != null)
             {
+                questProgress.TaskId = quest.Tasks[0].Id;
+                questProgress.TaskProgress = 0;
+            }
+            else
+            {
+                questProgress = new Quest(quest.Id)
+                {
+                    TaskId = quest.Tasks[0].Id,
+                    TaskProgress = 0
+                };
+
+                Quests.Add(questProgress);
+            }
+
+            if (quest.Tasks[0].Objective == QuestObjective.GatherItems) //Gather Items
+            {
+                UpdateGatherItemQuests(quest.Tasks[0].TargetId);
+            }
+
+            EnqueueStartCommonEvent(EventBase.Get(quest.StartEventId));
+            PacketSender.SendChatMsg(
+                this, Strings.Quests.started.ToString(quest.Name), ChatMessageType.Quest, CustomColors.QuestAlert.Started
+            );
+
+            PacketSender.SendQuestsProgress(this);
+        }
+    }
+
+    public void AcceptQuest(Guid questId)
+    {
+        if (QuestOffers.Contains(questId))
+        {
+            lock (mEventLock)
+            {
+                QuestOffers.Remove(questId);
                 var quest = QuestBase.Get(questId);
                 if (quest != null)
                 {
-                    if (questProgress.TaskId != Guid.Empty && quest.GetTaskIndex(questProgress.TaskId) != -1)
-                    {
-                        switch (progress)
-                        {
-                            case QuestProgressState.OnAnyTask:
-                                return true;
-                            case QuestProgressState.BeforeTask:
-                                if (quest.GetTaskIndex(taskId) != -1)
-                                {
-                                    return quest.GetTaskIndex(taskId) > quest.GetTaskIndex(questProgress.TaskId);
-                                }
-
-                                break;
-                            case QuestProgressState.OnTask:
-                                if (quest.GetTaskIndex(taskId) != -1)
-                                {
-                                    return quest.GetTaskIndex(taskId) == quest.GetTaskIndex(questProgress.TaskId);
-                                }
-
-                                break;
-                            case QuestProgressState.AfterTask:
-                                if (quest.GetTaskIndex(taskId) != -1)
-                                {
-                                    return quest.GetTaskIndex(taskId) < quest.GetTaskIndex(questProgress.TaskId);
-                                }
-
-                                break;
-                            default:
-                                throw new ArgumentOutOfRangeException(nameof(progress), progress, null);
-                        }
-                    }
-                }
-            }
-
-            return false;
-        }
-
-        public void OfferQuest(QuestBase quest)
-        {
-            if (CanStartQuest(quest))
-            {
-                QuestOffers.Add(quest.Id);
-                PacketSender.SendQuestOffer(this, quest.Id);
-            }
-        }
-
-        public Quest FindQuest(Guid questId)
-        {
-            foreach (var quest in Quests)
-            {
-                if (quest.QuestId == questId)
-                {
-                    return quest;
-                }
-            }
-
-            return null;
-        }
-
-        public void StartQuest(QuestBase quest)
-        {
-            if (CanStartQuest(quest))
-            {
-                var questProgress = FindQuest(quest.Id);
-                if (questProgress != null)
-                {
-                    questProgress.TaskId = quest.Tasks[0].Id;
-                    questProgress.TaskProgress = 0;
-                }
-                else
-                {
-                    questProgress = new Quest(quest.Id)
-                    {
-                        TaskId = quest.Tasks[0].Id,
-                        TaskProgress = 0
-                    };
-
-                    Quests.Add(questProgress);
-                }
-
-                if (quest.Tasks[0].Objective == QuestObjective.GatherItems) //Gather Items
-                {
-                    UpdateGatherItemQuests(quest.Tasks[0].TargetId);
-                }
-
-                EnqueueStartCommonEvent(EventBase.Get(quest.StartEventId));
-                PacketSender.SendChatMsg(
-                    this, Strings.Quests.started.ToString(quest.Name), ChatMessageType.Quest, CustomColors.QuestAlert.Started
-                );
-
-                PacketSender.SendQuestsProgress(this);
-            }
-        }
-
-        public void AcceptQuest(Guid questId)
-        {
-            if (QuestOffers.Contains(questId))
-            {
-                lock (mEventLock)
-                {
-                    QuestOffers.Remove(questId);
-                    var quest = QuestBase.Get(questId);
-                    if (quest != null)
-                    {
-                        StartQuest(quest);
-                        foreach (var evt in EventLookup)
-                        {
-                            if (evt.Value.CallStack.Count <= 0)
-                            {
-                                continue;
-                            }
-
-                            var stackInfo = evt.Value.CallStack.Peek();
-                            if (stackInfo.WaitingForResponse != CommandInstance.EventResponse.Quest)
-                            {
-                                continue;
-                            }
-
-                            if (((StartQuestCommand)stackInfo.WaitingOnCommand).QuestId == questId)
-                            {
-                                var tmpStack = new CommandInstance(stackInfo.Page, stackInfo.BranchIds[0]);
-                                evt.Value.CallStack.Peek().WaitingForResponse = CommandInstance.EventResponse.None;
-                                evt.Value.CallStack.Push(tmpStack);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        public void DeclineQuest(Guid questId)
-        {
-            if (QuestOffers.Contains(questId))
-            {
-                lock (mEventLock)
-                {
-                    QuestOffers.Remove(questId);
-                    PacketSender.SendChatMsg(
-                        this, Strings.Quests.declined.ToString(QuestBase.GetName(questId)), ChatMessageType.Quest, CustomColors.QuestAlert.Declined
-                    );
-
+                    StartQuest(quest);
                     foreach (var evt in EventLookup)
                     {
                         if (evt.Value.CallStack.Count <= 0)
@@ -6174,1465 +6138,1499 @@ namespace Intersect.Server.Entities
 
                         if (((StartQuestCommand)stackInfo.WaitingOnCommand).QuestId == questId)
                         {
-                            //Run failure branch
-                            var tmpStack = new CommandInstance(stackInfo.Page, stackInfo.BranchIds[1]);
-                            stackInfo.WaitingForResponse = CommandInstance.EventResponse.None;
+                            var tmpStack = new CommandInstance(stackInfo.Page, stackInfo.BranchIds[0]);
+                            evt.Value.CallStack.Peek().WaitingForResponse = CommandInstance.EventResponse.None;
                             evt.Value.CallStack.Push(tmpStack);
                         }
                     }
                 }
             }
         }
+    }
 
-        public void CancelQuest(Guid questId)
+    public void DeclineQuest(Guid questId)
+    {
+        if (QuestOffers.Contains(questId))
         {
-            var quest = QuestBase.Get(questId);
-            if (quest != null)
+            lock (mEventLock)
             {
-                if (QuestInProgress(quest.Id, QuestProgressState.OnAnyTask, Guid.Empty))
-                {
-                    //Cancel the quest somehow...
-                    if (quest.Quitable)
-                    {
-                        var questProgress = FindQuest(quest.Id);
-                        questProgress.TaskId = Guid.Empty;
-                        questProgress.TaskProgress = -1;
-                        PacketSender.SendChatMsg(
-                            this, Strings.Quests.abandoned.ToString(QuestBase.GetName(questId)), ChatMessageType.Quest,
-                            CustomColors.QuestAlert.Abandoned
-                        );
+                QuestOffers.Remove(questId);
+                PacketSender.SendChatMsg(
+                    this, Strings.Quests.declined.ToString(QuestBase.GetName(questId)), ChatMessageType.Quest, CustomColors.QuestAlert.Declined
+                );
 
-                        PacketSender.SendQuestsProgress(this);
+                foreach (var evt in EventLookup)
+                {
+                    if (evt.Value.CallStack.Count <= 0)
+                    {
+                        continue;
+                    }
+
+                    var stackInfo = evt.Value.CallStack.Peek();
+                    if (stackInfo.WaitingForResponse != CommandInstance.EventResponse.Quest)
+                    {
+                        continue;
+                    }
+
+                    if (((StartQuestCommand)stackInfo.WaitingOnCommand).QuestId == questId)
+                    {
+                        //Run failure branch
+                        var tmpStack = new CommandInstance(stackInfo.Page, stackInfo.BranchIds[1]);
+                        stackInfo.WaitingForResponse = CommandInstance.EventResponse.None;
+                        evt.Value.CallStack.Push(tmpStack);
                     }
                 }
             }
-            UnequipInvalidItems();
         }
+    }
 
-        public void CompleteQuestTask(Guid questId, Guid taskId)
+    public void CancelQuest(Guid questId)
+    {
+        var quest = QuestBase.Get(questId);
+        if (quest != null)
         {
-            var quest = QuestBase.Get(questId);
-            if (quest != null)
+            if (QuestInProgress(quest.Id, QuestProgressState.OnAnyTask, Guid.Empty))
             {
-                var questProgress = FindQuest(questId);
-                if (questProgress != null)
+                //Cancel the quest somehow...
+                if (quest.Quitable)
                 {
-                    if (questProgress.TaskId == taskId)
-                    {
-                        //Let's Advance this task or complete the quest
-                        for (var i = 0; i < quest.Tasks.Count; i++)
-                        {
-                            if (quest.Tasks[i].Id == taskId)
-                            {
-                                PacketSender.SendChatMsg(this, Strings.Quests.taskcompleted, ChatMessageType.Quest);
-                                if (i == quest.Tasks.Count - 1)
-                                {
-                                    //Complete Quest
-                                    questProgress.Completed = true;
-                                    questProgress.TaskId = Guid.Empty;
-                                    questProgress.TaskProgress = -1;
-                                    if (quest.Tasks[i].CompletionEvent != null)
-                                    {
-                                        EnqueueStartCommonEvent(quest.Tasks[i].CompletionEvent);
-                                    }
+                    var questProgress = FindQuest(quest.Id);
+                    questProgress.TaskId = Guid.Empty;
+                    questProgress.TaskProgress = -1;
+                    PacketSender.SendChatMsg(
+                        this, Strings.Quests.abandoned.ToString(QuestBase.GetName(questId)), ChatMessageType.Quest,
+                        CustomColors.QuestAlert.Abandoned
+                    );
 
-                                    EnqueueStartCommonEvent(EventBase.Get(quest.EndEventId));
-                                    PacketSender.SendChatMsg(
-                                        this, Strings.Quests.completed.ToString(quest.Name), ChatMessageType.Quest,
-                                        CustomColors.QuestAlert.Completed
-                                    );
+                    PacketSender.SendQuestsProgress(this);
+                }
+            }
+        }
+        UnequipInvalidItems();
+    }
+
+    public void CompleteQuestTask(Guid questId, Guid taskId)
+    {
+        var quest = QuestBase.Get(questId);
+        if (quest != null)
+        {
+            var questProgress = FindQuest(questId);
+            if (questProgress != null)
+            {
+                if (questProgress.TaskId == taskId)
+                {
+                    //Let's Advance this task or complete the quest
+                    for (var i = 0; i < quest.Tasks.Count; i++)
+                    {
+                        if (quest.Tasks[i].Id == taskId)
+                        {
+                            PacketSender.SendChatMsg(this, Strings.Quests.taskcompleted, ChatMessageType.Quest);
+                            if (i == quest.Tasks.Count - 1)
+                            {
+                                //Complete Quest
+                                questProgress.Completed = true;
+                                questProgress.TaskId = Guid.Empty;
+                                questProgress.TaskProgress = -1;
+                                if (quest.Tasks[i].CompletionEvent != null)
+                                {
+                                    EnqueueStartCommonEvent(quest.Tasks[i].CompletionEvent);
+                                }
+
+                                EnqueueStartCommonEvent(EventBase.Get(quest.EndEventId));
+                                PacketSender.SendChatMsg(
+                                    this, Strings.Quests.completed.ToString(quest.Name), ChatMessageType.Quest,
+                                    CustomColors.QuestAlert.Completed
+                                );
+                            }
+                            else
+                            {
+                                //Advance Task
+                                questProgress.TaskId = quest.Tasks[i + 1].Id;
+                                questProgress.TaskProgress = 0;
+                                if (quest.Tasks[i].CompletionEvent != null)
+                                {
+                                    EnqueueStartCommonEvent(quest.Tasks[i].CompletionEvent);
+                                }
+
+                                if (quest.Tasks[i + 1].Objective == QuestObjective.GatherItems)
+                                {
+                                    UpdateGatherItemQuests(quest.Tasks[i + 1].TargetId);
+                                }
+
+                                PacketSender.SendChatMsg(
+                                    this, Strings.Quests.updated.ToString(quest.Name),
+                                    ChatMessageType.Quest,
+                                    CustomColors.QuestAlert.TaskUpdated
+                                );
+                            }
+                        }
+                    }
+                }
+
+                PacketSender.SendQuestsProgress(this);
+            }
+        }
+        UnequipInvalidItems();
+    }
+
+    public void CompleteQuest(Guid questId, bool skipCompletionEvent)
+    {
+        var quest = QuestBase.Get(questId);
+        if (quest != null)
+        {
+            var questProgress = FindQuest(questId);
+            if (questProgress != null)
+            {
+                //Complete Quest
+                questProgress.Completed = true;
+                questProgress.TaskId = Guid.Empty;
+                questProgress.TaskProgress = -1;
+                if (!skipCompletionEvent)
+                {
+                    EnqueueStartCommonEvent(EventBase.Get(quest.EndEventId));
+                    PacketSender.SendChatMsg(
+                        this, Strings.Quests.completed.ToString(quest.Name), ChatMessageType.Quest,
+                        CustomColors.QuestAlert.Completed
+                    );
+                }
+                PacketSender.SendQuestsProgress(this);
+            }
+        }
+        UnequipInvalidItems();
+    }
+
+    private void UpdateGatherItemQuests(Guid itemId)
+    {
+        //If any quests demand that this item be gathered then let's handle it
+        var item = ItemBase.Get(itemId);
+        if (item != null)
+        {
+            foreach (var questProgress in Quests)
+            {
+                var questId = questProgress.QuestId;
+                var quest = QuestBase.Get(questId);
+                if (quest != null)
+                {
+                    if (questProgress.TaskId != Guid.Empty)
+                    {
+                        //Assume this quest is in progress. See if we can find the task in the quest
+                        var questTask = quest.FindTask(questProgress.TaskId);
+                        if (questTask?.Objective == QuestObjective.GatherItems && questTask.TargetId == item.Id)
+                        {
+                            if (questProgress.TaskProgress != CountItems(item.Id))
+                            {
+                                questProgress.TaskProgress = CountItems(item.Id);
+                                if (questProgress.TaskProgress >= questTask.Quantity)
+                                {
+                                    CompleteQuestTask(questId, questProgress.TaskId);
                                 }
                                 else
                                 {
-                                    //Advance Task
-                                    questProgress.TaskId = quest.Tasks[i + 1].Id;
-                                    questProgress.TaskProgress = 0;
-                                    if (quest.Tasks[i].CompletionEvent != null)
-                                    {
-                                        EnqueueStartCommonEvent(quest.Tasks[i].CompletionEvent);
-                                    }
-
-                                    if (quest.Tasks[i + 1].Objective == QuestObjective.GatherItems)
-                                    {
-                                        UpdateGatherItemQuests(quest.Tasks[i + 1].TargetId);
-                                    }
-
+                                    PacketSender.SendQuestsProgress(this);
                                     PacketSender.SendChatMsg(
-                                        this, Strings.Quests.updated.ToString(quest.Name),
-                                        ChatMessageType.Quest,
-                                        CustomColors.QuestAlert.TaskUpdated
+                                        this,
+                                        Strings.Quests.itemtask.ToString(
+                                            quest.Name, questProgress.TaskProgress, questTask.Quantity,
+                                            ItemBase.GetName(questTask.TargetId)
+                                        ),
+                                        ChatMessageType.Quest
                                     );
                                 }
                             }
                         }
                     }
-
-                    PacketSender.SendQuestsProgress(this);
                 }
             }
-            UnequipInvalidItems();
+        }
+        UnequipInvalidItems();
+    }
+
+    //Switches and Variables
+    private PlayerVariable GetSwitch(Guid id)
+    {
+        foreach (var s in Variables)
+        {
+            if (s.VariableId == id)
+            {
+                return s;
+            }
         }
 
-        public void CompleteQuest(Guid questId, bool skipCompletionEvent)
+        return null;
+    }
+
+    public bool GetSwitchValue(Guid id)
+    {
+        var s = GetSwitch(id);
+        if (s == null)
         {
-            var quest = QuestBase.Get(questId);
-            if (quest != null)
-            {
-                var questProgress = FindQuest(questId);
-                if (questProgress != null)
-                {
-                    //Complete Quest
-                    questProgress.Completed = true;
-                    questProgress.TaskId = Guid.Empty;
-                    questProgress.TaskProgress = -1;
-                    if (!skipCompletionEvent)
-                    {
-                        EnqueueStartCommonEvent(EventBase.Get(quest.EndEventId));
-                        PacketSender.SendChatMsg(
-                            this, Strings.Quests.completed.ToString(quest.Name), ChatMessageType.Quest,
-                            CustomColors.QuestAlert.Completed
-                        );
-                    }
-                    PacketSender.SendQuestsProgress(this);
-                }
-            }
-            UnequipInvalidItems();
+            return false;
         }
 
-        private void UpdateGatherItemQuests(Guid itemId)
+        return s.Value.Boolean;
+    }
+
+    public void SetSwitchValue(Guid id, bool value)
+    {
+        var s = GetSwitch(id);
+        var changed = true;
+        if (s != null)
         {
-            //If any quests demand that this item be gathered then let's handle it
-            var item = ItemBase.Get(itemId);
-            if (item != null)
+            if (s.Value?.Boolean == value)
             {
-                foreach (var questProgress in Quests)
-                {
-                    var questId = questProgress.QuestId;
-                    var quest = QuestBase.Get(questId);
-                    if (quest != null)
-                    {
-                        if (questProgress.TaskId != Guid.Empty)
-                        {
-                            //Assume this quest is in progress. See if we can find the task in the quest
-                            var questTask = quest.FindTask(questProgress.TaskId);
-                            if (questTask?.Objective == QuestObjective.GatherItems && questTask.TargetId == item.Id)
-                            {
-                                if (questProgress.TaskProgress != CountItems(item.Id))
-                                {
-                                    questProgress.TaskProgress = CountItems(item.Id);
-                                    if (questProgress.TaskProgress >= questTask.Quantity)
-                                    {
-                                        CompleteQuestTask(questId, questProgress.TaskId);
-                                    }
-                                    else
-                                    {
-                                        PacketSender.SendQuestsProgress(this);
-                                        PacketSender.SendChatMsg(
-                                            this,
-                                            Strings.Quests.itemtask.ToString(
-                                                quest.Name, questProgress.TaskProgress, questTask.Quantity,
-                                                ItemBase.GetName(questTask.TargetId)
-                                            ),
-                                            ChatMessageType.Quest
-                                        );
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
+                changed = false;
             }
-            UnequipInvalidItems();
+            s.Value.Boolean = value;
+        }
+        else
+        {
+            s = new PlayerVariable(id);
+            s.Value.Boolean = value;
+            Variables.Add(s);
         }
 
-        //Switches and Variables
-        private PlayerVariable GetSwitch(Guid id)
+        if (changed)
         {
-            foreach (var s in Variables)
-            {
-                if (s.VariableId == id)
-                {
-                    return s;
-                }
-            }
+            StartCommonEventsWithTrigger(CommonEventTrigger.PlayerVariableChange, "", id.ToString());
+        }
+    }
 
+    public PlayerVariable GetVariable(Guid id, bool createIfNull = false)
+    {
+        foreach (var v in Variables)
+        {
+            if (v.VariableId == id)
+            {
+                return v;
+            }
+        }
+
+        if (createIfNull)
+        {
+            return CreateVariable(id);
+        }
+
+        return null;
+    }
+
+    private PlayerVariable CreateVariable(Guid id)
+    {
+        if (PlayerVariableBase.Get(id) == null)
+        {
             return null;
         }
 
-        public bool GetSwitchValue(Guid id)
-        {
-            var s = GetSwitch(id);
-            if (s == null)
-            {
-                return false;
-            }
+        var variable = new PlayerVariable(id);
+        Variables.Add(variable);
 
-            return s.Value.Boolean;
+        return variable;
+    }
+
+    public VariableValue GetVariableValue(Guid id)
+    {
+        var v = GetVariable(id);
+        if (v == null)
+        {
+            v = CreateVariable(id);
         }
 
-        public void SetSwitchValue(Guid id, bool value)
+        if (v == null)
         {
-            var s = GetSwitch(id);
-            var changed = true;
-            if (s != null)
+            return new VariableValue();
+        }
+
+        return v.Value;
+    }
+
+    public void SetVariableValue(Guid id, long value)
+    {
+        var v = GetVariable(id);
+        var changed = true;
+        if (v != null)
+        {
+            if (v.Value?.Integer == value)
             {
-                if (s.Value?.Boolean == value)
+                changed = false;
+            }
+            v.Value.Integer = value;
+        }
+        else
+        {
+            v = new PlayerVariable(id);
+            v.Value.Integer = value;
+            Variables.Add(v);
+        }
+
+        if (changed)
+        {
+            StartCommonEventsWithTrigger(CommonEventTrigger.PlayerVariableChange, "", id.ToString());
+        }
+    }
+
+    public void SetVariableValue(Guid id, string value)
+    {
+        var v = GetVariable(id);
+        var changed = true;
+        if (v != null)
+        {
+            if (v.Value?.String == value)
+            {
+                changed = false;
+            }
+            v.Value.String = value;
+        }
+        else
+        {
+            v = new PlayerVariable(id);
+            v.Value.String = value;
+            Variables.Add(v);
+        }
+
+        if (changed)
+        {
+            StartCommonEventsWithTrigger(CommonEventTrigger.PlayerVariableChange, "", id.ToString());
+        }
+    }
+
+    //Event Processing Methods
+    public Event EventExists(MapTileLoc loc)
+    {
+        if (EventTileLookup.TryGetValue(loc, out Event val))
+        {
+            return val;
+        }
+
+        return null;
+    }
+
+    public EventPageInstance EventAt(Guid mapId, int x, int y, int z)
+    {
+        foreach (var evt in EventLookup)
+        {
+            if (evt.Value != null && evt.Value.PageInstance != null)
+            {
+                if (evt.Value.PageInstance.MapId == mapId &&
+                    evt.Value.PageInstance.X == x &&
+                    evt.Value.PageInstance.Y == y &&
+                    evt.Value.PageInstance.Z == z)
                 {
-                    changed = false;
+                    return evt.Value.PageInstance;
                 }
-                s.Value.Boolean = value;
-            }
-            else
-            {
-                s = new PlayerVariable(id);
-                s.Value.Boolean = value;
-                Variables.Add(s);
-            }
-
-            if (changed)
-            {
-                StartCommonEventsWithTrigger(CommonEventTrigger.PlayerVariableChange, "", id.ToString());
             }
         }
 
-        public PlayerVariable GetVariable(Guid id, bool createIfNull = false)
+        return null;
+    }
+
+    public void TryActivateEvent(Guid eventId)
+    {
+        foreach (var evt in EventLookup)
         {
-            foreach (var v in Variables)
+            if (evt.Value.PageInstance != null && evt.Value.PageInstance.Id == eventId)
             {
-                if (v.VariableId == id)
+                if (evt.Value.PageInstance.Trigger != EventTrigger.ActionButton)
                 {
-                    return v;
+                    return;
                 }
-            }
 
-            if (createIfNull)
-            {
-                return CreateVariable(id);
-            }
-
-            return null;
-        }
-
-        private PlayerVariable CreateVariable(Guid id)
-        {
-            if (PlayerVariableBase.Get(id) == null)
-            {
-                return null;
-            }
-
-            var variable = new PlayerVariable(id);
-            Variables.Add(variable);
-
-            return variable;
-        }
-
-        public VariableValue GetVariableValue(Guid id)
-        {
-            var v = GetVariable(id);
-            if (v == null)
-            {
-                v = CreateVariable(id);
-            }
-
-            if (v == null)
-            {
-                return new VariableValue();
-            }
-
-            return v.Value;
-        }
-
-        public void SetVariableValue(Guid id, long value)
-        {
-            var v = GetVariable(id);
-            var changed = true;
-            if (v != null)
-            {
-                if (v.Value?.Integer == value)
+                if (!IsEventOneBlockAway(evt.Value))
                 {
-                    changed = false;
+                    return;
                 }
-                v.Value.Integer = value;
-            }
-            else
-            {
-                v = new PlayerVariable(id);
-                v.Value.Integer = value;
-                Variables.Add(v);
-            }
 
-            if (changed)
-            {
-                StartCommonEventsWithTrigger(CommonEventTrigger.PlayerVariableChange, "", id.ToString());
-            }
-        }
-
-        public void SetVariableValue(Guid id, string value)
-        {
-            var v = GetVariable(id);
-            var changed = true;
-            if (v != null)
-            {
-                if (v.Value?.String == value)
+                if (evt.Value.CallStack.Count != 0)
                 {
-                    changed = false;
+                    return;
                 }
-                v.Value.String = value;
-            }
-            else
-            {
-                v = new PlayerVariable(id);
-                v.Value.String = value;
-                Variables.Add(v);
-            }
 
-            if (changed)
-            {
-                StartCommonEventsWithTrigger(CommonEventTrigger.PlayerVariableChange, "", id.ToString());
-            }
-        }
-
-        //Event Processing Methods
-        public Event EventExists(MapTileLoc loc)
-        {
-            if (EventTileLookup.TryGetValue(loc, out Event val))
-            {
-                return val;
-            }
-
-            return null;
-        }
-
-        public EventPageInstance EventAt(Guid mapId, int x, int y, int z)
-        {
-            foreach (var evt in EventLookup)
-            {
-                if (evt.Value != null && evt.Value.PageInstance != null)
+                var newStack = new CommandInstance(evt.Value.PageInstance.MyPage);
+                evt.Value.CallStack.Push(newStack);
+                if (!evt.Value.Global)
                 {
-                    if (evt.Value.PageInstance.MapId == mapId &&
-                        evt.Value.PageInstance.X == x &&
-                        evt.Value.PageInstance.Y == y &&
-                        evt.Value.PageInstance.Z == z)
+                    evt.Value.PageInstance.TurnTowardsPlayer();
+                }
+                else
+                {
+                    //Turn the global event opposite of the player
+                    switch (Dir)
                     {
-                        return evt.Value.PageInstance;
+                        case Direction.Up:
+                            evt.Value.PageInstance.GlobalClone.ChangeDir(Direction.Down);
+
+                            break;
+                        case Direction.Down:
+                            evt.Value.PageInstance.GlobalClone.ChangeDir(Direction.Up);
+
+                            break;
+                        case Direction.Left:
+                            evt.Value.PageInstance.GlobalClone.ChangeDir(Direction.Right);
+
+                            break;
+                        case Direction.Right:
+                            evt.Value.PageInstance.GlobalClone.ChangeDir(Direction.Left);
+
+                            break;
                     }
                 }
             }
-
-            return null;
         }
+    }
 
-        public void TryActivateEvent(Guid eventId)
+    public void RespondToEvent(Guid eventId, int responseId)
+    {
+        lock (mEventLock)
         {
             foreach (var evt in EventLookup)
             {
                 if (evt.Value.PageInstance != null && evt.Value.PageInstance.Id == eventId)
                 {
-                    if (evt.Value.PageInstance.Trigger != EventTrigger.ActionButton)
+                    if (evt.Value.CallStack.Count <= 0)
                     {
                         return;
                     }
 
-                    if (!IsEventOneBlockAway(evt.Value))
+                    var stackInfo = evt.Value.CallStack.Peek();
+                    if (stackInfo.WaitingForResponse != CommandInstance.EventResponse.Dialogue)
                     {
                         return;
                     }
 
-                    if (evt.Value.CallStack.Count != 0)
+                    stackInfo.WaitingForResponse = CommandInstance.EventResponse.None;
+                    if (stackInfo.WaitingOnCommand != null &&
+                        stackInfo.WaitingOnCommand.Type == EventCommandType.ShowOptions)
                     {
-                        return;
+                        var tmpStack = new CommandInstance(stackInfo.Page, stackInfo.BranchIds[responseId - 1]);
+                        evt.Value.CallStack.Push(tmpStack);
                     }
 
-                    var newStack = new CommandInstance(evt.Value.PageInstance.MyPage);
-                    evt.Value.CallStack.Push(newStack);
-                    if (!evt.Value.Global)
-                    {
-                        evt.Value.PageInstance.TurnTowardsPlayer();
-                    }
-                    else
-                    {
-                        //Turn the global event opposite of the player
-                        switch (Dir)
-                        {
-                            case Direction.Up:
-                                evt.Value.PageInstance.GlobalClone.ChangeDir(Direction.Down);
-
-                                break;
-                            case Direction.Down:
-                                evt.Value.PageInstance.GlobalClone.ChangeDir(Direction.Up);
-
-                                break;
-                            case Direction.Left:
-                                evt.Value.PageInstance.GlobalClone.ChangeDir(Direction.Right);
-
-                                break;
-                            case Direction.Right:
-                                evt.Value.PageInstance.GlobalClone.ChangeDir(Direction.Left);
-
-                                break;
-                        }
-                    }
+                    return;
                 }
             }
         }
+    }
 
-        public void RespondToEvent(Guid eventId, int responseId)
+    public void PictureClosed(Guid eventId)
+    {
+        lock (mEventLock)
         {
-            lock (mEventLock)
+            foreach (var evt in EventLookup)
             {
-                foreach (var evt in EventLookup)
+                if (evt.Value.PageInstance != null && evt.Value.PageInstance.Id == eventId)
                 {
-                    if (evt.Value.PageInstance != null && evt.Value.PageInstance.Id == eventId)
+                    if (evt.Value.CallStack.Count <= 0)
                     {
-                        if (evt.Value.CallStack.Count <= 0)
-                        {
-                            return;
-                        }
-
-                        var stackInfo = evt.Value.CallStack.Peek();
-                        if (stackInfo.WaitingForResponse != CommandInstance.EventResponse.Dialogue)
-                        {
-                            return;
-                        }
-
-                        stackInfo.WaitingForResponse = CommandInstance.EventResponse.None;
-                        if (stackInfo.WaitingOnCommand != null &&
-                            stackInfo.WaitingOnCommand.Type == EventCommandType.ShowOptions)
-                        {
-                            var tmpStack = new CommandInstance(stackInfo.Page, stackInfo.BranchIds[responseId - 1]);
-                            evt.Value.CallStack.Push(tmpStack);
-                        }
-
                         return;
                     }
+
+                    var stackInfo = evt.Value.CallStack.Peek();
+                    if (stackInfo.WaitingForResponse != CommandInstance.EventResponse.Picture)
+                    {
+                        return;
+                    }
+
+                    stackInfo.WaitingForResponse = CommandInstance.EventResponse.None;
+
+                    return;
                 }
             }
         }
+    }
 
-        public void PictureClosed(Guid eventId)
+    public void RespondToEventInput(Guid eventId, int newValue, string newValueString, bool canceled = false)
+    {
+        lock (mEventLock)
         {
-            lock (mEventLock)
+            foreach (var evt in EventLookup)
             {
-                foreach (var evt in EventLookup)
+                if (evt.Value.PageInstance != null && evt.Value.PageInstance.Id == eventId)
                 {
-                    if (evt.Value.PageInstance != null && evt.Value.PageInstance.Id == eventId)
+                    if (evt.Value.CallStack.Count <= 0)
                     {
-                        if (evt.Value.CallStack.Count <= 0)
-                        {
-                            return;
-                        }
-
-                        var stackInfo = evt.Value.CallStack.Peek();
-                        if (stackInfo.WaitingForResponse != CommandInstance.EventResponse.Picture)
-                        {
-                            return;
-                        }
-
-                        stackInfo.WaitingForResponse = CommandInstance.EventResponse.None;
-
                         return;
                     }
-                }
-            }
-        }
 
-        public void RespondToEventInput(Guid eventId, int newValue, string newValueString, bool canceled = false)
-        {
-            lock (mEventLock)
-            {
-                foreach (var evt in EventLookup)
-                {
-                    if (evt.Value.PageInstance != null && evt.Value.PageInstance.Id == eventId)
+                    var stackInfo = evt.Value.CallStack.Peek();
+                    if (stackInfo.WaitingForResponse != CommandInstance.EventResponse.Dialogue)
                     {
-                        if (evt.Value.CallStack.Count <= 0)
+                        return;
+                    }
+
+                    stackInfo.WaitingForResponse = CommandInstance.EventResponse.None;
+                    if (stackInfo.WaitingOnCommand != null &&
+                        stackInfo.WaitingOnCommand.Type == EventCommandType.InputVariable)
+                    {
+                        var cmd = (InputVariableCommand)stackInfo.WaitingOnCommand;
+                        VariableValue value = null;
+                        var type = VariableDataType.Boolean;
+                        if (cmd.VariableType == VariableType.PlayerVariable)
                         {
-                            return;
+                            var variable = PlayerVariableBase.Get(cmd.VariableId);
+                            if (variable != null)
+                            {
+                                type = variable.Type;
+                            }
+
+                            value = GetVariableValue(cmd.VariableId);
+                        }
+                        else if (cmd.VariableType == VariableType.ServerVariable)
+                        {
+                            var variable = ServerVariableBase.Get(cmd.VariableId);
+                            if (variable != null)
+                            {
+                                type = variable.Type;
+                            }
+
+                            value = ServerVariableBase.Get(cmd.VariableId)?.Value;
+                        }
+                        else if (cmd.VariableType == VariableType.GuildVariable)
+                        {
+                            var variable = GuildVariableBase.Get(cmd.VariableId);
+                            if (variable != null)
+                            {
+                                type = variable.Type;
+                            }
+
+                            value = Guild?.GetVariableValue(cmd.VariableId) ?? new VariableValue();
+                        }
+                        else if (cmd.VariableType == VariableType.UserVariable)
+                        {
+                            var variable = UserVariableBase.Get(cmd.VariableId);
+                            if (variable != null)
+                            {
+                                type = variable.Type;
+                            }
+
+                            value = User.GetVariableValue(cmd.VariableId) ?? new VariableValue();
                         }
 
-                        var stackInfo = evt.Value.CallStack.Peek();
-                        if (stackInfo.WaitingForResponse != CommandInstance.EventResponse.Dialogue)
+                        if (value == null)
                         {
-                            return;
+                            value = new VariableValue();
                         }
 
-                        stackInfo.WaitingForResponse = CommandInstance.EventResponse.None;
-                        if (stackInfo.WaitingOnCommand != null &&
-                            stackInfo.WaitingOnCommand.Type == EventCommandType.InputVariable)
+                        var success = false;
+                        var changed = false;
+
+                        if (!canceled)
                         {
-                            var cmd = (InputVariableCommand)stackInfo.WaitingOnCommand;
-                            VariableValue value = null;
-                            var type = VariableDataType.Boolean;
-                            if (cmd.VariableType == VariableType.PlayerVariable)
+                            switch (type)
                             {
-                                var variable = PlayerVariableBase.Get(cmd.VariableId);
-                                if (variable != null)
-                                {
-                                    type = variable.Type;
-                                }
-
-                                value = GetVariableValue(cmd.VariableId);
-                            }
-                            else if (cmd.VariableType == VariableType.ServerVariable)
-                            {
-                                var variable = ServerVariableBase.Get(cmd.VariableId);
-                                if (variable != null)
-                                {
-                                    type = variable.Type;
-                                }
-
-                                value = ServerVariableBase.Get(cmd.VariableId)?.Value;
-                            }
-                            else if (cmd.VariableType == VariableType.GuildVariable)
-                            {
-                                var variable = GuildVariableBase.Get(cmd.VariableId);
-                                if (variable != null)
-                                {
-                                    type = variable.Type;
-                                }
-
-                                value = Guild?.GetVariableValue(cmd.VariableId) ?? new VariableValue();
-                            }
-                            else if (cmd.VariableType == VariableType.UserVariable)
-                            {
-                                var variable = UserVariableBase.Get(cmd.VariableId);
-                                if (variable != null)
-                                {
-                                    type = variable.Type;
-                                }
-
-                                value = User.GetVariableValue(cmd.VariableId) ?? new VariableValue();
-                            }
-
-                            if (value == null)
-                            {
-                                value = new VariableValue();
-                            }
-
-                            var success = false;
-                            var changed = false;
-
-                            if (!canceled)
-                            {
-                                switch (type)
-                                {
-                                    case VariableDataType.Integer:
-                                        if (newValue >= cmd.Minimum && newValue <= cmd.Maximum)
-                                        {
-                                            if (value.Integer != newValue)
-                                            {
-                                                changed = true;
-                                            }
-                                            value.Integer = newValue;
-                                            success = true;
-                                        }
-
-                                        break;
-                                    case VariableDataType.Number:
-                                        if (newValue >= cmd.Minimum && newValue <= cmd.Maximum)
-                                        {
-                                            if (value.Number != newValue)
-                                            {
-                                                changed = true;
-                                            }
-                                            value.Number = newValue;
-                                            success = true;
-                                        }
-
-                                        break;
-                                    case VariableDataType.String:
-                                        if (newValueString.Length >= cmd.Minimum &&
-                                            newValueString.Length <= cmd.Maximum)
-                                        {
-                                            if (value.String != newValueString)
-                                            {
-                                                changed = true;
-                                            }
-                                            value.String = newValueString;
-                                            success = true;
-                                        }
-
-                                        break;
-                                    case VariableDataType.Boolean:
-                                        if (value.Boolean != newValue > 0)
+                                case VariableDataType.Integer:
+                                    if (newValue >= cmd.Minimum && newValue <= cmd.Maximum)
+                                    {
+                                        if (value.Integer != newValue)
                                         {
                                             changed = true;
                                         }
-                                        value.Boolean = newValue > 0;
+                                        value.Integer = newValue;
                                         success = true;
-
-                                        break;
-                                }
-                            }
-
-                            //Reassign variable values in case they didnt already exist and we made them from scratch at the null check above
-                            if (cmd.VariableType == VariableType.PlayerVariable)
-                            {
-                                var variable = GetVariable(cmd.VariableId);
-                                if (changed)
-                                {
-                                    variable.Value = value;
-                                    StartCommonEventsWithTrigger(CommonEventTrigger.PlayerVariableChange, "", cmd.VariableId.ToString());
-                                }
-                            }
-                            else if (cmd.VariableType == VariableType.ServerVariable)
-                            {
-                                var variable = ServerVariableBase.Get(cmd.VariableId);
-                                if (changed)
-                                {
-                                    variable.Value = value;
-                                    StartCommonEventsWithTriggerForAll(CommonEventTrigger.ServerVariableChange, "", cmd.VariableId.ToString());
-                                    DbInterface.UpdatedServerVariables.AddOrUpdate(variable.Id, variable, (key, oldValue) => variable);
-                                }
-                            }
-                            else if (cmd.VariableType == VariableType.GuildVariable)
-                            {
-                                if (Guild != null)
-                                {
-                                    var variable = Guild.GetVariable(cmd.VariableId);
-                                    if (variable.Value?.Value != value.Value)
-                                    {
-                                        variable.Value = value;
-                                        Guild.StartCommonEventsWithTriggerForAll(Enums.CommonEventTrigger.GuildVariableChange, "", cmd.VariableId.ToString());
-                                        Guild.UpdatedVariables.AddOrUpdate(cmd.VariableId, GuildVariableBase.Get(cmd.VariableId), (key, oldValue) => GuildVariableBase.Get(cmd.VariableId));
                                     }
-                                }
-                            }
-                            else if (cmd.VariableType == VariableType.UserVariable)
-                            {
-                                var variable = User.GetVariable(cmd.VariableId);
-                                if (changed)
-                                {
-                                    variable.Value = value;
-                                    User.StartCommonEventsWithTriggerForAll(CommonEventTrigger.UserVariableChange, "", cmd.VariableId.ToString());
-                                    User.UpdatedVariables.AddOrUpdate(cmd.VariableId, UserVariableBase.Get(cmd.VariableId), (key, oldValue) => UserVariableBase.Get(cmd.VariableId));
-                                }
-                            }
 
-                            var tmpStack = success
-                                ? new CommandInstance(stackInfo.Page, stackInfo.BranchIds[0])
-                                : new CommandInstance(stackInfo.Page, stackInfo.BranchIds[1]);
+                                    break;
+                                case VariableDataType.Number:
+                                    if (newValue >= cmd.Minimum && newValue <= cmd.Maximum)
+                                    {
+                                        if (value.Number != newValue)
+                                        {
+                                            changed = true;
+                                        }
+                                        value.Number = newValue;
+                                        success = true;
+                                    }
 
-                            evt.Value.CallStack.Push(tmpStack);
+                                    break;
+                                case VariableDataType.String:
+                                    if (newValueString.Length >= cmd.Minimum &&
+                                        newValueString.Length <= cmd.Maximum)
+                                    {
+                                        if (value.String != newValueString)
+                                        {
+                                            changed = true;
+                                        }
+                                        value.String = newValueString;
+                                        success = true;
+                                    }
+
+                                    break;
+                                case VariableDataType.Boolean:
+                                    if (value.Boolean != newValue > 0)
+                                    {
+                                        changed = true;
+                                    }
+                                    value.Boolean = newValue > 0;
+                                    success = true;
+
+                                    break;
+                            }
                         }
 
-                        return;
+                        //Reassign variable values in case they didnt already exist and we made them from scratch at the null check above
+                        if (cmd.VariableType == VariableType.PlayerVariable)
+                        {
+                            var variable = GetVariable(cmd.VariableId);
+                            if (changed)
+                            {
+                                variable.Value = value;
+                                StartCommonEventsWithTrigger(CommonEventTrigger.PlayerVariableChange, "", cmd.VariableId.ToString());
+                            }
+                        }
+                        else if (cmd.VariableType == VariableType.ServerVariable)
+                        {
+                            var variable = ServerVariableBase.Get(cmd.VariableId);
+                            if (changed)
+                            {
+                                variable.Value = value;
+                                StartCommonEventsWithTriggerForAll(CommonEventTrigger.ServerVariableChange, "", cmd.VariableId.ToString());
+                                DbInterface.UpdatedServerVariables.AddOrUpdate(variable.Id, variable, (key, oldValue) => variable);
+                            }
+                        }
+                        else if (cmd.VariableType == VariableType.GuildVariable)
+                        {
+                            if (Guild != null)
+                            {
+                                var variable = Guild.GetVariable(cmd.VariableId);
+                                if (variable.Value?.Value != value.Value)
+                                {
+                                    variable.Value = value;
+                                    Guild.StartCommonEventsWithTriggerForAll(Enums.CommonEventTrigger.GuildVariableChange, "", cmd.VariableId.ToString());
+                                    Guild.UpdatedVariables.AddOrUpdate(cmd.VariableId, GuildVariableBase.Get(cmd.VariableId), (key, oldValue) => GuildVariableBase.Get(cmd.VariableId));
+                                }
+                            }
+                        }
+                        else if (cmd.VariableType == VariableType.UserVariable)
+                        {
+                            var variable = User.GetVariable(cmd.VariableId);
+                            if (changed)
+                            {
+                                variable.Value = value;
+                                User.StartCommonEventsWithTriggerForAll(CommonEventTrigger.UserVariableChange, "", cmd.VariableId.ToString());
+                                User.UpdatedVariables.AddOrUpdate(cmd.VariableId, UserVariableBase.Get(cmd.VariableId), (key, oldValue) => UserVariableBase.Get(cmd.VariableId));
+                            }
+                        }
+
+                        var tmpStack = success
+                            ? new CommandInstance(stackInfo.Page, stackInfo.BranchIds[0])
+                            : new CommandInstance(stackInfo.Page, stackInfo.BranchIds[1]);
+
+                        evt.Value.CallStack.Push(tmpStack);
                     }
+
+                    return;
                 }
             }
         }
+    }
 
-        static bool IsEventOneBlockAway(Event evt)
+    static bool IsEventOneBlockAway(Event evt)
+    {
+        //todo this
+        return true;
+    }
+
+    public Event FindGlobalEventInstance(EventPageInstance en)
+    {
+        if (GlobalPageInstanceLookup.TryGetValue(en, out Event val))
         {
-            //todo this
+            return val;
+        }
+
+        return null;
+    }
+
+    public void SendEvents()
+    {
+        foreach (var evt in EventLookup)
+        {
+            if (evt.Value.PageInstance != null)
+            {
+                evt.Value.PageInstance.SendToPlayer();
+            }
+        }
+    }
+
+    [NotMapped, JsonIgnore]
+    private readonly ConcurrentQueue<StartCommonEventMetadata> _queueStartCommonEvent = new ConcurrentQueue<StartCommonEventMetadata>();
+
+    public class StartCommonEventMetadata
+    {
+        public string Command { get; }
+
+        public EventBase EventDescriptor { get; }
+
+        public string Parameter { get; }
+
+        public CommonEventTrigger Trigger { get; }
+
+        public StartCommonEventMetadata(
+            string command,
+            EventBase eventDescriptor,
+            string parameter,
+            CommonEventTrigger trigger
+        )
+        {
+            Command = command;
+            EventDescriptor = eventDescriptor;
+            Parameter = parameter;
+            Trigger = trigger;
+        }
+    }
+
+    public void EnqueueStartCommonEvent(
+        EventBase eventDescriptor,
+        CommonEventTrigger trigger = CommonEventTrigger.None,
+        string command = default,
+        string parameter = default
+    ) 
+    {
+        if (eventDescriptor == null)
+        {
+            return;
+        }
+
+        _queueStartCommonEvent.Enqueue(new StartCommonEventMetadata(command ?? string.Empty, eventDescriptor, parameter ?? string.Empty, trigger));
+    }
+
+    public bool UnsafeStartCommonEvent(
+        EventBase baseEvent,
+        CommonEventTrigger trigger = CommonEventTrigger.None,
+        string command = "",
+        string param = ""
+    )
+    {
+        if (baseEvent == null)
+        {
+            return false;
+        }
+
+        if (!baseEvent.CommonEvent && baseEvent.MapId != Guid.Empty)
+        {
+            return false;
+        }
+
+        if (EventBaseIdLookup.ContainsKey(baseEvent.Id) && !baseEvent.CanRunInParallel)
+        {
+            return false;
+        }
+
+        lock (mEventLock)
+        {
+            mCommonEventLaunches++;
+            var commonEventLaunch = mCommonEventLaunches;
+
+            //Use Fake Ids for Common Events Since they are not tied to maps and such
+            var evtId = Guid.NewGuid();
+            var mapId = Guid.Empty;
+
+            Event newEvent = null;
+
+            //Try to Spawn a PageInstance.. if we can
+            for (var i = baseEvent.Pages.Count - 1; i >= 0; i--)
+            {
+                if ((trigger == CommonEventTrigger.None || baseEvent.Pages[i].CommonTrigger == trigger) && Conditions.CanSpawnPage(baseEvent.Pages[i], this, null))
+                {
+                    if (trigger == CommonEventTrigger.SlashCommand && command.ToLower() != baseEvent.Pages[i].TriggerCommand.ToLower())
+                    {
+                        continue;
+                    }
+
+                    if (trigger == CommonEventTrigger.PlayerVariableChange && param != baseEvent.Pages[i].TriggerId.ToString())
+                    {
+                        continue;
+                    }
+
+                    if (trigger == CommonEventTrigger.ServerVariableChange && param != baseEvent.Pages[i].TriggerId.ToString())
+                    {
+                        continue;
+                    }
+
+                    newEvent = new Event(evtId, null, this, baseEvent)
+                    {
+                        MapId = mapId,
+                        SpawnX = -1,
+                        SpawnY = -1
+                    };
+                    newEvent.PageInstance = new EventPageInstance(
+                        baseEvent, baseEvent.Pages[i], mapId, MapInstanceId, newEvent, this
+                    );
+
+                    newEvent.PageIndex = i;
+
+                    if (trigger == CommonEventTrigger.SlashCommand)
+                    {
+                        //Split params up
+                        var prams = param.Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                        for (var x = 0; x < prams.Length; x++)
+                        {
+                            newEvent.SetParam("slashParam" + x, prams[x]);
+                        }
+                    }
+
+                    switch (trigger)
+                    {
+                        case CommonEventTrigger.None:
+                            break;
+                        case CommonEventTrigger.Login:
+                            break;
+                        case CommonEventTrigger.LevelUp:
+                            break;
+                        case CommonEventTrigger.OnRespawn:
+                            break;
+                        case CommonEventTrigger.SlashCommand:
+                            break;
+                        case CommonEventTrigger.Autorun:
+                            break;
+                        case CommonEventTrigger.PVPKill:
+                            //Add victim as a parameter
+                            newEvent.SetParam("victim", param);
+
+                            break;
+                        case CommonEventTrigger.PVPDeath:
+                            //Add killer as a parameter
+                            newEvent.SetParam("killer", param);
+
+                            break;
+                        case CommonEventTrigger.PlayerInteract:
+                            //Interactee as a parameter
+                            newEvent.SetParam("triggered", param);
+
+                            break;
+                        case CommonEventTrigger.GuildMemberJoined:
+                        case CommonEventTrigger.GuildMemberKicked:
+                        case CommonEventTrigger.GuildMemberLeft:
+                            newEvent.SetParam("member", param);
+                            newEvent.SetParam("guild", command);
+
+                            break;
+                    }
+
+                    var newStack = new CommandInstance(newEvent.PageInstance.MyPage);
+                    newEvent.CallStack.Push(newStack);
+
+                    break;
+                }
+            }
+
+            if (newEvent != null)
+            {
+                EventLookup.AddOrUpdate(evtId, newEvent, (key, oldValue) => newEvent);
+                EventBaseIdLookup.AddOrUpdate(baseEvent.Id, newEvent, (key, oldvalue) => newEvent);
+                return true;
+            }
+            return false;
+        }
+    }
+
+    /// <inheritdoc />
+    public override bool CanMoveInDirection(
+        Direction direction,
+        out MovementBlockerType blockerType,
+        out EntityType entityType
+    )
+    {
+        entityType = default;
+
+        // If crafting or locked by event return blocked
+        if (OpenCraftingTableId != default && CraftingState != default)
+        {
+            blockerType = MovementBlockerType.OutOfBounds;
+            return false;
+        }
+
+        // ReSharper disable once InvertIf
+        if (EventLookup.Values.Any(@event => @event.HoldingPlayer))
+        {
+            blockerType = MovementBlockerType.OutOfBounds;
+            return false;
+        }
+
+        return base.CanMoveInDirection(direction, out blockerType, out entityType);
+    }
+
+    protected override bool CanPassPlayer(MapController targetMap)
+    {
+        return Options.Instance.Passability.Passable[(int)targetMap.ZoneType];
+    }
+
+    protected override bool IsBlockedByEvent(MapInstance mapInstance, int tileX, int tileY)
+    {
+        return false;
+    }
+
+    protected override bool TryGetBlockerOnTile(MapController map, int x, int y, int z, out MovementBlockerType blockerType, out EntityType entityType)
+    {
+        if (base.TryGetBlockerOnTile(map, x, y, z, out blockerType, out entityType))
+        {
             return true;
         }
 
-        public Event FindGlobalEventInstance(EventPageInstance en)
+        foreach (var evt in EventLookup.Values.Where(evt => evt.PageInstance != default))
         {
-            if (GlobalPageInstanceLookup.TryGetValue(en, out Event val))
+            var instance = evt.PageInstance;
+            if (instance.GlobalClone != null)
             {
-                return val;
+                instance = instance.GlobalClone;
             }
 
-            return null;
+            if (instance.Map != map || instance.X != x || instance.Y != y || instance.Z != z || instance.Passable)
+            {
+                continue;
+            }
+
+            blockerType = MovementBlockerType.Entity;
+            entityType = EntityType.Event;
+            return true;
         }
 
-        public void SendEvents()
+        return false;
+    }
+
+    public override void Move(Direction moveDir, Player forPlayer, bool dontUpdate = false,
+        bool correction = false)
+    {
+        lock (EntityLock)
         {
+            var oldMap = MapId;
+            base.Move(moveDir, forPlayer, dontUpdate, correction);
+
+            // Check for a warp, if so warp the player.
+            var attribute = MapController.Get(MapId).Attributes[X, Y];
+            if (attribute != null && attribute.Type == MapAttribute.Warp)
+            {
+                var warpAtt = (MapWarpAttribute)attribute;
+                var dir = Dir;
+                if (warpAtt.Direction != WarpDirection.Retain)
+                {
+                    dir = (Direction)(warpAtt.Direction - 1);
+                }
+
+                MapInstanceType? instanceType = null;
+                if (warpAtt.ChangeInstance)
+                {
+                    instanceType = warpAtt.InstanceType;
+                }
+
+                if (warpAtt.WarpSound != null)
+                {
+                    PacketSender.SendPlaySound(this, warpAtt.WarpSound);
+                }
+
+                Warp(warpAtt.MapId, warpAtt.X, warpAtt.Y, dir, false, 0, false, false, instanceType);
+            }
+
             foreach (var evt in EventLookup)
             {
-                if (evt.Value.PageInstance != null)
+                if (evt.Value.MapId == MapId)
                 {
-                    evt.Value.PageInstance.SendToPlayer();
-                }
-            }
-        }
-
-        [NotMapped, JsonIgnore]
-        private readonly ConcurrentQueue<StartCommonEventMetadata> _queueStartCommonEvent = new ConcurrentQueue<StartCommonEventMetadata>();
-
-        public class StartCommonEventMetadata
-        {
-            public string Command { get; }
-
-            public EventBase EventDescriptor { get; }
-
-            public string Parameter { get; }
-
-            public CommonEventTrigger Trigger { get; }
-
-            public StartCommonEventMetadata(
-                string command,
-                EventBase eventDescriptor,
-                string parameter,
-                CommonEventTrigger trigger
-            )
-            {
-                Command = command;
-                EventDescriptor = eventDescriptor;
-                Parameter = parameter;
-                Trigger = trigger;
-            }
-        }
-
-        public void EnqueueStartCommonEvent(
-            EventBase eventDescriptor,
-            CommonEventTrigger trigger = CommonEventTrigger.None,
-            string command = default,
-            string parameter = default
-        ) 
-        {
-            if (eventDescriptor == null)
-            {
-                return;
-            }
-
-            _queueStartCommonEvent.Enqueue(new StartCommonEventMetadata(command ?? string.Empty, eventDescriptor, parameter ?? string.Empty, trigger));
-        }
-
-        public bool UnsafeStartCommonEvent(
-            EventBase baseEvent,
-            CommonEventTrigger trigger = CommonEventTrigger.None,
-            string command = "",
-            string param = ""
-        )
-        {
-            if (baseEvent == null)
-            {
-                return false;
-            }
-
-            if (!baseEvent.CommonEvent && baseEvent.MapId != Guid.Empty)
-            {
-                return false;
-            }
-
-            if (EventBaseIdLookup.ContainsKey(baseEvent.Id) && !baseEvent.CanRunInParallel)
-            {
-                return false;
-            }
-
-            lock (mEventLock)
-            {
-                mCommonEventLaunches++;
-                var commonEventLaunch = mCommonEventLaunches;
-
-                //Use Fake Ids for Common Events Since they are not tied to maps and such
-                var evtId = Guid.NewGuid();
-                var mapId = Guid.Empty;
-
-                Event newEvent = null;
-
-                //Try to Spawn a PageInstance.. if we can
-                for (var i = baseEvent.Pages.Count - 1; i >= 0; i--)
-                {
-                    if ((trigger == CommonEventTrigger.None || baseEvent.Pages[i].CommonTrigger == trigger) && Conditions.CanSpawnPage(baseEvent.Pages[i], this, null))
-                    {
-                        if (trigger == CommonEventTrigger.SlashCommand && command.ToLower() != baseEvent.Pages[i].TriggerCommand.ToLower())
-                        {
-                            continue;
-                        }
-
-                        if (trigger == CommonEventTrigger.PlayerVariableChange && param != baseEvent.Pages[i].TriggerId.ToString())
-                        {
-                            continue;
-                        }
-
-                        if (trigger == CommonEventTrigger.ServerVariableChange && param != baseEvent.Pages[i].TriggerId.ToString())
-                        {
-                            continue;
-                        }
-
-                        newEvent = new Event(evtId, null, this, baseEvent)
-                        {
-                            MapId = mapId,
-                            SpawnX = -1,
-                            SpawnY = -1
-                        };
-                        newEvent.PageInstance = new EventPageInstance(
-                            baseEvent, baseEvent.Pages[i], mapId, MapInstanceId, newEvent, this
-                        );
-
-                        newEvent.PageIndex = i;
-
-                        if (trigger == CommonEventTrigger.SlashCommand)
-                        {
-                            //Split params up
-                            var prams = param.Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
-                            for (var x = 0; x < prams.Length; x++)
-                            {
-                                newEvent.SetParam("slashParam" + x, prams[x]);
-                            }
-                        }
-
-                        switch (trigger)
-                        {
-                            case CommonEventTrigger.None:
-                                break;
-                            case CommonEventTrigger.Login:
-                                break;
-                            case CommonEventTrigger.LevelUp:
-                                break;
-                            case CommonEventTrigger.OnRespawn:
-                                break;
-                            case CommonEventTrigger.SlashCommand:
-                                break;
-                            case CommonEventTrigger.Autorun:
-                                break;
-                            case CommonEventTrigger.PVPKill:
-                                //Add victim as a parameter
-                                newEvent.SetParam("victim", param);
-
-                                break;
-                            case CommonEventTrigger.PVPDeath:
-                                //Add killer as a parameter
-                                newEvent.SetParam("killer", param);
-
-                                break;
-                            case CommonEventTrigger.PlayerInteract:
-                                //Interactee as a parameter
-                                newEvent.SetParam("triggered", param);
-
-                                break;
-                            case CommonEventTrigger.GuildMemberJoined:
-                            case CommonEventTrigger.GuildMemberKicked:
-                            case CommonEventTrigger.GuildMemberLeft:
-                                newEvent.SetParam("member", param);
-                                newEvent.SetParam("guild", command);
-
-                                break;
-                        }
-
-                        var newStack = new CommandInstance(newEvent.PageInstance.MyPage);
-                        newEvent.CallStack.Push(newStack);
-
-                        break;
-                    }
-                }
-
-                if (newEvent != null)
-                {
-                    EventLookup.AddOrUpdate(evtId, newEvent, (key, oldValue) => newEvent);
-                    EventBaseIdLookup.AddOrUpdate(baseEvent.Id, newEvent, (key, oldvalue) => newEvent);
-                    return true;
-                }
-                return false;
-            }
-        }
-
-        /// <inheritdoc />
-        public override bool CanMoveInDirection(
-            Direction direction,
-            out MovementBlockerType blockerType,
-            out EntityType entityType
-        )
-        {
-            entityType = default;
-
-            // If crafting or locked by event return blocked
-            if (OpenCraftingTableId != default && CraftingState != default)
-            {
-                blockerType = MovementBlockerType.OutOfBounds;
-                return false;
-            }
-
-            // ReSharper disable once InvertIf
-            if (EventLookup.Values.Any(@event => @event.HoldingPlayer))
-            {
-                blockerType = MovementBlockerType.OutOfBounds;
-                return false;
-            }
-
-            return base.CanMoveInDirection(direction, out blockerType, out entityType);
-        }
-
-        protected override bool CanPassPlayer(MapController targetMap)
-        {
-            return Options.Instance.Passability.Passable[(int)targetMap.ZoneType];
-        }
-
-        protected override bool IsBlockedByEvent(MapInstance mapInstance, int tileX, int tileY)
-        {
-            return false;
-        }
-
-        protected override bool TryGetBlockerOnTile(MapController map, int x, int y, int z, out MovementBlockerType blockerType, out EntityType entityType)
-        {
-            if (base.TryGetBlockerOnTile(map, x, y, z, out blockerType, out entityType))
-            {
-                return true;
-            }
-
-            foreach (var evt in EventLookup.Values.Where(evt => evt.PageInstance != default))
-            {
-                var instance = evt.PageInstance;
-                if (instance.GlobalClone != null)
-                {
-                    instance = instance.GlobalClone;
-                }
-
-                if (instance.Map != map || instance.X != x || instance.Y != y || instance.Z != z || instance.Passable)
-                {
-                    continue;
-                }
-
-                blockerType = MovementBlockerType.Entity;
-                entityType = EntityType.Event;
-                return true;
-            }
-
-            return false;
-        }
-
-        public override void Move(Direction moveDir, Player forPlayer, bool dontUpdate = false,
-            bool correction = false)
-        {
-            lock (EntityLock)
-            {
-                var oldMap = MapId;
-                base.Move(moveDir, forPlayer, dontUpdate, correction);
-
-                // Check for a warp, if so warp the player.
-                var attribute = MapController.Get(MapId).Attributes[X, Y];
-                if (attribute != null && attribute.Type == MapAttribute.Warp)
-                {
-                    var warpAtt = (MapWarpAttribute)attribute;
-                    var dir = Dir;
-                    if (warpAtt.Direction != WarpDirection.Retain)
-                    {
-                        dir = (Direction)(warpAtt.Direction - 1);
-                    }
-
-                    MapInstanceType? instanceType = null;
-                    if (warpAtt.ChangeInstance)
-                    {
-                        instanceType = warpAtt.InstanceType;
-                    }
-
-                    if (warpAtt.WarpSound != null)
-                    {
-                        PacketSender.SendPlaySound(this, warpAtt.WarpSound);
-                    }
-
-                    Warp(warpAtt.MapId, warpAtt.X, warpAtt.Y, dir, false, 0, false, false, instanceType);
-                }
-
-                foreach (var evt in EventLookup)
-                {
-                    if (evt.Value.MapId == MapId)
-                    {
-                        if (evt.Value.PageInstance != null && evt.Value.PageInstance.MapId == MapId)
-                        {
-                            var x = evt.Value.PageInstance.GlobalClone?.X ?? evt.Value.PageInstance.X;
-                            var y = evt.Value.PageInstance.GlobalClone?.Y ?? evt.Value.PageInstance.Y;
-                            var z = evt.Value.PageInstance.GlobalClone?.Z ?? evt.Value.PageInstance.Z;
-                            if (x == X && y == Y && z == Z)
-                            {
-                                HandleEventCollision(evt.Value, -1);
-                            }
-                        }
-                    }
-                }
-
-                // If we've changed maps, start relevant events!
-                if (oldMap != MapId)
-                {
-                    StartCommonEventsWithTrigger(CommonEventTrigger.MapChanged);
-                }
-            }
-        }
-
-        public void TryBumpEvent(Guid mapId, Guid eventId)
-        {
-            foreach (var evt in EventLookup)
-            {
-                if (evt.Value.MapId == mapId)
-                {
-                    if (evt.Value.PageInstance != null && evt.Value.PageInstance.MapId == mapId && evt.Value.BaseEvent.Id == eventId)
+                    if (evt.Value.PageInstance != null && evt.Value.PageInstance.MapId == MapId)
                     {
                         var x = evt.Value.PageInstance.GlobalClone?.X ?? evt.Value.PageInstance.X;
                         var y = evt.Value.PageInstance.GlobalClone?.Y ?? evt.Value.PageInstance.Y;
                         var z = evt.Value.PageInstance.GlobalClone?.Z ?? evt.Value.PageInstance.Z;
-                        if (IsOneBlockAway(mapId, x, y, z))
+                        if (x == X && y == Y && z == Z)
                         {
-                            if (evt.Value.PageInstance.Trigger != EventTrigger.PlayerBump)
-                            {
-                                return;
-                            }
-
-                            if (evt.Value.CallStack.Count != 0)
-                            {
-                                return;
-                            }
-
-                            var newStack = new CommandInstance(evt.Value.PageInstance.MyPage);
-                            evt.Value.CallStack.Push(newStack);
-                        }
-                    }
-                }
-            }
-        }
-
-        public void HandleEventCollision(Event evt, int pageNum)
-        {
-            var eventInstance = evt;
-            if (evt.Player == null) //Global
-            {
-                eventInstance = null;
-                foreach (var e in EventLookup)
-                {
-                    if (e.Value.BaseEvent.Id == evt.BaseEvent.Id)
-                    {
-                        if (e.Value.PageInstance.MyPage == e.Value.BaseEvent.Pages[pageNum])
-                        {
-                            eventInstance = e.Value;
-
-                            break;
+                            HandleEventCollision(evt.Value, -1);
                         }
                     }
                 }
             }
 
-            if (eventInstance != null)
+            // If we've changed maps, start relevant events!
+            if (oldMap != MapId)
             {
-                if (eventInstance.PageInstance.Trigger != EventTrigger.PlayerCollide)
+                StartCommonEventsWithTrigger(CommonEventTrigger.MapChanged);
+            }
+        }
+    }
+
+    public void TryBumpEvent(Guid mapId, Guid eventId)
+    {
+        foreach (var evt in EventLookup)
+        {
+            if (evt.Value.MapId == mapId)
+            {
+                if (evt.Value.PageInstance != null && evt.Value.PageInstance.MapId == mapId && evt.Value.BaseEvent.Id == eventId)
                 {
-                    return;
-                }
-
-                if (eventInstance.CallStack.Count != 0)
-                {
-                    return;
-                }
-
-                var newStack = new CommandInstance(eventInstance.PageInstance.MyPage);
-                eventInstance.CallStack.Push(newStack);
-            }
-        }
-
-        /// <summary>
-        /// Update the cooldown for a specific item.
-        /// </summary>
-        /// <param name="item">The <see cref="ItemBase"/> to update the cooldown for.</param>
-        public void UpdateCooldown(ItemBase item)
-        {
-            if (item == null)
-            {
-                return;
-            }
-
-            // Are we dealing with a cooldown group?
-            if (!string.IsNullOrWhiteSpace(item.CooldownGroup))
-            {
-                // Yes, so handle it!
-                UpdateCooldownGroup(GameObjectType.Item, item.CooldownGroup, item.Cooldown, item.IgnoreCooldownReduction);
-            }
-            else
-            {
-                // No, handle singular cooldown as normal.
-
-                var cooldownReduction = 1 - (item.IgnoreCooldownReduction ? 0 : GetEquipmentBonusEffect(ItemEffect.CooldownReduction) / 100f);
-                AssignItemCooldown(item.Id, Timing.Global.MillisecondsUtc + (long)(item.Cooldown * cooldownReduction));
-                PacketSender.SendItemCooldown(this, item.Id);
-            }
-        }
-
-        /// <summary>
-        /// Update the cooldown for a specific spell.
-        /// </summary>
-        /// <param name="item">The <see cref="SpellBase"/> to update the cooldown for.</param>
-        public void UpdateCooldown(SpellBase spell)
-        {
-            if (spell == null)
-            {
-                return;
-            }
-
-            // Are we dealing with a cooldown group?
-            if (spell.CooldownGroup.Trim().Length > 0)
-            {
-                // Yes, so handle it!
-                UpdateCooldownGroup(GameObjectType.Spell, spell.CooldownGroup, spell.CooldownDuration, spell.IgnoreCooldownReduction);
-            }
-            else
-            {
-                // No, handle singular cooldown as normal.
-                var cooldownReduction = 1 - (spell.IgnoreCooldownReduction ? 0 : GetEquipmentBonusEffect(ItemEffect.CooldownReduction) / 100f);
-                AssignSpellCooldown(spell.Id, Timing.Global.MillisecondsUtc + (long)(spell.CooldownDuration * cooldownReduction));
-                PacketSender.SendSpellCooldown(this, spell.Id);
-            }
-        }
-
-        /// <summary>
-        /// Forces an update of the global cooldown.
-        /// Does nothing when disabled by configuration.
-        /// </summary>
-        public void UpdateGlobalCooldown()
-        {
-            // Are we allowed to execute this code?
-            if (!Options.Combat.EnableGlobalCooldowns)
-            {
-                return;
-            }
-
-            // Calculate our global cooldown and set it.
-            var cooldownReduction = 1 - GetEquipmentBonusEffect(ItemEffect.CooldownReduction) / 100f;
-            mGlobalCooldownTimer = Timing.Global.MillisecondsUtc + (long)(Options.Combat.GlobalCooldownDuration * cooldownReduction);
-
-
-            // Send these cooldowns to the user!
-            PacketSender.SendGlobalCooldown(this, mGlobalCooldownTimer);
-        }
-
-        /// <summary>
-        /// Update all cooldowns within the specified cooldown group on a type of object, or all when configured as such.
-        /// </summary>
-        /// <param name="type">The <see cref="GameObjectType"/> to set trigger the cooldown group for. Currently only accepts Items and Spells</param>
-        /// <param name="group">The cooldown group to trigger.</param>
-        /// <param name="cooldown">The base cooldown of the object that triggered this cooldown group.</param>
-        /// <param name="ignoreCdr">Whether or not this item/spell is set to ignore cdr, in which case the group will ignore it too.</param>
-        private void UpdateCooldownGroup(GameObjectType type, string group, int cooldown, bool ignoreCdr)
-        {
-            // We're only dealing with these two types for now.
-            if (type != GameObjectType.Item && type != GameObjectType.Spell)
-            {
-                return;
-            }
-
-            var cooldownReduction = 1 - (ignoreCdr ? 0 : GetEquipmentBonusEffect(ItemEffect.CooldownReduction) / 100f);
-
-            // Retrieve a list of all items and/or spells depending on our settings to set the cooldown for.
-            var matchingItems = Array.Empty<ItemBase>();
-            var matchingSpells = Array.Empty<SpellBase>();
-            var itemsUpdated = false;
-            var spellsUpdated = false;
-
-            if (type == GameObjectType.Item || Options.Combat.LinkSpellAndItemCooldowns)
-            {
-                matchingItems = ItemBase.GetCooldownGroup(group);
-            }
-            if (type == GameObjectType.Spell || Options.Combat.LinkSpellAndItemCooldowns)
-            {
-                matchingSpells = SpellBase.GetCooldownGroup(group);
-            }
-
-            // Set our matched cooldown, should we need to use it.
-            var matchedCooldowntime = cooldown;
-            if (Options.Combat.MatchGroupCooldownHighest)
-            {
-                // Get our highest cooldown value from all available options.
-                matchedCooldowntime = Math.Max(
-                    matchingItems.Length > 0 ? matchingItems.Max(i => i.Cooldown) : 0,
-                    matchingSpells.Length > 0 ? matchingSpells.Max(i => i.CooldownDuration) : 0);
-            }
-
-            // Set the cooldown for all items matching this cooldown group.
-            var baseTime = Timing.Global.MillisecondsUtc;
-            if (type == GameObjectType.Item || Options.Combat.LinkSpellAndItemCooldowns)
-            {
-                foreach (var item in matchingItems)
-                {
-                    // Do we have to match our cooldown times, or do we use each individual item cooldown?
-                    var tempCooldown = Options.Combat.MatchGroupCooldowns ? matchedCooldowntime : item.Cooldown;
-
-                    // Asign it! Assuming our cooldown isn't already going..
-                    if (!ItemCooldowns.ContainsKey(item.Id) || ItemCooldowns[item.Id] < Timing.Global.MillisecondsUtc)
+                    var x = evt.Value.PageInstance.GlobalClone?.X ?? evt.Value.PageInstance.X;
+                    var y = evt.Value.PageInstance.GlobalClone?.Y ?? evt.Value.PageInstance.Y;
+                    var z = evt.Value.PageInstance.GlobalClone?.Z ?? evt.Value.PageInstance.Z;
+                    if (IsOneBlockAway(mapId, x, y, z))
                     {
-                        AssignItemCooldown(item.Id, baseTime + (long)(tempCooldown * cooldownReduction));
-                        itemsUpdated = true;
+                        if (evt.Value.PageInstance.Trigger != EventTrigger.PlayerBump)
+                        {
+                            return;
+                        }
+
+                        if (evt.Value.CallStack.Count != 0)
+                        {
+                            return;
+                        }
+
+                        var newStack = new CommandInstance(evt.Value.PageInstance.MyPage);
+                        evt.Value.CallStack.Push(newStack);
                     }
                 }
             }
+        }
+    }
 
-            // Set the cooldown for all Spells matching this cooldown group.
-            if (type == GameObjectType.Spell || Options.Combat.LinkSpellAndItemCooldowns)
+    public void HandleEventCollision(Event evt, int pageNum)
+    {
+        var eventInstance = evt;
+        if (evt.Player == null) //Global
+        {
+            eventInstance = null;
+            foreach (var e in EventLookup)
             {
-                foreach (var spell in matchingSpells)
+                if (e.Value.BaseEvent.Id == evt.BaseEvent.Id)
                 {
-                    // Do we have to match our cooldown times, or do we use each individual item cooldown?
-                    var tempCooldown = Options.Combat.MatchGroupCooldowns ? matchedCooldowntime : spell.CooldownDuration;
-
-                    // Asign it! Assuming our cooldown isn't already going...
-                    if (!SpellCooldowns.ContainsKey(spell.Id) || SpellCooldowns[spell.Id] < Timing.Global.MillisecondsUtc)
+                    if (e.Value.PageInstance.MyPage == e.Value.BaseEvent.Pages[pageNum])
                     {
-                        AssignSpellCooldown(spell.Id, baseTime + (long)(tempCooldown * cooldownReduction));
-                        spellsUpdated = true;
+                        eventInstance = e.Value;
+
+                        break;
                     }
                 }
             }
-
-            // Send all of our updated cooldowns.
-            if (itemsUpdated)
-            {
-                PacketSender.SendItemCooldowns(this);
-            }
-            if (spellsUpdated)
-            {
-                PacketSender.SendSpellCooldowns(this);
-            }
         }
 
-        /// <summary>
-        /// Assign a cooldown time to a specified item.
-        /// WARNING: Makes no checks at all to see whether this SHOULD happen!
-        /// </summary>
-        /// <param name="itemId">The <see cref="ItemBase"/> id to assign the cooldown for.</param>
-        /// <param name="cooldownTime">The cooldown time to assign.</param>
-        private void AssignItemCooldown(Guid itemId, long cooldownTime)
+        if (eventInstance != null)
         {
-            // Do we already have a cooldown entry for this item?
-            if (ItemCooldowns.ContainsKey(itemId))
+            if (eventInstance.PageInstance.Trigger != EventTrigger.PlayerCollide)
             {
-                ItemCooldowns[itemId] = cooldownTime;
+                return;
             }
-            else
+
+            if (eventInstance.CallStack.Count != 0)
             {
-                ItemCooldowns.TryAdd(itemId, cooldownTime);
+                return;
             }
+
+            var newStack = new CommandInstance(eventInstance.PageInstance.MyPage);
+            eventInstance.CallStack.Push(newStack);
+        }
+    }
+
+    /// <summary>
+    /// Update the cooldown for a specific item.
+    /// </summary>
+    /// <param name="item">The <see cref="ItemBase"/> to update the cooldown for.</param>
+    public void UpdateCooldown(ItemBase item)
+    {
+        if (item == null)
+        {
+            return;
         }
 
-        /// <summary>
-        /// Assign a cooldown time to a specified spell.
-        /// WARNING: Makes no checks at all to see whether this SHOULD happen!
-        /// </summary>
-        /// <param name="itemId">The <see cref="SpellBase"/> id to assign the cooldown for.</param>
-        /// <param name="cooldownTime">The cooldown time to assign.</param>
-        private void AssignSpellCooldown(Guid spellId, long cooldownTime)
+        // Are we dealing with a cooldown group?
+        if (!string.IsNullOrWhiteSpace(item.CooldownGroup))
         {
-            // Do we already have a cooldown entry for this item?
-            if (SpellCooldowns.ContainsKey(spellId))
-            {
-                SpellCooldowns[spellId] = cooldownTime;
-            }
-            else
-            {
-                SpellCooldowns.TryAdd(spellId, cooldownTime);
-            }
+            // Yes, so handle it!
+            UpdateCooldownGroup(GameObjectType.Item, item.CooldownGroup, item.Cooldown, item.IgnoreCooldownReduction);
+        }
+        else
+        {
+            // No, handle singular cooldown as normal.
+
+            var cooldownReduction = 1 - (item.IgnoreCooldownReduction ? 0 : GetEquipmentBonusEffect(ItemEffect.CooldownReduction) / 100f);
+            AssignItemCooldown(item.Id, Timing.Global.MillisecondsUtc + (long)(item.Cooldown * cooldownReduction));
+            PacketSender.SendItemCooldown(this, item.Id);
+        }
+    }
+
+    /// <summary>
+    /// Update the cooldown for a specific spell.
+    /// </summary>
+    /// <param name="item">The <see cref="SpellBase"/> to update the cooldown for.</param>
+    public void UpdateCooldown(SpellBase spell)
+    {
+        if (spell == null)
+        {
+            return;
         }
 
-        /// <summary>
-        /// Remove the cooldown time entry for a specified Item.
-        /// </summary>
-        /// <param name="itemId">The <see cref="ItemBase"/> id to remove the cooldown entry for.</param>
-        private void RemoveItemCooldown(Guid itemId)
+        // Are we dealing with a cooldown group?
+        if (spell.CooldownGroup.Trim().Length > 0)
         {
-            ItemCooldowns.TryRemove(itemId, out _);
+            // Yes, so handle it!
+            UpdateCooldownGroup(GameObjectType.Spell, spell.CooldownGroup, spell.CooldownDuration, spell.IgnoreCooldownReduction);
+        }
+        else
+        {
+            // No, handle singular cooldown as normal.
+            var cooldownReduction = 1 - (spell.IgnoreCooldownReduction ? 0 : GetEquipmentBonusEffect(ItemEffect.CooldownReduction) / 100f);
+            AssignSpellCooldown(spell.Id, Timing.Global.MillisecondsUtc + (long)(spell.CooldownDuration * cooldownReduction));
+            PacketSender.SendSpellCooldown(this, spell.Id);
+        }
+    }
+
+    /// <summary>
+    /// Forces an update of the global cooldown.
+    /// Does nothing when disabled by configuration.
+    /// </summary>
+    public void UpdateGlobalCooldown()
+    {
+        // Are we allowed to execute this code?
+        if (!Options.Combat.EnableGlobalCooldowns)
+        {
+            return;
         }
 
-        /// <summary>
-        /// Remove the cooldown time entry for a specified Spell.
-        /// </summary>
-        /// <param name="itemId">The <see cref="SpellBase"/> id to remove the cooldown entry for.</param>
-        private void RemoveSpellCooldown(Guid itemId)
+        // Calculate our global cooldown and set it.
+        var cooldownReduction = 1 - GetEquipmentBonusEffect(ItemEffect.CooldownReduction) / 100f;
+        mGlobalCooldownTimer = Timing.Global.MillisecondsUtc + (long)(Options.Combat.GlobalCooldownDuration * cooldownReduction);
+
+
+        // Send these cooldowns to the user!
+        PacketSender.SendGlobalCooldown(this, mGlobalCooldownTimer);
+    }
+
+    /// <summary>
+    /// Update all cooldowns within the specified cooldown group on a type of object, or all when configured as such.
+    /// </summary>
+    /// <param name="type">The <see cref="GameObjectType"/> to set trigger the cooldown group for. Currently only accepts Items and Spells</param>
+    /// <param name="group">The cooldown group to trigger.</param>
+    /// <param name="cooldown">The base cooldown of the object that triggered this cooldown group.</param>
+    /// <param name="ignoreCdr">Whether or not this item/spell is set to ignore cdr, in which case the group will ignore it too.</param>
+    private void UpdateCooldownGroup(GameObjectType type, string group, int cooldown, bool ignoreCdr)
+    {
+        // We're only dealing with these two types for now.
+        if (type != GameObjectType.Item && type != GameObjectType.Spell)
         {
-            SpellCooldowns.TryRemove(itemId, out _);
+            return;
         }
 
-        /// <summary>
-        /// Remove all stale spell cooldowns.
-        /// </summary>
-        private void RemoveStaleSpellCooldowns()
+        var cooldownReduction = 1 - (ignoreCdr ? 0 : GetEquipmentBonusEffect(ItemEffect.CooldownReduction) / 100f);
+
+        // Retrieve a list of all items and/or spells depending on our settings to set the cooldown for.
+        var matchingItems = Array.Empty<ItemBase>();
+        var matchingSpells = Array.Empty<SpellBase>();
+        var itemsUpdated = false;
+        var spellsUpdated = false;
+
+        if (type == GameObjectType.Item || Options.Combat.LinkSpellAndItemCooldowns)
         {
-            var spellcds = SpellCooldowns.ToArray();
-            foreach (var cd in spellcds)
+            matchingItems = ItemBase.GetCooldownGroup(group);
+        }
+        if (type == GameObjectType.Spell || Options.Combat.LinkSpellAndItemCooldowns)
+        {
+            matchingSpells = SpellBase.GetCooldownGroup(group);
+        }
+
+        // Set our matched cooldown, should we need to use it.
+        var matchedCooldowntime = cooldown;
+        if (Options.Combat.MatchGroupCooldownHighest)
+        {
+            // Get our highest cooldown value from all available options.
+            matchedCooldowntime = Math.Max(
+                matchingItems.Length > 0 ? matchingItems.Max(i => i.Cooldown) : 0,
+                matchingSpells.Length > 0 ? matchingSpells.Max(i => i.CooldownDuration) : 0);
+        }
+
+        // Set the cooldown for all items matching this cooldown group.
+        var baseTime = Timing.Global.MillisecondsUtc;
+        if (type == GameObjectType.Item || Options.Combat.LinkSpellAndItemCooldowns)
+        {
+            foreach (var item in matchingItems)
             {
-                if (cd.Value <= Timing.Global.Milliseconds)
+                // Do we have to match our cooldown times, or do we use each individual item cooldown?
+                var tempCooldown = Options.Combat.MatchGroupCooldowns ? matchedCooldowntime : item.Cooldown;
+
+                // Asign it! Assuming our cooldown isn't already going..
+                if (!ItemCooldowns.ContainsKey(item.Id) || ItemCooldowns[item.Id] < Timing.Global.MillisecondsUtc)
                 {
-                    RemoveSpellCooldown(cd.Key);
+                    AssignItemCooldown(item.Id, baseTime + (long)(tempCooldown * cooldownReduction));
+                    itemsUpdated = true;
                 }
             }
         }
 
-        /// <summary>
-        /// Remove all stale item cooldowns.
-        /// </summary>
-        private void RemoveStaleItemCooldowns()
+        // Set the cooldown for all Spells matching this cooldown group.
+        if (type == GameObjectType.Spell || Options.Combat.LinkSpellAndItemCooldowns)
         {
-            var itemcds = ItemCooldowns.ToArray();
-            foreach (var cd in itemcds)
+            foreach (var spell in matchingSpells)
             {
-                if (cd.Value <= Timing.Global.Milliseconds)
+                // Do we have to match our cooldown times, or do we use each individual item cooldown?
+                var tempCooldown = Options.Combat.MatchGroupCooldowns ? matchedCooldowntime : spell.CooldownDuration;
+
+                // Asign it! Assuming our cooldown isn't already going...
+                if (!SpellCooldowns.ContainsKey(spell.Id) || SpellCooldowns[spell.Id] < Timing.Global.MillisecondsUtc)
                 {
-                    RemoveItemCooldown(cd.Key);
+                    AssignSpellCooldown(spell.Id, baseTime + (long)(tempCooldown * cooldownReduction));
+                    spellsUpdated = true;
                 }
             }
         }
 
-        public bool TryChangeName(string newName)
+        // Send all of our updated cooldowns.
+        if (itemsUpdated)
         {
-            // Is the name available?
-            if (!FieldChecking.IsValidUsername(newName, Strings.Regex.username))
-            {
-                return false;
-            }
-
-            if (PlayerExists(newName))
-            {
-                return false;
-            }
-
-            // Change their name and force save it!
-            var oldName = Name;
-            Name = newName;
-            if (User?.Save() == UserSaveResult.DatabaseFailure)
-            {
-                Client?.LogAndDisconnect(Id, nameof(TryChangeName));
-                return false;
-            }
-
-            // Log the activity.
-            UserActivityHistory.LogActivity(UserId, Id, Client?.Ip, UserActivityHistory.PeerType.Client, UserActivityHistory.UserAction.NameChange, $"Changing Character name from {oldName} to {newName}");
-
-            // Send our data around!
-            PacketSender.SendEntityDataToProximity(this);
-
-            return true;
-
+            PacketSender.SendItemCooldowns(this);
         }
-
-        public bool TryAddToInstanceController()
+        if (spellsUpdated)
         {
-            if (InstanceProcessor.TryGetInstanceController(MapInstanceId, out var instanceController))
-            {
-                instanceController.AddPlayer(this);
-                return true;
-            }
+            PacketSender.SendSpellCooldowns(this);
+        }
+    }
 
+    /// <summary>
+    /// Assign a cooldown time to a specified item.
+    /// WARNING: Makes no checks at all to see whether this SHOULD happen!
+    /// </summary>
+    /// <param name="itemId">The <see cref="ItemBase"/> id to assign the cooldown for.</param>
+    /// <param name="cooldownTime">The cooldown time to assign.</param>
+    private void AssignItemCooldown(Guid itemId, long cooldownTime)
+    {
+        // Do we already have a cooldown entry for this item?
+        if (ItemCooldowns.ContainsKey(itemId))
+        {
+            ItemCooldowns[itemId] = cooldownTime;
+        }
+        else
+        {
+            ItemCooldowns.TryAdd(itemId, cooldownTime);
+        }
+    }
+
+    /// <summary>
+    /// Assign a cooldown time to a specified spell.
+    /// WARNING: Makes no checks at all to see whether this SHOULD happen!
+    /// </summary>
+    /// <param name="itemId">The <see cref="SpellBase"/> id to assign the cooldown for.</param>
+    /// <param name="cooldownTime">The cooldown time to assign.</param>
+    private void AssignSpellCooldown(Guid spellId, long cooldownTime)
+    {
+        // Do we already have a cooldown entry for this item?
+        if (SpellCooldowns.ContainsKey(spellId))
+        {
+            SpellCooldowns[spellId] = cooldownTime;
+        }
+        else
+        {
+            SpellCooldowns.TryAdd(spellId, cooldownTime);
+        }
+    }
+
+    /// <summary>
+    /// Remove the cooldown time entry for a specified Item.
+    /// </summary>
+    /// <param name="itemId">The <see cref="ItemBase"/> id to remove the cooldown entry for.</param>
+    private void RemoveItemCooldown(Guid itemId)
+    {
+        ItemCooldowns.TryRemove(itemId, out _);
+    }
+
+    /// <summary>
+    /// Remove the cooldown time entry for a specified Spell.
+    /// </summary>
+    /// <param name="itemId">The <see cref="SpellBase"/> id to remove the cooldown entry for.</param>
+    private void RemoveSpellCooldown(Guid itemId)
+    {
+        SpellCooldowns.TryRemove(itemId, out _);
+    }
+
+    /// <summary>
+    /// Remove all stale spell cooldowns.
+    /// </summary>
+    private void RemoveStaleSpellCooldowns()
+    {
+        var spellcds = SpellCooldowns.ToArray();
+        foreach (var cd in spellcds)
+        {
+            if (cd.Value <= Timing.Global.Milliseconds)
+            {
+                RemoveSpellCooldown(cd.Key);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Remove all stale item cooldowns.
+    /// </summary>
+    private void RemoveStaleItemCooldowns()
+    {
+        var itemcds = ItemCooldowns.ToArray();
+        foreach (var cd in itemcds)
+        {
+            if (cd.Value <= Timing.Global.Milliseconds)
+            {
+                RemoveItemCooldown(cd.Key);
+            }
+        }
+    }
+
+    public bool TryChangeName(string newName)
+    {
+        // Is the name available?
+        if (!FieldChecking.IsValidUsername(newName, Strings.Regex.username))
+        {
             return false;
         }
 
-        //TODO: Clean all of this stuff up
-
-        #region Temporary Values
-
-        [NotMapped, JsonIgnore] public bool InGame;
-
-        [NotMapped, JsonIgnore] public Guid LastMapEntered = Guid.Empty;
-
-        [JsonIgnore, NotMapped] public Client Client { get; set; }
-
-        [JsonIgnore, NotMapped]
-        public UserRights Power => Client?.Power ?? UserRights.None;
-
-        [JsonIgnore, NotMapped] private bool mSentMap;
-
-        [JsonIgnore, NotMapped] private int mCommonEventLaunches = 0;
-
-        [JsonIgnore, NotMapped] private object mEventLock = new object();
-
-        [JsonIgnore, NotMapped]
-        public ConcurrentDictionary<Guid, Event> EventLookup = new ConcurrentDictionary<Guid, Event>();
-
-        [JsonIgnore, NotMapped]
-        public ConcurrentDictionary<MapTileLoc, Event> EventTileLookup = new ConcurrentDictionary<MapTileLoc, Event>();
-
-        [JsonIgnore, NotMapped]
-        public ConcurrentDictionary<Guid, Event> EventBaseIdLookup = new ConcurrentDictionary<Guid, Event>();
-
-        [JsonIgnore, NotMapped]
-        public ConcurrentDictionary<EventPageInstance, Event> GlobalPageInstanceLookup = new ConcurrentDictionary<EventPageInstance, Event>();
-
-        #endregion
-
-        #region Trading
-
-        [JsonProperty(nameof(Trading))]
-        private Guid JsonTradingId => Trading.Counterparty?.Id ?? Guid.Empty;
-
-        [JsonIgnore, NotMapped] public Trading Trading;
-
-        #endregion
-
-        #region Crafting
-
-        [NotMapped, JsonIgnore] public CraftingState CraftingState { get; set; }
-
-        [NotMapped, JsonIgnore] public Guid OpenCraftingTableId { get; set; }
-        
-        [NotMapped, JsonIgnore] public bool CraftJournalMode { get; set; }
-
-        #endregion
-
-        #region Parties
-
-        private List<Guid> JsonPartyIds => Party.Select(partyMember => partyMember?.Id ?? Guid.Empty).ToList();
-
-        private Guid JsonPartyRequesterId => PartyRequester?.Id ?? Guid.Empty;
-
-        private Dictionary<Guid, long> JsonPartyRequests => PartyRequests.ToDictionary(
-            pair => pair.Key?.Id ?? Guid.Empty, pair => pair.Value
-        );
-
-        [JsonIgnore, NotMapped] public List<Player> Party = new List<Player>();
-
-        [JsonIgnore, NotMapped] public Player PartyLeader => Party.FirstOrDefault();
-
-        [JsonIgnore, NotMapped] public Player PartyRequester;
-
-        [JsonIgnore, NotMapped] public Dictionary<Player, long> PartyRequests = new Dictionary<Player, long>();
-
-        #endregion
-
-        #region Friends
-
-        private Guid JsonFriendRequesterId => FriendRequester?.Id ?? Guid.Empty;
-
-        private Dictionary<Guid, long> JsonFriendRequests => FriendRequests.ToDictionary(
-            pair => pair.Key?.Id ?? Guid.Empty, pair => pair.Value
-        );
-
-        [JsonIgnore, NotMapped] public Player FriendRequester;
-
-        [JsonIgnore, NotMapped] public Dictionary<Player, long> FriendRequests = new Dictionary<Player, long>();
-
-        #endregion
-
-        #region Bag/Shops/etc
-
-        [JsonProperty(nameof(InBag))]
-        private bool JsonInBag => InBag != null;
-
-        [JsonProperty(nameof(InShop))]
-        private bool JsonInShop => InShop != null;
-
-        [JsonIgnore, NotMapped] public Bag InBag;
-        
-        [JsonIgnore, NotMapped] public bool IsInBag => InBag != null;
-
-        [JsonIgnore, NotMapped] public ShopBase InShop;
-
-        [NotMapped] public bool InBank => BankInterface != null;
-
-        [NotMapped][JsonIgnore] public BankInterface BankInterface;
-
-        #endregion
-
-        #region Item Cooldowns
-
-        [JsonIgnore, Column("ItemCooldowns")]
-        public string ItemCooldownsJson
+        if (PlayerExists(newName))
         {
-            get => JsonConvert.SerializeObject(ItemCooldowns);
-            set => ItemCooldowns = JsonConvert.DeserializeObject<ConcurrentDictionary<Guid, long>>(value ?? "{}");
+            return false;
         }
 
-        [JsonIgnore] public ConcurrentDictionary<Guid, long> ItemCooldowns = new ConcurrentDictionary<Guid, long>();
+        // Change their name and force save it!
+        var oldName = Name;
+        Name = newName;
+        if (User?.Save() == UserSaveResult.DatabaseFailure)
+        {
+            Client?.LogAndDisconnect(Id, nameof(TryChangeName));
+            return false;
+        }
 
-        #endregion
+        // Log the activity.
+        UserActivityHistory.LogActivity(UserId, Id, Client?.Ip, UserActivityHistory.PeerType.Client, UserActivityHistory.UserAction.NameChange, $"Changing Character name from {oldName} to {newName}");
+
+        // Send our data around!
+        PacketSender.SendEntityDataToProximity(this);
+
+        return true;
 
     }
 
-    public class CraftingState
+    public bool TryAddToInstanceController()
     {
-        public Guid Id { get; set; }
+        if (InstanceProcessor.TryGetInstanceController(MapInstanceId, out var instanceController))
+        {
+            instanceController.AddPlayer(this);
+            return true;
+        }
 
-        public int CraftCount { get; set; }
-
-        public int RemainingCount { get; set; }
-
-        public int DurationPerCraft { get; set; }
-
-        public long NextCraftCompletionTime { get; set; }
+        return false;
     }
 
+    //TODO: Clean all of this stuff up
+
+    #region Temporary Values
+
+    [NotMapped, JsonIgnore] public bool InGame;
+
+    [NotMapped, JsonIgnore] public Guid LastMapEntered = Guid.Empty;
+
+    [JsonIgnore, NotMapped] public Client Client { get; set; }
+
+    [JsonIgnore, NotMapped]
+    public UserRights Power => Client?.Power ?? UserRights.None;
+
+    [JsonIgnore, NotMapped] private bool mSentMap;
+
+    [JsonIgnore, NotMapped] private int mCommonEventLaunches = 0;
+
+    [JsonIgnore, NotMapped] private object mEventLock = new object();
+
+    [JsonIgnore, NotMapped]
+    public ConcurrentDictionary<Guid, Event> EventLookup = new ConcurrentDictionary<Guid, Event>();
+
+    [JsonIgnore, NotMapped]
+    public ConcurrentDictionary<MapTileLoc, Event> EventTileLookup = new ConcurrentDictionary<MapTileLoc, Event>();
+
+    [JsonIgnore, NotMapped]
+    public ConcurrentDictionary<Guid, Event> EventBaseIdLookup = new ConcurrentDictionary<Guid, Event>();
+
+    [JsonIgnore, NotMapped]
+    public ConcurrentDictionary<EventPageInstance, Event> GlobalPageInstanceLookup = new ConcurrentDictionary<EventPageInstance, Event>();
+
+    #endregion
+
+    #region Trading
+
+    [JsonProperty(nameof(Trading))]
+    private Guid JsonTradingId => Trading.Counterparty?.Id ?? Guid.Empty;
+
+    [JsonIgnore, NotMapped] public Trading Trading;
+
+    #endregion
+
+    #region Crafting
+
+    [NotMapped, JsonIgnore] public CraftingState CraftingState { get; set; }
+
+    [NotMapped, JsonIgnore] public Guid OpenCraftingTableId { get; set; }
+    
+    [NotMapped, JsonIgnore] public bool CraftJournalMode { get; set; }
+
+    #endregion
+
+    #region Parties
+
+    private List<Guid> JsonPartyIds => Party.Select(partyMember => partyMember?.Id ?? Guid.Empty).ToList();
+
+    private Guid JsonPartyRequesterId => PartyRequester?.Id ?? Guid.Empty;
+
+    private Dictionary<Guid, long> JsonPartyRequests => PartyRequests.ToDictionary(
+        pair => pair.Key?.Id ?? Guid.Empty, pair => pair.Value
+    );
+
+    [JsonIgnore, NotMapped] public List<Player> Party = new List<Player>();
+
+    [JsonIgnore, NotMapped] public Player PartyLeader => Party.FirstOrDefault();
+
+    [JsonIgnore, NotMapped] public Player PartyRequester;
+
+    [JsonIgnore, NotMapped] public Dictionary<Player, long> PartyRequests = new Dictionary<Player, long>();
+
+    #endregion
+
+    #region Friends
+
+    private Guid JsonFriendRequesterId => FriendRequester?.Id ?? Guid.Empty;
+
+    private Dictionary<Guid, long> JsonFriendRequests => FriendRequests.ToDictionary(
+        pair => pair.Key?.Id ?? Guid.Empty, pair => pair.Value
+    );
+
+    [JsonIgnore, NotMapped] public Player FriendRequester;
+
+    [JsonIgnore, NotMapped] public Dictionary<Player, long> FriendRequests = new Dictionary<Player, long>();
+
+    #endregion
+
+    #region Bag/Shops/etc
+
+    [JsonProperty(nameof(InBag))]
+    private bool JsonInBag => InBag != null;
+
+    [JsonProperty(nameof(InShop))]
+    private bool JsonInShop => InShop != null;
+
+    [JsonIgnore, NotMapped] public Bag InBag;
+    
+    [JsonIgnore, NotMapped] public bool IsInBag => InBag != null;
+
+    [JsonIgnore, NotMapped] public ShopBase InShop;
+
+    [NotMapped] public bool InBank => BankInterface != null;
+
+    [NotMapped][JsonIgnore] public BankInterface BankInterface;
+
+    #endregion
+
+    #region Item Cooldowns
+
+    [JsonIgnore, Column("ItemCooldowns")]
+    public string ItemCooldownsJson
+    {
+        get => JsonConvert.SerializeObject(ItemCooldowns);
+        set => ItemCooldowns = JsonConvert.DeserializeObject<ConcurrentDictionary<Guid, long>>(value ?? "{}");
+    }
+
+    [JsonIgnore] public ConcurrentDictionary<Guid, long> ItemCooldowns = new ConcurrentDictionary<Guid, long>();
+
+    #endregion
+
+}
+
+public class CraftingState
+{
+    public Guid Id { get; set; }
+
+    public int CraftCount { get; set; }
+
+    public int RemainingCount { get; set; }
+
+    public int DurationPerCraft { get; set; }
+
+    public long NextCraftCompletionTime { get; set; }
 }

--- a/Intersect.Server.Core/Entities/Projectile.cs
+++ b/Intersect.Server.Core/Entities/Projectile.cs
@@ -8,653 +8,651 @@ using Intersect.Server.Maps;
 using Intersect.Utilities;
 using MapAttribute = Intersect.Enums.MapAttribute;
 
-namespace Intersect.Server.Entities
+namespace Intersect.Server.Entities;
+
+
+public partial class Projectile : Entity
 {
 
-    public partial class Projectile : Entity
+    public ProjectileBase Base;
+
+    public bool HasGrappled;
+
+    public ItemBase Item;
+
+    private int _quantity;
+
+    private int _spawnCount;
+
+    private int _spawnedAmount;
+
+    private long _spawnTime;
+
+    private int _totalSpawns;
+
+    public Entity Owner;
+
+    // Individual Spawns
+    public ProjectileSpawn[] Spawns;
+
+    public SpellBase Spell;
+
+    public new Entity Target;
+
+    private int _lastTargetX = -1;
+
+    private int _lastTargetY = -1;
+
+    private Guid _lastTargetMapId = Guid.Empty;
+
+    public Projectile(
+        Entity owner,
+        SpellBase parentSpell,
+        ItemBase parentItem,
+        ProjectileBase projectile,
+        Guid mapId,
+        byte X,
+        byte Y,
+        byte z,
+        Direction direction,
+        Entity target
+    ) : base()
     {
+        Base = projectile;
+        Name = Base.Name;
+        Owner = owner;
+        Target = owner.Target;
+        Stat = owner.Stat;
+        MapId = mapId;
+        base.X = X;
+        base.Y = Y;
+        Z = z;
+        SetMaxVital(Vital.Health, 1);
+        SetVital(Vital.Health, 1);
+        Dir = direction;
+        Spell = parentSpell;
+        Item = parentItem;
 
-        public ProjectileBase Base;
-
-        public bool HasGrappled;
-
-        public ItemBase Item;
-
-        private int _quantity;
-
-        private int _spawnCount;
-
-        private int _spawnedAmount;
-
-        private long _spawnTime;
-
-        private int _totalSpawns;
-
-        public Entity Owner;
-
-        // Individual Spawns
-        public ProjectileSpawn[] Spawns;
-
-        public SpellBase Spell;
-
-        public new Entity Target;
-
-        private int _lastTargetX = -1;
-
-        private int _lastTargetY = -1;
-
-        private Guid _lastTargetMapId = Guid.Empty;
-
-        public Projectile(
-            Entity owner,
-            SpellBase parentSpell,
-            ItemBase parentItem,
-            ProjectileBase projectile,
-            Guid mapId,
-            byte X,
-            byte Y,
-            byte z,
-            Direction direction,
-            Entity target
-        ) : base()
+        Passable = true;
+        HideName = true;
+        for (var x = 0; x < ProjectileBase.SPAWN_LOCATIONS_WIDTH; x++)
         {
-            Base = projectile;
-            Name = Base.Name;
-            Owner = owner;
-            Target = owner.Target;
-            Stat = owner.Stat;
-            MapId = mapId;
-            base.X = X;
-            base.Y = Y;
-            Z = z;
-            SetMaxVital(Vital.Health, 1);
-            SetVital(Vital.Health, 1);
-            Dir = direction;
-            Spell = parentSpell;
-            Item = parentItem;
-
-            Passable = true;
-            HideName = true;
-            for (var x = 0; x < ProjectileBase.SPAWN_LOCATIONS_WIDTH; x++)
+            for (var y = 0; y < ProjectileBase.SPAWN_LOCATIONS_HEIGHT; y++)
             {
-                for (var y = 0; y < ProjectileBase.SPAWN_LOCATIONS_HEIGHT; y++)
+                for (var d = 0; d < ProjectileBase.MAX_PROJECTILE_DIRECTIONS; d++)
                 {
-                    for (var d = 0; d < ProjectileBase.MAX_PROJECTILE_DIRECTIONS; d++)
+                    if (Base.SpawnLocations[x, y].Directions[d] == true)
                     {
-                        if (Base.SpawnLocations[x, y].Directions[d] == true)
+                        _totalSpawns++;
+                    }
+                }
+            }
+        }
+
+        _totalSpawns *= Base.Quantity;
+        Spawns = new ProjectileSpawn[_totalSpawns];
+    }
+
+    /// <summary>
+    /// Adds projectile spawns based on predefined spawn locations and directions.
+    /// </summary>
+    private void AddProjectileSpawns()
+    {
+        // Iterate over all possible spawn locations within the defined width and height
+        for (byte x = 0; x < ProjectileBase.SPAWN_LOCATIONS_WIDTH; x++)
+        {
+            for (byte y = 0; y < ProjectileBase.SPAWN_LOCATIONS_HEIGHT; y++)
+            {
+                // Iterate over all possible directions a projectile can be spawned in
+                for (byte d = 0; d < ProjectileBase.MAX_PROJECTILE_DIRECTIONS; d++)
+                {
+                    // Check if the current direction is enabled for spawning at this location
+                    // and if the maximum number of spawned projectiles has not been reached
+                    if (Base.SpawnLocations[x, y].Directions[d] && _spawnedAmount < Spawns.Length)
+                    {
+                        // Calculate the spawn position and direction for the new projectile
+                        var s = new ProjectileSpawn(
+                            FindProjectileRotationDir(Dir, (Direction)d),
+                            (byte)(X + FindProjectileRotation(Dir, x - 2, y - 2, true)),
+                            (byte)(Y + FindProjectileRotation(Dir, x - 2, y - 2, false)),
+                            (byte)Z, MapId, MapInstanceId, Base, this
+                        );
+
+                        // Add the new spawn to the array and increment counters
+                        Spawns[_spawnedAmount] = s;
+                        _spawnedAmount++;
+                        _spawnCount++;
+
+                        if (CheckForCollision(s))
                         {
-                            _totalSpawns++;
+                            s.Dead = true;
                         }
                     }
                 }
             }
-
-            _totalSpawns *= Base.Quantity;
-            Spawns = new ProjectileSpawn[_totalSpawns];
         }
 
-        /// <summary>
-        /// Adds projectile spawns based on predefined spawn locations and directions.
-        /// </summary>
-        private void AddProjectileSpawns()
+        // Increment the quantity of projectiles spawned and update the spawn time based on the delay
+        _quantity++;
+        _spawnTime = Timing.Global.Milliseconds + Base.Delay;
+    }
+
+    /// <summary>
+    /// Finds the projectile rotation value based on the direction, position and the axis.
+    /// </summary>
+    /// <param name="direction">The direction of the projectile.</param>
+    /// <param name="x">The x-coordinate value.</param>
+    /// <param name="y">The y-coordinate value.</param>
+    /// <param name="isXAxis">True for horizontal (X-axis), false for vertical (Y-axis) calculation.</param>
+    /// <returns>The rotation value for the specified axis based on the direction.</returns>
+    private static int FindProjectileRotation(Direction direction, int x, int y, bool isXAxis)
+    {
+        if (isXAxis)
         {
-            // Iterate over all possible spawn locations within the defined width and height
-            for (byte x = 0; x < ProjectileBase.SPAWN_LOCATIONS_WIDTH; x++)
+            return direction switch
             {
-                for (byte y = 0; y < ProjectileBase.SPAWN_LOCATIONS_HEIGHT; y++)
+                Direction.Up => x,
+                Direction.Down => -x,
+                Direction.Left or Direction.UpLeft or Direction.DownLeft => y,
+                Direction.Right or Direction.UpRight or Direction.DownRight => -y,
+                _ => x,
+            };
+        }
+        else
+        {
+            return direction switch
+            {
+                Direction.Up => y,
+                Direction.Down => -y,
+                Direction.Left or Direction.UpLeft or Direction.DownLeft => -x,
+                Direction.Right or Direction.UpRight or Direction.DownRight => x,
+                _ => y,
+            };
+        }
+    }
+
+    private static Direction FindProjectileRotationDir(Direction entityDir, Direction projectionDir) =>
+        (Direction)ProjectileBase.ProjectileRotationDir[(int)entityDir * ProjectileBase.MAX_PROJECTILE_DIRECTIONS + (int)projectionDir];
+
+    public void Update(List<Guid> projDeaths, List<KeyValuePair<Guid, int>> spawnDeaths)
+    {
+        if (_quantity < Base.Quantity && Timing.Global.Milliseconds > _spawnTime)
+        {
+            AddProjectileSpawns();
+        }
+
+        ProcessFragments(projDeaths, spawnDeaths);
+    }
+
+    /// <summary>
+    /// Calculates the projectile range based on the given direction, range, and axis.
+    /// </summary>
+    /// <param name="direction">The direction of the projectile.</param>
+    /// <param name="range">The range of the projectile.</param>
+    /// <param name="isXAxis">True for horizontal (X-axis), false for vertical (Y-axis) calculation.</param>
+    /// <returns>The calculated range value.</returns>
+    private static float GetRange(Direction direction, float range, bool isXAxis)
+    {
+        if (isXAxis)
+        {
+            return direction switch
+            {
+                Direction.Left or Direction.UpLeft or Direction.DownLeft => -range,
+                Direction.Right or Direction.UpRight or Direction.DownRight => range,
+                _ => 0,
+            };
+        }
+        else
+        {
+            return direction switch
+            {
+                Direction.Up or Direction.UpLeft or Direction.UpRight => -range,
+                Direction.Down or Direction.DownLeft or Direction.DownRight => range,
+                _ => 0,
+            };
+        }
+    }
+
+    public void ProcessFragments(List<Guid> projDeaths, List<KeyValuePair<Guid, int>> spawnDeaths)
+    {
+        if (Base == null)
+        {
+            return;
+        }
+
+        if (_spawnCount != 0 || _quantity < Base.Quantity)
+        {
+            for (var i = 0; i < _spawnedAmount; i++)
+            {
+                var spawn = Spawns[i];
+                if (spawn != null)
                 {
-                    // Iterate over all possible directions a projectile can be spawned in
-                    for (byte d = 0; d < ProjectileBase.MAX_PROJECTILE_DIRECTIONS; d++)
+                    while (Timing.Global.Milliseconds > spawn.TransmissionTimer && Spawns[i] != null)
                     {
-                        // Check if the current direction is enabled for spawning at this location
-                        // and if the maximum number of spawned projectiles has not been reached
-                        if (Base.SpawnLocations[x, y].Directions[d] && _spawnedAmount < Spawns.Length)
+                        var x = spawn.X;
+                        var y = spawn.Y;
+                        var map = spawn.MapId;
+                        var killSpawn = false;
+                        if (!spawn.Dead)
                         {
-                            // Calculate the spawn position and direction for the new projectile
-                            var s = new ProjectileSpawn(
-                                FindProjectileRotationDir(Dir, (Direction)d),
-                                (byte)(X + FindProjectileRotation(Dir, x - 2, y - 2, true)),
-                                (byte)(Y + FindProjectileRotation(Dir, x - 2, y - 2, false)),
-                                (byte)Z, MapId, MapInstanceId, Base, this
-                            );
-
-                            // Add the new spawn to the array and increment counters
-                            Spawns[_spawnedAmount] = s;
-                            _spawnedAmount++;
-                            _spawnCount++;
-
-                            if (CheckForCollision(s))
+                            killSpawn = MoveFragment(spawn);
+                            if (!killSpawn && (x != spawn.X || y != spawn.Y || map != spawn.MapId))
                             {
-                                s.Dead = true;
+                                killSpawn = CheckForCollision(spawn);
                             }
                         }
-                    }
-                }
-            }
 
-            // Increment the quantity of projectiles spawned and update the spawn time based on the delay
-            _quantity++;
-            _spawnTime = Timing.Global.Milliseconds + Base.Delay;
-        }
-
-        /// <summary>
-        /// Finds the projectile rotation value based on the direction, position and the axis.
-        /// </summary>
-        /// <param name="direction">The direction of the projectile.</param>
-        /// <param name="x">The x-coordinate value.</param>
-        /// <param name="y">The y-coordinate value.</param>
-        /// <param name="isXAxis">True for horizontal (X-axis), false for vertical (Y-axis) calculation.</param>
-        /// <returns>The rotation value for the specified axis based on the direction.</returns>
-        private static int FindProjectileRotation(Direction direction, int x, int y, bool isXAxis)
-        {
-            if (isXAxis)
-            {
-                return direction switch
-                {
-                    Direction.Up => x,
-                    Direction.Down => -x,
-                    Direction.Left or Direction.UpLeft or Direction.DownLeft => y,
-                    Direction.Right or Direction.UpRight or Direction.DownRight => -y,
-                    _ => x,
-                };
-            }
-            else
-            {
-                return direction switch
-                {
-                    Direction.Up => y,
-                    Direction.Down => -y,
-                    Direction.Left or Direction.UpLeft or Direction.DownLeft => -x,
-                    Direction.Right or Direction.UpRight or Direction.DownRight => x,
-                    _ => y,
-                };
-            }
-        }
-
-        private static Direction FindProjectileRotationDir(Direction entityDir, Direction projectionDir) =>
-            (Direction)ProjectileBase.ProjectileRotationDir[(int)entityDir * ProjectileBase.MAX_PROJECTILE_DIRECTIONS + (int)projectionDir];
-
-        public void Update(List<Guid> projDeaths, List<KeyValuePair<Guid, int>> spawnDeaths)
-        {
-            if (_quantity < Base.Quantity && Timing.Global.Milliseconds > _spawnTime)
-            {
-                AddProjectileSpawns();
-            }
-
-            ProcessFragments(projDeaths, spawnDeaths);
-        }
-
-        /// <summary>
-        /// Calculates the projectile range based on the given direction, range, and axis.
-        /// </summary>
-        /// <param name="direction">The direction of the projectile.</param>
-        /// <param name="range">The range of the projectile.</param>
-        /// <param name="isXAxis">True for horizontal (X-axis), false for vertical (Y-axis) calculation.</param>
-        /// <returns>The calculated range value.</returns>
-        private static float GetRange(Direction direction, float range, bool isXAxis)
-        {
-            if (isXAxis)
-            {
-                return direction switch
-                {
-                    Direction.Left or Direction.UpLeft or Direction.DownLeft => -range,
-                    Direction.Right or Direction.UpRight or Direction.DownRight => range,
-                    _ => 0,
-                };
-            }
-            else
-            {
-                return direction switch
-                {
-                    Direction.Up or Direction.UpLeft or Direction.UpRight => -range,
-                    Direction.Down or Direction.DownLeft or Direction.DownRight => range,
-                    _ => 0,
-                };
-            }
-        }
-
-        public void ProcessFragments(List<Guid> projDeaths, List<KeyValuePair<Guid, int>> spawnDeaths)
-        {
-            if (Base == null)
-            {
-                return;
-            }
-
-            if (_spawnCount != 0 || _quantity < Base.Quantity)
-            {
-                for (var i = 0; i < _spawnedAmount; i++)
-                {
-                    var spawn = Spawns[i];
-                    if (spawn != null)
-                    {
-                        while (Timing.Global.Milliseconds > spawn.TransmissionTimer && Spawns[i] != null)
+                        if (killSpawn || spawn.Dead || CheckForCollision(spawn))
                         {
-                            var x = spawn.X;
-                            var y = spawn.Y;
-                            var map = spawn.MapId;
-                            var killSpawn = false;
-                            if (!spawn.Dead)
-                            {
-                                killSpawn = MoveFragment(spawn);
-                                if (!killSpawn && (x != spawn.X || y != spawn.Y || map != spawn.MapId))
-                                {
-                                    killSpawn = CheckForCollision(spawn);
-                                }
-                            }
-
-                            if (killSpawn || spawn.Dead || CheckForCollision(spawn))
-                            {
-                                spawnDeaths.Add(new KeyValuePair<Guid, int>(Id, i));
-                                Spawns[i] = null;
-                                _spawnCount--;
-                            }
+                            spawnDeaths.Add(new KeyValuePair<Guid, int>(Id, i));
+                            Spawns[i] = null;
+                            _spawnCount--;
                         }
                     }
                 }
             }
-            else
+        }
+        else
+        {
+            lock (EntityLock)
             {
-                lock (EntityLock)
-                {
-                    projDeaths.Add(Id);
-                    Die(false);
-                }
+                projDeaths.Add(Id);
+                Die(false);
             }
         }
+    }
 
-        /// <summary>
-        /// Checks for collision between the projectile with other entities and attributes on the map.
-        /// </summary>
-        /// <param name="spawn">The projectile spawn information.</param>
-        /// <returns>True if the projectile collides with an entity or attributes, false otherwise.</returns>
-        public bool CheckForCollision(ProjectileSpawn spawn)
+    /// <summary>
+    /// Checks for collision between the projectile with other entities and attributes on the map.
+    /// </summary>
+    /// <param name="spawn">The projectile spawn information.</param>
+    /// <returns>True if the projectile collides with an entity or attributes, false otherwise.</returns>
+    public bool CheckForCollision(ProjectileSpawn spawn)
+    {
+        if (spawn == null)
         {
-            if (spawn == null)
+            return false;
+        }
+
+        var killSpawn = MoveFragment(spawn, false);
+
+        //Check Map Entities For Hits
+        var map = MapController.Get(spawn.MapId);
+        if (map == null)
+        {
+            return false;
+        }
+
+        var roundedX = MathF.Round(spawn.X);
+        var roundedY = MathF.Round(spawn.Y);
+
+        //Checking if the coordinates are within the map boundaries
+        if (roundedX < 0 || roundedX >= Options.MapWidth ||
+            roundedY < 0 || roundedY >= Options.MapHeight)
+        {
+            return false;
+        }
+
+        GameObjects.Maps.MapAttribute attribute;
+
+        // Before accessing map attributes, check if the coordinates are within the bounds of the map's attribute array.
+        if (roundedX >= 0 && roundedX < map.Attributes.GetLength(0) &&
+            roundedY >= 0 && roundedY < map.Attributes.GetLength(1))
+        {
+            attribute = map.Attributes[(int)roundedX, (int)roundedY];
+        }
+        else
+        {
+            attribute = null;
+        }
+
+        if (!killSpawn && attribute != null)
+        {
+            // Check for Z-Dimension
+            if (!spawn.ProjectileBase.IgnoreZDimension && attribute is MapZDimensionAttribute zDimAttr && zDimAttr != null)
             {
-                return false;
-            }
-
-            var killSpawn = MoveFragment(spawn, false);
-
-            //Check Map Entities For Hits
-            var map = MapController.Get(spawn.MapId);
-            if (map == null)
-            {
-                return false;
-            }
-
-            var roundedX = MathF.Round(spawn.X);
-            var roundedY = MathF.Round(spawn.Y);
-
-            //Checking if the coordinates are within the map boundaries
-            if (roundedX < 0 || roundedX >= Options.MapWidth ||
-                roundedY < 0 || roundedY >= Options.MapHeight)
-            {
-                return false;
-            }
-
-            GameObjects.Maps.MapAttribute attribute;
-
-            // Before accessing map attributes, check if the coordinates are within the bounds of the map's attribute array.
-            if (roundedX >= 0 && roundedX < map.Attributes.GetLength(0) &&
-                roundedY >= 0 && roundedY < map.Attributes.GetLength(1))
-            {
-                attribute = map.Attributes[(int)roundedX, (int)roundedY];
-            }
-            else
-            {
-                attribute = null;
-            }
-
-            if (!killSpawn && attribute != null)
-            {
-                // Check for Z-Dimension
-                if (!spawn.ProjectileBase.IgnoreZDimension && attribute is MapZDimensionAttribute zDimAttr && zDimAttr != null)
+                // If the Z dimension attribute specifies a blocked level that matches the projectile's current Z level,
+                // mark the projectile for destruction.
+                if (zDimAttr.BlockedLevel > 0 && spawn.Z == zDimAttr.BlockedLevel - 1)
                 {
-                    // If the Z dimension attribute specifies a blocked level that matches the projectile's current Z level,
-                    // mark the projectile for destruction.
-                    if (zDimAttr.BlockedLevel > 0 && spawn.Z == zDimAttr.BlockedLevel - 1)
-                    {
-                        killSpawn = true;
-                    }
-
-                    // If the Z dimension attribute specifies a gateway to another level,
-                    // adjust the projectile's Z level to the specified gateway level.
-                    if (zDimAttr.GatewayTo > 0)
-                    {
-                        spawn.Z = (byte)(zDimAttr.GatewayTo - 1);
-                    }
+                    killSpawn = true;
                 }
 
-                //Check for grapplehooks.
-                if (attribute.Type == MapAttribute.GrappleStone &&
-                    Base.GrappleHookOptions.Contains(GrappleOption.MapAttribute) &&
-                    !spawn.Parent.HasGrappled &&
-                    (spawn.X != Owner.X || spawn.Y != Owner.Y))
+                // If the Z dimension attribute specifies a gateway to another level,
+                // adjust the projectile's Z level to the specified gateway level.
+                if (zDimAttr.GatewayTo > 0)
                 {
-                    // Grapple hooks are only allowed in the default projectile behavior
-                    if (!spawn.ProjectileBase.HomingBehavior && !spawn.ProjectileBase.DirectShotBehavior &&
-                        (spawn.Dir <= Direction.Right || (spawn.Dir != Direction.None && Options.Instance.MapOpts.EnableDiagonalMovement)))
-                    {
-                        spawn.Parent.HasGrappled = true;
-
-                        //Only grapple if the player hasnt left the firing position.. if they have then we assume they dont wanna grapple
-                        if (Owner.X == X && Owner.Y == Y && Owner.MapId == MapId)
-                        {
-                            Owner.Dir = spawn.Dir;
-                            new Dash(
-                                Owner, spawn.Distance, Owner.Dir, Base.IgnoreMapBlocks,
-                                Base.IgnoreActiveResources, Base.IgnoreExhaustedResources, Base.IgnoreZDimension
-                            );
-                        }
-
-                        killSpawn = true;
-                    }
+                    spawn.Z = (byte)(zDimAttr.GatewayTo - 1);
                 }
+            }
 
-                if (!spawn.ProjectileBase.IgnoreMapBlocks &&
-                    ((attribute.Type == MapAttribute.Blocked) || (attribute.Type == MapAttribute.Animation && ((MapAnimationAttribute)attribute).IsBlock)))
+            //Check for grapplehooks.
+            if (attribute.Type == MapAttribute.GrappleStone &&
+                Base.GrappleHookOptions.Contains(GrappleOption.MapAttribute) &&
+                !spawn.Parent.HasGrappled &&
+                (spawn.X != Owner.X || spawn.Y != Owner.Y))
+            {
+                // Grapple hooks are only allowed in the default projectile behavior
+                if (!spawn.ProjectileBase.HomingBehavior && !spawn.ProjectileBase.DirectShotBehavior &&
+                    (spawn.Dir <= Direction.Right || (spawn.Dir != Direction.None && Options.Instance.MapOpts.EnableDiagonalMovement)))
                 {
+                    spawn.Parent.HasGrappled = true;
+
+                    //Only grapple if the player hasnt left the firing position.. if they have then we assume they dont wanna grapple
+                    if (Owner.X == X && Owner.Y == Y && Owner.MapId == MapId)
+                    {
+                        Owner.Dir = spawn.Dir;
+                        new Dash(
+                            Owner, spawn.Distance, Owner.Dir, Base.IgnoreMapBlocks,
+                            Base.IgnoreActiveResources, Base.IgnoreExhaustedResources, Base.IgnoreZDimension
+                        );
+                    }
+
                     killSpawn = true;
                 }
             }
 
-            if (!killSpawn && MapController.TryGetInstanceFromMap(map.Id, MapInstanceId, out var mapInstance))
+            if (!spawn.ProjectileBase.IgnoreMapBlocks &&
+                ((attribute.Type == MapAttribute.Blocked) || (attribute.Type == MapAttribute.Animation && ((MapAnimationAttribute)attribute).IsBlock)))
             {
-                var entities = mapInstance.GetEntities();
-                for (var z = 0; z < entities.Count; z++)
-                {
-                    var entity = entities[z];
-                    if (entity != null && entity != spawn.Parent.Owner && entity.Z == spawn.Z &&
-                        entity.X == roundedX && entity.Y == roundedY &&
-                        (spawn.X != Owner.X || spawn.Y != Owner.Y))
-                    {
-                        killSpawn = spawn.HitEntity(entity);
-                        if (killSpawn && !spawn.ProjectileBase.PierceTarget)
-                        {
-                            return killSpawn;
-                        }
-                    }
-                    else if (z == entities.Count - 1 && spawn.Distance >= Base.Range)
-                    {
-                        killSpawn = true;
-                    }
-                }
+                killSpawn = true;
             }
-
-            return killSpawn || spawn?.Distance >= Base.Range;
         }
 
-        /// <summary>
-        /// Calculates the offset for the projectile spawn position based on the target map and spawn location.
-        /// </summary>
-        /// <param name="spawn">The projectile spawn information.</param>
-        /// <param name="isXAxis">True for horizontal (X-axis), false for vertical (Y-axis) calculation.</param>
-        /// <returns>The calculated offset value.</returns>
-        private float GetProjectileOffset(ProjectileSpawn spawn, bool isXAxis)
+        if (!killSpawn && MapController.TryGetInstanceFromMap(map.Id, MapInstanceId, out var mapInstance))
         {
-            if (_lastTargetMapId == Guid.Empty || _lastTargetMapId == spawn.MapId || !MapController.TryGet(spawn.MapId, out var map))
+            var entities = mapInstance.GetEntities();
+            for (var z = 0; z < entities.Count; z++)
             {
-                return isXAxis ? _lastTargetX - spawn.X : _lastTargetY - spawn.Y;
-            }
-
-            var grid = DbInterface.GetGrid(map.MapGrid);
-
-            for (var y = map.MapGridY - 1; y <= map.MapGridY + 1; y++)
-            {
-                for (var x = map.MapGridX - 1; x <= map.MapGridX + 1; x++)
+                var entity = entities[z];
+                if (entity != null && entity != spawn.Parent.Owner && entity.Z == spawn.Z &&
+                    entity.X == roundedX && entity.Y == roundedY &&
+                    (spawn.X != Owner.X || spawn.Y != Owner.Y))
                 {
-                    if (x < 0 || x >= grid.MapIdGrid.GetLength(0) || y < 0 || y >= grid.MapIdGrid.GetLength(1))
+                    killSpawn = spawn.HitEntity(entity);
+                    if (killSpawn && !spawn.ProjectileBase.PierceTarget)
                     {
-                        continue;
-                    }
-
-                    if (grid.MapIdGrid[x, y] != _lastTargetMapId || grid.MapIdGrid[x, y] == Guid.Empty)
-                    {
-                        continue;
-                    }
-
-                    if (isXAxis)
-                    {
-                        var leftSide = x == map.MapGridX - 1;
-                        var rightSide = x == map.MapGridX + 1;
-
-                        if (leftSide)
-                        {
-                            return _lastTargetX - Options.MapWidth - spawn.X;
-                        }
-
-                        if (rightSide)
-                        {
-                            return _lastTargetX + Options.MapWidth - spawn.X;
-                        }
-                    }
-                    else
-                    {
-                        var topSide = y == map.MapGridY - 1;
-                        var bottomSide = y == map.MapGridY + 1;
-
-                        if (topSide)
-                        {
-                            return _lastTargetY - Options.MapHeight - spawn.Y;
-                        }
-
-                        if (bottomSide)
-                        {
-                            return _lastTargetY + Options.MapHeight - spawn.Y;
-                        }
+                        return killSpawn;
                     }
                 }
+                else if (z == entities.Count - 1 && spawn.Distance >= Base.Range)
+                {
+                    killSpawn = true;
+                }
             }
+        }
 
+        return killSpawn || spawn?.Distance >= Base.Range;
+    }
+
+    /// <summary>
+    /// Calculates the offset for the projectile spawn position based on the target map and spawn location.
+    /// </summary>
+    /// <param name="spawn">The projectile spawn information.</param>
+    /// <param name="isXAxis">True for horizontal (X-axis), false for vertical (Y-axis) calculation.</param>
+    /// <returns>The calculated offset value.</returns>
+    private float GetProjectileOffset(ProjectileSpawn spawn, bool isXAxis)
+    {
+        if (_lastTargetMapId == Guid.Empty || _lastTargetMapId == spawn.MapId || !MapController.TryGet(spawn.MapId, out var map))
+        {
             return isXAxis ? _lastTargetX - spawn.X : _lastTargetY - spawn.Y;
         }
 
-        /// <summary>
-        /// Moves the projectile fragment based on the specified spawn information. This method is responsible for
-        /// updating the position of the projectile, handling homing and direct shot behaviors, and checking for out-of-bounds conditions.
-        /// </summary>
-        /// <param name="spawn">The projectile spawn information, including current position, direction, and other relevant details.</param>
-        /// <param name="move">Indicates whether the fragment should be moved. This can be used to pause movement if needed. Default is true.</param>
-        /// <returns>True if the projectile goes out of bounds after moving, false otherwise.</returns>
-        public bool MoveFragment(ProjectileSpawn spawn, bool move = true)
+        var grid = DbInterface.GetGrid(map.MapGrid);
+
+        for (var y = map.MapGridY - 1; y <= map.MapGridY + 1; y++)
         {
-            if (move)
+            for (var x = map.MapGridX - 1; x <= map.MapGridX + 1; x++)
             {
-                // Increase the distance traveled by the projectile and update its transmission timer.
-                spawn.Distance++;
-                spawn.TransmissionTimer += (long)(Base.Speed / (float)Base.Range);
-
-                if (Target != default && Target.Id != Owner.Id && (Base.HomingBehavior || Base.DirectShotBehavior))
+                if (x < 0 || x >= grid.MapIdGrid.GetLength(0) || y < 0 || y >= grid.MapIdGrid.GetLength(1))
                 {
-                    // Homing or direct shot logic: Adjusts the projectile's trajectory towards the target.
-                    _lastTargetX = Target.X;
-                    _lastTargetY = Target.Y;
-                    _lastTargetMapId = Target.MapId;
-                    var (directionX, directionY) = (GetProjectileOffset(spawn, true), GetProjectileOffset(spawn, false));
-                    var distance = MathF.Sqrt(directionX * directionX + directionY * directionY);
-
-                    // Normalize the direction and update the projectile's position.
-                    spawn.X += directionX / distance;
-                    spawn.Y += directionY / distance;
-
-                    // For direct shots, reset the target after moving towards it once.
-                    if (Base.DirectShotBehavior)
-                    {
-                        Target = default;
-                    }
+                    continue;
                 }
-                else if (_lastTargetX != -1 && _lastTargetY != -1)
-                {
-                    // Last known target location logic: Moves the projectile towards the last known position of the target.
-                    var (directionX, directionY) = (GetProjectileOffset(spawn, true), GetProjectileOffset(spawn, false));
-                    var distance = MathF.Sqrt(directionX * directionX + directionY * directionY);
 
-                    // Normalize the direction and update the projectile's position.
-                    spawn.X += directionX / distance;
-                    spawn.Y += directionY / distance;
+                if (grid.MapIdGrid[x, y] != _lastTargetMapId || grid.MapIdGrid[x, y] == Guid.Empty)
+                {
+                    continue;
+                }
+
+                if (isXAxis)
+                {
+                    var leftSide = x == map.MapGridX - 1;
+                    var rightSide = x == map.MapGridX + 1;
+
+                    if (leftSide)
+                    {
+                        return _lastTargetX - Options.MapWidth - spawn.X;
+                    }
+
+                    if (rightSide)
+                    {
+                        return _lastTargetX + Options.MapWidth - spawn.X;
+                    }
                 }
                 else
                 {
-                    // Default movement logic: Moves the projectile in its current direction.
-                    spawn.X += GetRange(spawn.Dir, 1, true);
-                    spawn.Y += GetRange(spawn.Dir, 1, false);
+                    var topSide = y == map.MapGridY - 1;
+                    var bottomSide = y == map.MapGridY + 1;
+
+                    if (topSide)
+                    {
+                        return _lastTargetY - Options.MapHeight - spawn.Y;
+                    }
+
+                    if (bottomSide)
+                    {
+                        return _lastTargetY + Options.MapHeight - spawn.Y;
+                    }
                 }
             }
-
-            // Adjust the projectile's position if it crosses map boundaries and potentially transitions it to a neighboring map.
-            AdjustPositionOnMapBoundaries(ref spawn.X, ref spawn.Y, ref spawn);
-
-            // Check for map boundaries and remove the spawn if the projectile has gone out of bounds after moving.
-            return spawn.X < 0 || spawn.X >= Options.MapWidth || spawn.Y < 0 || spawn.Y >= Options.MapHeight;
         }
 
-        /// <summary>
-        /// Adjusts the position of a projectile when it crosses the boundaries of the current map.
-        /// This method checks if the projectile crosses the map boundaries and, if so, attempts to
-        /// transition the projectile to the adjacent map in the direction it is moving. The new position
-        /// on the adjacent map is calculated to maintain the continuity of the projectile's path.
-        /// </summary>
-        /// <param name="newx">The new x-coordinate of the projectile, which may be adjusted if crossing map boundaries.</param>
-        /// <param name="newy">The new y-coordinate of the projectile, which may be adjusted if crossing map boundaries.</param>
-        /// <param name="spawn">The projectile spawn information, including the current map ID, which may be updated to a new map.</param>
-        private static void AdjustPositionOnMapBoundaries(ref float newx, ref float newy, ref ProjectileSpawn spawn)
+        return isXAxis ? _lastTargetX - spawn.X : _lastTargetY - spawn.Y;
+    }
+
+    /// <summary>
+    /// Moves the projectile fragment based on the specified spawn information. This method is responsible for
+    /// updating the position of the projectile, handling homing and direct shot behaviors, and checking for out-of-bounds conditions.
+    /// </summary>
+    /// <param name="spawn">The projectile spawn information, including current position, direction, and other relevant details.</param>
+    /// <param name="move">Indicates whether the fragment should be moved. This can be used to pause movement if needed. Default is true.</param>
+    /// <returns>True if the projectile goes out of bounds after moving, false otherwise.</returns>
+    public bool MoveFragment(ProjectileSpawn spawn, bool move = true)
+    {
+        if (move)
         {
-            // Retrieve the current map based on the projectile's spawn information.
-            var map = MapController.Get(spawn.MapId);
-            int MapWidth = Options.MapWidth;
-            int MapHeight = Options.MapHeight;
+            // Increase the distance traveled by the projectile and update its transmission timer.
+            spawn.Distance++;
+            spawn.TransmissionTimer += (long)(Base.Speed / (float)Base.Range);
 
-            // Determine if the projectile crosses any of the map's boundaries.
-            bool crossesLeftBoundary = MathF.Floor(newx) < 0;
-            bool crossesRightBoundary = MathF.Ceiling(newx) > MapWidth - 1;
-            bool crossesTopBoundary = MathF.Floor(newy) < 0;
-            bool crossesBottomBoundary = MathF.Ceiling(newy) > MapHeight - 1;
+            if (Target != default && Target.Id != Owner.Id && (Base.HomingBehavior || Base.DirectShotBehavior))
+            {
+                // Homing or direct shot logic: Adjusts the projectile's trajectory towards the target.
+                _lastTargetX = Target.X;
+                _lastTargetY = Target.Y;
+                _lastTargetMapId = Target.MapId;
+                var (directionX, directionY) = (GetProjectileOffset(spawn, true), GetProjectileOffset(spawn, false));
+                var distance = MathF.Sqrt(directionX * directionX + directionY * directionY);
 
-            // Check for corner cases where the projectile crosses two boundaries.
-            if (crossesLeftBoundary && crossesTopBoundary)
-            {
-                // Projectile crosses the top-left corner of the map.
-                if (MapController.TryGet(map.Up, out var upMap) &&
-                    MapController.TryGet(upMap.Left, out var upLeftMap))
+                // Normalize the direction and update the projectile's position.
+                spawn.X += directionX / distance;
+                spawn.Y += directionY / distance;
+
+                // For direct shots, reset the target after moving towards it once.
+                if (Base.DirectShotBehavior)
                 {
-                    // Transition to the map diagonally up-left and adjust position to bottom-right corner.
-                    spawn.MapId = upLeftMap.Id;
-                    newx = MapWidth - 1;
-                    newy = MapHeight - 1;
+                    Target = default;
                 }
             }
-            else if (crossesRightBoundary && crossesTopBoundary)
+            else if (_lastTargetX != -1 && _lastTargetY != -1)
             {
-                // Projectile crosses the top-right corner of the map.
-                if (MapController.TryGet(map.Up, out var upMap) &&
-                    MapController.TryGet(upMap.Right, out var upRightMap))
-                {
-                    // Transition to the map diagonally up-right and adjust position to bottom-left corner.
-                    spawn.MapId = upRightMap.Id;
-                    newx = 0;
-                    newy = MapHeight - 1;
-                }
+                // Last known target location logic: Moves the projectile towards the last known position of the target.
+                var (directionX, directionY) = (GetProjectileOffset(spawn, true), GetProjectileOffset(spawn, false));
+                var distance = MathF.Sqrt(directionX * directionX + directionY * directionY);
+
+                // Normalize the direction and update the projectile's position.
+                spawn.X += directionX / distance;
+                spawn.Y += directionY / distance;
             }
-            else if (crossesLeftBoundary && crossesBottomBoundary)
+            else
             {
-                // Projectile crosses the bottom-left corner of the map.
-                if (MapController.TryGet(map.Down, out var downMap) &&
-                    MapController.TryGet(downMap.Left, out var downLeftMap))
-                {
-                    // Transition to the map diagonally down-left and adjust position to top-right corner.
-                    spawn.MapId = downLeftMap.Id;
-                    newx = MapWidth - 1;
-                    newy = 0;
-                }
-            }
-            else if (crossesRightBoundary && crossesBottomBoundary)
-            {
-                // Projectile crosses the bottom-right corner of the map.
-                if (MapController.TryGet(map.Down, out var downMap) &&
-                    MapController.TryGet(downMap.Right, out var downRightMap))
-                {
-                    // Transition to the map diagonally down-right and adjust position to top-left corner.
-                    spawn.MapId = downRightMap.Id;
-                    newx = 0;
-                    newy = 0;
-                }
-            }
-            // Check for single boundary crossings and adjust position accordingly.
-            else if (crossesLeftBoundary)
-            {
-                // Projectile crosses the left boundary of the map.
-                if (MapController.TryGet(map.Left, out var leftMap))
-                {
-                    // Transition to the map on the left and adjust position to the right edge.
-                    spawn.MapId = leftMap.Id;
-                    newx = MapWidth - 1;
-                }
-            }
-            else if (crossesRightBoundary)
-            {
-                // Projectile crosses the right boundary of the map.
-                if (MapController.TryGet(map.Right, out var rightMap))
-                {
-                    // Transition to the map on the right and adjust position to the left edge.
-                    spawn.MapId = rightMap.Id;
-                    newx = 0;
-                }
-            }
-            else if (crossesTopBoundary)
-            {
-                // Projectile crosses the top boundary of the map.
-                if (MapController.TryGet(map.Up, out var upMap))
-                {
-                    // Transition to the map above and adjust position to the bottom edge.
-                    spawn.MapId = upMap.Id;
-                    newy = MapHeight - 1;
-                }
-            }
-            else if (crossesBottomBoundary)
-            {
-                // Projectile crosses the bottom boundary of the map.
-                if (MapController.TryGet(map.Down, out var downMap))
-                {
-                    // Transition to the map below and adjust position to the top edge.
-                    spawn.MapId = downMap.Id;
-                    newy = 0;
-                }
+                // Default movement logic: Moves the projectile in its current direction.
+                spawn.X += GetRange(spawn.Dir, 1, true);
+                spawn.Y += GetRange(spawn.Dir, 1, false);
             }
         }
 
-        public override void Die(bool dropItems = true, Entity killer = null)
+        // Adjust the projectile's position if it crosses map boundaries and potentially transitions it to a neighboring map.
+        AdjustPositionOnMapBoundaries(ref spawn.X, ref spawn.Y, ref spawn);
+
+        // Check for map boundaries and remove the spawn if the projectile has gone out of bounds after moving.
+        return spawn.X < 0 || spawn.X >= Options.MapWidth || spawn.Y < 0 || spawn.Y >= Options.MapHeight;
+    }
+
+    /// <summary>
+    /// Adjusts the position of a projectile when it crosses the boundaries of the current map.
+    /// This method checks if the projectile crosses the map boundaries and, if so, attempts to
+    /// transition the projectile to the adjacent map in the direction it is moving. The new position
+    /// on the adjacent map is calculated to maintain the continuity of the projectile's path.
+    /// </summary>
+    /// <param name="newx">The new x-coordinate of the projectile, which may be adjusted if crossing map boundaries.</param>
+    /// <param name="newy">The new y-coordinate of the projectile, which may be adjusted if crossing map boundaries.</param>
+    /// <param name="spawn">The projectile spawn information, including the current map ID, which may be updated to a new map.</param>
+    private static void AdjustPositionOnMapBoundaries(ref float newx, ref float newy, ref ProjectileSpawn spawn)
+    {
+        // Retrieve the current map based on the projectile's spawn information.
+        var map = MapController.Get(spawn.MapId);
+        int MapWidth = Options.MapWidth;
+        int MapHeight = Options.MapHeight;
+
+        // Determine if the projectile crosses any of the map's boundaries.
+        bool crossesLeftBoundary = MathF.Floor(newx) < 0;
+        bool crossesRightBoundary = MathF.Ceiling(newx) > MapWidth - 1;
+        bool crossesTopBoundary = MathF.Floor(newy) < 0;
+        bool crossesBottomBoundary = MathF.Ceiling(newy) > MapHeight - 1;
+
+        // Check for corner cases where the projectile crosses two boundaries.
+        if (crossesLeftBoundary && crossesTopBoundary)
         {
-            for (var i = 0; i < Spawns.Length; i++)
+            // Projectile crosses the top-left corner of the map.
+            if (MapController.TryGet(map.Up, out var upMap) &&
+                MapController.TryGet(upMap.Left, out var upLeftMap))
             {
-                Spawns[i] = null;
+                // Transition to the map diagonally up-left and adjust position to bottom-right corner.
+                spawn.MapId = upLeftMap.Id;
+                newx = MapWidth - 1;
+                newy = MapHeight - 1;
             }
-
-            if (MapController.TryGetInstanceFromMap(MapId, MapInstanceId, out var mapInstance))
+        }
+        else if (crossesRightBoundary && crossesTopBoundary)
+        {
+            // Projectile crosses the top-right corner of the map.
+            if (MapController.TryGet(map.Up, out var upMap) &&
+                MapController.TryGet(upMap.Right, out var upRightMap))
             {
-                mapInstance.RemoveProjectile(this);
+                // Transition to the map diagonally up-right and adjust position to bottom-left corner.
+                spawn.MapId = upRightMap.Id;
+                newx = 0;
+                newy = MapHeight - 1;
             }
         }
-
-        public override EntityPacket EntityPacket(EntityPacket packet = null, Player forPlayer = null)
+        else if (crossesLeftBoundary && crossesBottomBoundary)
         {
-            packet ??= new ProjectileEntityPacket();
-            packet = base.EntityPacket(packet, forPlayer);
+            // Projectile crosses the bottom-left corner of the map.
+            if (MapController.TryGet(map.Down, out var downMap) &&
+                MapController.TryGet(downMap.Left, out var downLeftMap))
+            {
+                // Transition to the map diagonally down-left and adjust position to top-right corner.
+                spawn.MapId = downLeftMap.Id;
+                newx = MapWidth - 1;
+                newy = 0;
+            }
+        }
+        else if (crossesRightBoundary && crossesBottomBoundary)
+        {
+            // Projectile crosses the bottom-right corner of the map.
+            if (MapController.TryGet(map.Down, out var downMap) &&
+                MapController.TryGet(downMap.Right, out var downRightMap))
+            {
+                // Transition to the map diagonally down-right and adjust position to top-left corner.
+                spawn.MapId = downRightMap.Id;
+                newx = 0;
+                newy = 0;
+            }
+        }
+        // Check for single boundary crossings and adjust position accordingly.
+        else if (crossesLeftBoundary)
+        {
+            // Projectile crosses the left boundary of the map.
+            if (MapController.TryGet(map.Left, out var leftMap))
+            {
+                // Transition to the map on the left and adjust position to the right edge.
+                spawn.MapId = leftMap.Id;
+                newx = MapWidth - 1;
+            }
+        }
+        else if (crossesRightBoundary)
+        {
+            // Projectile crosses the right boundary of the map.
+            if (MapController.TryGet(map.Right, out var rightMap))
+            {
+                // Transition to the map on the right and adjust position to the left edge.
+                spawn.MapId = rightMap.Id;
+                newx = 0;
+            }
+        }
+        else if (crossesTopBoundary)
+        {
+            // Projectile crosses the top boundary of the map.
+            if (MapController.TryGet(map.Up, out var upMap))
+            {
+                // Transition to the map above and adjust position to the bottom edge.
+                spawn.MapId = upMap.Id;
+                newy = MapHeight - 1;
+            }
+        }
+        else if (crossesBottomBoundary)
+        {
+            // Projectile crosses the bottom boundary of the map.
+            if (MapController.TryGet(map.Down, out var downMap))
+            {
+                // Transition to the map below and adjust position to the top edge.
+                spawn.MapId = downMap.Id;
+                newy = 0;
+            }
+        }
+    }
 
-            var pkt = (ProjectileEntityPacket)packet;
-            pkt.ProjectileId = Base.Id;
-            pkt.ProjectileDirection = (byte)Dir;
-            pkt.TargetId = Owner.Target != default && Owner.Target.Id != Guid.Empty ? Owner.Target.Id : Guid.Empty;
-            pkt.OwnerId = Owner?.Id ?? Guid.Empty;
-
-            return pkt;
+    public override void Die(bool dropItems = true, Entity killer = null)
+    {
+        for (var i = 0; i < Spawns.Length; i++)
+        {
+            Spawns[i] = null;
         }
 
-        public override EntityType GetEntityType()
+        if (MapController.TryGetInstanceFromMap(MapId, MapInstanceId, out var mapInstance))
         {
-            return EntityType.Projectile;
+            mapInstance.RemoveProjectile(this);
         }
+    }
 
+    public override EntityPacket EntityPacket(EntityPacket packet = null, Player forPlayer = null)
+    {
+        packet ??= new ProjectileEntityPacket();
+        packet = base.EntityPacket(packet, forPlayer);
+
+        var pkt = (ProjectileEntityPacket)packet;
+        pkt.ProjectileId = Base.Id;
+        pkt.ProjectileDirection = (byte)Dir;
+        pkt.TargetId = Owner.Target != default && Owner.Target.Id != Guid.Empty ? Owner.Target.Id : Guid.Empty;
+        pkt.OwnerId = Owner?.Id ?? Guid.Empty;
+
+        return pkt;
+    }
+
+    public override EntityType GetEntityType()
+    {
+        return EntityType.Projectile;
     }
 
 }

--- a/Intersect.Server.Core/Entities/ProjectileSpawn.cs
+++ b/Intersect.Server.Core/Entities/ProjectileSpawn.cs
@@ -4,201 +4,199 @@ using Intersect.Server.Entities.Combat;
 using Intersect.Server.Entities.Events;
 using Intersect.Utilities;
 
-namespace Intersect.Server.Entities
+namespace Intersect.Server.Entities;
+
+
+public partial class ProjectileSpawn
 {
 
-    public partial class ProjectileSpawn
+    public Direction Dir;
+
+    public int Distance;
+
+    public Guid MapId;
+
+    public Projectile Parent;
+
+    public ProjectileBase ProjectileBase;
+
+    public long TransmissionTimer = Timing.Global.Milliseconds;
+
+    public float X;
+
+    public float Y;
+
+    public byte Z;
+
+    public bool Dead;
+
+    public Guid MapInstanceId;
+
+    private List<Guid> _entitiesCollided = new List<Guid>();
+
+    public ProjectileSpawn(
+        Direction dir,
+        byte x,
+        byte y,
+        byte z,
+        Guid mapId,
+        Guid mapInstanceId,
+        ProjectileBase projectileBase,
+        Projectile parent
+    )
     {
+        MapId = mapId;
+        MapInstanceId = mapInstanceId;
+        X = x;
+        Y = y;
+        Z = z;
+        Dir = dir;
+        ProjectileBase = projectileBase;
+        Parent = parent;
+        TransmissionTimer = Timing.Global.Milliseconds +
+                            (long)(ProjectileBase.Speed / (float)ProjectileBase.Range);
+    }
 
-        public Direction Dir;
+    public bool IsAtLocation(Guid mapId, int x, int y, int z)
+    {
+        return MapId == mapId && X == x && Y == y && Z == z;
+    }
 
-        public int Distance;
-
-        public Guid MapId;
-
-        public Projectile Parent;
-
-        public ProjectileBase ProjectileBase;
-
-        public long TransmissionTimer = Timing.Global.Milliseconds;
-
-        public float X;
-
-        public float Y;
-
-        public byte Z;
-
-        public bool Dead;
-
-        public Guid MapInstanceId;
-
-        private List<Guid> _entitiesCollided = new List<Guid>();
-
-        public ProjectileSpawn(
-            Direction dir,
-            byte x,
-            byte y,
-            byte z,
-            Guid mapId,
-            Guid mapInstanceId,
-            ProjectileBase projectileBase,
-            Projectile parent
-        )
+    public bool HitEntity(Entity targetEntity)
+    {
+        if (targetEntity is EventPageInstance)
         {
-            MapId = mapId;
-            MapInstanceId = mapInstanceId;
-            X = x;
-            Y = y;
-            Z = z;
-            Dir = dir;
-            ProjectileBase = projectileBase;
-            Parent = parent;
-            TransmissionTimer = Timing.Global.Milliseconds +
-                                (long)(ProjectileBase.Speed / (float)ProjectileBase.Range);
-        }
-
-        public bool IsAtLocation(Guid mapId, int x, int y, int z)
-        {
-            return MapId == mapId && X == x && Y == y && Z == z;
-        }
-
-        public bool HitEntity(Entity targetEntity)
-        {
-            if (targetEntity is EventPageInstance)
-            {
-                return false;
-            }
-
-            Player targetPlayer = targetEntity as Player;
-
-            if (targetEntity != null && targetEntity != Parent.Owner)
-            {
-                // Have we collided with this entity before? If so, cancel out.
-                if (_entitiesCollided.Contains(targetEntity.Id))
-                {
-                    if (!Parent.Base.PierceTarget)
-                    {
-                        if (targetPlayer != null)
-                        {
-                            if (targetPlayer.Map.ZoneType == Enums.MapZone.Safe ||
-                                Parent.Owner is Player plyr && plyr.InParty(targetPlayer))
-                            {
-                                return false;
-                            }
-                        }
-
-                        return true;
-                    }
-                    else
-                    {
-                        return false;
-                    }
-                }
-                _entitiesCollided.Add(targetEntity.Id);
-
-                if (targetPlayer != null)
-                {
-                    if (Parent.Owner != Parent.Target)
-                    {
-                        Parent.Owner.TryAttack(targetEntity, Parent.Base, Parent.Spell, Parent.Item, Dir);
-
-                        if (Dir <= Direction.Right && ShouldHook(targetEntity) && !Parent.HasGrappled)
-                        {
-                            HookEntity();
-                        }
-
-                        if (!Parent.Base.PierceTarget)
-                        {
-                            if (targetPlayer.Map.ZoneType == Enums.MapZone.Safe ||
-                                Parent.Owner is Player plyr && plyr.InParty(targetPlayer))
-                            {
-                                return false;
-                            }
-
-                            return true;
-                        }
-                    }
-                }
-                else if (targetEntity is Resource targetResource)
-                {
-                    if (targetResource.IsDead())
-                    {
-                        if (!ProjectileBase.IgnoreExhaustedResources)
-                        {
-                            return true;
-                        }
-                    }
-                    else if (!ProjectileBase.IgnoreActiveResources)
-                    {
-                        Parent.Owner.TryAttack(targetResource, Parent.Base, Parent.Spell, Parent.Item, Dir);
-
-                        if (Dir <= Direction.Right && ShouldHook(targetResource) && !Parent.HasGrappled)
-                        {
-                            HookEntity();
-                        }
-
-                        return true;
-                    }
-                }
-                else //Any other Parent.Target
-                {
-                    if (Parent.Owner is not Npc ownerNpc ||
-                        ownerNpc.CanNpcCombat(targetEntity, Parent.Spell != null && Parent.Spell.Combat.Friendly))
-                    {
-                        Parent.Owner.TryAttack(targetEntity, Parent.Base, Parent.Spell, Parent.Item, Dir);
-
-                        if (Dir <= Direction.Right && ShouldHook(targetEntity) && !Parent.HasGrappled)
-                        {
-                            HookEntity();
-                        }
-
-                        if (!Parent.Base.PierceTarget)
-                        {
-                            return true;
-                        }
-                    }
-                }
-            }
-
             return false;
         }
 
-        /// <summary>
-        /// Returns whether or not to hook the player to the target
-        /// </summary>
-        /// <param name="en"></param>
-        /// <returns></returns>
-        public bool ShouldHook(Entity en)
+        Player targetPlayer = targetEntity as Player;
+
+        if (targetEntity != null && targetEntity != Parent.Owner)
         {
-            if (en == null)
+            // Have we collided with this entity before? If so, cancel out.
+            if (_entitiesCollided.Contains(targetEntity.Id))
             {
-                return false;
+                if (!Parent.Base.PierceTarget)
+                {
+                    if (targetPlayer != null)
+                    {
+                        if (targetPlayer.Map.ZoneType == Enums.MapZone.Safe ||
+                            Parent.Owner is Player plyr && plyr.InParty(targetPlayer))
+                        {
+                            return false;
+                        }
+                    }
+
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
             }
+            _entitiesCollided.Add(targetEntity.Id);
 
-            return en switch
+            if (targetPlayer != null)
             {
-                Player => ProjectileBase.GrappleHookOptions.Contains(Enums.GrappleOption.Player),
-                Npc => ProjectileBase.GrappleHookOptions.Contains(Enums.GrappleOption.NPC),
-                Resource => ProjectileBase.GrappleHookOptions.Contains(Enums.GrappleOption.Resource),
-                _ => throw new ArgumentException($"Unsupported entity type {en.GetType().FullName}", nameof(en)),
-            };
+                if (Parent.Owner != Parent.Target)
+                {
+                    Parent.Owner.TryAttack(targetEntity, Parent.Base, Parent.Spell, Parent.Item, Dir);
+
+                    if (Dir <= Direction.Right && ShouldHook(targetEntity) && !Parent.HasGrappled)
+                    {
+                        HookEntity();
+                    }
+
+                    if (!Parent.Base.PierceTarget)
+                    {
+                        if (targetPlayer.Map.ZoneType == Enums.MapZone.Safe ||
+                            Parent.Owner is Player plyr && plyr.InParty(targetPlayer))
+                        {
+                            return false;
+                        }
+
+                        return true;
+                    }
+                }
+            }
+            else if (targetEntity is Resource targetResource)
+            {
+                if (targetResource.IsDead())
+                {
+                    if (!ProjectileBase.IgnoreExhaustedResources)
+                    {
+                        return true;
+                    }
+                }
+                else if (!ProjectileBase.IgnoreActiveResources)
+                {
+                    Parent.Owner.TryAttack(targetResource, Parent.Base, Parent.Spell, Parent.Item, Dir);
+
+                    if (Dir <= Direction.Right && ShouldHook(targetResource) && !Parent.HasGrappled)
+                    {
+                        HookEntity();
+                    }
+
+                    return true;
+                }
+            }
+            else //Any other Parent.Target
+            {
+                if (Parent.Owner is not Npc ownerNpc ||
+                    ownerNpc.CanNpcCombat(targetEntity, Parent.Spell != null && Parent.Spell.Combat.Friendly))
+                {
+                    Parent.Owner.TryAttack(targetEntity, Parent.Base, Parent.Spell, Parent.Item, Dir);
+
+                    if (Dir <= Direction.Right && ShouldHook(targetEntity) && !Parent.HasGrappled)
+                    {
+                        HookEntity();
+                    }
+
+                    if (!Parent.Base.PierceTarget)
+                    {
+                        return true;
+                    }
+                }
+            }
         }
 
-        /// <summary>
-        /// Hook the player to the target
-        /// </summary>
-        public void HookEntity()
+        return false;
+    }
+
+    /// <summary>
+    /// Returns whether or not to hook the player to the target
+    /// </summary>
+    /// <param name="en"></param>
+    /// <returns></returns>
+    public bool ShouldHook(Entity en)
+    {
+        if (en == null)
         {
-            //Don't handle directional projectile grapplehooks
-            Parent.HasGrappled = true;
-            Parent.Owner.Dir = Dir;
-            var _ = new Dash(
-                Parent.Owner, Distance, Parent.Owner.Dir, Parent.Base.IgnoreMapBlocks,
-                Parent.Base.IgnoreActiveResources, Parent.Base.IgnoreExhaustedResources,
-                Parent.Base.IgnoreZDimension
-            );
+            return false;
         }
 
+        return en switch
+        {
+            Player => ProjectileBase.GrappleHookOptions.Contains(Enums.GrappleOption.Player),
+            Npc => ProjectileBase.GrappleHookOptions.Contains(Enums.GrappleOption.NPC),
+            Resource => ProjectileBase.GrappleHookOptions.Contains(Enums.GrappleOption.Resource),
+            _ => throw new ArgumentException($"Unsupported entity type {en.GetType().FullName}", nameof(en)),
+        };
+    }
+
+    /// <summary>
+    /// Hook the player to the target
+    /// </summary>
+    public void HookEntity()
+    {
+        //Don't handle directional projectile grapplehooks
+        Parent.HasGrappled = true;
+        Parent.Owner.Dir = Dir;
+        var _ = new Dash(
+            Parent.Owner, Distance, Parent.Owner.Dir, Parent.Base.IgnoreMapBlocks,
+            Parent.Base.IgnoreActiveResources, Parent.Base.IgnoreExhaustedResources,
+            Parent.Base.IgnoreZDimension
+        );
     }
 
 }

--- a/Intersect.Server.Core/Entities/Resource.cs
+++ b/Intersect.Server.Core/Entities/Resource.cs
@@ -7,224 +7,222 @@ using Intersect.Server.Maps;
 using Intersect.Server.Networking;
 using Intersect.Utilities;
 
-namespace Intersect.Server.Entities
+namespace Intersect.Server.Entities;
+
+
+public partial class Resource : Entity
 {
 
-    public partial class Resource : Entity
+    // Resource Number
+    public ResourceBase Base;
+
+    //Respawn
+    public long RespawnTime = 0;
+
+    public Resource(ResourceBase resource) : base()
     {
+        Base = resource;
+        Name = resource.Name;
+        Sprite = resource.Initial.Graphic;
+        SetMaxVital(
+            Vital.Health,
+            Randomization.Next(
+                Math.Min(1, resource.MinHp), Math.Max(resource.MaxHp, Math.Min(1, resource.MinHp)) + 1
+            )
+        );
 
-        // Resource Number
-        public ResourceBase Base;
+        RestoreVital(Vital.Health);
+        Passable = resource.WalkableBefore;
+        HideName = true;
+    }
 
-        //Respawn
-        public long RespawnTime = 0;
-
-        public Resource(ResourceBase resource) : base()
+    public void Destroy(bool dropItems = false, Entity killer = null)
+    {
+        lock (EntityLock)
         {
-            Base = resource;
-            Name = resource.Name;
-            Sprite = resource.Initial.Graphic;
-            SetMaxVital(
-                Vital.Health,
-                Randomization.Next(
-                    Math.Min(1, resource.MinHp), Math.Max(resource.MaxHp, Math.Min(1, resource.MinHp)) + 1
-                )
-            );
+            Die(dropItems, killer);
+        }
+        
+        PacketSender.SendEntityDie(this);
+        PacketSender.SendEntityLeave(this);
+    }
 
-            RestoreVital(Vital.Health);
-            Passable = resource.WalkableBefore;
-            HideName = true;
+    public override void Die(bool dropItems = true, Entity killer = null)
+    {
+        lock (EntityLock)
+        {
+            base.Die(false, killer);
+        }
+        
+        Sprite = Base.Exhausted.Graphic;
+        Passable = Base.WalkableAfter;
+        Dead = true;
+
+        if (dropItems)
+        {
+            SpawnResourceItems(killer);
+            if (Base.AnimationId != Guid.Empty)
+            {
+                PacketSender.SendAnimationToProximity(
+                    Base.AnimationId, -1, Guid.Empty, MapId, X, Y, Direction.Up, MapInstanceId
+                );
+            }
         }
 
-        public void Destroy(bool dropItems = false, Entity killer = null)
+        PacketSender.SendEntityDataToProximity(this);
+        PacketSender.SendEntityPositionToAll(this);
+    }
+
+    public void Spawn()
+    {
+        Sprite = Base.Initial.Graphic;
+        if (Base.MaxHp < Base.MinHp)
         {
-            lock (EntityLock)
-            {
-                Die(dropItems, killer);
-            }
-            
-            PacketSender.SendEntityDie(this);
-            PacketSender.SendEntityLeave(this);
+            Base.MaxHp = Base.MinHp;
         }
 
-        public override void Die(bool dropItems = true, Entity killer = null)
-        {
-            lock (EntityLock)
-            {
-                base.Die(false, killer);
-            }
-            
-            Sprite = Base.Exhausted.Graphic;
-            Passable = Base.WalkableAfter;
-            Dead = true;
+        SetMaxVital(Vital.Health, Randomization.Next(Base.MinHp, Base.MaxHp + 1));
+        RestoreVital(Vital.Health);
+        Passable = Base.WalkableBefore;
+        Items.Clear();
 
-            if (dropItems)
+        //Give Resource Drops
+        var itemSlot = 0;
+        foreach (var drop in Base.Drops)
+        {
+            if (Randomization.Next(1, 10001) <= drop.Chance * 100 && ItemBase.Get(drop.ItemId) != null)
             {
-                SpawnResourceItems(killer);
-                if (Base.AnimationId != Guid.Empty)
+                var slot = new InventorySlot(itemSlot);
+                slot.Set(new Item(drop.ItemId, drop.Quantity));
+                Items.Add(slot);
+                itemSlot++;
+            }
+        }
+
+        Dead = false;
+        PacketSender.SendEntityDataToProximity(this);
+        PacketSender.SendEntityPositionToAll(this);
+    }
+
+    public void SpawnResourceItems(Entity killer)
+    {
+        //Find tile to spawn items
+        var tiles = new List<TileHelper>();
+        for (var x = X - 1; x <= X + 1; x++)
+        {
+            for (var y = Y - 1; y <= Y + 1; y++)
+            {
+                var tileHelper = new TileHelper(MapId, x, y);
+                if (tileHelper.TryFix())
                 {
-                    PacketSender.SendAnimationToProximity(
-                        Base.AnimationId, -1, Guid.Empty, MapId, X, Y, Direction.Up, MapInstanceId
-                    );
-                }
-            }
- 
-            PacketSender.SendEntityDataToProximity(this);
-            PacketSender.SendEntityPositionToAll(this);
-        }
-
-        public void Spawn()
-        {
-            Sprite = Base.Initial.Graphic;
-            if (Base.MaxHp < Base.MinHp)
-            {
-                Base.MaxHp = Base.MinHp;
-            }
-
-            SetMaxVital(Vital.Health, Randomization.Next(Base.MinHp, Base.MaxHp + 1));
-            RestoreVital(Vital.Health);
-            Passable = Base.WalkableBefore;
-            Items.Clear();
-
-            //Give Resource Drops
-            var itemSlot = 0;
-            foreach (var drop in Base.Drops)
-            {
-                if (Randomization.Next(1, 10001) <= drop.Chance * 100 && ItemBase.Get(drop.ItemId) != null)
-                {
-                    var slot = new InventorySlot(itemSlot);
-                    slot.Set(new Item(drop.ItemId, drop.Quantity));
-                    Items.Add(slot);
-                    itemSlot++;
-                }
-            }
-
-            Dead = false;
-            PacketSender.SendEntityDataToProximity(this);
-            PacketSender.SendEntityPositionToAll(this);
-        }
-
-        public void SpawnResourceItems(Entity killer)
-        {
-            //Find tile to spawn items
-            var tiles = new List<TileHelper>();
-            for (var x = X - 1; x <= X + 1; x++)
-            {
-                for (var y = Y - 1; y <= Y + 1; y++)
-                {
-                    var tileHelper = new TileHelper(MapId, x, y);
-                    if (tileHelper.TryFix())
+                    //Tile is valid.. let's see if its open
+                    var mapId = tileHelper.GetMapId();
+                    if (MapController.TryGetInstanceFromMap(mapId, MapInstanceId, out var mapInstance))
                     {
-                        //Tile is valid.. let's see if its open
-                        var mapId = tileHelper.GetMapId();
-                        if (MapController.TryGetInstanceFromMap(mapId, MapInstanceId, out var mapInstance))
+                        if (!mapInstance.TileBlocked(tileHelper.GetX(), tileHelper.GetY()))
                         {
-                            if (!mapInstance.TileBlocked(tileHelper.GetX(), tileHelper.GetY()))
+                            tiles.Add(tileHelper);
+                        }
+                        else
+                        {
+                            if (killer.MapId == tileHelper.GetMapId() &&
+                                killer.X == tileHelper.GetX() &&
+                                killer.Y == tileHelper.GetY())
                             {
                                 tiles.Add(tileHelper);
                             }
-                            else
-                            {
-                                if (killer.MapId == tileHelper.GetMapId() &&
-                                    killer.X == tileHelper.GetX() &&
-                                    killer.Y == tileHelper.GetY())
-                                {
-                                    tiles.Add(tileHelper);
-                                }
-                            }
                         }
                     }
                 }
             }
+        }
 
-            if (tiles.Count > 0)
+        if (tiles.Count > 0)
+        {
+            TileHelper selectedTile = null;
+
+            //Prefer the players tile, otherwise choose randomly
+            for (var i = 0; i < tiles.Count; i++)
             {
-                TileHelper selectedTile = null;
-
-                //Prefer the players tile, otherwise choose randomly
-                for (var i = 0; i < tiles.Count; i++)
+                if (tiles[i].GetMapId() == killer.MapId &&
+                    tiles[i].GetX() == killer.X &&
+                    tiles[i].GetY() == killer.Y)
                 {
-                    if (tiles[i].GetMapId() == killer.MapId &&
-                        tiles[i].GetX() == killer.X &&
-                        tiles[i].GetY() == killer.Y)
+                    selectedTile = tiles[i];
+                }
+            }
+
+            if (selectedTile == null)
+            {
+                selectedTile = tiles[Randomization.Next(0, tiles.Count)];
+            }
+
+            // Drop items
+            foreach (var item in Items)
+            {
+                if (ItemBase.Get(item.ItemId) != null)
+                {
+                    var mapId = selectedTile.GetMapId();
+                    if (MapController.TryGetInstanceFromMap(mapId, MapInstanceId, out var mapInstance))
                     {
-                        selectedTile = tiles[i];
+                        mapInstance.SpawnItem(selectedTile.GetX(), selectedTile.GetY(), item, item.Quantity, killer.Id);
                     }
                 }
-
-                if (selectedTile == null)
-                {
-                    selectedTile = tiles[Randomization.Next(0, tiles.Count)];
-                }
-
-                // Drop items
-                foreach (var item in Items)
-                {
-                    if (ItemBase.Get(item.ItemId) != null)
-                    {
-                        var mapId = selectedTile.GetMapId();
-                        if (MapController.TryGetInstanceFromMap(mapId, MapInstanceId, out var mapInstance))
-                        {
-                            mapInstance.SpawnItem(selectedTile.GetX(), selectedTile.GetY(), item, item.Quantity, killer.Id);
-                        }
-                    }
-                }
             }
-
-            Items.Clear();
         }
 
-        public override void ProcessRegen()
+        Items.Clear();
+    }
+
+    public override void ProcessRegen()
+    {
+        //For now give npcs/resources 10% health back every regen tick... in the future we should put per-npc and per-resource regen settings into their respective editors.
+        if (!IsDead())
         {
-            //For now give npcs/resources 10% health back every regen tick... in the future we should put per-npc and per-resource regen settings into their respective editors.
-            if (!IsDead())
+            if (Base == null)
             {
-                if (Base == null)
-                {
-                    return;
-                }
-                
-                var vital = Vital.Health;
-
-                var vitalId = (int) vital;
-                var vitalValue = GetVital(vital);
-                var maxVitalValue = GetMaxVital(vital);
-                if (vitalValue < maxVitalValue)
-                {
-                    var vitalRegenRate = Base.VitalRegen / 100f;
-                    var regenValue = (long) Math.Max(1, maxVitalValue * vitalRegenRate) *
-                                     Math.Abs(Math.Sign(vitalRegenRate));
-
-                    AddVital(vital, regenValue);
-                }
+                return;
             }
-        }
+            
+            var vital = Vital.Health;
 
-        public override bool IsPassable()
-        {
-            return IsDead() & Base.WalkableAfter || !IsDead() && Base.WalkableBefore;
-        }
-
-        public override EntityPacket EntityPacket(EntityPacket packet = null, Player forPlayer = null)
-        {
-            if (packet == null)
+            var vitalId = (int) vital;
+            var vitalValue = GetVital(vital);
+            var maxVitalValue = GetMaxVital(vital);
+            if (vitalValue < maxVitalValue)
             {
-                packet = new ResourceEntityPacket();
+                var vitalRegenRate = Base.VitalRegen / 100f;
+                var regenValue = (long) Math.Max(1, maxVitalValue * vitalRegenRate) *
+                                 Math.Abs(Math.Sign(vitalRegenRate));
+
+                AddVital(vital, regenValue);
             }
-
-            packet = base.EntityPacket(packet, forPlayer);
-
-            var pkt = (ResourceEntityPacket) packet;
-            pkt.ResourceId = Base.Id;
-            pkt.IsDead = IsDead();
-
-            return pkt;
-        }
-
-        public override EntityType GetEntityType()
-        {
-            return EntityType.Resource;
         }
     }
 
+    public override bool IsPassable()
+    {
+        return IsDead() & Base.WalkableAfter || !IsDead() && Base.WalkableBefore;
+    }
+
+    public override EntityPacket EntityPacket(EntityPacket packet = null, Player forPlayer = null)
+    {
+        if (packet == null)
+        {
+            packet = new ResourceEntityPacket();
+        }
+
+        packet = base.EntityPacket(packet, forPlayer);
+
+        var pkt = (ResourceEntityPacket) packet;
+        pkt.ResourceId = Base.Id;
+        pkt.IsDead = IsDead();
+
+        return pkt;
+    }
+
+    public override EntityType GetEntityType()
+    {
+        return EntityType.Resource;
+    }
 }

--- a/Intersect.Server.Core/Entities/Trading.cs
+++ b/Intersect.Server.Core/Entities/Trading.cs
@@ -1,43 +1,41 @@
 using Intersect.Server.Database;
 
-namespace Intersect.Server.Entities
+namespace Intersect.Server.Entities;
+
+
+public partial struct Trading : IDisposable
 {
 
-    public partial struct Trading : IDisposable
+    private readonly Player mPlayer;
+
+    public bool Actively => Counterparty != null;
+
+    public Player Counterparty;
+
+    public bool Accepted;
+
+    public Item[] Offer;
+
+    public Player Requester;
+
+    public Dictionary<Player, long> Requests;
+
+    public Trading(Player player)
     {
+        mPlayer = player;
 
-        private readonly Player mPlayer;
+        Accepted = false;
+        Counterparty = null;
+        Offer = new Item[Options.MaxInvItems];
+        Requester = null;
+        Requests = new Dictionary<Player, long>();
+    }
 
-        public bool Actively => Counterparty != null;
-
-        public Player Counterparty;
-
-        public bool Accepted;
-
-        public Item[] Offer;
-
-        public Player Requester;
-
-        public Dictionary<Player, long> Requests;
-
-        public Trading(Player player)
-        {
-            mPlayer = player;
-
-            Accepted = false;
-            Counterparty = null;
-            Offer = new Item[Options.MaxInvItems];
-            Requester = null;
-            Requests = new Dictionary<Player, long>();
-        }
-
-        public void Dispose()
-        {
-            Offer = Array.Empty<Item>();
-            Requester = null;
-            Requests.Clear();
-        }
-
+    public void Dispose()
+    {
+        Offer = Array.Empty<Item>();
+        Requester = null;
+        Requests.Clear();
     }
 
 }

--- a/Intersect.Server.Core/Extensions/EnumerableExtensions.cs
+++ b/Intersect.Server.Core/Extensions/EnumerableExtensions.cs
@@ -1,59 +1,54 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-
-using Intersect.Server.Web.RestApi.Payloads;
+﻿using Intersect.Server.Web.RestApi.Payloads;
 
 using Microsoft.EntityFrameworkCore;
 
-namespace Intersect.Server.Extensions
+namespace Intersect.Server.Extensions;
+
+
+public static partial class EnumerableExtensions
 {
 
-    public static partial class EnumerableExtensions
+    public static IEnumerable<TValue> Sort<TValue>(
+        this IEnumerable<TValue> queryable,
+        IReadOnlyCollection<Sort> sort
+    )
     {
-
-        public static IEnumerable<TValue> Sort<TValue>(
-            this IEnumerable<TValue> queryable,
-            IReadOnlyCollection<Sort> sort
-        )
+        if (sort == null || sort.Count < 1)
         {
-            if (sort == null || sort.Count < 1)
-            {
-                return queryable;
-            }
-
-            var sorted = queryable;
-            var orderedOnce = false;
-            foreach (var sortPair in sort)
-            {
-                if (string.IsNullOrWhiteSpace(sortPair.By))
-                {
-                    continue;
-                }
-
-                object OrderLambda(TValue entity)
-                {
-                    return EF.Property<object>(entity, sortPair.By);
-                }
-
-                if (sortPair.Direction == SortDirection.Ascending)
-                {
-                    sorted = orderedOnce
-                        ? ((IOrderedEnumerable<TValue>) sorted).ThenBy(OrderLambda)
-                        : sorted.OrderBy(OrderLambda);
-                }
-                else
-                {
-                    sorted = orderedOnce
-                        ? ((IOrderedEnumerable<TValue>) sorted).ThenByDescending(OrderLambda)
-                        : sorted.OrderByDescending(OrderLambda);
-                }
-
-                orderedOnce = true;
-            }
-
-            return sorted;
+            return queryable;
         }
 
+        var sorted = queryable;
+        var orderedOnce = false;
+        foreach (var sortPair in sort)
+        {
+            if (string.IsNullOrWhiteSpace(sortPair.By))
+            {
+                continue;
+            }
+
+            object OrderLambda(TValue entity)
+            {
+                return EF.Property<object>(entity, sortPair.By);
+            }
+
+            if (sortPair.Direction == SortDirection.Ascending)
+            {
+                sorted = orderedOnce
+                    ? ((IOrderedEnumerable<TValue>) sorted).ThenBy(OrderLambda)
+                    : sorted.OrderBy(OrderLambda);
+            }
+            else
+            {
+                sorted = orderedOnce
+                    ? ((IOrderedEnumerable<TValue>) sorted).ThenByDescending(OrderLambda)
+                    : sorted.OrderByDescending(OrderLambda);
+            }
+
+            orderedOnce = true;
+        }
+
+        return sorted;
     }
 
 }

--- a/Intersect.Server.Core/Extensions/QueryableExtensions.cs
+++ b/Intersect.Server.Core/Extensions/QueryableExtensions.cs
@@ -1,120 +1,115 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
+﻿using System.Linq.Expressions;
 
 using Intersect.Server.Web.RestApi.Payloads;
 
 using Microsoft.EntityFrameworkCore;
 
-namespace Intersect.Server.Extensions
+namespace Intersect.Server.Extensions;
+
+
+public static partial class QueryableExtensions
 {
 
-    public static partial class QueryableExtensions
+    public static IQueryable<TValue> Sort<TValue>(
+        this IQueryable<TValue> queryable,
+        IReadOnlyCollection<Sort> sort
+    )
     {
+        return DoSort(queryable, sort);
+    }
 
-        public static IQueryable<TValue> Sort<TValue>(
-            this IQueryable<TValue> queryable,
-            IReadOnlyCollection<Sort> sort
-        )
+    public static bool IsOrdered<TValue>(this IQueryable<TValue> queryable)
+    {
+        return queryable.Expression.Type == typeof(IOrderedQueryable<TValue>);
+    }
+
+    public static IOrderedQueryable<TValue> SmartOrderBy<TValue>(
+        this IQueryable<TValue> queryable,
+        Sort sort
+    )
+    {
+        return sort.Direction == SortDirection.Ascending
+            ? queryable.OrderBy(entity => EF.Property<object>(entity, sort.By))
+            : queryable.OrderByDescending(entity => EF.Property<object>(entity, sort.By));
+    }
+
+    public static IOrderedQueryable<TValue> SmartThenBy<TValue>(
+        this IOrderedQueryable<TValue> queryable,
+        Sort sort
+    )
+    {
+        return sort.Direction == SortDirection.Ascending
+            ? queryable.ThenBy(entity => EF.Property<object>(entity, sort.By))
+            : queryable.ThenByDescending(entity => EF.Property<object>(entity, sort.By));
+    }
+
+    public static IQueryable<TValue> SmartSort<TValue>(this IQueryable<TValue> queryable, Sort sort)
+    {
+        return sort.Direction == SortDirection.Ascending
+            ? SmartSortAscending(queryable, sort)
+            : SmartSortDescending(queryable, sort);
+    }
+
+    public static IQueryable<TValue> SmartSortAscending<TValue>(
+        this IQueryable<TValue> queryable,
+        Sort sort
+    )
+    {
+        return queryable.IsOrdered()
+            ? (queryable as IOrderedQueryable<TValue>)?.ThenBy(entity => EF.Property<object>(entity, sort.By))
+            : queryable.OrderBy(entity => EF.Property<object>(entity, sort.By));
+    }
+
+    public static IQueryable<TValue> SmartSortDescending<TValue>(
+        this IQueryable<TValue> queryable,
+        Sort sort
+    )
+    {
+        return queryable.IsOrdered()
+            ? (queryable as IOrderedQueryable<TValue>)?.ThenByDescending(
+                entity => EF.Property<object>(entity, sort.By)
+            )
+            : queryable.OrderByDescending(entity => EF.Property<object>(entity, sort.By));
+    }
+
+    public static IQueryable<TValue> DoSort<TValue>(
+        IQueryable<TValue> queryable,
+        IReadOnlyCollection<Sort> sort
+    )
+    {
+        if (sort == null || sort.Count < 1)
         {
-            return DoSort(queryable, sort);
+            return queryable;
         }
 
-        public static bool IsOrdered<TValue>(this IQueryable<TValue> queryable)
+        var sorted = queryable;
+        var orderedOnce = false;
+        foreach (var sortPair in sort)
         {
-            return queryable.Expression.Type == typeof(IOrderedQueryable<TValue>);
-        }
-
-        public static IOrderedQueryable<TValue> SmartOrderBy<TValue>(
-            this IQueryable<TValue> queryable,
-            Sort sort
-        )
-        {
-            return sort.Direction == SortDirection.Ascending
-                ? queryable.OrderBy(entity => EF.Property<object>(entity, sort.By))
-                : queryable.OrderByDescending(entity => EF.Property<object>(entity, sort.By));
-        }
-
-        public static IOrderedQueryable<TValue> SmartThenBy<TValue>(
-            this IOrderedQueryable<TValue> queryable,
-            Sort sort
-        )
-        {
-            return sort.Direction == SortDirection.Ascending
-                ? queryable.ThenBy(entity => EF.Property<object>(entity, sort.By))
-                : queryable.ThenByDescending(entity => EF.Property<object>(entity, sort.By));
-        }
-
-        public static IQueryable<TValue> SmartSort<TValue>(this IQueryable<TValue> queryable, Sort sort)
-        {
-            return sort.Direction == SortDirection.Ascending
-                ? SmartSortAscending(queryable, sort)
-                : SmartSortDescending(queryable, sort);
-        }
-
-        public static IQueryable<TValue> SmartSortAscending<TValue>(
-            this IQueryable<TValue> queryable,
-            Sort sort
-        )
-        {
-            return queryable.IsOrdered()
-                ? (queryable as IOrderedQueryable<TValue>)?.ThenBy(entity => EF.Property<object>(entity, sort.By))
-                : queryable.OrderBy(entity => EF.Property<object>(entity, sort.By));
-        }
-
-        public static IQueryable<TValue> SmartSortDescending<TValue>(
-            this IQueryable<TValue> queryable,
-            Sort sort
-        )
-        {
-            return queryable.IsOrdered()
-                ? (queryable as IOrderedQueryable<TValue>)?.ThenByDescending(
-                    entity => EF.Property<object>(entity, sort.By)
-                )
-                : queryable.OrderByDescending(entity => EF.Property<object>(entity, sort.By));
-        }
-
-        public static IQueryable<TValue> DoSort<TValue>(
-            IQueryable<TValue> queryable,
-            IReadOnlyCollection<Sort> sort
-        )
-        {
-            if (sort == null || sort.Count < 1)
+            if (string.IsNullOrWhiteSpace(sortPair.By))
             {
-                return queryable;
+                continue;
             }
 
-            var sorted = queryable;
-            var orderedOnce = false;
-            foreach (var sortPair in sort)
+            Expression<Func<TValue, object>> orderLambda = entity => EF.Property<object>(entity, sortPair.By);
+
+            if (sortPair.Direction == SortDirection.Ascending)
             {
-                if (string.IsNullOrWhiteSpace(sortPair.By))
-                {
-                    continue;
-                }
-
-                Expression<Func<TValue, object>> orderLambda = entity => EF.Property<object>(entity, sortPair.By);
-
-                if (sortPair.Direction == SortDirection.Ascending)
-                {
-                    sorted = orderedOnce
-                        ? ((IOrderedQueryable<TValue>) sorted).ThenBy(orderLambda)
-                        : sorted.OrderBy(orderLambda);
-                }
-                else
-                {
-                    sorted = orderedOnce
-                        ? ((IOrderedQueryable<TValue>) sorted).ThenByDescending(orderLambda)
-                        : sorted.OrderByDescending(orderLambda);
-                }
-
-                orderedOnce = true;
+                sorted = orderedOnce
+                    ? ((IOrderedQueryable<TValue>) sorted).ThenBy(orderLambda)
+                    : sorted.OrderBy(orderLambda);
+            }
+            else
+            {
+                sorted = orderedOnce
+                    ? ((IOrderedQueryable<TValue>) sorted).ThenByDescending(orderLambda)
+                    : sorted.OrderByDescending(orderLambda);
             }
 
-            return sorted;
+            orderedOnce = true;
         }
 
+        return sorted;
     }
 
 }

--- a/Intersect.Server.Core/General/Formulas.cs
+++ b/Intersect.Server.Core/General/Formulas.cs
@@ -8,191 +8,189 @@ using NCalc;
 
 using Newtonsoft.Json;
 
-namespace Intersect.Server.General
+namespace Intersect.Server.General;
+
+
+public partial class Formulas
 {
 
-    public partial class Formulas
+    private static string FORMULAS_FILE => Path.Combine(ServerContext.ResourceDirectory, "formulas.json");
+
+    private static Formulas mFormulas;
+
+    public Formula ExpFormula = new Formula("BaseExp * Power(Gain, Level)");
+
+    public string MagicDamage =
+        "Random(((BaseDamage + (ScalingStat * ScaleFactor))) * CritMultiplier * .975, ((BaseDamage + (ScalingStat * ScaleFactor))) * CritMultiplier * 1.025) * (100 / (100 + V_MagicResist))";
+
+    public string PhysicalDamage =
+        "Random(((BaseDamage + (ScalingStat * ScaleFactor))) * CritMultiplier * .975, ((BaseDamage + (ScalingStat * ScaleFactor))) * CritMultiplier * 1.025) * (100 / (100 + V_Defense))";
+
+    public string TrueDamage =
+        "Random(((BaseDamage + (ScalingStat * ScaleFactor))) * CritMultiplier * .975, ((BaseDamage + (ScalingStat * ScaleFactor))) * CritMultiplier * 1.025)";
+
+    public static void LoadFormulas()
     {
+        Console.WriteLine("Loading formulae...");
 
-        private static string FORMULAS_FILE => Path.Combine(ServerContext.ResourceDirectory, "formulas.json");
-
-        private static Formulas mFormulas;
-
-        public Formula ExpFormula = new Formula("BaseExp * Power(Gain, Level)");
-
-        public string MagicDamage =
-            "Random(((BaseDamage + (ScalingStat * ScaleFactor))) * CritMultiplier * .975, ((BaseDamage + (ScalingStat * ScaleFactor))) * CritMultiplier * 1.025) * (100 / (100 + V_MagicResist))";
-
-        public string PhysicalDamage =
-            "Random(((BaseDamage + (ScalingStat * ScaleFactor))) * CritMultiplier * .975, ((BaseDamage + (ScalingStat * ScaleFactor))) * CritMultiplier * 1.025) * (100 / (100 + V_Defense))";
-
-        public string TrueDamage =
-            "Random(((BaseDamage + (ScalingStat * ScaleFactor))) * CritMultiplier * .975, ((BaseDamage + (ScalingStat * ScaleFactor))) * CritMultiplier * 1.025)";
-
-        public static void LoadFormulas()
+        try
         {
-            Console.WriteLine("Loading formulae...");
-
-            try
+            mFormulas = new Formulas();
+            if (File.Exists(FORMULAS_FILE))
             {
-                mFormulas = new Formulas();
-                if (File.Exists(FORMULAS_FILE))
+                mFormulas = JsonConvert.DeserializeObject<Formulas>(File.ReadAllText(FORMULAS_FILE));
+            }
+
+            File.WriteAllText(FORMULAS_FILE, JsonConvert.SerializeObject(mFormulas, Formatting.Indented));
+
+            Expression.CacheEnabled = false;
+        }
+        catch (Exception ex)
+        {
+            throw new Exception(Strings.Formulas.missing, ex);
+        }
+    }
+
+    public static long CalculateDamage(
+        long baseDamage,
+        DamageType damageType,
+        Stat scalingStat,
+        int scaling,
+        double critMultiplier,
+        Entity attacker,
+        Entity victim
+    )
+    {
+        if (mFormulas == null)
+        {
+            throw new ArgumentNullException(nameof(mFormulas));
+        }
+
+        if (attacker == null)
+        {
+            throw new ArgumentNullException(nameof(attacker));
+        }
+
+        if (attacker.Stat == null)
+        {
+            throw new ArgumentNullException(
+                nameof(attacker.Stat), $@"{nameof(attacker)}.{nameof(attacker.Stat)} is null"
+            );
+        }
+
+        if (victim == null)
+        {
+            throw new ArgumentNullException(nameof(victim));
+        }
+
+        if (victim.Stat == null)
+        {
+            throw new ArgumentNullException(
+                nameof(victim.Stat), $@"{nameof(victim)}.{nameof(victim.Stat)} is null"
+            );
+        }
+
+        string expressionString;
+        switch (damageType)
+        {
+            case DamageType.Physical:
+                expressionString = mFormulas.PhysicalDamage;
+
+                break;
+            case DamageType.Magic:
+                expressionString = mFormulas.MagicDamage;
+
+                break;
+            case DamageType.True:
+                expressionString = mFormulas.TrueDamage;
+
+                break;
+            default:
+                expressionString = mFormulas.TrueDamage;
+
+                break;
+        }
+
+        var expression = new Expression(expressionString);
+        var negate = false;
+        if (baseDamage < 0)
+        {
+            baseDamage = Math.Abs(baseDamage);
+            negate = true;
+        }
+
+        if (expression.Parameters == null)
+        {
+            throw new ArgumentNullException(nameof(expression.Parameters));
+        }
+
+        try
+        {
+            expression.Parameters["BaseDamage"] = baseDamage;
+            expression.Parameters["ScalingStat"] = attacker.Stat[(int) scalingStat].Value();
+            expression.Parameters["ScaleFactor"] = scaling / 100f;
+            expression.Parameters["CritMultiplier"] = critMultiplier;
+            expression.Parameters["A_Attack"] = attacker.Stat[(int) Stat.Attack].Value();
+            expression.Parameters["A_Defense"] = attacker.Stat[(int) Stat.Defense].Value();
+            expression.Parameters["A_Speed"] = attacker.Stat[(int) Stat.Speed].Value();
+            expression.Parameters["A_AbilityPwr"] = attacker.Stat[(int) Stat.AbilityPower].Value();
+            expression.Parameters["A_MagicResist"] = attacker.Stat[(int) Stat.MagicResist].Value();
+            expression.Parameters["V_Attack"] = victim.Stat[(int) Stat.Attack].Value();
+            expression.Parameters["V_Defense"] = victim.Stat[(int) Stat.Defense].Value();
+            expression.Parameters["V_Speed"] = victim.Stat[(int) Stat.Speed].Value();
+            expression.Parameters["V_AbilityPwr"] = victim.Stat[(int) Stat.AbilityPower].Value();
+            expression.Parameters["V_MagicResist"] = victim.Stat[(int) Stat.MagicResist].Value();
+            expression.EvaluateFunction += delegate(string name, FunctionArgs args)
+            {
+                if (args == null)
                 {
-                    mFormulas = JsonConvert.DeserializeObject<Formulas>(File.ReadAllText(FORMULAS_FILE));
+                    throw new ArgumentNullException(nameof(args));
                 }
 
-                File.WriteAllText(FORMULAS_FILE, JsonConvert.SerializeObject(mFormulas, Formatting.Indented));
-
-                Expression.CacheEnabled = false;
-            }
-            catch (Exception ex)
-            {
-                throw new Exception(Strings.Formulas.missing, ex);
-            }
-        }
-
-        public static long CalculateDamage(
-            long baseDamage,
-            DamageType damageType,
-            Stat scalingStat,
-            int scaling,
-            double critMultiplier,
-            Entity attacker,
-            Entity victim
-        )
-        {
-            if (mFormulas == null)
-            {
-                throw new ArgumentNullException(nameof(mFormulas));
-            }
-
-            if (attacker == null)
-            {
-                throw new ArgumentNullException(nameof(attacker));
-            }
-
-            if (attacker.Stat == null)
-            {
-                throw new ArgumentNullException(
-                    nameof(attacker.Stat), $@"{nameof(attacker)}.{nameof(attacker.Stat)} is null"
-                );
-            }
-
-            if (victim == null)
-            {
-                throw new ArgumentNullException(nameof(victim));
-            }
-
-            if (victim.Stat == null)
-            {
-                throw new ArgumentNullException(
-                    nameof(victim.Stat), $@"{nameof(victim)}.{nameof(victim.Stat)} is null"
-                );
-            }
-
-            string expressionString;
-            switch (damageType)
-            {
-                case DamageType.Physical:
-                    expressionString = mFormulas.PhysicalDamage;
-
-                    break;
-                case DamageType.Magic:
-                    expressionString = mFormulas.MagicDamage;
-
-                    break;
-                case DamageType.True:
-                    expressionString = mFormulas.TrueDamage;
-
-                    break;
-                default:
-                    expressionString = mFormulas.TrueDamage;
-
-                    break;
-            }
-
-            var expression = new Expression(expressionString);
-            var negate = false;
-            if (baseDamage < 0)
-            {
-                baseDamage = Math.Abs(baseDamage);
-                negate = true;
-            }
-
-            if (expression.Parameters == null)
-            {
-                throw new ArgumentNullException(nameof(expression.Parameters));
-            }
-
-            try
-            {
-                expression.Parameters["BaseDamage"] = baseDamage;
-                expression.Parameters["ScalingStat"] = attacker.Stat[(int) scalingStat].Value();
-                expression.Parameters["ScaleFactor"] = scaling / 100f;
-                expression.Parameters["CritMultiplier"] = critMultiplier;
-                expression.Parameters["A_Attack"] = attacker.Stat[(int) Stat.Attack].Value();
-                expression.Parameters["A_Defense"] = attacker.Stat[(int) Stat.Defense].Value();
-                expression.Parameters["A_Speed"] = attacker.Stat[(int) Stat.Speed].Value();
-                expression.Parameters["A_AbilityPwr"] = attacker.Stat[(int) Stat.AbilityPower].Value();
-                expression.Parameters["A_MagicResist"] = attacker.Stat[(int) Stat.MagicResist].Value();
-                expression.Parameters["V_Attack"] = victim.Stat[(int) Stat.Attack].Value();
-                expression.Parameters["V_Defense"] = victim.Stat[(int) Stat.Defense].Value();
-                expression.Parameters["V_Speed"] = victim.Stat[(int) Stat.Speed].Value();
-                expression.Parameters["V_AbilityPwr"] = victim.Stat[(int) Stat.AbilityPower].Value();
-                expression.Parameters["V_MagicResist"] = victim.Stat[(int) Stat.MagicResist].Value();
-                expression.EvaluateFunction += delegate(string name, FunctionArgs args)
+                if (name == "Random")
                 {
-                    if (args == null)
-                    {
-                        throw new ArgumentNullException(nameof(args));
-                    }
-
-                    if (name == "Random")
-                    {
-                        args.Result = Random(args);
-                    }
-                };
-
-                var result = Convert.ToDouble(expression.Evaluate());
-                if (negate)
-                {
-                    result = -result;
+                    args.Result = Random(args);
                 }
+            };
 
-                return (long) Math.Round(result);
-            }
-            catch (Exception ex)
+            var result = Convert.ToDouble(expression.Evaluate());
+            if (negate)
             {
-                throw new Exception("Failed to evaluate damage formula", ex);
+                result = -result;
             }
-        }
 
-        private static int Random(FunctionArgs args)
+            return (long) Math.Round(result);
+        }
+        catch (Exception ex)
         {
-            if (args.Parameters == null)
-            {
-                throw new ArgumentNullException(nameof(args.Parameters));
-            }
+            throw new Exception("Failed to evaluate damage formula", ex);
+        }
+    }
 
-            var parameters = args.EvaluateParameters() ??
-                             throw new NullReferenceException($"{nameof(args.EvaluateParameters)}() returned null.");
-
-            if (parameters.Length < 2)
-            {
-                throw new ArgumentException($"{nameof(Random)}() requires 2 numerical parameters.");
-            }
-
-            var min = (int) Math.Round(
-                (double) (parameters[0] ?? throw new NullReferenceException("First parameter is null."))
-            );
-
-            var max = (int) Math.Round(
-                (double) (parameters[1] ?? throw new NullReferenceException("First parameter is null."))
-            );
-
-            return min >= max ? min : Randomization.Next(min, max + 1);
+    private static int Random(FunctionArgs args)
+    {
+        if (args.Parameters == null)
+        {
+            throw new ArgumentNullException(nameof(args.Parameters));
         }
 
+        var parameters = args.EvaluateParameters() ??
+                         throw new NullReferenceException($"{nameof(args.EvaluateParameters)}() returned null.");
+
+        if (parameters.Length < 2)
+        {
+            throw new ArgumentException($"{nameof(Random)}() requires 2 numerical parameters.");
+        }
+
+        var min = (int) Math.Round(
+            (double) (parameters[0] ?? throw new NullReferenceException("First parameter is null."))
+        );
+
+        var max = (int) Math.Round(
+            (double) (parameters[1] ?? throw new NullReferenceException("First parameter is null."))
+        );
+
+        return min >= max ? min : Randomization.Next(min, max + 1);
     }
 
 }

--- a/Intersect.Server.Core/General/Globals.cs
+++ b/Intersect.Server.Core/General/Globals.cs
@@ -3,58 +3,56 @@ using Intersect.Server.Entities;
 using Intersect.Server.Maps;
 using Intersect.Server.Networking;
 
-namespace Intersect.Server.General
+namespace Intersect.Server.General;
+
+
+public static partial class Globals
 {
 
-    public static partial class Globals
+    public static readonly object ClientLock = new object();
+
+    public static readonly IDictionary<Guid, Client> ClientLookup = new Dictionary<Guid, Client>();
+
+    public static readonly List<Client> Clients = new List<Client>();
+
+    public static Client[] ClientArray = new Client[0];
+
+    public static long Cps = 0;
+
+    public static List<Player> OnlineList => Clients.FindAll(client => client?.Entity != null)
+        .Select(client => client.Entity)
+        .ToList();
+
+    public static void KillResourcesOf(ResourceBase resource)
     {
-
-        public static readonly object ClientLock = new object();
-
-        public static readonly IDictionary<Guid, Client> ClientLookup = new Dictionary<Guid, Client>();
-
-        public static readonly List<Client> Clients = new List<Client>();
-
-        public static Client[] ClientArray = new Client[0];
-
-        public static long Cps = 0;
-
-        public static List<Player> OnlineList => Clients.FindAll(client => client?.Entity != null)
-            .Select(client => client.Entity)
-            .ToList();
-
-        public static void KillResourcesOf(ResourceBase resource)
+        foreach (MapController map in MapController.Lookup.Values)
         {
-            foreach (MapController map in MapController.Lookup.Values)
-            {
-                map?.DespawnResourceAcrossInstances(resource);
-            }
+            map?.DespawnResourceAcrossInstances(resource);
         }
+    }
 
-        public static void KillNpcsOf(NpcBase npc)
+    public static void KillNpcsOf(NpcBase npc)
+    {
+        foreach (MapController map in MapController.Lookup.Values)
         {
-            foreach (MapController map in MapController.Lookup.Values)
-            {
-                map?.DespawnNpcAcrossInstances(npc);
-            }
+            map?.DespawnNpcAcrossInstances(npc);
         }
+    }
 
-        public static void KillProjectilesOf(ProjectileBase projectile)
+    public static void KillProjectilesOf(ProjectileBase projectile)
+    {
+        foreach (MapController map in MapController.Lookup.Values)
         {
-            foreach (MapController map in MapController.Lookup.Values)
-            {
-                map?.DespawnProjectileAcrossInstances(projectile);
-            }
+            map?.DespawnProjectileAcrossInstances(projectile);
         }
+    }
 
-        public static void KillItemsOf(ItemBase item)
+    public static void KillItemsOf(ItemBase item)
+    {
+        foreach (MapController map in MapController.Lookup.Values)
         {
-            foreach (MapController map in MapController.Lookup.Values)
-            {
-                map?.DespawnItemAcrossInstances(item);
-            }
+            map?.DespawnItemAcrossInstances(item);
         }
-
     }
 
 }

--- a/Intersect.Server.Core/General/Time.cs
+++ b/Intersect.Server.Core/General/Time.cs
@@ -2,101 +2,99 @@ using Intersect.GameObjects;
 using Intersect.Server.Networking;
 using Intersect.Utilities;
 
-namespace Intersect.Server.General
+namespace Intersect.Server.General;
+
+
+public static partial class Time
 {
 
-    public static partial class Time
+    private static DateTime sGameTime;
+
+    private static int sTimeRange;
+
+    private static long sUpdateTime;
+
+    public static string Hour = "00";
+    public static string MilitaryHour = "00";
+    public static string Minute = "00";
+    public static string Second = "00";
+
+
+    public static void Init()
     {
-
-        private static DateTime sGameTime;
-
-        private static int sTimeRange;
-
-        private static long sUpdateTime;
-
-        public static string Hour = "00";
-        public static string MilitaryHour = "00";
-        public static string Minute = "00";
-        public static string Second = "00";
-
-
-        public static void Init()
+        var timeBase = TimeBase.GetTimeBase();
+        if (timeBase.SyncTime)
         {
-            var timeBase = TimeBase.GetTimeBase();
+            sGameTime = DateTime.Now;
+        }
+        else
+        {
+            sGameTime = new DateTime(
+                DateTime.Now.Year,
+                DateTime.Now.Month,
+                DateTime.Now.Day,
+                Randomization.Next(0, 24),
+                Randomization.Next(0, 60),
+                Randomization.Next(0, 60)
+            );
+        }
+
+        sTimeRange = 0;
+        sUpdateTime = 0;
+    }
+
+    public static void Update()
+    {
+        var timeBase = TimeBase.GetTimeBase();
+        if (Timing.Global.Milliseconds > sUpdateTime)
+        {
             if (timeBase.SyncTime)
             {
                 sGameTime = DateTime.Now;
             }
             else
             {
-                sGameTime = new DateTime(
-                    DateTime.Now.Year,
-                    DateTime.Now.Month,
-                    DateTime.Now.Day,
-                    Randomization.Next(0, 24),
-                    Randomization.Next(0, 60),
-                    Randomization.Next(0, 60)
-                );
+                sGameTime = sGameTime.Add(new TimeSpan(0, 0, 0, 0, (int)(1000 * timeBase.Rate)));
+
+                //Not sure if Rate is negative if time will go backwards but we can hope!
             }
 
-            sTimeRange = 0;
-            sUpdateTime = 0;
-        }
+            //Calculate what "timeRange" we should be in, if we're not then switch and notify the world
+            //Gonna do this by minutes
+            var minuteOfDay = sGameTime.Hour * 60 + sGameTime.Minute;
+            var expectedRange = (int) Math.Floor(minuteOfDay / (float) timeBase.RangeInterval);
 
-        public static void Update()
-        {
-            var timeBase = TimeBase.GetTimeBase();
-            if (Timing.Global.Milliseconds > sUpdateTime)
+            if (expectedRange != sTimeRange)
             {
-                if (timeBase.SyncTime)
-                {
-                    sGameTime = DateTime.Now;
-                }
-                else
-                {
-                    sGameTime = sGameTime.Add(new TimeSpan(0, 0, 0, 0, (int)(1000 * timeBase.Rate)));
+                sTimeRange = expectedRange;
 
-                    //Not sure if Rate is negative if time will go backwards but we can hope!
-                }
-
-                //Calculate what "timeRange" we should be in, if we're not then switch and notify the world
-                //Gonna do this by minutes
-                var minuteOfDay = sGameTime.Hour * 60 + sGameTime.Minute;
-                var expectedRange = (int) Math.Floor(minuteOfDay / (float) timeBase.RangeInterval);
-
-                if (expectedRange != sTimeRange)
-                {
-                    sTimeRange = expectedRange;
-
-                    //Send the Update to everyone!
-                    PacketSender.SendTimeToAll();
-                }
-
-                Hour = sGameTime.ToString("%h");
-                MilitaryHour = sGameTime.ToString("HH");
-                Minute = sGameTime.ToString("mm");
-                Second = sGameTime.ToString("ss");
-
-                sUpdateTime = Timing.Global.Milliseconds + 1000;
+                //Send the Update to everyone!
+                PacketSender.SendTimeToAll();
             }
-        }
 
-        public static Color GetTimeColor()
-        {
-            var time = TimeBase.GetTimeBase();
-            return time.DaylightHues[sTimeRange];
-        }
+            Hour = sGameTime.ToString("%h");
+            MilitaryHour = sGameTime.ToString("HH");
+            Minute = sGameTime.ToString("mm");
+            Second = sGameTime.ToString("ss");
 
-        public static int GetTimeRange()
-        {
-            return sTimeRange;
+            sUpdateTime = Timing.Global.Milliseconds + 1000;
         }
+    }
 
-        public static DateTime GetTime()
-        {
-            return sGameTime;
-        }
+    public static Color GetTimeColor()
+    {
+        var time = TimeBase.GetTimeBase();
+        return time.DaylightHues[sTimeRange];
+    }
 
+    public static int GetTimeRange()
+    {
+        return sTimeRange;
+    }
+
+    public static DateTime GetTime()
+    {
+        return sGameTime;
     }
 
 }

--- a/Intersect.Server.Core/Localization/CommandsNamespace.cs
+++ b/Intersect.Server.Core/Localization/CommandsNamespace.cs
@@ -2,492 +2,491 @@ using Intersect.Localization;
 using Intersect.Server.Core.CommandParsing;
 using Newtonsoft.Json;
 
-namespace Intersect.Server.Localization
+namespace Intersect.Server.Localization;
+
+
+public static partial class Strings
 {
 
-    public static partial class Strings
+    public sealed partial class CommandsNamespace : LocaleCommandNamespace
     {
 
-        public sealed partial class CommandsNamespace : LocaleCommandNamespace
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocaleCommand Announcement = new LocaleCommand
+        {
+            Name = @"announcement",
+            Description = @"Sends a global message to all users playing the game.",
+            Help = @"sends a global message to all players"
+        };
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocaleCommand Api = new LocaleCommand
+        {
+            Name = @"api",
+            Description =
+                @"Sets the api access (enabled/disabled) of a selected account. true is enabled, false is disabled",
+            Help = @"enables or disables api access for an account"
+        };
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocaleCommand ApiGrant = new LocaleCommand
+        {
+            Name = @"apigrant",
+            Description = @"Grants extra api access roles for a user. (Options: users.query, users.manage)",
+            Help = @"enables extra api access roles for a account. (Options: users.query, users.manage)"
+        };
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocaleCommand ApiRevoke = new LocaleCommand
+        {
+            Name = @"apirevoke",
+            Description = @"Revokes extra api access roles for a account. (Options: users.query, users.manage)",
+            Help = @"revokes extra api access roles for a account. (Options: users.query, users.manage)"
+        };
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocaleCommand ApiRoles = new LocaleCommand
+        {
+            Name = @"apiroles",
+            Description = @"Lists extra api access roles assigned to a user.",
+            Help = @"lists extra api access roles for an account (Options: users.query, users.manage)"
+        };
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly ArgumentsNamespace Arguments = new ArgumentsNamespace();
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocaleCommand Ban = new LocaleCommand
+        {
+            Name = @"ban",
+            Description = @"Bans a player from the server.",
+            Help = @"bans a player from the server"
+        };
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString banuser = @"console";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString commandinfo = @"/?";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocaleCommand Cps = new LocaleCommand
+        {
+            Name = @"cps",
+            Description =
+                @"Prints the current CPS.",
+            Help = @"prints the current server cps"
+        };
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocaleCommand Exit = new LocaleCommand
+        {
+            Name = @"exit",
+            Description = @"Closes down the server.",
+            Help = @"closes the server"
+        };
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString exited =
+            @"Main server shutdown completed. If your server is stuck you may safely kill it.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString exiting =
+            @"Server is now closing. Please wait while your game and player data is saved!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString ExperimentalFlagNotFound = @"Experimental flag '{00}' was not found!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocaleCommand Experiments = new LocaleCommand
+        {
+            Name = @"experiments",
+            Description = @"Sets the enablement of an experimental feature. true is enabled, false is disabled",
+            Help = @"enables or disables an experimental feature"
+        };
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString FlagInfo = @"(flag)";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocaleCommand Help = new LocaleCommand
+        {
+            Name = @"help",
+            Description = @"help",
+            Help = @"displays list of available commands"
+        };
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString invalid = @"Invalid /command.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocaleCommand Kick = new LocaleCommand
+        {
+            Name = @"kick",
+            Description = @"Kicks a player from the server.",
+            Help = @"kicks a player from the server"
+        };
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocaleCommand SetVariable = new LocaleCommand
+        {
+            Name = @"setvar",
+            Description =
+                @"sets a server variable by id to a value",
+            Help = @"sets a variable by id; e.g. 'setvar <id> true'"
+        };
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocaleCommand GetVariable = new LocaleCommand
+        {
+            Name = @"getvar",
+            Description = @"gets a server variable by id",
+            Help = @"gets a variable by id"
+        };
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocaleCommand ListVariables = new LocaleCommand
+        {
+            Name = @"listvars",
+            Description = @"queries for server variables by page/page size",
+            Help = @"queries for server variables by page/page size; e.g. 'listvars 1 10'"
+        };
+
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocaleCommand Kill = new LocaleCommand
+        {
+            Name = @"kill",
+            Description = @"Kills a player on the server.",
+            Help = @"kills a player on the server"
+        };
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString madeprivate =
+            @"The server has now been made private and can only be accessed by admins. To change this use the makepublic command or edit the adminonly field in config.json";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString madepublic =
+            @"The server has now been made public and can be accessed by all players. To change this use the makepublic command or edit the adminonly field in config.json";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocaleCommand MakePrivate = new LocaleCommand
+        {
+            Name = @"makeprivate",
+            Description = @"Makes the server private and can only be accessed by admins.",
+            Help = @"Makes the server private and can only be accessed by admins."
+        };
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocaleCommand MakePublic = new LocaleCommand
+        {
+            Name = @"makepublic",
+            Description = @"Makes the server public to all players.",
+            Help = @"Makes the server public to all players."
+        };
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocaleCommand Metrics = new LocaleCommand
+        {
+            Name = @"metrics",
+            Description =
+                @"Enables or disables metrics collection.",
+            Help = @"enables or disables metrics collection"
+        };
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocaleCommand Migrate = new LocaleCommand
+        {
+            Name = @"migrate",
+            Description = @"Walks you through migrating your player or game database between sqlite and mysql.",
+            Help = @"walks you through migrating your player or game database between sqlite and mysql"
+        };
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocaleCommand Mute = new LocaleCommand
+        {
+            Name = @"mute",
+            Description = @"mutes a player preventing them from talking.",
+            Help = @"mutes a player preventing them from talking"
+        };
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString muteuser = @"console";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocaleCommand NetDebug = new LocaleCommand
+        {
+            Name = @"netdebug",
+        };
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocaleCommand OnlineList = new LocaleCommand
+        {
+            Name = @"onlinelist",
+            Help = @"shows all players online"
+        };
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocaleCommand Panic = new LocaleCommand
+        {
+            Name = @"panic",
+            Description = @"Collects and dumps information -- THIS WILL CRASH YOUR SERVER",
+            Help = @"collects and dumps information -- THIS WILL CRASH YOUR SERVER"
+        };
+
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly CommandParsingNamespace Parsing = new CommandParsingNamespace();
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocaleCommand Power = new LocaleCommand
+        {
+            Name = @"power",
+            Description =
+                @"Sets the power or access of a selected account. Power 0 is regular user. Power 1 is in-game moderator. Power 2 is owner/designer and allows editor access.",
+            Help = @"sets the administrative access of a user"
+        };
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocaleCommand PowerAccount = new LocaleCommand
+        {
+            Name = @"poweracc",
+            Description =
+                @"Sets the power or access of a selected account. Power 0 is regular user. Power 1 is in-game moderator. Power 2 is owner/designer and allows editor access.",
+            Help = @"sets the administrative access of an account"
+        };
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString RequiredInfo = @"(required)";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocaleCommand Unban = new LocaleCommand
+        {
+            Name = @"unban",
+            Description = @"Unbans a player from the server.",
+            Help = @"unbans a player from the server"
+        };
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocaleCommand Unmute = new LocaleCommand
+        {
+            Name = @"unmute",
+            Description = @"unmutes a player allowing them to talk.",
+            Help = @"unmutes a player allowing them to talk"
+        };
+
+        public sealed partial class ArgumentsNamespace : LocaleNamespace
         {
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocaleCommand Announcement = new LocaleCommand
+            public readonly LocaleArgument AccessBoolean = new LocaleArgument
             {
-                Name = @"announcement",
-                Description = @"Sends a global message to all users playing the game.",
-                Help = @"sends a global message to all players"
+                Name = @"access",
+                Description = @"whether or not to grant/revoke access"
             };
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocaleCommand Api = new LocaleCommand
+            public readonly LocaleArgument AnnouncementMessage = new LocaleArgument
             {
-                Name = @"api",
-                Description =
-                    @"Sets the api access (enabled/disabled) of a selected account. true is enabled, false is disabled",
-                Help = @"enables or disables api access for an account"
+                Name = @"message",
+                Description = @"the message to send"
             };
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocaleCommand ApiGrant = new LocaleCommand
+            public readonly LocaleArgument ApiRole = new LocaleArgument
             {
-                Name = @"apigrant",
-                Description = @"Grants extra api access roles for a user. (Options: users.query, users.manage)",
-                Help = @"enables extra api access roles for a account. (Options: users.query, users.manage)"
+                Name = @"role",
+                Description = @"role to grant or revoke (users.query or users.manage)"
             };
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocaleCommand ApiRevoke = new LocaleCommand
+            public readonly LocalizedString CpsLock = @"lock";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public readonly LocaleArgument CpsOperation = new LocaleArgument
             {
-                Name = @"apirevoke",
-                Description = @"Revokes extra api access roles for a account. (Options: users.query, users.manage)",
-                Help = @"revokes extra api access roles for a account. (Options: users.query, users.manage)"
+                Name = @"operation",
+                Description = @"one of the following: status, lock, unlock"
             };
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocaleCommand ApiRoles = new LocaleCommand
-            {
-                Name = @"apiroles",
-                Description = @"Lists extra api access roles assigned to a user.",
-                Help = @"lists extra api access roles for an account (Options: users.query, users.manage)"
-            };
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly ArgumentsNamespace Arguments = new ArgumentsNamespace();
+            public readonly LocalizedString CpsStatus = @"status";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocaleCommand Ban = new LocaleCommand
-            {
-                Name = @"ban",
-                Description = @"Bans a player from the server.",
-                Help = @"bans a player from the server"
-            };
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString banuser = @"console";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString commandinfo = @"/?";
+            public readonly LocalizedString CpsUnlock = @"unlock";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocaleCommand Cps = new LocaleCommand
+            public readonly LocaleArgument DurationBan = new LocaleArgument
             {
-                Name = @"cps",
-                Description =
-                    @"Prints the current CPS.",
-                Help = @"prints the current server cps"
+                Name = @"duration",
+                Description = @"the duration to ban (in days)"
             };
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocaleCommand Exit = new LocaleCommand
+            public readonly LocaleArgument DurationMute = new LocaleArgument
             {
-                Name = @"exit",
-                Description = @"Closes down the server.",
-                Help = @"closes the server"
+                Name = @"duration",
+                Description = @"the duration to mute (in days)"
             };
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString exited =
-                @"Main server shutdown completed. If your server is stuck you may safely kill it.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString exiting =
-                @"Server is now closing. Please wait while your game and player data is saved!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString ExperimentalFlagNotFound = @"Experimental flag '{00}' was not found!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocaleCommand Experiments = new LocaleCommand
+            public readonly LocaleArgument EnablementBoolean = new LocaleArgument
             {
-                Name = @"experiments",
-                Description = @"Sets the enablement of an experimental feature. true is enabled, false is disabled",
-                Help = @"enables or disables an experimental feature"
+                Name = @"enablement",
+                Description = @"whether or not this is enabled"
             };
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString FlagInfo = @"(flag)";
-
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocaleCommand Help = new LocaleCommand
+            public readonly LocaleArgument Help = new LocaleArgument
             {
                 Name = @"help",
-                Description = @"help",
-                Help = @"displays list of available commands"
-            };
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString invalid = @"Invalid /command.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocaleCommand Kick = new LocaleCommand
-            {
-                Name = @"kick",
-                Description = @"Kicks a player from the server.",
-                Help = @"kicks a player from the server"
+                ShortName = 'h',
+                Description = @"shows this help message"
             };
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocaleCommand SetVariable = new LocaleCommand
+            public readonly LocaleArgument IpBan = new LocaleArgument
             {
-                Name = @"setvar",
-                Description =
-                    @"sets a server variable by id to a value",
-                Help = @"sets a variable by id; e.g. 'setvar <id> true'"
+                Name = @"ip-ban",
+                Description = @"if it is an IP ban (true/false)"
             };
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocaleCommand GetVariable = new LocaleCommand
+            public readonly LocaleArgument IpMute = new LocaleArgument
             {
-                Name = @"getvar",
-                Description = @"gets a server variable by id",
-                Help = @"gets a variable by id"
+                Name = @"ip-ban",
+                Description = @"if it is an IP mute (true/false)"
             };
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocaleCommand ListVariables = new LocaleCommand
-            {
-                Name = @"listvars",
-                Description = @"queries for server variables by page/page size",
-                Help = @"queries for server variables by page/page size; e.g. 'listvars 1 10'"
-            };
-
+            public readonly LocalizedString MetricsDisable = @"disable";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocaleCommand Kill = new LocaleCommand
+            public readonly LocaleArgument MetricsOperation = new LocaleArgument
             {
-                Name = @"kill",
-                Description = @"Kills a player on the server.",
-                Help = @"kills a player on the server"
+                Name = @"operation",
+                Description = @"one of the following: disable, enable"
             };
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString madeprivate =
-                @"The server has now been made private and can only be accessed by admins. To change this use the makepublic command or edit the adminonly field in config.json";
+            public readonly LocalizedString MetricsEnable = @"enable";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString madepublic =
-                @"The server has now been made public and can be accessed by all players. To change this use the makepublic command or edit the adminonly field in config.json";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocaleCommand MakePrivate = new LocaleCommand
+            public readonly LocaleArgument Page = new LocaleArgument
             {
-                Name = @"makeprivate",
-                Description = @"Makes the server private and can only be accessed by admins.",
-                Help = @"Makes the server private and can only be accessed by admins."
+                Name = @"page",
+                Description = @"the page of items to query for"
             };
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocaleCommand MakePublic = new LocaleCommand
+            public readonly LocaleArgument PageSize = new LocaleArgument
             {
-                Name = @"makepublic",
-                Description = @"Makes the server public to all players.",
-                Help = @"Makes the server public to all players."
+                Name = @"page-size",
+                Description = @"the number of items to display per page"
             };
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocaleCommand Metrics = new LocaleCommand
+            public readonly LocaleArgument PanicType = new LocaleArgument
             {
-                Name = @"metrics",
-                Description =
-                    @"Enables or disables metrics collection.",
-                Help = @"enables or disables metrics collection"
+                Name = @"type",
+                Description = @"which information dump to process (attack/stack)"
             };
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocaleCommand Migrate = new LocaleCommand
+            public readonly LocaleArgument Power = new LocaleArgument
             {
-                Name = @"migrate",
-                Description = @"Walks you through migrating your player or game database between sqlite and mysql.",
-                Help = @"walks you through migrating your player or game database between sqlite and mysql"
+                Name = @"access",
+                Description = @"the access level to assign"
             };
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocaleCommand Mute = new LocaleCommand
+            public readonly LocaleArgument ReasonBan = new LocaleArgument
             {
-                Name = @"mute",
-                Description = @"mutes a player preventing them from talking.",
-                Help = @"mutes a player preventing them from talking"
-            };
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString muteuser = @"console";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocaleCommand NetDebug = new LocaleCommand
-            {
-                Name = @"netdebug",
+                Name = @"reason",
+                Description = @"the reason for the ban"
             };
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocaleCommand OnlineList = new LocaleCommand
+            public readonly LocaleArgument ReasonMute = new LocaleArgument
             {
-                Name = @"onlinelist",
-                Help = @"shows all players online"
+                Name = @"reason",
+                Description = @"the reason for the mute"
             };
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocaleCommand Panic = new LocaleCommand
+            public readonly LocaleArgument TargetApi = new LocaleArgument
             {
-                Name = @"panic",
-                Description = @"Collects and dumps information -- THIS WILL CRASH YOUR SERVER",
-                Help = @"collects and dumps information -- THIS WILL CRASH YOUR SERVER"
-            };
-
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly CommandParsingNamespace Parsing = new CommandParsingNamespace();
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocaleCommand Power = new LocaleCommand
-            {
-                Name = @"power",
-                Description =
-                    @"Sets the power or access of a selected account. Power 0 is regular user. Power 1 is in-game moderator. Power 2 is owner/designer and allows editor access.",
-                Help = @"sets the administrative access of a user"
+                Name = @"account-name",
+                Description = @"the name of the acount to change the API access of"
             };
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocaleCommand PowerAccount = new LocaleCommand
+            public readonly LocaleArgument TargetBan = new LocaleArgument
             {
-                Name = @"poweracc",
-                Description =
-                    @"Sets the power or access of a selected account. Power 0 is regular user. Power 1 is in-game moderator. Power 2 is owner/designer and allows editor access.",
-                Help = @"sets the administrative access of an account"
-            };
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString RequiredInfo = @"(required)";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocaleCommand Unban = new LocaleCommand
-            {
-                Name = @"unban",
-                Description = @"Unbans a player from the server.",
-                Help = @"unbans a player from the server"
+                Name = @"player-name",
+                Description = @"the name of the player to ban"
             };
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocaleCommand Unmute = new LocaleCommand
+            public readonly LocaleArgument TargetExperimentalFeature = new LocaleArgument
             {
-                Name = @"unmute",
-                Description = @"unmutes a player allowing them to talk.",
-                Help = @"unmutes a player allowing them to talk"
+                Name = @"experimental-feature-name-or-id",
+                Description = @"the Guid or name of the experimental feature to configure"
             };
 
-            public sealed partial class ArgumentsNamespace : LocaleNamespace
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public readonly LocaleArgument TargetKick = new LocaleArgument
             {
+                Name = @"player-name",
+                Description = @"the name of the player to kick"
+            };
 
-                [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-                public readonly LocaleArgument AccessBoolean = new LocaleArgument
-                {
-                    Name = @"access",
-                    Description = @"whether or not to grant/revoke access"
-                };
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public readonly LocaleArgument TargetKill = new LocaleArgument
+            {
+                Name = @"player-name",
+                Description = @"the name of the player to kill"
+            };
 
-                [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-                public readonly LocaleArgument AnnouncementMessage = new LocaleArgument
-                {
-                    Name = @"message",
-                    Description = @"the message to send"
-                };
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public readonly LocaleArgument TargetMute = new LocaleArgument
+            {
+                Name = @"player-name",
+                Description = @"the name of the player to mute"
+            };
 
-                [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-                public readonly LocaleArgument ApiRole = new LocaleArgument
-                {
-                    Name = @"role",
-                    Description = @"role to grant or revoke (users.query or users.manage)"
-                };
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public readonly LocaleArgument TargetPower = new LocaleArgument
+            {
+                Name = @"player-name",
+                Description = @"the name of the player to change the access of"
+            };
 
-                [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-                public readonly LocalizedString CpsLock = @"lock";
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public readonly LocaleArgument TargetPowerAccount = new LocaleArgument
+            {
+                Name = @"account-name",
+                Description = @"the name of the acount to change the access of"
+            };
 
-                [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-                public readonly LocaleArgument CpsOperation = new LocaleArgument
-                {
-                    Name = @"operation",
-                    Description = @"one of the following: status, lock, unlock"
-                };
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public readonly LocaleArgument TargetUnban = new LocaleArgument
+            {
+                Name = @"player-name",
+                Description = @"the name of the player to unban"
+            };
 
-                [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-                public readonly LocalizedString CpsStatus = @"status";
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public readonly LocaleArgument TargetUnmute = new LocaleArgument
+            {
+                Name = @"player-name",
+                Description = @"the name of the player to unmute"
+            };
 
-                [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-                public readonly LocalizedString CpsUnlock = @"unlock";
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public readonly LocaleArgument VariableId = new LocaleArgument
+            {
+                Name = @"id",
+                Description = @"the id of the server variable to set"
+            };
 
-                [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-                public readonly LocaleArgument DurationBan = new LocaleArgument
-                {
-                    Name = @"duration",
-                    Description = @"the duration to ban (in days)"
-                };
-
-                [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-                public readonly LocaleArgument DurationMute = new LocaleArgument
-                {
-                    Name = @"duration",
-                    Description = @"the duration to mute (in days)"
-                };
-
-                [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-                public readonly LocaleArgument EnablementBoolean = new LocaleArgument
-                {
-                    Name = @"enablement",
-                    Description = @"whether or not this is enabled"
-                };
-
-                [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-                public readonly LocaleArgument Help = new LocaleArgument
-                {
-                    Name = @"help",
-                    ShortName = 'h',
-                    Description = @"shows this help message"
-                };
-
-                [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-                public readonly LocaleArgument IpBan = new LocaleArgument
-                {
-                    Name = @"ip-ban",
-                    Description = @"if it is an IP ban (true/false)"
-                };
-
-                [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-                public readonly LocaleArgument IpMute = new LocaleArgument
-                {
-                    Name = @"ip-ban",
-                    Description = @"if it is an IP mute (true/false)"
-                };
-
-                [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-                public readonly LocalizedString MetricsDisable = @"disable";
-
-                [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-                public readonly LocaleArgument MetricsOperation = new LocaleArgument
-                {
-                    Name = @"operation",
-                    Description = @"one of the following: disable, enable"
-                };
-
-                [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-                public readonly LocalizedString MetricsEnable = @"enable";
-
-                [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-                public readonly LocaleArgument Page = new LocaleArgument
-                {
-                    Name = @"page",
-                    Description = @"the page of items to query for"
-                };
-
-                [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-                public readonly LocaleArgument PageSize = new LocaleArgument
-                {
-                    Name = @"page-size",
-                    Description = @"the number of items to display per page"
-                };
-
-                [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-                public readonly LocaleArgument PanicType = new LocaleArgument
-                {
-                    Name = @"type",
-                    Description = @"which information dump to process (attack/stack)"
-                };
-
-                [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-                public readonly LocaleArgument Power = new LocaleArgument
-                {
-                    Name = @"access",
-                    Description = @"the access level to assign"
-                };
-
-                [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-                public readonly LocaleArgument ReasonBan = new LocaleArgument
-                {
-                    Name = @"reason",
-                    Description = @"the reason for the ban"
-                };
-
-                [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-                public readonly LocaleArgument ReasonMute = new LocaleArgument
-                {
-                    Name = @"reason",
-                    Description = @"the reason for the mute"
-                };
-
-                [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-                public readonly LocaleArgument TargetApi = new LocaleArgument
-                {
-                    Name = @"account-name",
-                    Description = @"the name of the acount to change the API access of"
-                };
-
-                [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-                public readonly LocaleArgument TargetBan = new LocaleArgument
-                {
-                    Name = @"player-name",
-                    Description = @"the name of the player to ban"
-                };
-
-                [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-                public readonly LocaleArgument TargetExperimentalFeature = new LocaleArgument
-                {
-                    Name = @"experimental-feature-name-or-id",
-                    Description = @"the Guid or name of the experimental feature to configure"
-                };
-
-                [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-                public readonly LocaleArgument TargetKick = new LocaleArgument
-                {
-                    Name = @"player-name",
-                    Description = @"the name of the player to kick"
-                };
-
-                [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-                public readonly LocaleArgument TargetKill = new LocaleArgument
-                {
-                    Name = @"player-name",
-                    Description = @"the name of the player to kill"
-                };
-
-                [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-                public readonly LocaleArgument TargetMute = new LocaleArgument
-                {
-                    Name = @"player-name",
-                    Description = @"the name of the player to mute"
-                };
-
-                [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-                public readonly LocaleArgument TargetPower = new LocaleArgument
-                {
-                    Name = @"player-name",
-                    Description = @"the name of the player to change the access of"
-                };
-
-                [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-                public readonly LocaleArgument TargetPowerAccount = new LocaleArgument
-                {
-                    Name = @"account-name",
-                    Description = @"the name of the acount to change the access of"
-                };
-
-                [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-                public readonly LocaleArgument TargetUnban = new LocaleArgument
-                {
-                    Name = @"player-name",
-                    Description = @"the name of the player to unban"
-                };
-
-                [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-                public readonly LocaleArgument TargetUnmute = new LocaleArgument
-                {
-                    Name = @"player-name",
-                    Description = @"the name of the player to unmute"
-                };
-
-                [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-                public readonly LocaleArgument VariableId = new LocaleArgument
-                {
-                    Name = @"id",
-                    Description = @"the id of the server variable to set"
-                };
-
-                [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-                public readonly LocaleArgument VariableValue = new LocaleArgument
-                {
-                    Name = @"value",
-                    Description = @"the value to set the server variable to"
-                };
-            }
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public readonly LocaleArgument VariableValue = new LocaleArgument
+            {
+                Name = @"value",
+                Description = @"the value to set the server variable to"
+            };
         }
     }
 }

--- a/Intersect.Server.Core/Localization/Strings.cs
+++ b/Intersect.Server.Core/Localization/Strings.cs
@@ -6,1742 +6,1740 @@ using Intersect.Server.Core;
 using Intersect.Server.Networking.Helpers;
 using Newtonsoft.Json;
 
-namespace Intersect.Server.Localization
+namespace Intersect.Server.Localization;
+
+
+public static partial class Strings
 {
 
-    public static partial class Strings
+    public sealed partial class AccountNamespace : LocaleNamespace
     {
 
-        public sealed partial class AccountNamespace : LocaleNamespace
-        {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString adminonly =
+            @"The server is currently allowing only admins to connect. Come back later!";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString adminonly =
-                @"The server is currently allowing only admins to connect. Come back later!";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString alreadybanned = @"{00} has already been banned!";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString alreadybanned = @"{00} has already been banned!";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString alreadymuted = @"{00} has already been muted!";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString alreadymuted = @"{00} has already been muted!";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString badaccess = @"Access denied! Invalid power level!";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString badaccess = @"Access denied! Invalid power level!";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString badlogin = @"Username or password incorrect.";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString badlogin = @"Username or password incorrect.";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString banned = @"{00} has been banned!";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString banned = @"{00} has been banned!";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString UnbanSuccess = @"{00} has been unbanned!";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString UnbanSuccess = @"{00} has been unbanned!";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString UnbanFail = @"Failed to unban {00}. The user is not banned!";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString UnbanFail = @"Failed to unban {00}. The user is not banned!";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString NotAllowed = @"You do not have the permission to do this.";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString NotAllowed = @"You do not have the permission to do this.";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString banstatus =
+            @"Your account has been banned since: {00} (UTC) by {01}. Ban expires: {02} (UTC). Reason for ban: {03}";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString banstatus =
-                @"Your account has been banned since: {00} (UTC) by {01}. Ban expires: {02} (UTC). Reason for ban: {03}";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString characterexists =
+            @"An account with this character name exists. Please choose another.";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString characterexists =
-                @"An account with this character name exists. Please choose another.";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString deletechar = @"The character has been deleted.";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString deletechar = @"The character has been deleted.";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString deleted = @"Delete Character";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString deleted = @"Delete Character";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString deletecharerror = @"This character cannot be deleted, they may be stuck online in combat.";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString deletecharerror = @"This character cannot be deleted, they may be stuck online in combat.";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString deletederror = @"Error Deleting Character";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString deletederror = @"Error Deleting Character";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString doesnotexist = @"Account does not exist.";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString doesnotexist = @"Account does not exist.";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString emailexists = @"An account with this email address already exists.";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString emailexists = @"An account with this email address already exists.";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString exists = @"Account already exists!";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString exists = @"Account already exists!";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString invalidclass = @"Invalid class selected. Try again.";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString invalidclass = @"Invalid class selected. Try again.";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString invalidemail =
+            @"The chosen email does not meet requirements set by the server.";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString invalidemail =
-                @"The chosen email does not meet requirements set by the server.";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString invalidname =
+            @"The chosen name does not meet requirements set by the server.";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString invalidname =
-                @"The chosen name does not meet requirements set by the server.";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString loadfail = @"Failed to load account. Please try logging in again.";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString loadfail = @"Failed to load account. Please try logging in again.";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString maxchars =
+            @"You have already created the maximum number of characters. Delete one before creating a new one.";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString maxchars =
-                @"You have already created the maximum number of characters. Delete one before creating a new one.";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString muted = @"{00} has been muted!";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString muted = @"{00} has been muted!";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString UnmuteSuccess = @"{00} has been unmuted!";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString UnmuteSuccess = @"{00} has been unmuted!";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString UnmuteFail = @"Failed to unmute {00}. The user is not muted!";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString UnmuteFail = @"Failed to unmute {00}. The user is not muted!";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString mutestatus =
+            @"Your account has been muted since: {00} by {01}. Mute expires: {02}. Reason for mute: {03}";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString mutestatus =
-                @"Your account has been muted since: {00} by {01}. Mute expires: {02}. Reason for mute: {03}";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString notfound = @"Error: Account {00} was not found!";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString notfound = @"Error: Account {00} was not found!";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString registrationsblocked =
+            @"Account registrations are currently blocked by the server.";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString registrationsblocked =
-                @"Account registrations are currently blocked by the server.";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString emailfail = @"Failed to send your password reset email at this time. Please try again later.";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString emailfail = @"Failed to send your password reset email at this time. Please try again later.";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString UnknownError = @"An unknown error occurred while saving the user.";
+    }
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString UnknownError = @"An unknown error occurred while saving the user.";
-        }
+    public sealed partial class BagsNamespace : LocaleNamespace
+    {
 
-        public sealed partial class BagsNamespace : LocaleNamespace
-        {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString baginbag = @"You cannot store a bag inside another bag!";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString baginbag = @"You cannot store a bag inside another bag!";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString baginself = @"You cannot store a bag in within itself!";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString baginself = @"You cannot store a bag in within itself!";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString bagnospace = @"There is no space left in your bag for that item!";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString bagnospace = @"There is no space left in your bag for that item!";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString depositinvalid = @"Invalid item selected to store!";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString depositinvalid = @"Invalid item selected to store!";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString dropnotempty = @"You cannot drop a bag unless it's empty!";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString dropnotempty = @"You cannot drop a bag unless it's empty!";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString inventorynospace =
+            @"There is no space left in your inventory for that item!";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString inventorynospace =
-                @"There is no space left in your inventory for that item!";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString onlysellempty = @"Cannot sell bag unless it's empty!";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString onlysellempty = @"Cannot sell bag unless it's empty!";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString onlytradeempty = @"Cannot trade bag unless it's empty!";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString onlytradeempty = @"Cannot trade bag unless it's empty!";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString SlotOccupied = @"That slot is occupied by another item!";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString SlotOccupied = @"That slot is occupied by another item!";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString tradebound = @"Cannot trade bound items!";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString tradebound = @"Cannot trade bound items!";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString withdrawinvalid = @"Invalid item selected to retreive!";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString withdrawinvalid = @"Invalid item selected to retreive!";
+    }
 
-        }
+    public sealed partial class BanksNamespace : LocaleNamespace
+    {
 
-        public sealed partial class BanksNamespace : LocaleNamespace
-        {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString banknospace = @"There is no space left in your bank for that item!";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString banknospace = @"There is no space left in your bank for that item!";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString depositinvalid = @"Invalid item selected to deposit!";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString depositinvalid = @"Invalid item selected to deposit!";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString DepositSuccessStackable =
+            @"You have stored: {00} {01}";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString DepositSuccessStackable =
-                @"You have stored: {00} {01}";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString DepositSuccessNonStackable =
+            @"You have stored: {00}";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString DepositSuccessNonStackable =
-                @"You have stored: {00}";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString InvalidSlotToSwap = @"Invalid slots to swap!";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString InvalidSlotToSwap = @"Invalid slots to swap!";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString inventorynospace =
+            @"There is no space left in your inventory for that item!";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString inventorynospace =
-                @"There is no space left in your inventory for that item!";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString withdrawinvalid = @"Invalid item selected to withdraw!";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString withdrawinvalid = @"Invalid item selected to withdraw!";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString WithdrawSuccessStackable =
+            @"You have withdrawn: {00} {01}";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString WithdrawSuccessStackable =
-                @"You have withdrawn: {00} {01}";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString WithdrawSuccessNonStackable =
+            @"You have withdrawn: {00}";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString WithdrawSuccessNonStackable =
-                @"You have withdrawn: {00}";
+    }
 
-        }
+    public sealed partial class ChatNamespace : LocaleNamespace
+    {
 
-        public sealed partial class ChatNamespace : LocaleNamespace
-        {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString admin = @"[ADMIN] {00}: {01}";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString admin = @"[ADMIN] {00}: {01}";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString admincmd = @"/admin";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString admincmd = @"/admin";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString allcmd = @"/all";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString allcmd = @"/all";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString announcement = @"[ANNOUNCEMENT] {00}: {01}";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString announcement = @"[ANNOUNCEMENT] {00}: {01}";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString announcementcmd = @"/announcement";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString announcementcmd = @"/announcement";
+        [JsonProperty("global", NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString Global = @"[GLOBAL] {00}: {01}";
 
-            [JsonProperty("global", NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString Global = @"[GLOBAL] {00}: {01}";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString globalcmd = @"/global";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString globalcmd = @"/global";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString local = @"{00}: {01}";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString local = @"{00}: {01}";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString localcmd = @"/local";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString localcmd = @"/local";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString messagecmd = @"/message";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString messagecmd = @"/message";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString party = @"[PARTY] {00}: {01}";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString party = @"[PARTY] {00}: {01}";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString partycmd = @"/party";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString partycmd = @"/party";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString pmcmd = @"/pm";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString pmcmd = @"/pm";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString PrivateTo = @"[PM] To {00}: {01}";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString PrivateTo = @"[PM] To {00}: {01}";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString PrivateFrom = @"[PM] From {00}: {01}";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString PrivateFrom = @"[PM] From {00}: {01}";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString rcmd = @"/r";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString rcmd = @"/r";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString replycmd = @"/reply";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString replycmd = @"/reply";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString toofast = @"You are chatting too fast!";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString toofast = @"You are chatting too fast!";
+    }
 
-        }
+    public sealed partial class ClassesNamespace : LocaleNamespace
+    {
 
-        public sealed partial class ClassesNamespace : LocaleNamespace
-        {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString lastclass = @"Last Class";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString lastclass = @"Last Class";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString lastclasserror =
+            @"Failed to delete class, you must have at least one class at all times!";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString lastclasserror =
-                @"Failed to delete class, you must have at least one class at all times!";
+    }
 
-        }
+    public sealed partial class ColorsNamespace : LocaleNamespace
+    {
 
-        public sealed partial class ColorsNamespace : LocaleNamespace
-        {
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocaleDictionary<int, LocalizedString> presets = new LocaleDictionary<int, LocalizedString>(
-                new Dictionary<int, LocalizedString>
-                {
-                    {0, @"Black"},
-                    {1, @"White"},
-                    {2, @"Pink"},
-                    {3, @"Blue"},
-                    {4, @"Red"},
-                    {5, @"Green"},
-                    {6, @"Yellow"},
-                    {7, @"Orange"},
-                    {8, @"Purple"},
-                    {9, @"Gray"},
-                    {10, @"Cyan"}
-                }
-            );
-
-        }
-
-        public sealed partial class CombatNamespace : LocaleNamespace
-        {
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString addsymbol = @"+";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString blocked = @"BLOCKED!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString channeling = @"You are currently channeling another skill.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString channelingnoattack =
-                @"You are currently channeling a spell, you cannot attack.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString cooldown = @"This skill is on cooldown.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString critical = @"CRITICAL HIT!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocaleDictionary<int, LocalizedString> damagetypes =
-                new LocaleDictionary<int, LocalizedString>(
-                    new Dictionary<int, LocalizedString>
-                    {
-                        {0, @"Physical"},
-                        {1, @"Magic"},
-                        {2, @"True"}
-                    }
-                );
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString dash = @"DASH!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString dynamicreq = @"You do not meet the requirements to cast the spell!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString exp = @"Experience";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString ImmuneToEffect = @"IMMUNE!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString invulnerable = @"INVULNERABLE!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString levelreq = @"You are not a high enough level to use this ability.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString levelup = @"LEVEL UP!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString lowhealth = @"Not enough health.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString lowmana = @"Not enough mana.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString miss = @"MISS!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString notarget = @"No Target!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString removesymbol = @"-";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString
-                resourcereqs = @"You do not meet the requirements to harvest this resource!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString silenced = @"You cannot cast this ability whilst silenced.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString sleep = @"You cannot cast this ability whilst asleep";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString Snared = @"You cannot cast this ability whilst snared";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString sleepattacking = @"You are asleep and can't attack.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString sleepblocking = @"You are asleep and can't block.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString statreq =
-                @"You do not possess the correct combat stats to use this ability.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocaleDictionary<int, LocalizedString> stats = new LocaleDictionary<int, LocalizedString>(
-                new Dictionary<int, LocalizedString>
-                {
-                    {0, @"Attack"},
-                    {1, @"Ability Power"},
-                    {2, @"Defense"},
-                    {3, @"Magic Resist"},
-                    {4, @"Speed"}
-                }
-            );
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocaleDictionary<int, LocalizedString> status = new LocaleDictionary<int, LocalizedString>(
-                new Dictionary<int, LocalizedString>
-                {
-                    {0, @"NONE!"},
-                    {1, @"SILENCED!"},
-                    {2, @"STUNNED!"},
-                    {3, @"SNARED!"},
-                    {4, @"BLINDED!"},
-                    {5, @"STEALTH!"},
-                    {6, @"TRANSFORMED!"},
-                    {7, @"CLEANSED!"},
-                    {8, @"INVULNERABLE!"},
-                    {9, @"SHIELD!"},
-                    {10, @"SLEEP!"},
-                    {11, @"ON HIT!"},
-                    {12, @"TAUNT!"},
-                }
-            );
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString stunattacking = @"You are stunned and can't attack.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString stunblocking = @"You are stunned and can't block.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString stunned = @"You cannot cast this ability whilst stunned.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString targetoutsiderange = @"Target is out of range!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString toolrequired = @"You require a {00} to interact with this resource!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString tryforgetboundspell = @"You cannot forget this spell.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocaleDictionary<int, LocalizedString> vitals = new LocaleDictionary<int, LocalizedString>(
-                new Dictionary<int, LocalizedString>
-                {
-                    {0, @"Health"},
-                    {1, @"Mana"}
-                }
-            );
-
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString InvalidTarget = @"Invalid target for this spell.";
-        }
-
-        public sealed partial class CommandoutputNamespace : LocaleNamespace
-        {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString OnlineListActiveConnectionsN = @"Active connections: {00}";
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString OnlineListNoClientsConnected = @"No clients connected";
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString OnlineListStrayConnectionsN = @"Stray connections: {00}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString apigranted = @"{00} now has api access!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString apirevoked = @"{00} has had their api access revoked!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString apirolegranted = @"{00} now has the {01} api role!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString apirolenotfound = @"Api role {00} not found!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString apirolenotgranted =
-                @"Failed to assign api role {00}, api access must be enabled for {01} first!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString
-                apiroleprereq = @"Api role {00} could not be granted! Depends on {01} role.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString apirolerevoked = @"{00} has had their {01} api role revoked!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString apiroles = @"Api roles for {00}:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString cps = @"Current CPS: {00}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString cpslocked = @"CPS Locked";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString cpsunlocked = @"CPS Unlocked";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString VariableChanged = @"'{01}' set to {02} (was {03}) ({00})";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString VariableNotFound = @"Variable '{00}' not found";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString VariablePrint = @"{00} {01} = {02}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString VariableListEmpty = @"There are no variables to display.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString ExperimentalFeatureEnablement = @"{00} is {01}.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString gametime = @"Game time is now: {00}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString helpfooter =
-                @"Type in any command followed by {00} for parameters and usage information.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString helpheader = @"List of available commands:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString invalidparameters =
-                @"Invalid parameters provided! Use {00} to get more info about a command.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString killsuccess = @"{00} has been killed!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString listaccount = @"Account";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString listcharacter = @"Character";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString listid = @"ID";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString metricsenabled = @"Metrics collection enabled";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString metricsdisabled = @"Metrics collection disabled";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString notfound =
-                @"Command not recoginized. Enter help for a list of commands. Remember console commands are case sensitive!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString parseerror =
-                @"Parse Error: Parameter could not be read. Type {00} {01} for usage information.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString ServerInfo = @"Server has:";
-            
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString AccountCount = @" - {00} accounts.";
-            
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString CharacterCount = @" - {00} characters.";
-            
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString NpcCount = @" - {00} NPCs.";
-            
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString SpellCount = @" - {00} spells.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString MapCount = @" - {00} maps.";
-            
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString EventCount = @" - {00} events.";
-            
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString ItemCount = @" - {00} items.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString powerchanged = @"{00} has had their power updated!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString powerlevel = @"{00}'s power has been set to {01}!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString syntaxerror =
-                @"Syntax Error: Expected parameter not found. Type {00} {01} for usage information.";
-
-        }
-
-        public sealed partial class CraftingNamespace : LocaleNamespace
-        {
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString crafted = @"You successfully crafted {00}!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString nospace = @"You do not have enough inventory space to craft {00}!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString CraftFailure = @"The attempt to create the item {00} failed!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString CraftFailureLostItems = @"The attempt to create the item {00} failed and you lost the materials!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString InJournalMode = @"You cannot craft from your crafting journal!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString RequirementsNotMet = @"You do not meet the requirements in order to craft this item!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString AlreadyCrafting = @"You are already crafting!";
-
-        }
-
-        public sealed partial class DatabaseNamespace : LocaleNamespace
-        {
-            public readonly LocaleDictionary<DatabaseType, LocalizedString> DatabaseTypes = new(
-                new Dictionary<DatabaseType, LocalizedString>
-                {
-                    { DatabaseType.Sqlite, "SQLite" },
-                    { DatabaseType.MySql, "MySql" }
-                }
-            );
-
-            [JsonProperty("default", NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString Default = @"Default";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString MigratingAutomatically = @"The --migrate-automatically flag was passed to the server on startup and the user will not be prompted...";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString noclasses = @"No classes found! - Creating a default class!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString nomaps = @"No maps found! - Creating an empty map!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString nullerror = @"Tried to load one or more null game objects!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString nullfound = @"Tried to load null value for index {00} of {01}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString upgradebackup =
-                @"Please make a backup of your game and player databases, and then type '{00}' to continue or '{01}' to quit.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString upgradeexit = @"EXIT";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString upgradepleasewait =
-                @"Please wait! Migrations can take several minutes, and even longer if you are using MySQL databases!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString upgradeready = @"READY";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString upgraderequired =
-                @"Your databases need to be upgraded! This process could corrupt your game data if any errors are encountered.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString usingsqlite = @"Using SQLite Database for account and data storage.";
-
-        }
-
-        public sealed partial class ErrorsNamespace : LocaleNamespace
-        {
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString errorloadingconfig =
-                @"Failed to load server options! Press any key to shut down.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString
-                ErrorLoadingStrings = @"Failed to load strings! Press any key to shut down.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString errorlogged = @"An error was logged into errors.log";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString errorservercrash =
-                @"The Intersect server has encountered an error and must close. Error information can be found in resources/logs/errors.log. Press enter to exit.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString errorservercrashnohalt =
-                @"The Intersect server has encountered an error and must close. Error information can be found in resources/logs/errors.log.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString errortimeout = @"Too many failed requests. Please wait and try again!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString floodaverage =
-                @"[Flood]: 3+ Rapid Detections. Total Detections: {00} [User: {01} | Player: {02} | IP {03}]";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString floodburst =
-                @"[Flood]: {00} Burst Packets [User: {01} | Player: {02} | IP {03}]";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString floodsize =
-                @"[Flood]: Packet Size: {00} [User: {01} | Player: {02} | IP {03}]";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString warpfail = @"Failed to warp player to new map -- warping to spawn.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString UnknownErrorTryAgain = @"An unknown error occurred, please try again.";
-
-        }
-
-        public sealed partial class EventsNamespace : LocaleNamespace
-        {
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString commandparameter = @"\param";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString eventnamecommand = @"\en";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString eventparam = @"\evtparam";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString eventparams = @"\evtparams";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString globalswitch = @"\gs";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString globalvar = @"\gv";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString militaryhour = @"\24hour";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString onlinecountcommand = @"\onlinecount";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString onlinelistcommand = @"\onlinelist";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString periodevening = @"PM";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString periodmorning = @"AM";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString playernamecommand = @"\pn";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString playerguildcommand = @"\pg";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString playerswitch = @"\ps";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString playervar = @"\pv";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString timehour = @"\hour";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString timeminute = @"\minute";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString timeperiod = @"\period";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString timesecond = @"\second";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString watchdogkill =
-                @"Event killed due to commands processed in a single frame surpassing Event Watchdog Threshhold.  (Map: {00}  Event: {01})";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString watchdogkillcommon =
-                @"Common event killed due to commands processed in a single frame surpassing the Event Watchdog Threshhold.  (Event {00})";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString guildvar = @"\guildvar";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString UserVariable = @"\uservar";
-
-        }
-
-        public sealed partial class FormulasNamespace : LocaleNamespace
-        {
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString loadfailed = @"Failed to load formulas! Press any key to shut down.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString missing = @"Formulas.json missing. Generated default formulas file.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString syntax =
-                @"Error loading formulas! Please make sure the file exists and is free on syntax errors.";
-
-        }
-
-        public sealed partial class FriendsNamespace : LocaleNamespace
-        {
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString accept = @"{00} has accepted your friend request!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString alreadyfriends = @"You are already friends with {00}.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString busy = @"{00} is busy. Please try again later!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString notification = @"You are now friends with {00}!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString remove = @"Friend removed.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString sent = @"Friend request sent.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString LoggedIn = @"{00} has logged in.";
-
-        }
-
-        public sealed partial class GeneralNamespace : LocaleNamespace
-        {
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString Disabled = @"Disabled";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString DisabledLowerCase = @"disabled";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString Enabled = @"Enabled";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString EnabledLowerCase = @"enabled";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString none = @"None";
-
-        }
-
-        public sealed partial class GuildsNamespace : LocaleNamespace
-        {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString VariableNotString = @"The given guild name does not contain any text.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString VariableInvalid = @"Invalid guild name!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString VariableNoText = @"A guild name can not be empty!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString GuildNameInUse = @"Your chosen guild name is already in use!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString AlreadyInGuild = @"You are already in a guild!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString Welcome = @"Welcome to {00}!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString NotInGuild = @"You are not in a guild.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString NotReceivedInvite = @"You've not received any guild invites yet.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString NotAllowed = @"You do not have the permission to do this.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString InviteNotOnline = @"The player you're trying to invite is either not online or does not exist.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString InviteAlreadyInGuild = @"The player you're trying to invite is already in a guild or has a pending invite.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString InviteSent = @"You've invited {00} to join {01}!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString InviteDeclinedResponse = @"{00} has declined your request for them to join {01}.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString InviteDeclined = @"You have declined the request to join {00}.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString GuildLeaderLeave = @"A Guildmaster can not leave their own guild, please transfer ownership rights first!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString NoSuchPlayer = @"There is no such player in this guild.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString Promoted = @"{00} has been promoted to {01}!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString PromotionFailed = @"{00} can not be promoted any further.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString Demoted = @"{00} has been demoted to {01}!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString DemotionFailed = @"{00} can not be demoted any further.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString DisbandGuild = @"{00} has been disbanded!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString deleteguildleader = @"You can not delete a character that is a guild {00}, please disband the guild or transfer ownership before trying again.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString guildcmd = @"/guild";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString guildchat = @"[{00}] {01}: {02}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString Transferred = @"Guild ownership of {00} has been transferred from {01} to {02}!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString NotAllowedWithdraw = @"You do not have permission to withdraw from {00}'s guild bank!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString NotAllowedDeposit = @"You do not have permission to deposit items into {00}'s guild bank!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString NotAllowedSwap = @"You do not have permission to swap items around within {00}'s guild bank!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString RankLimit = @"Failed to join {00} because their guild is full!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString RankLimitResponse = @"This guild has already hit it's member limit for the rank of {00}. Promote or demote other members in order to make room for {01}.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString NotAllowedInInstance = @"You must be in a guild to warp to a guild instance.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString NoLongerAllowedInInstance = @"You are no longer in the guild who's instance you were logged into. You have been warped back to the overworld.";
-        }
-
-        public sealed partial class IntroNamespace : LocaleNamespace
-        {
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString api = @"API listening on '{00}'.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString apifailed = @"Failed to start API.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString consoleactive =
-                @"Type exit to shutdown the server, or help for a list of commands.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString exit = @"Press enter to exit.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString loading = @"Loading, please wait.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString started = @"Server Started. Using UDP Port #{00}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString support =
-                @"For help, support, and updates visit: https://www.ascensiongamedev.com";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString tagline = @"                          free 2d orpg engine";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString title = @"Intersect Server";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString version = @"Version {00}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString websocketstarted =
-                @"Websocket listener started for Unity WebGL Clients using Port #{00}";
-
-        }
-
-        public sealed partial class ItemsNamespace : LocaleNamespace
-        {
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString bound = @"You cannot drop this item.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString nobag = @"You cannot store this item in a bag.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString nobank = @"You cannot store this item in a bank.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString cannotuse = @"You cannot use this item!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString cooldown = @"You must wait before using this item again!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString dynamicreq = @"You do not meet the requirements to use this item!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString equipped = @"You cannot drop equipped items.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString notenough = @"Not enough {00}s!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString notimplemented = @"Use of this item type is not yet implemented.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString sleep = @"You cannot use this item whilst asleep.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString statreq = @"You do not possess the correct combat stats to use this item.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString stunned = @"You cannot use this item whilst stunned.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString NotYours = @"This item does not belong to you!";
-
-            // TODO: Generalize this shit. It's everywhere!
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString InventoryNoSpace =
-                @"There is no space left in your inventory for that item!";
-
-        }
-
-        public sealed partial class MappingNamespace : LocaleNamespace
-        {
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString lastmap = @"Last Map";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString lastmaperror =
-                @"Failed to delete map, you must have at least one map at all times!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString linkfail = @"Map Link Failure";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString linkfailerror =
-                @"Failed to link map {00} to map {01}. If this merge were to happen, maps {02} and {03} would occupy the same space in the world.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString newfolder = @"New Folder";
-
-        }
-
-        public sealed partial class MigrationNamespace : LocaleNamespace
-        {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString AlreadyUsingProvider =
-                @"   Migration Error: {00} database is already using {01}!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString Cancel = @"   Press any other key to cancel migration.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString CurrentlyUsing = @"currently using {00}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString DefaultHost = @"localhost";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString DefaultPortMySql = @"3306";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString DefaultUsername = @"root";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString DefaultDatabase = "intersect_{00}_{01}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString EnterConnectionStringParameters = @"Please enter your connection string parameters:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString GameDatabaseName = @"Game";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString LoggingDatabaseName = @"Logging";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString OptionMySql = @"   [2] Mysql";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString OptionSqlite = @"   [1] Sqlite";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString MigratingDbSet = @"Migrating entities in {00}...";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString MigrationCanceled = @"Migration Cancelled";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString MigrationComplete = @"Migration complete! Press enter to exit.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString MySqlConnecting = @"Please wait, attempting to connect to database...";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString MySqlConnectionError = @"Error opening db connection! Error: {00}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString MySqlNotEmpty =
-                @"Database must be empty before migration! Please delete any tables before proceeding! Migration Cancelled.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString MySqlTryAgain =
-                @"Would you like to try entering your connection info again? (y/n)  ";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString ConfirmCharacter = @"y";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString PlayerDatabaseName = @"Player";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString PromptDatabase = @"Database ({00}): ";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString PromptHost = @"Host ({00}): ";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString PromptPassword = @"Password (empty): ";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString PromptPort = @"Port ({00}): ";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString PromptUsername = @"User ({00}): ";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString SelectContext = @"Which database would you like to migrate:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString SelectProvider = @"Select which engine to migrate the {00} database to:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString SqliteRecommended = "Sqlite strongly recommended!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString SelectDatabase = @"    [{00}] {01} (currently using {02}) {03}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString SelectDatabaseType = @"    [{00}] {01}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString SelectGameDatabaseProvider =
-                "   [1] Game Database ({00})  -  Sqlite Strongly Recommended!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString SelectGameDatabaseKey = @"1";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString SelectMySqlKey = @"2";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString SelectPlayerDatabaseProvider = "   [2] Player Database ({00})";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString SelectPlayerDatabaseKey = @"2";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString SelectSqliteKey = @"1";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString DatabaseFileAlreadyExists = @"{00} already exists, overwrite? (y/n)  ";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString StartingMigration =
-                @"Starting migration, please wait! (This could take several minutes depending on the size of your game)";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString StoppingServer =
-                @"Please wait, stopping server, and saving current database...";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString TryAgainCharacter = @"y";
-        }
-
-        public sealed partial class NetDebugNamespace : LocaleNamespace
-        {
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString hastebin =
-                @"Network Debug information uploaded to {00} (copied to clipboard) share this link with AGD when requesting for help getting your game online!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString pleasewait = @"Please wait while network diagnostics run....";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString savedtofile =
-                @"Network Debug information saved to netdebug.txt! Upload that file and share it with AGD when requesting for help getting your game online!";
-
-        }
-
-        public sealed partial class NetworkingNamespace : LocaleNamespace
-        {
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString badpacket =
-                @"Error handling client packet. Disconnecting client. More info logged to errors.log";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString disconnected = @"Client disconnected.";
-
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString ServerFull = @"The server is currently full, please try again later.";
-
-        }
-
-        public sealed partial class NotificationsNamespace : LocaleNamespace
-        {
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString copyright = "Copyright (C) 2020 Ascension Game Dev, All Rights Reserved";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString product = @"Intersect Game Engine";
-
-        }
-
-        public sealed partial class PartiesNamespace : LocaleNamespace
-        {
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString alreadydenied = @"Your party invitation has already been rejected!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString busy = @"{00} is busy. Please try again later!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString declined = @"{00} has declined your party invitation!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString disbanded = @"The party has been disbanded.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString InInstance = @"You cannot invite someone to a party while in an instance!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString inparty = @"{00} is already in a party!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString joined = @"{00} has joined the party!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString kicked = @"You have been kicked from the party!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString
-                leaderinvonly = @"Only the party leader can send invitations to your party.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString left = @"You have left the party.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString limitreached =
-                @"You have reached the maximum limit of party members. Kick another member before adding more.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString memberkicked = @"{00} has been kicked from the party!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString memberleft = @"{00} has left the party!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString notinparty = @"You are not in a party.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString outofrange = @"Target is out of range or offline.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString InstanceInUse = @"Can not create new instance - party members are still in the old one.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString CannotCreateInstance = @"Only the party leader can create a shared instance.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString InstanceInProgress = @"The party has not yet completed their instance.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString WrongInstance = @"Your party is currently doing a different instance.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString InstanceLivesRemaining = @"Your party has {00} lives remaining on this instance!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString NoMoreLivesRemaining = @"Your party has no more lives remaining! You will respawn out of the instance on your next death.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString InstanceFailed = @"Your party has failed the instance...";
-
-        }
-
-        public sealed partial class PasswordResetNotificationNamespace : LocaleNamespace
-        {
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString subject = @"Intersect Game Engine - Password Reset Code";
-
-        }
-
-        public sealed partial class PlayerNamespace : LocaleNamespace
-        {
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString admin = @"{00} has been given administrative powers!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString adminjoined =
-                @"You are an administrator! Press Insert at any time to access the administration menu or F2 for debug information.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString adminsetpower = @"Only admins can set power!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString InstanceUpdate = @"Your instance ID has changed from {00} to {01}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString OverworldReturnAdmin = @"You have returned {00} to the overworld.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString OverworldReturned = @"You have been returned to the overworld.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString beenwarpedto = @"You have been warped to {00}.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString changeownpower = @"You cannot alter your own power!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString deadmin = @"{00} has had their administrative powers revoked!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString demod = @"{00} has had their moderation powers revoked!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString haswarpedto = @"{00} has been warped to you.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString joined = @"{00} has joined {01}.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString kicked = @"{00} has been kicked by {01}!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString killed = @"{00} has been killed by {01}!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString left = @"{00} has left {01}.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString levelup = @"You have leveled up! You are now level {00}!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString mod = @"{00} has been given moderation powers!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString modjoined =
-                @"You are a moderator! Press Insert at any time to access the administration menu or F2 for debug information.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString notarget = @"You need to select a valid target.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString CannotWarpToYourself =
-                @"You cannot warp to yourself.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString offline = @"User not online!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString PlayerNotFound = @"The player '{00}' was not found!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString powerchanged = @"Your power has been modified!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString serverkicked = @"{00} has been kicked by the server!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString serverkilled = @"{00} has been killed by the server!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString spelltaughtlevelup = @"You've learned the {00} spell!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString statpoints = @"You have {00} stat points available to be spent!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString targetoutsiderange = @"Target not in range.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString warpedto = @"Warped to {00}.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString warpedtoyou = @"{00} warped to you.";
-
-        }
-
-        public sealed partial class PortcheckingNamespace : LocaleNamespace
-        {
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString accessible = @"Your game is accesible to the public!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString checkantivirus =
-                @"   2. Antivirus programs might also be blocking connections and you may need to add Intersect Server.exe to your antivirus exclusions.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString checkfirewalls =
-                @"   1. Firewalls might be blocking connections to your server. Check firewalls on your system. (i.e. iptables, FirewallD, Windows Firewall)";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString checkrouterupnp =
-                @"It appears that UPnP Failed. Your might need to enable UPnP on your router or manually port forward to allow connections to your server.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString connectioninfo = @"Connection Information:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString debuggingsteps = @"Debugging Steps (To allow public access):";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString letothersjoin =
-                @"Enter your public ip and port into the client/editor config for others to join!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString notaccessible =
-                @"It does not appear that your game is accessible to the outside world.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString notconnected =
-                @"   Could not retreive connection information from AGD servers. Do you have an internet connection?";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString publicip = @"   Public IP: {00}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString publicport = @"   Public Port: {00}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString screwed =
-                @"   3. If on a college campus, or within a business network you likely do not have permission to open ports or host games in which case you should explore external hosting options!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocaleDictionary<PortCheckResult, LocalizedString> PortCheckerResults = new LocaleDictionary<PortCheckResult, LocalizedString>(
-                new Dictionary<PortCheckResult, LocalizedString>
-                {
-                    { PortCheckResult.Unknown, "This server is possibly inaccessible from the outside world, try to connect with the client to verify." },
-                    { PortCheckResult.Open, "This server is accessible from the outside world, properly configured clients can connect." },
-                    { PortCheckResult.PossiblyOpen, "This server is possible accessible from the outside world, but the AscensionGameDev port checker server gave an inconclusive response." },
-                    { PortCheckResult.IntersectResponseNoPlayerCount, "This server is not reporting a player count and may not be accessible, please see the Port Forwarding documentation for more information: {0}" },
-                    { PortCheckResult.IntersectResponseInvalidPlayerCount, "This server reporting an invalid player count and may not be accessible, please see the Port Forwarding documentation for more information: {0}" },
-                    { PortCheckResult.InvalidPortCheckerRequest, "The AscensionGameDev port checker server is down and this server may or may not be accessible from the outside world, try to connect with the client to verify" },
-                    { PortCheckResult.PortCheckerServerError, "The AscensionGameDev port checker server encountered an error and this server may or may not be accessible from the outside world, try to connect with the client to verify." },
-                    { PortCheckResult.PortCheckerServerDown, "The AscensionGameDev port checker server is down and this server may or may not be accessible from the outside world, try to connect with the client to verify" },
-                    { PortCheckResult.PortCheckerServerUnexpectedResponse, "The AscensionGameDev port checker server is down and this server may or may not be accessible from the outside world, try to connect with the client to verify" },
-                    { PortCheckResult.Inaccessible, "This server is not accessible from the outside world, please see the Port Forwarding documentation for more information: {0}" },
-                }
-            );
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString DocumentationUrl =
-                @"https://docs.freemmorpgmaker.com/en-US/deploy/forwarding/";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString PortNotOpenTryingUPnP = @"Port {0} is not open, trying UPnP...";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString PortNotOpenUPnPDisabled = @"Port {0} is not open, but UPnP is disabled. Check your router port forwarding and computer firewall configurations.";
-            
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString PortCheckerAndUPnPDisabled =
-                @"The port checker service and UPnP have both been disabled, please verify the server status manually with a client.";
-            
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString UPnPSucceededPortCheckerDisabled =
-                @"UPnP succeeded but the port checker is disabled. Please verify the server status manually using a client.";
-            
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString UPnPFailed =
-                @"UPnP failed, please verify the server status manually using a client.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString TryingUPnP =
-                @"Trying to open the port using UPnP...";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString ProbablyFirewall =
-                @"UPnP supposedly succeeded but the server is not accessible on port {0}, check the firewall of the machine this server is running on.";
-        }
-
-        public sealed partial class QuestsNamespace : LocaleNamespace
-        {
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString abandoned = @"Quest Abandoned: {00}!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString completed = @"Quest: {00} completed!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString declined = @"Quest Declined: {00}!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString itemtask = @"{00}  updated! {01}/{02} {03}(s) gathered!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString npctask = @"{00}  updated! {01}/{02} {03}(s) slain!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString started = @"Quest Started: {00}!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString taskcompleted = @"Task Completed!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString updated = @"Quest: {00} updated!";
-
-        }
-
-        public sealed partial class RegexNamespace : LocaleNamespace
-        {
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString email =
-                @"^(([\w-]+\.)+[\w-]+|([a-zA-Z]{1}|[\w-]{2,}))@((([0-1]?[0-9]{1,2}|25[0-5]|2[0-4][0-9])\.([0-1]?[0-9]{1,2}|25[0-5]|2[0-4][0-9])\.([0-1]?[0-9]{1,2}|25[0-5]|2[0-4][0-9])\.([0-1]?[0-9]{1,2}|25[0-5]|2[0-4][0-9])){1}|([a-zA-Z]+[\w-]+\.)+[a-zA-Z]{2,4})$";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString
-                password = @"^[-_=\+`~!@#\$%\^&\*()\[\]{}\\|;\:'"",<\.>/\?a-zA-Z0-9]{4,64}$";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString username = @"^[a-zA-Z0-9]{2,20}$";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString guildname = @"^[a-zA-Z0-9 ]{3,20}$";
-
-        }
-
-        public sealed partial class ShopsNamespace : LocaleNamespace
-        {
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString bound = @"This item is bound to you and cannot be sold!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString TransactionFailed = @"Transaction failed!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString cantafford = @"Transaction failed due to insufficent funds.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString doesnotaccept = @"This shop does not accept that item!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString inventoryfull = @"You do not have space to purchase that item!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString SuccessfullyRemovedItem = @"Successfully took {00} items from slot {01} for player {02} at {03}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString FailedRemovedItem = @"Failed to take items from slot {00} for player {01}. Quantity to remove: {02} at {03}";
-
-        }
-
-        public sealed partial class TradingNamespace : LocaleNamespace
-        {
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString accepted = @"The trade was successful!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString alreadydenied = @"Your trade request has already been denied!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString bound = @"This item is bound to you and cannot be traded!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString busy = @"{00} is busy. Please try again later!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString declined = @"The trade was declined!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString inventorynospace =
-                @"There is no space left in your inventory for that item!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString itemsdropped =
-                @"Out of inventory space. Some of your items have been dropped on the ground!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString OfferAccepted = @"{00} has accepted your offer. Please confirm the trade.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString offerinvalid = @"Invalid item selected to offer!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString RevokeNotAllowed = @"You can't revoke this item, {00} already accepted the trade!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString outofrange = @"Trade target is out of range or offline.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString revokeinvalid = @"Invalid item selected to revoke!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString tradenospace = @"There is no space left in the trade window for that item!";
-
-        }
-
-        public sealed partial class UpnpNamespace : LocaleNamespace
-        {
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString failedforwardingtcp =
-                @"Failed to automatically port forward tcp port {00} using UPnP. (UPnP possibly disabled in your router settings, or this port might already be forwarded!)";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString failedforwardingudp =
-                @"Failed to automatically port forward udp port {00} using UPnP. (UPnP possibly disabled in your router settings, or this port might already be forwarded!)";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString
-                forwardedtcp = @"Successfully auto port forwarded tcp port {00} using UPnP.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString
-                forwardedudp = @"Successfully auto port forwarded udp port {00} using UPnP.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString initializationfailed =
-                @"UPnP Service Initialization Failed. You might not have a router, or UPnP on your router might be disabled.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString initialized = @"UPnP Service Initialization Succeeded";
-
-        }
-
-        #region Serialization
-
-        public static bool Load()
-        {
-            var filepath = Path.Combine(ServerContext.ResourceDirectory, "server_strings.json");
-
-            // Really don't want two JsonSave() return points...
-            // ReSharper disable once InvertIf
-            if (File.Exists(filepath))
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocaleDictionary<int, LocalizedString> presets = new LocaleDictionary<int, LocalizedString>(
+            new Dictionary<int, LocalizedString>
             {
-                var json = File.ReadAllText(filepath, Encoding.UTF8);
-                try
-                {
-                    Root = JsonConvert.DeserializeObject<RootNamespace>(json) ?? Root;
-                }
-                catch (Exception exception)
-                {
-                    if (exception.Message.Contains("Commands.announcement"))
-                    {
-                        throw new Exception(
-                            "Server strings invalid! Upgrade steps to B6 were not followed correctly. Server must close!"
-                        );
-                    }
-
-                    Log.Error(exception);
-
-                    return false;
-                }
+                {0, @"Black"},
+                {1, @"White"},
+                {2, @"Pink"},
+                {3, @"Blue"},
+                {4, @"Red"},
+                {5, @"Green"},
+                {6, @"Yellow"},
+                {7, @"Orange"},
+                {8, @"Purple"},
+                {9, @"Gray"},
+                {10, @"Cyan"}
             }
+        );
 
-            return Save();
-        }
+    }
 
-        public static bool Save()
+    public sealed partial class CombatNamespace : LocaleNamespace
+    {
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString addsymbol = @"+";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString blocked = @"BLOCKED!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString channeling = @"You are currently channeling another skill.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString channelingnoattack =
+            @"You are currently channeling a spell, you cannot attack.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString cooldown = @"This skill is on cooldown.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString critical = @"CRITICAL HIT!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocaleDictionary<int, LocalizedString> damagetypes =
+            new LocaleDictionary<int, LocalizedString>(
+                new Dictionary<int, LocalizedString>
+                {
+                    {0, @"Physical"},
+                    {1, @"Magic"},
+                    {2, @"True"}
+                }
+            );
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString dash = @"DASH!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString dynamicreq = @"You do not meet the requirements to cast the spell!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString exp = @"Experience";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString ImmuneToEffect = @"IMMUNE!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString invulnerable = @"INVULNERABLE!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString levelreq = @"You are not a high enough level to use this ability.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString levelup = @"LEVEL UP!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString lowhealth = @"Not enough health.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString lowmana = @"Not enough mana.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString miss = @"MISS!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString notarget = @"No Target!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString removesymbol = @"-";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString
+            resourcereqs = @"You do not meet the requirements to harvest this resource!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString silenced = @"You cannot cast this ability whilst silenced.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString sleep = @"You cannot cast this ability whilst asleep";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString Snared = @"You cannot cast this ability whilst snared";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString sleepattacking = @"You are asleep and can't attack.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString sleepblocking = @"You are asleep and can't block.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString statreq =
+            @"You do not possess the correct combat stats to use this ability.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocaleDictionary<int, LocalizedString> stats = new LocaleDictionary<int, LocalizedString>(
+            new Dictionary<int, LocalizedString>
+            {
+                {0, @"Attack"},
+                {1, @"Ability Power"},
+                {2, @"Defense"},
+                {3, @"Magic Resist"},
+                {4, @"Speed"}
+            }
+        );
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocaleDictionary<int, LocalizedString> status = new LocaleDictionary<int, LocalizedString>(
+            new Dictionary<int, LocalizedString>
+            {
+                {0, @"NONE!"},
+                {1, @"SILENCED!"},
+                {2, @"STUNNED!"},
+                {3, @"SNARED!"},
+                {4, @"BLINDED!"},
+                {5, @"STEALTH!"},
+                {6, @"TRANSFORMED!"},
+                {7, @"CLEANSED!"},
+                {8, @"INVULNERABLE!"},
+                {9, @"SHIELD!"},
+                {10, @"SLEEP!"},
+                {11, @"ON HIT!"},
+                {12, @"TAUNT!"},
+            }
+        );
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString stunattacking = @"You are stunned and can't attack.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString stunblocking = @"You are stunned and can't block.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString stunned = @"You cannot cast this ability whilst stunned.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString targetoutsiderange = @"Target is out of range!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString toolrequired = @"You require a {00} to interact with this resource!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString tryforgetboundspell = @"You cannot forget this spell.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocaleDictionary<int, LocalizedString> vitals = new LocaleDictionary<int, LocalizedString>(
+            new Dictionary<int, LocalizedString>
+            {
+                {0, @"Health"},
+                {1, @"Mana"}
+            }
+        );
+
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString InvalidTarget = @"Invalid target for this spell.";
+    }
+
+    public sealed partial class CommandoutputNamespace : LocaleNamespace
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString OnlineListActiveConnectionsN = @"Active connections: {00}";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString OnlineListNoClientsConnected = @"No clients connected";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString OnlineListStrayConnectionsN = @"Stray connections: {00}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString apigranted = @"{00} now has api access!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString apirevoked = @"{00} has had their api access revoked!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString apirolegranted = @"{00} now has the {01} api role!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString apirolenotfound = @"Api role {00} not found!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString apirolenotgranted =
+            @"Failed to assign api role {00}, api access must be enabled for {01} first!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString
+            apiroleprereq = @"Api role {00} could not be granted! Depends on {01} role.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString apirolerevoked = @"{00} has had their {01} api role revoked!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString apiroles = @"Api roles for {00}:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString cps = @"Current CPS: {00}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString cpslocked = @"CPS Locked";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString cpsunlocked = @"CPS Unlocked";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString VariableChanged = @"'{01}' set to {02} (was {03}) ({00})";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString VariableNotFound = @"Variable '{00}' not found";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString VariablePrint = @"{00} {01} = {02}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString VariableListEmpty = @"There are no variables to display.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString ExperimentalFeatureEnablement = @"{00} is {01}.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString gametime = @"Game time is now: {00}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString helpfooter =
+            @"Type in any command followed by {00} for parameters and usage information.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString helpheader = @"List of available commands:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString invalidparameters =
+            @"Invalid parameters provided! Use {00} to get more info about a command.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString killsuccess = @"{00} has been killed!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString listaccount = @"Account";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString listcharacter = @"Character";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString listid = @"ID";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString metricsenabled = @"Metrics collection enabled";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString metricsdisabled = @"Metrics collection disabled";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString notfound =
+            @"Command not recoginized. Enter help for a list of commands. Remember console commands are case sensitive!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString parseerror =
+            @"Parse Error: Parameter could not be read. Type {00} {01} for usage information.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString ServerInfo = @"Server has:";
+        
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString AccountCount = @" - {00} accounts.";
+        
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString CharacterCount = @" - {00} characters.";
+        
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString NpcCount = @" - {00} NPCs.";
+        
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString SpellCount = @" - {00} spells.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString MapCount = @" - {00} maps.";
+        
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString EventCount = @" - {00} events.";
+        
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString ItemCount = @" - {00} items.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString powerchanged = @"{00} has had their power updated!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString powerlevel = @"{00}'s power has been set to {01}!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString syntaxerror =
+            @"Syntax Error: Expected parameter not found. Type {00} {01} for usage information.";
+
+    }
+
+    public sealed partial class CraftingNamespace : LocaleNamespace
+    {
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString crafted = @"You successfully crafted {00}!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString nospace = @"You do not have enough inventory space to craft {00}!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString CraftFailure = @"The attempt to create the item {00} failed!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString CraftFailureLostItems = @"The attempt to create the item {00} failed and you lost the materials!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString InJournalMode = @"You cannot craft from your crafting journal!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString RequirementsNotMet = @"You do not meet the requirements in order to craft this item!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString AlreadyCrafting = @"You are already crafting!";
+
+    }
+
+    public sealed partial class DatabaseNamespace : LocaleNamespace
+    {
+        public readonly LocaleDictionary<DatabaseType, LocalizedString> DatabaseTypes = new(
+            new Dictionary<DatabaseType, LocalizedString>
+            {
+                { DatabaseType.Sqlite, "SQLite" },
+                { DatabaseType.MySql, "MySql" }
+            }
+        );
+
+        [JsonProperty("default", NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString Default = @"Default";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString MigratingAutomatically = @"The --migrate-automatically flag was passed to the server on startup and the user will not be prompted...";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString noclasses = @"No classes found! - Creating a default class!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString nomaps = @"No maps found! - Creating an empty map!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString nullerror = @"Tried to load one or more null game objects!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString nullfound = @"Tried to load null value for index {00} of {01}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString upgradebackup =
+            @"Please make a backup of your game and player databases, and then type '{00}' to continue or '{01}' to quit.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString upgradeexit = @"EXIT";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString upgradepleasewait =
+            @"Please wait! Migrations can take several minutes, and even longer if you are using MySQL databases!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString upgradeready = @"READY";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString upgraderequired =
+            @"Your databases need to be upgraded! This process could corrupt your game data if any errors are encountered.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString usingsqlite = @"Using SQLite Database for account and data storage.";
+
+    }
+
+    public sealed partial class ErrorsNamespace : LocaleNamespace
+    {
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString errorloadingconfig =
+            @"Failed to load server options! Press any key to shut down.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString
+            ErrorLoadingStrings = @"Failed to load strings! Press any key to shut down.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString errorlogged = @"An error was logged into errors.log";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString errorservercrash =
+            @"The Intersect server has encountered an error and must close. Error information can be found in resources/logs/errors.log. Press enter to exit.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString errorservercrashnohalt =
+            @"The Intersect server has encountered an error and must close. Error information can be found in resources/logs/errors.log.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString errortimeout = @"Too many failed requests. Please wait and try again!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString floodaverage =
+            @"[Flood]: 3+ Rapid Detections. Total Detections: {00} [User: {01} | Player: {02} | IP {03}]";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString floodburst =
+            @"[Flood]: {00} Burst Packets [User: {01} | Player: {02} | IP {03}]";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString floodsize =
+            @"[Flood]: Packet Size: {00} [User: {01} | Player: {02} | IP {03}]";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString warpfail = @"Failed to warp player to new map -- warping to spawn.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString UnknownErrorTryAgain = @"An unknown error occurred, please try again.";
+
+    }
+
+    public sealed partial class EventsNamespace : LocaleNamespace
+    {
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString commandparameter = @"\param";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString eventnamecommand = @"\en";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString eventparam = @"\evtparam";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString eventparams = @"\evtparams";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString globalswitch = @"\gs";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString globalvar = @"\gv";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString militaryhour = @"\24hour";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString onlinecountcommand = @"\onlinecount";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString onlinelistcommand = @"\onlinelist";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString periodevening = @"PM";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString periodmorning = @"AM";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString playernamecommand = @"\pn";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString playerguildcommand = @"\pg";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString playerswitch = @"\ps";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString playervar = @"\pv";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString timehour = @"\hour";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString timeminute = @"\minute";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString timeperiod = @"\period";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString timesecond = @"\second";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString watchdogkill =
+            @"Event killed due to commands processed in a single frame surpassing Event Watchdog Threshhold.  (Map: {00}  Event: {01})";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString watchdogkillcommon =
+            @"Common event killed due to commands processed in a single frame surpassing the Event Watchdog Threshhold.  (Event {00})";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString guildvar = @"\guildvar";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString UserVariable = @"\uservar";
+
+    }
+
+    public sealed partial class FormulasNamespace : LocaleNamespace
+    {
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString loadfailed = @"Failed to load formulas! Press any key to shut down.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString missing = @"Formulas.json missing. Generated default formulas file.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString syntax =
+            @"Error loading formulas! Please make sure the file exists and is free on syntax errors.";
+
+    }
+
+    public sealed partial class FriendsNamespace : LocaleNamespace
+    {
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString accept = @"{00} has accepted your friend request!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString alreadyfriends = @"You are already friends with {00}.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString busy = @"{00} is busy. Please try again later!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString notification = @"You are now friends with {00}!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString remove = @"Friend removed.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString sent = @"Friend request sent.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString LoggedIn = @"{00} has logged in.";
+
+    }
+
+    public sealed partial class GeneralNamespace : LocaleNamespace
+    {
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString Disabled = @"Disabled";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString DisabledLowerCase = @"disabled";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString Enabled = @"Enabled";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString EnabledLowerCase = @"enabled";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString none = @"None";
+
+    }
+
+    public sealed partial class GuildsNamespace : LocaleNamespace
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString VariableNotString = @"The given guild name does not contain any text.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString VariableInvalid = @"Invalid guild name!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString VariableNoText = @"A guild name can not be empty!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString GuildNameInUse = @"Your chosen guild name is already in use!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString AlreadyInGuild = @"You are already in a guild!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString Welcome = @"Welcome to {00}!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString NotInGuild = @"You are not in a guild.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString NotReceivedInvite = @"You've not received any guild invites yet.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString NotAllowed = @"You do not have the permission to do this.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString InviteNotOnline = @"The player you're trying to invite is either not online or does not exist.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString InviteAlreadyInGuild = @"The player you're trying to invite is already in a guild or has a pending invite.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString InviteSent = @"You've invited {00} to join {01}!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString InviteDeclinedResponse = @"{00} has declined your request for them to join {01}.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString InviteDeclined = @"You have declined the request to join {00}.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString GuildLeaderLeave = @"A Guildmaster can not leave their own guild, please transfer ownership rights first!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString NoSuchPlayer = @"There is no such player in this guild.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString Promoted = @"{00} has been promoted to {01}!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString PromotionFailed = @"{00} can not be promoted any further.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString Demoted = @"{00} has been demoted to {01}!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString DemotionFailed = @"{00} can not be demoted any further.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString DisbandGuild = @"{00} has been disbanded!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString deleteguildleader = @"You can not delete a character that is a guild {00}, please disband the guild or transfer ownership before trying again.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString guildcmd = @"/guild";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString guildchat = @"[{00}] {01}: {02}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString Transferred = @"Guild ownership of {00} has been transferred from {01} to {02}!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString NotAllowedWithdraw = @"You do not have permission to withdraw from {00}'s guild bank!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString NotAllowedDeposit = @"You do not have permission to deposit items into {00}'s guild bank!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString NotAllowedSwap = @"You do not have permission to swap items around within {00}'s guild bank!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString RankLimit = @"Failed to join {00} because their guild is full!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString RankLimitResponse = @"This guild has already hit it's member limit for the rank of {00}. Promote or demote other members in order to make room for {01}.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString NotAllowedInInstance = @"You must be in a guild to warp to a guild instance.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString NoLongerAllowedInInstance = @"You are no longer in the guild who's instance you were logged into. You have been warped back to the overworld.";
+    }
+
+    public sealed partial class IntroNamespace : LocaleNamespace
+    {
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString api = @"API listening on '{00}'.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString apifailed = @"Failed to start API.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString consoleactive =
+            @"Type exit to shutdown the server, or help for a list of commands.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString exit = @"Press enter to exit.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString loading = @"Loading, please wait.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString started = @"Server Started. Using UDP Port #{00}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString support =
+            @"For help, support, and updates visit: https://www.ascensiongamedev.com";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString tagline = @"                          free 2d orpg engine";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString title = @"Intersect Server";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString version = @"Version {00}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString websocketstarted =
+            @"Websocket listener started for Unity WebGL Clients using Port #{00}";
+
+    }
+
+    public sealed partial class ItemsNamespace : LocaleNamespace
+    {
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString bound = @"You cannot drop this item.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString nobag = @"You cannot store this item in a bag.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString nobank = @"You cannot store this item in a bank.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString cannotuse = @"You cannot use this item!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString cooldown = @"You must wait before using this item again!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString dynamicreq = @"You do not meet the requirements to use this item!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString equipped = @"You cannot drop equipped items.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString notenough = @"Not enough {00}s!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString notimplemented = @"Use of this item type is not yet implemented.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString sleep = @"You cannot use this item whilst asleep.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString statreq = @"You do not possess the correct combat stats to use this item.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString stunned = @"You cannot use this item whilst stunned.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString NotYours = @"This item does not belong to you!";
+
+        // TODO: Generalize this shit. It's everywhere!
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString InventoryNoSpace =
+            @"There is no space left in your inventory for that item!";
+
+    }
+
+    public sealed partial class MappingNamespace : LocaleNamespace
+    {
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString lastmap = @"Last Map";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString lastmaperror =
+            @"Failed to delete map, you must have at least one map at all times!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString linkfail = @"Map Link Failure";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString linkfailerror =
+            @"Failed to link map {00} to map {01}. If this merge were to happen, maps {02} and {03} would occupy the same space in the world.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString newfolder = @"New Folder";
+
+    }
+
+    public sealed partial class MigrationNamespace : LocaleNamespace
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString AlreadyUsingProvider =
+            @"   Migration Error: {00} database is already using {01}!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString Cancel = @"   Press any other key to cancel migration.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString CurrentlyUsing = @"currently using {00}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString DefaultHost = @"localhost";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString DefaultPortMySql = @"3306";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString DefaultUsername = @"root";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString DefaultDatabase = "intersect_{00}_{01}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString EnterConnectionStringParameters = @"Please enter your connection string parameters:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString GameDatabaseName = @"Game";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString LoggingDatabaseName = @"Logging";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString OptionMySql = @"   [2] Mysql";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString OptionSqlite = @"   [1] Sqlite";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString MigratingDbSet = @"Migrating entities in {00}...";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString MigrationCanceled = @"Migration Cancelled";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString MigrationComplete = @"Migration complete! Press enter to exit.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString MySqlConnecting = @"Please wait, attempting to connect to database...";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString MySqlConnectionError = @"Error opening db connection! Error: {00}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString MySqlNotEmpty =
+            @"Database must be empty before migration! Please delete any tables before proceeding! Migration Cancelled.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString MySqlTryAgain =
+            @"Would you like to try entering your connection info again? (y/n)  ";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString ConfirmCharacter = @"y";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString PlayerDatabaseName = @"Player";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString PromptDatabase = @"Database ({00}): ";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString PromptHost = @"Host ({00}): ";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString PromptPassword = @"Password (empty): ";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString PromptPort = @"Port ({00}): ";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString PromptUsername = @"User ({00}): ";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString SelectContext = @"Which database would you like to migrate:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString SelectProvider = @"Select which engine to migrate the {00} database to:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString SqliteRecommended = "Sqlite strongly recommended!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString SelectDatabase = @"    [{00}] {01} (currently using {02}) {03}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString SelectDatabaseType = @"    [{00}] {01}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString SelectGameDatabaseProvider =
+            "   [1] Game Database ({00})  -  Sqlite Strongly Recommended!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString SelectGameDatabaseKey = @"1";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString SelectMySqlKey = @"2";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString SelectPlayerDatabaseProvider = "   [2] Player Database ({00})";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString SelectPlayerDatabaseKey = @"2";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString SelectSqliteKey = @"1";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString DatabaseFileAlreadyExists = @"{00} already exists, overwrite? (y/n)  ";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString StartingMigration =
+            @"Starting migration, please wait! (This could take several minutes depending on the size of your game)";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString StoppingServer =
+            @"Please wait, stopping server, and saving current database...";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString TryAgainCharacter = @"y";
+    }
+
+    public sealed partial class NetDebugNamespace : LocaleNamespace
+    {
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString hastebin =
+            @"Network Debug information uploaded to {00} (copied to clipboard) share this link with AGD when requesting for help getting your game online!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString pleasewait = @"Please wait while network diagnostics run....";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString savedtofile =
+            @"Network Debug information saved to netdebug.txt! Upload that file and share it with AGD when requesting for help getting your game online!";
+
+    }
+
+    public sealed partial class NetworkingNamespace : LocaleNamespace
+    {
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString badpacket =
+            @"Error handling client packet. Disconnecting client. More info logged to errors.log";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString disconnected = @"Client disconnected.";
+
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString ServerFull = @"The server is currently full, please try again later.";
+
+    }
+
+    public sealed partial class NotificationsNamespace : LocaleNamespace
+    {
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString copyright = "Copyright (C) 2020 Ascension Game Dev, All Rights Reserved";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString product = @"Intersect Game Engine";
+
+    }
+
+    public sealed partial class PartiesNamespace : LocaleNamespace
+    {
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString alreadydenied = @"Your party invitation has already been rejected!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString busy = @"{00} is busy. Please try again later!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString declined = @"{00} has declined your party invitation!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString disbanded = @"The party has been disbanded.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString InInstance = @"You cannot invite someone to a party while in an instance!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString inparty = @"{00} is already in a party!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString joined = @"{00} has joined the party!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString kicked = @"You have been kicked from the party!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString
+            leaderinvonly = @"Only the party leader can send invitations to your party.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString left = @"You have left the party.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString limitreached =
+            @"You have reached the maximum limit of party members. Kick another member before adding more.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString memberkicked = @"{00} has been kicked from the party!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString memberleft = @"{00} has left the party!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString notinparty = @"You are not in a party.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString outofrange = @"Target is out of range or offline.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString InstanceInUse = @"Can not create new instance - party members are still in the old one.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString CannotCreateInstance = @"Only the party leader can create a shared instance.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString InstanceInProgress = @"The party has not yet completed their instance.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString WrongInstance = @"Your party is currently doing a different instance.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString InstanceLivesRemaining = @"Your party has {00} lives remaining on this instance!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString NoMoreLivesRemaining = @"Your party has no more lives remaining! You will respawn out of the instance on your next death.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString InstanceFailed = @"Your party has failed the instance...";
+
+    }
+
+    public sealed partial class PasswordResetNotificationNamespace : LocaleNamespace
+    {
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString subject = @"Intersect Game Engine - Password Reset Code";
+
+    }
+
+    public sealed partial class PlayerNamespace : LocaleNamespace
+    {
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString admin = @"{00} has been given administrative powers!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString adminjoined =
+            @"You are an administrator! Press Insert at any time to access the administration menu or F2 for debug information.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString adminsetpower = @"Only admins can set power!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString InstanceUpdate = @"Your instance ID has changed from {00} to {01}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString OverworldReturnAdmin = @"You have returned {00} to the overworld.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString OverworldReturned = @"You have been returned to the overworld.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString beenwarpedto = @"You have been warped to {00}.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString changeownpower = @"You cannot alter your own power!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString deadmin = @"{00} has had their administrative powers revoked!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString demod = @"{00} has had their moderation powers revoked!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString haswarpedto = @"{00} has been warped to you.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString joined = @"{00} has joined {01}.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString kicked = @"{00} has been kicked by {01}!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString killed = @"{00} has been killed by {01}!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString left = @"{00} has left {01}.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString levelup = @"You have leveled up! You are now level {00}!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString mod = @"{00} has been given moderation powers!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString modjoined =
+            @"You are a moderator! Press Insert at any time to access the administration menu or F2 for debug information.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString notarget = @"You need to select a valid target.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString CannotWarpToYourself =
+            @"You cannot warp to yourself.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString offline = @"User not online!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString PlayerNotFound = @"The player '{00}' was not found!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString powerchanged = @"Your power has been modified!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString serverkicked = @"{00} has been kicked by the server!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString serverkilled = @"{00} has been killed by the server!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString spelltaughtlevelup = @"You've learned the {00} spell!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString statpoints = @"You have {00} stat points available to be spent!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString targetoutsiderange = @"Target not in range.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString warpedto = @"Warped to {00}.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString warpedtoyou = @"{00} warped to you.";
+
+    }
+
+    public sealed partial class PortcheckingNamespace : LocaleNamespace
+    {
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString accessible = @"Your game is accesible to the public!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString checkantivirus =
+            @"   2. Antivirus programs might also be blocking connections and you may need to add Intersect Server.exe to your antivirus exclusions.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString checkfirewalls =
+            @"   1. Firewalls might be blocking connections to your server. Check firewalls on your system. (i.e. iptables, FirewallD, Windows Firewall)";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString checkrouterupnp =
+            @"It appears that UPnP Failed. Your might need to enable UPnP on your router or manually port forward to allow connections to your server.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString connectioninfo = @"Connection Information:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString debuggingsteps = @"Debugging Steps (To allow public access):";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString letothersjoin =
+            @"Enter your public ip and port into the client/editor config for others to join!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString notaccessible =
+            @"It does not appear that your game is accessible to the outside world.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString notconnected =
+            @"   Could not retreive connection information from AGD servers. Do you have an internet connection?";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString publicip = @"   Public IP: {00}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString publicport = @"   Public Port: {00}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString screwed =
+            @"   3. If on a college campus, or within a business network you likely do not have permission to open ports or host games in which case you should explore external hosting options!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocaleDictionary<PortCheckResult, LocalizedString> PortCheckerResults = new LocaleDictionary<PortCheckResult, LocalizedString>(
+            new Dictionary<PortCheckResult, LocalizedString>
+            {
+                { PortCheckResult.Unknown, "This server is possibly inaccessible from the outside world, try to connect with the client to verify." },
+                { PortCheckResult.Open, "This server is accessible from the outside world, properly configured clients can connect." },
+                { PortCheckResult.PossiblyOpen, "This server is possible accessible from the outside world, but the AscensionGameDev port checker server gave an inconclusive response." },
+                { PortCheckResult.IntersectResponseNoPlayerCount, "This server is not reporting a player count and may not be accessible, please see the Port Forwarding documentation for more information: {0}" },
+                { PortCheckResult.IntersectResponseInvalidPlayerCount, "This server reporting an invalid player count and may not be accessible, please see the Port Forwarding documentation for more information: {0}" },
+                { PortCheckResult.InvalidPortCheckerRequest, "The AscensionGameDev port checker server is down and this server may or may not be accessible from the outside world, try to connect with the client to verify" },
+                { PortCheckResult.PortCheckerServerError, "The AscensionGameDev port checker server encountered an error and this server may or may not be accessible from the outside world, try to connect with the client to verify." },
+                { PortCheckResult.PortCheckerServerDown, "The AscensionGameDev port checker server is down and this server may or may not be accessible from the outside world, try to connect with the client to verify" },
+                { PortCheckResult.PortCheckerServerUnexpectedResponse, "The AscensionGameDev port checker server is down and this server may or may not be accessible from the outside world, try to connect with the client to verify" },
+                { PortCheckResult.Inaccessible, "This server is not accessible from the outside world, please see the Port Forwarding documentation for more information: {0}" },
+            }
+        );
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString DocumentationUrl =
+            @"https://docs.freemmorpgmaker.com/en-US/deploy/forwarding/";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString PortNotOpenTryingUPnP = @"Port {0} is not open, trying UPnP...";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString PortNotOpenUPnPDisabled = @"Port {0} is not open, but UPnP is disabled. Check your router port forwarding and computer firewall configurations.";
+        
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString PortCheckerAndUPnPDisabled =
+            @"The port checker service and UPnP have both been disabled, please verify the server status manually with a client.";
+        
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString UPnPSucceededPortCheckerDisabled =
+            @"UPnP succeeded but the port checker is disabled. Please verify the server status manually using a client.";
+        
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString UPnPFailed =
+            @"UPnP failed, please verify the server status manually using a client.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString TryingUPnP =
+            @"Trying to open the port using UPnP...";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString ProbablyFirewall =
+            @"UPnP supposedly succeeded but the server is not accessible on port {0}, check the firewall of the machine this server is running on.";
+    }
+
+    public sealed partial class QuestsNamespace : LocaleNamespace
+    {
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString abandoned = @"Quest Abandoned: {00}!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString completed = @"Quest: {00} completed!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString declined = @"Quest Declined: {00}!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString itemtask = @"{00}  updated! {01}/{02} {03}(s) gathered!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString npctask = @"{00}  updated! {01}/{02} {03}(s) slain!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString started = @"Quest Started: {00}!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString taskcompleted = @"Task Completed!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString updated = @"Quest: {00} updated!";
+
+    }
+
+    public sealed partial class RegexNamespace : LocaleNamespace
+    {
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString email =
+            @"^(([\w-]+\.)+[\w-]+|([a-zA-Z]{1}|[\w-]{2,}))@((([0-1]?[0-9]{1,2}|25[0-5]|2[0-4][0-9])\.([0-1]?[0-9]{1,2}|25[0-5]|2[0-4][0-9])\.([0-1]?[0-9]{1,2}|25[0-5]|2[0-4][0-9])\.([0-1]?[0-9]{1,2}|25[0-5]|2[0-4][0-9])){1}|([a-zA-Z]+[\w-]+\.)+[a-zA-Z]{2,4})$";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString
+            password = @"^[-_=\+`~!@#\$%\^&\*()\[\]{}\\|;\:'"",<\.>/\?a-zA-Z0-9]{4,64}$";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString username = @"^[a-zA-Z0-9]{2,20}$";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString guildname = @"^[a-zA-Z0-9 ]{3,20}$";
+
+    }
+
+    public sealed partial class ShopsNamespace : LocaleNamespace
+    {
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString bound = @"This item is bound to you and cannot be sold!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString TransactionFailed = @"Transaction failed!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString cantafford = @"Transaction failed due to insufficent funds.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString doesnotaccept = @"This shop does not accept that item!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString inventoryfull = @"You do not have space to purchase that item!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString SuccessfullyRemovedItem = @"Successfully took {00} items from slot {01} for player {02} at {03}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString FailedRemovedItem = @"Failed to take items from slot {00} for player {01}. Quantity to remove: {02} at {03}";
+
+    }
+
+    public sealed partial class TradingNamespace : LocaleNamespace
+    {
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString accepted = @"The trade was successful!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString alreadydenied = @"Your trade request has already been denied!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString bound = @"This item is bound to you and cannot be traded!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString busy = @"{00} is busy. Please try again later!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString declined = @"The trade was declined!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString inventorynospace =
+            @"There is no space left in your inventory for that item!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString itemsdropped =
+            @"Out of inventory space. Some of your items have been dropped on the ground!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString OfferAccepted = @"{00} has accepted your offer. Please confirm the trade.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString offerinvalid = @"Invalid item selected to offer!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString RevokeNotAllowed = @"You can't revoke this item, {00} already accepted the trade!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString outofrange = @"Trade target is out of range or offline.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString revokeinvalid = @"Invalid item selected to revoke!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString tradenospace = @"There is no space left in the trade window for that item!";
+
+    }
+
+    public sealed partial class UpnpNamespace : LocaleNamespace
+    {
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString failedforwardingtcp =
+            @"Failed to automatically port forward tcp port {00} using UPnP. (UPnP possibly disabled in your router settings, or this port might already be forwarded!)";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString failedforwardingudp =
+            @"Failed to automatically port forward udp port {00} using UPnP. (UPnP possibly disabled in your router settings, or this port might already be forwarded!)";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString
+            forwardedtcp = @"Successfully auto port forwarded tcp port {00} using UPnP.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString
+            forwardedudp = @"Successfully auto port forwarded udp port {00} using UPnP.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString initializationfailed =
+            @"UPnP Service Initialization Failed. You might not have a router, or UPnP on your router might be disabled.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString initialized = @"UPnP Service Initialization Succeeded";
+
+    }
+
+    #region Serialization
+
+    public static bool Load()
+    {
+        var filepath = Path.Combine(ServerContext.ResourceDirectory, "server_strings.json");
+
+        // Really don't want two JsonSave() return points...
+        // ReSharper disable once InvertIf
+        if (File.Exists(filepath))
         {
+            var json = File.ReadAllText(filepath, Encoding.UTF8);
             try
             {
-                var filepath = Path.Combine(ServerContext.ResourceDirectory, "server_strings.json");
-                Directory.CreateDirectory(ServerContext.ResourceDirectory);
-                var json = JsonConvert.SerializeObject(Root, Formatting.Indented, new LocalizedStringConverter());
-                File.WriteAllText(filepath, json, Encoding.UTF8);
-
-                return true;
+                Root = JsonConvert.DeserializeObject<RootNamespace>(json) ?? Root;
             }
             catch (Exception exception)
             {
+                if (exception.Message.Contains("Commands.announcement"))
+                {
+                    throw new Exception(
+                        "Server strings invalid! Upgrade steps to B6 were not followed correctly. Server must close!"
+                    );
+                }
+
                 Log.Error(exception);
 
                 return false;
             }
         }
 
-        #endregion
+        return Save();
+    }
 
-        #region Root Namespace
-
-        static Strings()
+    public static bool Save()
+    {
+        try
         {
-            Root = new RootNamespace();
+            var filepath = Path.Combine(ServerContext.ResourceDirectory, "server_strings.json");
+            Directory.CreateDirectory(ServerContext.ResourceDirectory);
+            var json = JsonConvert.SerializeObject(Root, Formatting.Indented, new LocalizedStringConverter());
+            File.WriteAllText(filepath, json, Encoding.UTF8);
+
+            return true;
         }
-
-        private static RootNamespace Root { get; set; }
-
-        // ReSharper disable MemberHidesStaticFromOuterClass
-        private sealed partial class RootNamespace : LocaleNamespace
+        catch (Exception exception)
         {
+            Log.Error(exception);
 
-            public readonly AccountNamespace Account = new AccountNamespace();
-
-            public readonly BagsNamespace Bags = new BagsNamespace();
-
-            public readonly BanksNamespace Banks = new BanksNamespace();
-
-            public readonly ChatNamespace Chat = new ChatNamespace();
-
-            public readonly ClassesNamespace Classes = new ClassesNamespace();
-
-            public readonly ColorsNamespace Colors = new ColorsNamespace();
-
-            public readonly CombatNamespace Combat = new CombatNamespace();
-
-            public readonly CommandoutputNamespace Commandoutput = new CommandoutputNamespace();
-
-            public readonly CommandsNamespace Commands = new CommandsNamespace();
-
-            public readonly CraftingNamespace Crafting = new CraftingNamespace();
-
-            public readonly DatabaseNamespace Database = new DatabaseNamespace();
-
-            public readonly ErrorsNamespace Errors = new ErrorsNamespace();
-
-            public readonly EventsNamespace Events = new EventsNamespace();
-
-            public readonly FormulasNamespace Formulas = new FormulasNamespace();
-
-            public readonly FriendsNamespace Friends = new FriendsNamespace();
-
-            public readonly GeneralNamespace General = new GeneralNamespace();
-
-            public readonly IntroNamespace Intro = new IntroNamespace();
-
-            public readonly ItemsNamespace Items = new ItemsNamespace();
-
-            public readonly MappingNamespace Mapping = new MappingNamespace();
-
-            public readonly MigrationNamespace Migration = new MigrationNamespace();
-
-            public readonly NetDebugNamespace NetDebug = new NetDebugNamespace();
-
-            public readonly NetworkingNamespace Networking = new NetworkingNamespace();
-
-            public readonly NotificationsNamespace NotificationsNamespace = new NotificationsNamespace();
-
-            public readonly PartiesNamespace Parties = new PartiesNamespace();
-
-            public readonly PasswordResetNotificationNamespace PasswordResetNotificationNamespace =
-                new PasswordResetNotificationNamespace();
-
-            public readonly PlayerNamespace Player = new PlayerNamespace();
-
-            public readonly PortcheckingNamespace Portchecking = new PortcheckingNamespace();
-
-            public readonly QuestsNamespace Quests = new QuestsNamespace();
-
-            public readonly RegexNamespace Regex = new RegexNamespace();
-
-            public readonly ShopsNamespace Shops = new ShopsNamespace();
-
-            public readonly TradingNamespace Trading = new TradingNamespace();
-
-            public readonly UpnpNamespace Upnp = new UpnpNamespace();
-
-            public readonly GuildsNamespace Guilds = new GuildsNamespace();
-
+            return false;
         }
+    }
 
-        // ReSharper restore MemberHidesStaticFromOuterClass
+    #endregion
 
-        #endregion
+    #region Root Namespace
 
-        #region Namespace Exposure
+    static Strings()
+    {
+        Root = new RootNamespace();
+    }
 
-        public static AccountNamespace Account => Root.Account;
+    private static RootNamespace Root { get; set; }
 
-        public static BagsNamespace Bags => Root.Bags;
+    // ReSharper disable MemberHidesStaticFromOuterClass
+    private sealed partial class RootNamespace : LocaleNamespace
+    {
 
-        public static BanksNamespace Banks => Root.Banks;
+        public readonly AccountNamespace Account = new AccountNamespace();
 
-        public static ChatNamespace Chat => Root.Chat;
+        public readonly BagsNamespace Bags = new BagsNamespace();
 
-        public static ClassesNamespace Classes => Root.Classes;
+        public readonly BanksNamespace Banks = new BanksNamespace();
 
-        public static ColorsNamespace Colors => Root.Colors;
+        public readonly ChatNamespace Chat = new ChatNamespace();
 
-        public static CombatNamespace Combat => Root.Combat;
+        public readonly ClassesNamespace Classes = new ClassesNamespace();
 
-        public static CommandoutputNamespace Commandoutput => Root.Commandoutput;
+        public readonly ColorsNamespace Colors = new ColorsNamespace();
 
-        public static CommandsNamespace Commands => Root.Commands;
+        public readonly CombatNamespace Combat = new CombatNamespace();
 
-        public static CraftingNamespace Crafting => Root.Crafting;
+        public readonly CommandoutputNamespace Commandoutput = new CommandoutputNamespace();
 
-        public static DatabaseNamespace Database => Root.Database;
+        public readonly CommandsNamespace Commands = new CommandsNamespace();
 
-        public static ErrorsNamespace Errors => Root.Errors;
+        public readonly CraftingNamespace Crafting = new CraftingNamespace();
 
-        public static EventsNamespace Events => Root.Events;
+        public readonly DatabaseNamespace Database = new DatabaseNamespace();
 
-        public static FormulasNamespace Formulas => Root.Formulas;
+        public readonly ErrorsNamespace Errors = new ErrorsNamespace();
 
-        public static FriendsNamespace Friends => Root.Friends;
+        public readonly EventsNamespace Events = new EventsNamespace();
 
-        public static GeneralNamespace General => Root.General;
+        public readonly FormulasNamespace Formulas = new FormulasNamespace();
 
-        public static GuildsNamespace Guilds => Root.Guilds;
+        public readonly FriendsNamespace Friends = new FriendsNamespace();
 
-        public static IntroNamespace Intro => Root.Intro;
+        public readonly GeneralNamespace General = new GeneralNamespace();
 
-        public static ItemsNamespace Items => Root.Items;
+        public readonly IntroNamespace Intro = new IntroNamespace();
 
-        public static MappingNamespace Mapping => Root.Mapping;
+        public readonly ItemsNamespace Items = new ItemsNamespace();
 
-        public static MigrationNamespace Migration => Root.Migration;
+        public readonly MappingNamespace Mapping = new MappingNamespace();
 
-        public static NetDebugNamespace NetDebug => Root.NetDebug;
+        public readonly MigrationNamespace Migration = new MigrationNamespace();
 
-        public static NetworkingNamespace Networking => Root.Networking;
+        public readonly NetDebugNamespace NetDebug = new NetDebugNamespace();
 
-        public static NotificationsNamespace Notifications => Root.NotificationsNamespace;
+        public readonly NetworkingNamespace Networking = new NetworkingNamespace();
 
-        public static PartiesNamespace Parties => Root.Parties;
+        public readonly NotificationsNamespace NotificationsNamespace = new NotificationsNamespace();
 
-        public static PasswordResetNotificationNamespace PasswordResetNotification =>
-            Root.PasswordResetNotificationNamespace;
+        public readonly PartiesNamespace Parties = new PartiesNamespace();
 
-        public static PlayerNamespace Player => Root.Player;
+        public readonly PasswordResetNotificationNamespace PasswordResetNotificationNamespace =
+            new PasswordResetNotificationNamespace();
 
-        public static PortcheckingNamespace Portchecking => Root.Portchecking;
+        public readonly PlayerNamespace Player = new PlayerNamespace();
 
-        public static QuestsNamespace Quests => Root.Quests;
+        public readonly PortcheckingNamespace Portchecking = new PortcheckingNamespace();
 
-        public static RegexNamespace Regex => Root.Regex;
+        public readonly QuestsNamespace Quests = new QuestsNamespace();
 
-        public static ShopsNamespace Shops => Root.Shops;
+        public readonly RegexNamespace Regex = new RegexNamespace();
 
-        public static TradingNamespace Trading => Root.Trading;
+        public readonly ShopsNamespace Shops = new ShopsNamespace();
 
-        public static UpnpNamespace Upnp => Root.Upnp;
+        public readonly TradingNamespace Trading = new TradingNamespace();
 
-        #endregion
+        public readonly UpnpNamespace Upnp = new UpnpNamespace();
+
+        public readonly GuildsNamespace Guilds = new GuildsNamespace();
 
     }
+
+    // ReSharper restore MemberHidesStaticFromOuterClass
+
+    #endregion
+
+    #region Namespace Exposure
+
+    public static AccountNamespace Account => Root.Account;
+
+    public static BagsNamespace Bags => Root.Bags;
+
+    public static BanksNamespace Banks => Root.Banks;
+
+    public static ChatNamespace Chat => Root.Chat;
+
+    public static ClassesNamespace Classes => Root.Classes;
+
+    public static ColorsNamespace Colors => Root.Colors;
+
+    public static CombatNamespace Combat => Root.Combat;
+
+    public static CommandoutputNamespace Commandoutput => Root.Commandoutput;
+
+    public static CommandsNamespace Commands => Root.Commands;
+
+    public static CraftingNamespace Crafting => Root.Crafting;
+
+    public static DatabaseNamespace Database => Root.Database;
+
+    public static ErrorsNamespace Errors => Root.Errors;
+
+    public static EventsNamespace Events => Root.Events;
+
+    public static FormulasNamespace Formulas => Root.Formulas;
+
+    public static FriendsNamespace Friends => Root.Friends;
+
+    public static GeneralNamespace General => Root.General;
+
+    public static GuildsNamespace Guilds => Root.Guilds;
+
+    public static IntroNamespace Intro => Root.Intro;
+
+    public static ItemsNamespace Items => Root.Items;
+
+    public static MappingNamespace Mapping => Root.Mapping;
+
+    public static MigrationNamespace Migration => Root.Migration;
+
+    public static NetDebugNamespace NetDebug => Root.NetDebug;
+
+    public static NetworkingNamespace Networking => Root.Networking;
+
+    public static NotificationsNamespace Notifications => Root.NotificationsNamespace;
+
+    public static PartiesNamespace Parties => Root.Parties;
+
+    public static PasswordResetNotificationNamespace PasswordResetNotification =>
+        Root.PasswordResetNotificationNamespace;
+
+    public static PlayerNamespace Player => Root.Player;
+
+    public static PortcheckingNamespace Portchecking => Root.Portchecking;
+
+    public static QuestsNamespace Quests => Root.Quests;
+
+    public static RegexNamespace Regex => Root.Regex;
+
+    public static ShopsNamespace Shops => Root.Shops;
+
+    public static TradingNamespace Trading => Root.Trading;
+
+    public static UpnpNamespace Upnp => Root.Upnp;
+
+    #endregion
 
 }

--- a/Intersect.Server.Core/Maps/MapActionMessages.cs
+++ b/Intersect.Server.Core/Maps/MapActionMessages.cs
@@ -1,36 +1,35 @@
 using Intersect.Network.Packets.Server;
 using Intersect.Server.Entities;
 
-namespace Intersect.Server.Maps
-{
-    public partial class MapActionMessages
-    {
-        public List<ActionMsgPacket> mActionMessages = new List<ActionMsgPacket>();
+namespace Intersect.Server.Maps;
 
-        public void Add(ActionMsgPacket pkt)
+public partial class MapActionMessages
+{
+    public List<ActionMsgPacket> mActionMessages = new List<ActionMsgPacket>();
+
+    public void Add(ActionMsgPacket pkt)
+    {
+        lock (mActionMessages)
+        {
+            mActionMessages.Add(pkt);
+        }
+    }
+
+    public void SendPackets(HashSet<Player> nearbyPlayers)
+    {
+        if (mActionMessages.Count > 0)
         {
             lock (mActionMessages)
             {
-                mActionMessages.Add(pkt);
-            }
-        }
-
-        public void SendPackets(HashSet<Player> nearbyPlayers)
-        {
-            if (mActionMessages.Count > 0)
-            {
-                lock (mActionMessages)
+                var pkt = new ActionMsgPackets()
                 {
-                    var pkt = new ActionMsgPackets()
-                    {
-                        Packets = mActionMessages.ToArray()
-                    };
-                    foreach (var plyr in nearbyPlayers)
-                    {
-                        plyr.SendPacket(pkt, Network.TransmissionMode.Any);
-                    }
-                    mActionMessages.Clear();
+                    Packets = mActionMessages.ToArray()
+                };
+                foreach (var plyr in nearbyPlayers)
+                {
+                    plyr.SendPacket(pkt, Network.TransmissionMode.Any);
                 }
+                mActionMessages.Clear();
             }
         }
     }

--- a/Intersect.Server.Core/Maps/MapAnimations.cs
+++ b/Intersect.Server.Core/Maps/MapAnimations.cs
@@ -1,36 +1,35 @@
 using Intersect.Network.Packets.Server;
 using Intersect.Server.Entities;
 
-namespace Intersect.Server.Maps
-{
-    public partial class MapAnimations
-    {
-        public List<PlayAnimationPacket> mAnimations = new List<PlayAnimationPacket>();
+namespace Intersect.Server.Maps;
 
-        public void Add(PlayAnimationPacket pkt)
+public partial class MapAnimations
+{
+    public List<PlayAnimationPacket> mAnimations = new List<PlayAnimationPacket>();
+
+    public void Add(PlayAnimationPacket pkt)
+    {
+        lock (mAnimations)
+        {
+            mAnimations.Add(pkt);
+        }
+    }
+
+    public void SendPackets(HashSet<Player> nearbyPlayers)
+    {
+        if (mAnimations.Count > 0)
         {
             lock (mAnimations)
             {
-                mAnimations.Add(pkt);
-            }
-        }
-
-        public void SendPackets(HashSet<Player> nearbyPlayers)
-        {
-            if (mAnimations.Count > 0)
-            {
-                lock (mAnimations)
+                var pkt = new PlayAnimationPackets()
                 {
-                    var pkt = new PlayAnimationPackets()
-                    {
-                        Packets = mAnimations.ToArray()
-                    };
-                    foreach (var plyr in nearbyPlayers)
-                    {
-                        plyr.SendPacket(pkt, Network.TransmissionMode.Any);
-                    }
-                    mAnimations.Clear();
+                    Packets = mAnimations.ToArray()
+                };
+                foreach (var plyr in nearbyPlayers)
+                {
+                    plyr.SendPacket(pkt, Network.TransmissionMode.Any);
                 }
+                mAnimations.Clear();
             }
         }
     }

--- a/Intersect.Server.Core/Maps/MapController.cs
+++ b/Intersect.Server.Core/Maps/MapController.cs
@@ -13,648 +13,647 @@ using Intersect.Server.Networking;
 
 using Newtonsoft.Json;
 
-namespace Intersect.Server.Maps
+namespace Intersect.Server.Maps;
+
+
+/// <summary>
+/// A <see cref="MapController"/> exists to provide a reference to some <see cref="Map"/> and it's neighbors, as well as give
+/// hooks to the Instance's list of <see cref="MapInstance"/>.
+/// <remarks>
+/// A Map Controller is generally not responsible for sending packets to players, that is the job of the Instances, stored in <see cref="mInstances"/>.
+/// However, the exception to that case is whenever we want to perform some action for ALL players on a map, regardless of
+/// whatever Instance they are currently on. In those cases, that logic should live here, and generally means iterating
+/// over the map instance that belong to this <see cref="MapController"/>.
+/// <para>
+/// A good example of this can be seen in the Respawn/Despawning functions of a <see cref="MapController"/> - these functions are called
+/// when we update a Map from the editor, or otherwise need to refresh what a <see cref="Map"/> looks like under the hood, and the
+/// methods go out to each instance to refresh the packets that are being sent to the player/instances that are being processed
+/// by the <see cref="MapInstance"/>.
+/// </para>
+/// </remarks>
+/// </summary>
+public partial class MapController : MapBase
 {
+    private ConcurrentDictionary<Guid, MapInstance> mInstances = new ConcurrentDictionary<Guid, MapInstance>();
+
+    private static MapControllers sLookup;
+
+    //Location of Map in the current grid
+    [JsonIgnore] [NotMapped] public int MapGrid;
+
+    [JsonIgnore] [NotMapped] public int MapGridX = -1;
+
+    [JsonIgnore] [NotMapped] public int MapGridY = -1;
+
+    //Temporary Values
+    private Guid[] mSurroundingMapIds = new Guid[0];
+    private Guid[] mSurroundingMapsIdsWithSelf = new Guid[0];
+    private MapController[] mSurroundingMaps = new MapController[0];
+    private MapController[] mSurroundingMapsWithSelf = new MapController[0];
+
+    [NotMapped, JsonIgnore] public MapPacket? CachedMapClientPacket { get; set; }
 
     /// <summary>
-    /// A <see cref="MapController"/> exists to provide a reference to some <see cref="Map"/> and it's neighbors, as well as give
-    /// hooks to the Instance's list of <see cref="MapInstance"/>.
-    /// <remarks>
-    /// A Map Controller is generally not responsible for sending packets to players, that is the job of the Instances, stored in <see cref="mInstances"/>.
-    /// However, the exception to that case is whenever we want to perform some action for ALL players on a map, regardless of
-    /// whatever Instance they are currently on. In those cases, that logic should live here, and generally means iterating
-    /// over the map instance that belong to this <see cref="MapController"/>.
-    /// <para>
-    /// A good example of this can be seen in the Respawn/Despawning functions of a <see cref="MapController"/> - these functions are called
-    /// when we update a Map from the editor, or otherwise need to refresh what a <see cref="Map"/> looks like under the hood, and the
-    /// methods go out to each instance to refresh the packets that are being sent to the player/instances that are being processed
-    /// by the <see cref="MapInstance"/>.
-    /// </para>
-    /// </remarks>
+    /// Contains a list of all surrounding Map (controller) IDs
     /// </summary>
-    public partial class MapController : MapBase
+    [JsonIgnore]
+    [NotMapped]
+    public Guid[] SurroundingMapIds
     {
-        private ConcurrentDictionary<Guid, MapInstance> mInstances = new ConcurrentDictionary<Guid, MapInstance>();
+        get => mSurroundingMapIds;
 
-        private static MapControllers sLookup;
-
-        //Location of Map in the current grid
-        [JsonIgnore] [NotMapped] public int MapGrid;
-
-        [JsonIgnore] [NotMapped] public int MapGridX = -1;
-
-        [JsonIgnore] [NotMapped] public int MapGridY = -1;
-
-        //Temporary Values
-        private Guid[] mSurroundingMapIds = new Guid[0];
-        private Guid[] mSurroundingMapsIdsWithSelf = new Guid[0];
-        private MapController[] mSurroundingMaps = new MapController[0];
-        private MapController[] mSurroundingMapsWithSelf = new MapController[0];
-
-        [NotMapped, JsonIgnore] public MapPacket? CachedMapClientPacket { get; set; }
-
-        /// <summary>
-        /// Contains a list of all surrounding Map (controller) IDs
-        /// </summary>
-        [JsonIgnore]
-        [NotMapped]
-        public Guid[] SurroundingMapIds
-        {
-            get => mSurroundingMapIds;
-
-            set
-            {
-                lock (GetMapLock())
-                {
-                    mSurroundingMapIds = value;
-                    var surroundingMapsIdsWithSelf = new List<Guid>(value);
-                    surroundingMapsIdsWithSelf.Add(Id);
-                    mSurroundingMapsIdsWithSelf = surroundingMapsIdsWithSelf.ToArray();
-                }
-            }
-        }
-
-        /// <summary>
-        /// Contains a list of all surrounding maps (controllers)
-        /// </summary>
-        [JsonIgnore]
-        [NotMapped]
-        public MapController[] SurroundingMaps
-        {
-            get => mSurroundingMaps;
-
-            set
-            {
-                lock (GetMapLock())
-                {
-                    mSurroundingMaps = value;
-                    var surroundingMapsWithSelf = new List<MapController>(value);
-                    surroundingMapsWithSelf.Add(this);
-                    mSurroundingMapsWithSelf = surroundingMapsWithSelf.ToArray();
-                }
-            }
-        }
-
-        //EF
-        public MapController() : base()
-        {
-            Name = "New Map";
-            Layers = null;
-        }
-
-        //For New Maps!
-        public MapController(bool newMap = false) : base(Guid.NewGuid())
-        {
-            Name = "New Map";
-            Layers = null;
-        }
-
-        [JsonConstructor]
-        public MapController(Guid id) : base(id)
-        {
-            if (id == Guid.Empty)
-            {
-                return;
-            }
-
-            Layers = null;
-        }
-
-        /// <summary>
-        /// Quick reference for DB lookup of the relevant <see cref="MapBase"/>
-        /// </summary>
-        public new static MapControllers Lookup => sLookup = sLookup ?? new MapControllers(MapBase.Lookup);
-
-        /// <summary>
-        /// Quick reference to get a Map Controller from its <see cref="MapBase"/> ID
-        /// </summary>
-        /// <param name="id"></param>
-        /// <returns></returns>
-        public static MapController Get(Guid id)
-        {
-            return Lookup.Get<MapController>(id);
-        }
-
-        /// <summary>
-        /// Tries to get a Map Controller from its <see cref="MapBase"/> ID
-        /// </summary>
-        /// <param name="id"></param>
-        /// <param name="mapController">The retrieved Map Controller, if successful</param>
-        /// <returns><c>true</c> if the Map Controller was found; otherwise, <c>false</c></returns>
-        public static bool TryGet(Guid id, [NotNullWhen(true)] out MapController? mapController)
-        {
-            mapController = Lookup.Get<MapController>(id);
-            return mapController != null;
-        }
-
-        /// <summary>
-        /// Tries to get a <see cref="MapInstance"/> when given an instanceId.
-        /// </summary>
-        /// <param name="mapControllerId">The id of the <see cref="MapController"/></param>
-        /// <param name="instanceId">The instance ID we want - crucially, NOT the unique ID of the <see cref="MapInstance"/>. Matches with some entity's InstanceId</param>
-        /// <param name="mapInstance">Out value for the successfully found <see cref="MapInstance"/></param>
-        /// <returns>True if successful in retrieving a <see cref="MapInstance"/>, false otherwise</returns>
-        public static bool TryGetInstanceFromMap(Guid mapControllerId, Guid instanceId, out MapInstance mapInstance)
-        {
-            mapInstance = null;
-            var controller = Get(mapControllerId);
-            if (controller != null && controller.TryGetInstance(instanceId, out mapInstance))
-            {
-                return mapInstance != null;
-            }
-            else
-            {
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Gets each instance of a map's surrounding maps with a given instanceID
-        /// </summary>
-        /// <param name="mapControllerId">The relevant map controller ID</param>
-        /// <param name="instanceId">The instance ID we're requesting from each map</param>
-        /// <param name="includeSelf">Whether or not to include the map of which we're checking the surroundings of</param>
-        /// <param name="createIfNew">Whether or not to create any instances that do not exist with the requested InstanceID on any of the surrounding maps</param>
-        /// <returns>A list of <see cref="MapInstance"/>, containing the instances of the requested surrounding maps with the given instance ID.</returns>
-        public static List<MapInstance> GetSurroundingMapInstances(Guid mapControllerId, Guid instanceId, bool includeSelf, bool createIfNew = false)
-        {
-            List<MapInstance> instances = new List<MapInstance>();
-            var controller = Get(mapControllerId);
-            if (controller != null)
-            {
-                foreach (var controllerId in controller.GetSurroundingMapIds(includeSelf).ToList())
-                {
-                    if (TryGetInstanceFromMap(controllerId, instanceId, out var instance))
-                    {
-                        instances.Add(instance);
-                    }
-                }
-            }
-            return instances;
-        }
-
-        //GameObject Functions
-
-        public object GetMapLock()
-        {
-            return mMapLock;
-        }
-
-        public override void Load(string json, bool keepCreationTime = true)
-        {
-            Load(json, -1);
-        }
-
-        /// <summary>
-        /// Refreshes all of this controller's instances
-        /// </summary>
-        public void Initialize()
-        {
-            lock (mMapLock)
-            {
-                DespawnAllInstances();
-                RespawnAllInstances();
-            }
-        }
-
-        /// <summary>
-        /// Load this map from JSON
-        /// </summary>
-        /// <param name="json">The JSON containing map data</param>
-        /// <param name="keepRevision">The revision number</param>
-        public void Load(string json, int keepRevision = -1)
-        {
-            lock (mMapLock)
-            {
-                CachedMapClientPacket = default;
-                DespawnAllInstances();
-                base.Load(json);
-                if (keepRevision > -1)
-                {
-                    Revision = keepRevision;
-                }
-            }
-        }
-
-        /// <summary>
-        /// Despawns NPCs of a given <see cref="NpcBase"/> from all instances of this controller.
-        /// </summary>
-        /// <param name="npcBase">The <see cref="NpcBase"/> to despawn</param>
-        public void DespawnNpcAcrossInstances(NpcBase npcBase)
-        {
-            foreach (var entity in GetEntitiesOnAllInstances())
-            {
-                if (entity is Npc npc && npc.Base == npcBase)
-                {
-                    lock (npc.EntityLock)
-                    {
-                        npc.Die(false);
-                    }
-                }
-            }
-        }
-
-        /// <summary>
-        /// Despawns resources of a given <see cref="ResourceBase"/> from all instances of this controller.
-        /// </summary>
-        /// <param name="resourceBase">The <see cref="ResourceBase"/> to despawn</param>
-        public void DespawnResourceAcrossInstances(ResourceBase resourceBase)
-        {
-            foreach (var entity in GetEntitiesOnAllInstances())
-            {
-                if (entity is Resource res && res.Base == resourceBase)
-                {
-                    lock (res.EntityLock)
-                    {
-                        res.Die(false);
-                    }
-                }
-            }
-        }
-
-        /// <summary>
-        /// Despawns projectiles of a given <see cref="ProjectileBase"/> from all instances of this controller.
-        /// </summary>
-        /// <param name="projectileBase">The <see cref="ProjectileBase"/> to despawn</param>
-        public void DespawnProjectileAcrossInstances(ProjectileBase projectileBase)
-        {
-            var guids = new List<Guid>();
-            foreach (var entity in GetEntitiesOnAllInstances())
-            {
-                if (entity is Projectile proj && proj.Base == projectileBase)
-                {
-                    lock (proj.EntityLock)
-                    {
-                        guids.Add(proj.Id);
-                        proj.Die(false);
-                    }
-                }
-            }
-            PacketSender.SendRemoveProjectileSpawnsFromAllLayers(Id, guids.ToArray(), null);
-        }
-
-        /// <summary>
-        /// Despawns items of a given <see cref="ItemBase"/> from all instances of this controller.
-        /// </summary>
-        /// <param name="itemBase">The <see cref="ItemBase"/> to despawn</param>
-        public void DespawnItemAcrossInstances(ItemBase itemBase)
-        {
-            foreach(var mapInstance in mInstances.Values)
-            {
-                foreach (var item in mapInstance.AllMapItems.Values)
-                {
-                    if (ItemBase.Get(item.ItemId) == itemBase)
-                    {
-                        mapInstance.RemoveItem(item);
-                    }
-                }
-            }
-        }
-
-        /// <summary>
-        /// Gets an array of MapControllers out of the maps surrounding this one
-        /// </summary>
-        /// <param name="includingSelf">Whether or not to also include the calling controller in the array</param>
-        /// <returns>An array of MapControllers out of the maps surrounding this one</returns>
-        public MapController[] GetSurroundingMaps(bool includingSelf = false)
-        {
-            return includingSelf ? mSurroundingMapsWithSelf : mSurroundingMaps;
-        }
-
-        /// <summary>
-        /// Gets an array of Guids out of the map IDs surrounding this one
-        /// </summary>
-        /// <param name="includingSelf">Whether or not to also include the calling controller in the array</param>
-        /// <returns>An array of Guids out of the maps surrounding this one</returns>
-        public Guid[] GetSurroundingMapIds(bool includingSelf = false)
-        {
-            return includingSelf ? mSurroundingMapsIdsWithSelf : mSurroundingMapIds;
-        }
-
-        /// <summary>
-        /// Gets every player that is on every instance of this map controller
-        /// </summary>
-        /// <returns>A generic collection of <see cref="Player"/>s</returns>
-        public ICollection<Player> GetPlayersOnAllInstances()
-        {
-            var players = new List<Player>();
-            foreach (var instance in mInstances.Keys.ToList())
-            {
-                players.AddRange(mInstances[instance].GetPlayers());
-            }
-            return players;
-        }
-
-        /// <summary>
-        /// Gets every entity that is on every instance of this map controller
-        /// </summary>
-        /// <returns>A generic collection of <see cref="Entity"/>s</returns>s
-        public ICollection<Entity> GetEntitiesOnAllInstances()
-        {
-            var entities = new List<Entity>();
-            foreach (var mapInstance in mInstances)
-            {
-                entities.AddRange(mapInstance.Value.GetEntities());
-            }
-            return entities;
-        }
-
-        /// <summary>
-        /// Destroys connections to other maps from this controller
-        /// </summary>
-        /// <param name="side">Which side to destroy connections from. -1 will clear all directionsm and is the default</param>
-        public void ClearConnections(Direction side = Direction.None)
-        {
-            if (side == Direction.None || side == Direction.Up)
-            {
-                Up = Guid.Empty;
-            }
-
-            if (side == Direction.None || side == Direction.Down)
-            {
-                Down = Guid.Empty;
-            }
-
-            if (side == Direction.None || side == Direction.Left)
-            {
-                Left = Guid.Empty;
-            }
-
-            if (side == Direction.None || side == Direction.Right)
-            {
-                Right = Guid.Empty;
-            }
-
-            DbInterface.SaveGameObject(this);
-        }
-
-        #region Map Instance Management
-        /// <summary>
-        /// Despawns all entities/items/projectiles on each instance that belongs to this controller
-        /// </summary>
-        public void DespawnAllInstances()
-        {
-            foreach (var mapInstance in mInstances.Values)
-            {
-                mapInstance.DespawnEverything();
-            }
-        }
-
-        /// <summary>
-        /// Respawns all entities/items/projectiles on each instance that belongs to this controller.
-        /// </summary>
-        public void RespawnAllInstances()
-        {
-            foreach (var mapInstance in mInstances.Values)
-            {
-                mapInstance.RespawnEverything();
-            }
-        }
-
-        /// <summary>
-        /// Creates a new instance
-        /// </summary>
-        /// <param name="instanceId"></param>
-        /// <returns>Whether or not we needed to create a new map instance</returns>
-        public bool TryCreateInstance(Guid instanceId, out MapInstance newLayer, Player creator)
-        {
-            newLayer = null;
-            lock (GetMapLock())
-            {
-                if (!mInstances.ContainsKey(instanceId))
-                {
-                    Log.Debug($"Creating new instance with ID {instanceId} for map {Name}");
-                    newLayer = new MapInstance(this, instanceId, creator);
-                    newLayer.Initialize();
-                    mInstances[instanceId] = newLayer;
-
-                    return true;
-                }
-
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Attempts to get an instance with some given instance ID
-        /// </summary>
-        /// <param name="mapInstanceId">The id of the instance - NOT the unique id of a <see cref="MapInstance"/></param>
-        /// <param name="instance">Out value - the mapInstance we find. Null if not found</param>
-        /// <returns>True if successful in finding the requested instance, false otherwise</returns>
-        public bool TryGetInstance(Guid mapInstanceId, out MapInstance instance)
-        {
-            return mInstances.TryGetValue(mapInstanceId, out instance) ? instance != default : false;
-        }
-
-        /// <summary>
-        /// Removes a requested <see cref="Entity"/> from a requested instance on all surrounding maps, including this one
-        /// </summary>
-        /// <param name="entity">The entity we wish to remove</param>
-        /// <param name="mapInstanceId">The instance we're removing the entity from</param>
-        public void RemoveEntityFromAllSurroundingMapsInInstance(Entity entity, Guid mapInstanceId)
-        {
-            foreach (var instance in GetSurroundingMapInstances(Id, mapInstanceId, true))
-            {
-                instance.RemoveEntity(entity);
-            }
-        }
-
-        /// <summary>
-        /// Disposes of an instance from this controllers <see cref="mInstances"/>
-        /// </summary>
-        /// <param name="mapInstanceId">The instance ID to dispose of</param>
-        public void DisposeInstanceWithId(Guid mapInstanceId)
+        set
         {
             lock (GetMapLock())
             {
-                if (mInstances[mapInstanceId] != null)
-                {
-                    if (mInstances.TryRemove(mapInstanceId, out var removedInstance))
-                    {
-                        removedInstance.Dispose();
-                        Log.Debug($"Cleaning up Instance {mapInstanceId} for map: {Name}");
-                    }
-                }
+                mSurroundingMapIds = value;
+                var surroundingMapsIdsWithSelf = new List<Guid>(value);
+                surroundingMapsIdsWithSelf.Add(Id);
+                mSurroundingMapsIdsWithSelf = surroundingMapsIdsWithSelf.ToArray();
             }
         }
+    }
 
-        /// <summary>
-        /// Gets a list of players that are on the same instance
-        /// </summary>
-        /// <param name="mapInstanceId">The instance ID to check for</param>
-        /// <param name="except">An entity that we do NOT wish to include in the returned list</param>
-        /// <returns>A list of players on this map who share the same instance ID</returns>
-        public List<Player> GetPlayersOnSharedInstance(Guid mapInstanceId, Entity except)
+    /// <summary>
+    /// Contains a list of all surrounding maps (controllers)
+    /// </summary>
+    [JsonIgnore]
+    [NotMapped]
+    public MapController[] SurroundingMaps
+    {
+        get => mSurroundingMaps;
+
+        set
         {
-            var entitiesOnSharedLayer = new List<Player>();
-
-            if (mInstances.TryGetValue(mapInstanceId, out var instance))
+            lock (GetMapLock())
             {
-                foreach (var player in instance.GetPlayers())
-                {
-                    if (player != except && player.MapInstanceId == mapInstanceId)
-                    {
-                        entitiesOnSharedLayer.Add(player);
-                    }
-                }
+                mSurroundingMaps = value;
+                var surroundingMapsWithSelf = new List<MapController>(value);
+                surroundingMapsWithSelf.Add(this);
+                mSurroundingMapsWithSelf = surroundingMapsWithSelf.ToArray();
             }
+        }
+    }
 
-            return entitiesOnSharedLayer;
+    //EF
+    public MapController() : base()
+    {
+        Name = "New Map";
+        Layers = null;
+    }
+
+    //For New Maps!
+    public MapController(bool newMap = false) : base(Guid.NewGuid())
+    {
+        Name = "New Map";
+        Layers = null;
+    }
+
+    [JsonConstructor]
+    public MapController(Guid id) : base(id)
+    {
+        if (id == Guid.Empty)
+        {
+            return;
         }
 
-        /// <summary>
-        /// Clears <see cref="mInstances"/>
-        /// </summary>
-        public void ClearAllInstances()
-        {
-            mInstances.Clear();
-        }
-        #endregion
+        Layers = null;
+    }
 
-        /// <summary>
-        /// Gets rid of any orphaned tile layers
-        /// </summary>
-        public void DestroyOrphanedLayers()
+    /// <summary>
+    /// Quick reference for DB lookup of the relevant <see cref="MapBase"/>
+    /// </summary>
+    public new static MapControllers Lookup => sLookup = sLookup ?? new MapControllers(MapBase.Lookup);
+
+    /// <summary>
+    /// Quick reference to get a Map Controller from its <see cref="MapBase"/> ID
+    /// </summary>
+    /// <param name="id"></param>
+    /// <returns></returns>
+    public static MapController Get(Guid id)
+    {
+        return Lookup.Get<MapController>(id);
+    }
+
+    /// <summary>
+    /// Tries to get a Map Controller from its <see cref="MapBase"/> ID
+    /// </summary>
+    /// <param name="id"></param>
+    /// <param name="mapController">The retrieved Map Controller, if successful</param>
+    /// <returns><c>true</c> if the Map Controller was found; otherwise, <c>false</c></returns>
+    public static bool TryGet(Guid id, [NotNullWhen(true)] out MapController? mapController)
+    {
+        mapController = Lookup.Get<MapController>(id);
+        return mapController != null;
+    }
+
+    /// <summary>
+    /// Tries to get a <see cref="MapInstance"/> when given an instanceId.
+    /// </summary>
+    /// <param name="mapControllerId">The id of the <see cref="MapController"/></param>
+    /// <param name="instanceId">The instance ID we want - crucially, NOT the unique ID of the <see cref="MapInstance"/>. Matches with some entity's InstanceId</param>
+    /// <param name="mapInstance">Out value for the successfully found <see cref="MapInstance"/></param>
+    /// <returns>True if successful in retrieving a <see cref="MapInstance"/>, false otherwise</returns>
+    public static bool TryGetInstanceFromMap(Guid mapControllerId, Guid instanceId, out MapInstance mapInstance)
+    {
+        mapInstance = null;
+        var controller = Get(mapControllerId);
+        if (controller != null && controller.TryGetInstance(instanceId, out mapInstance))
         {
-            if (Layers == null && TileData != null)
+            return mapInstance != null;
+        }
+        else
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Gets each instance of a map's surrounding maps with a given instanceID
+    /// </summary>
+    /// <param name="mapControllerId">The relevant map controller ID</param>
+    /// <param name="instanceId">The instance ID we're requesting from each map</param>
+    /// <param name="includeSelf">Whether or not to include the map of which we're checking the surroundings of</param>
+    /// <param name="createIfNew">Whether or not to create any instances that do not exist with the requested InstanceID on any of the surrounding maps</param>
+    /// <returns>A list of <see cref="MapInstance"/>, containing the instances of the requested surrounding maps with the given instance ID.</returns>
+    public static List<MapInstance> GetSurroundingMapInstances(Guid mapControllerId, Guid instanceId, bool includeSelf, bool createIfNew = false)
+    {
+        List<MapInstance> instances = new List<MapInstance>();
+        var controller = Get(mapControllerId);
+        if (controller != null)
+        {
+            foreach (var controllerId in controller.GetSurroundingMapIds(includeSelf).ToList())
             {
-                Layers = JsonConvert.DeserializeObject<Dictionary<string, Tile[,]>>(LZ4.UnPickleString(TileData), mJsonSerializerSettings);
-                foreach (var key in Layers.Keys.ToArray())
+                if (TryGetInstanceFromMap(controllerId, instanceId, out var instance))
                 {
-                    if (!Options.Instance.MapOpts.Layers.All.Contains(key))
-                    {
-                        Layers.Remove(key);
-                    }
+                    instances.Add(instance);
                 }
-                TileData = LZ4.PickleString(JsonConvert.SerializeObject(Layers, Formatting.None, mJsonSerializerSettings));
-                Layers = null;
-                
             }
         }
+        return instances;
+    }
 
-        /// <summary>
-        /// Removes this map from the database
-        /// </summary>
-        public override void Delete()
+    //GameObject Functions
+
+    public object GetMapLock()
+    {
+        return mMapLock;
+    }
+
+    public override void Load(string json, bool keepCreationTime = true)
+    {
+        Load(json, -1);
+    }
+
+    /// <summary>
+    /// Refreshes all of this controller's instances
+    /// </summary>
+    public void Initialize()
+    {
+        lock (mMapLock)
         {
-            Lookup?.Delete(this);
+            DespawnAllInstances();
+            RespawnAllInstances();
         }
+    }
 
-        /// <summary>
-        /// Get back a list of tiles surrounding a requested tile, with a given distance
-        /// </summary>
-        /// <param name="location">The tile to search for</param>
-        /// <param name="distance">The distance from the requested tile to search out from</param>
-        /// <returns>A dictionary of tiles on their own maps</returns>
-        public Dictionary<MapController, List<int>> FindSurroundingTiles(Point location, int distance)
+    /// <summary>
+    /// Load this map from JSON
+    /// </summary>
+    /// <param name="json">The JSON containing map data</param>
+    /// <param name="keepRevision">The revision number</param>
+    public void Load(string json, int keepRevision = -1)
+    {
+        lock (mMapLock)
         {
-            // Loop through all locations surrounding us to get valid tiles.
-            var locations = new Dictionary<MapController, List<int>>();
-            for (var x = 0 - distance; x <= distance; x++)
+            CachedMapClientPacket = default;
+            DespawnAllInstances();
+            base.Load(json);
+            if (keepRevision > -1)
             {
-                for (var y = 0 - distance; y <= distance; y++)
+                Revision = keepRevision;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Despawns NPCs of a given <see cref="NpcBase"/> from all instances of this controller.
+    /// </summary>
+    /// <param name="npcBase">The <see cref="NpcBase"/> to despawn</param>
+    public void DespawnNpcAcrossInstances(NpcBase npcBase)
+    {
+        foreach (var entity in GetEntitiesOnAllInstances())
+        {
+            if (entity is Npc npc && npc.Base == npcBase)
+            {
+                lock (npc.EntityLock)
                 {
-                    // Use these to keep track of our translation.
-                    var currentMap = this;
-                    var currentX = location.X + x;
-                    var currentY = location.Y + y;
-
-                    // Are we on a valid map at all?
-                    if (currentMap == null)
-                    {
-                        break;
-                    }
-
-                    // Are we going to the map on our left?
-                    if (currentX < 0)
-                    {
-                        var oldMap = currentMap;
-                        if (currentMap.Left != Guid.Empty)
-                        {
-                            currentMap = MapController.Get(currentMap.Left);
-                            if (currentMap == null)
-                            {
-                                currentMap = oldMap;
-                                continue;
-                            }
-
-                            currentX = (Options.MapWidth + 1) + x;
-                        }
-                    }
-
-                    // Are we going to the map on our right?
-                    if (currentX >= Options.MapWidth)
-                    {
-                        var oldMap = currentMap;
-                        if (currentMap.Right != Guid.Empty)
-                        {
-                            currentMap = MapController.Get(currentMap.Right);
-                            if (currentMap == null)
-                            {
-                                currentMap = oldMap;
-                                continue;
-                            }
-
-                            currentX = -1 + x;
-                        }
-                    }
-
-                    // Are we going to the map up from us?
-                    if (currentY < 0)
-                    {
-                        var oldMap = currentMap;
-                        if (currentMap.Up != Guid.Empty)
-                        {
-                            currentMap = MapController.Get(currentMap.Up);
-                            if (currentMap == null)
-                            {
-                                currentMap = oldMap;
-                                continue;
-                            }
-
-                            currentY = (Options.MapHeight + 1) + y;
-                        }
-                    }
-
-                    // Are we going to the map down from us?
-                    if (currentY >= Options.MapHeight)
-                    {
-                        var oldMap = currentMap;
-                        if (currentMap.Down != Guid.Empty)
-                        {
-                            currentMap = MapController.Get(currentMap.Down);
-                            if (currentMap == null)
-                            {
-                                currentMap = oldMap;
-                                continue;
-                            }
-
-                            currentY = -1 + y;
-                        }
-                    }
-
-                    if (currentX < 0 || currentY < 0 || currentX >= Options.MapWidth || currentY >= Options.MapHeight)
-                    {
-                        continue;
-                    }
-
-                    if (!locations.ContainsKey(currentMap))
-                    {
-                        locations.Add(currentMap, new List<int>());
-                    }
-                    locations[currentMap].Add(currentY * Options.MapWidth + currentX);
+                    npc.Die(false);
                 }
             }
-
-            return locations;
         }
+    }
 
-        /// <summary>
-        /// A destructor, responsible for making sure that if a map controller is removed, all of its instances are as well
-        /// </summary>
-        ~MapController()
+    /// <summary>
+    /// Despawns resources of a given <see cref="ResourceBase"/> from all instances of this controller.
+    /// </summary>
+    /// <param name="resourceBase">The <see cref="ResourceBase"/> to despawn</param>
+    public void DespawnResourceAcrossInstances(ResourceBase resourceBase)
+    {
+        foreach (var entity in GetEntitiesOnAllInstances())
         {
-            ClearAllInstances();
+            if (entity is Resource res && res.Base == resourceBase)
+            {
+                lock (res.EntityLock)
+                {
+                    res.Die(false);
+                }
+            }
         }
+    }
+
+    /// <summary>
+    /// Despawns projectiles of a given <see cref="ProjectileBase"/> from all instances of this controller.
+    /// </summary>
+    /// <param name="projectileBase">The <see cref="ProjectileBase"/> to despawn</param>
+    public void DespawnProjectileAcrossInstances(ProjectileBase projectileBase)
+    {
+        var guids = new List<Guid>();
+        foreach (var entity in GetEntitiesOnAllInstances())
+        {
+            if (entity is Projectile proj && proj.Base == projectileBase)
+            {
+                lock (proj.EntityLock)
+                {
+                    guids.Add(proj.Id);
+                    proj.Die(false);
+                }
+            }
+        }
+        PacketSender.SendRemoveProjectileSpawnsFromAllLayers(Id, guids.ToArray(), null);
+    }
+
+    /// <summary>
+    /// Despawns items of a given <see cref="ItemBase"/> from all instances of this controller.
+    /// </summary>
+    /// <param name="itemBase">The <see cref="ItemBase"/> to despawn</param>
+    public void DespawnItemAcrossInstances(ItemBase itemBase)
+    {
+        foreach(var mapInstance in mInstances.Values)
+        {
+            foreach (var item in mapInstance.AllMapItems.Values)
+            {
+                if (ItemBase.Get(item.ItemId) == itemBase)
+                {
+                    mapInstance.RemoveItem(item);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets an array of MapControllers out of the maps surrounding this one
+    /// </summary>
+    /// <param name="includingSelf">Whether or not to also include the calling controller in the array</param>
+    /// <returns>An array of MapControllers out of the maps surrounding this one</returns>
+    public MapController[] GetSurroundingMaps(bool includingSelf = false)
+    {
+        return includingSelf ? mSurroundingMapsWithSelf : mSurroundingMaps;
+    }
+
+    /// <summary>
+    /// Gets an array of Guids out of the map IDs surrounding this one
+    /// </summary>
+    /// <param name="includingSelf">Whether or not to also include the calling controller in the array</param>
+    /// <returns>An array of Guids out of the maps surrounding this one</returns>
+    public Guid[] GetSurroundingMapIds(bool includingSelf = false)
+    {
+        return includingSelf ? mSurroundingMapsIdsWithSelf : mSurroundingMapIds;
+    }
+
+    /// <summary>
+    /// Gets every player that is on every instance of this map controller
+    /// </summary>
+    /// <returns>A generic collection of <see cref="Player"/>s</returns>
+    public ICollection<Player> GetPlayersOnAllInstances()
+    {
+        var players = new List<Player>();
+        foreach (var instance in mInstances.Keys.ToList())
+        {
+            players.AddRange(mInstances[instance].GetPlayers());
+        }
+        return players;
+    }
+
+    /// <summary>
+    /// Gets every entity that is on every instance of this map controller
+    /// </summary>
+    /// <returns>A generic collection of <see cref="Entity"/>s</returns>s
+    public ICollection<Entity> GetEntitiesOnAllInstances()
+    {
+        var entities = new List<Entity>();
+        foreach (var mapInstance in mInstances)
+        {
+            entities.AddRange(mapInstance.Value.GetEntities());
+        }
+        return entities;
+    }
+
+    /// <summary>
+    /// Destroys connections to other maps from this controller
+    /// </summary>
+    /// <param name="side">Which side to destroy connections from. -1 will clear all directionsm and is the default</param>
+    public void ClearConnections(Direction side = Direction.None)
+    {
+        if (side == Direction.None || side == Direction.Up)
+        {
+            Up = Guid.Empty;
+        }
+
+        if (side == Direction.None || side == Direction.Down)
+        {
+            Down = Guid.Empty;
+        }
+
+        if (side == Direction.None || side == Direction.Left)
+        {
+            Left = Guid.Empty;
+        }
+
+        if (side == Direction.None || side == Direction.Right)
+        {
+            Right = Guid.Empty;
+        }
+
+        DbInterface.SaveGameObject(this);
+    }
+
+    #region Map Instance Management
+    /// <summary>
+    /// Despawns all entities/items/projectiles on each instance that belongs to this controller
+    /// </summary>
+    public void DespawnAllInstances()
+    {
+        foreach (var mapInstance in mInstances.Values)
+        {
+            mapInstance.DespawnEverything();
+        }
+    }
+
+    /// <summary>
+    /// Respawns all entities/items/projectiles on each instance that belongs to this controller.
+    /// </summary>
+    public void RespawnAllInstances()
+    {
+        foreach (var mapInstance in mInstances.Values)
+        {
+            mapInstance.RespawnEverything();
+        }
+    }
+
+    /// <summary>
+    /// Creates a new instance
+    /// </summary>
+    /// <param name="instanceId"></param>
+    /// <returns>Whether or not we needed to create a new map instance</returns>
+    public bool TryCreateInstance(Guid instanceId, out MapInstance newLayer, Player creator)
+    {
+        newLayer = null;
+        lock (GetMapLock())
+        {
+            if (!mInstances.ContainsKey(instanceId))
+            {
+                Log.Debug($"Creating new instance with ID {instanceId} for map {Name}");
+                newLayer = new MapInstance(this, instanceId, creator);
+                newLayer.Initialize();
+                mInstances[instanceId] = newLayer;
+
+                return true;
+            }
+
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Attempts to get an instance with some given instance ID
+    /// </summary>
+    /// <param name="mapInstanceId">The id of the instance - NOT the unique id of a <see cref="MapInstance"/></param>
+    /// <param name="instance">Out value - the mapInstance we find. Null if not found</param>
+    /// <returns>True if successful in finding the requested instance, false otherwise</returns>
+    public bool TryGetInstance(Guid mapInstanceId, out MapInstance instance)
+    {
+        return mInstances.TryGetValue(mapInstanceId, out instance) ? instance != default : false;
+    }
+
+    /// <summary>
+    /// Removes a requested <see cref="Entity"/> from a requested instance on all surrounding maps, including this one
+    /// </summary>
+    /// <param name="entity">The entity we wish to remove</param>
+    /// <param name="mapInstanceId">The instance we're removing the entity from</param>
+    public void RemoveEntityFromAllSurroundingMapsInInstance(Entity entity, Guid mapInstanceId)
+    {
+        foreach (var instance in GetSurroundingMapInstances(Id, mapInstanceId, true))
+        {
+            instance.RemoveEntity(entity);
+        }
+    }
+
+    /// <summary>
+    /// Disposes of an instance from this controllers <see cref="mInstances"/>
+    /// </summary>
+    /// <param name="mapInstanceId">The instance ID to dispose of</param>
+    public void DisposeInstanceWithId(Guid mapInstanceId)
+    {
+        lock (GetMapLock())
+        {
+            if (mInstances[mapInstanceId] != null)
+            {
+                if (mInstances.TryRemove(mapInstanceId, out var removedInstance))
+                {
+                    removedInstance.Dispose();
+                    Log.Debug($"Cleaning up Instance {mapInstanceId} for map: {Name}");
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets a list of players that are on the same instance
+    /// </summary>
+    /// <param name="mapInstanceId">The instance ID to check for</param>
+    /// <param name="except">An entity that we do NOT wish to include in the returned list</param>
+    /// <returns>A list of players on this map who share the same instance ID</returns>
+    public List<Player> GetPlayersOnSharedInstance(Guid mapInstanceId, Entity except)
+    {
+        var entitiesOnSharedLayer = new List<Player>();
+
+        if (mInstances.TryGetValue(mapInstanceId, out var instance))
+        {
+            foreach (var player in instance.GetPlayers())
+            {
+                if (player != except && player.MapInstanceId == mapInstanceId)
+                {
+                    entitiesOnSharedLayer.Add(player);
+                }
+            }
+        }
+
+        return entitiesOnSharedLayer;
+    }
+
+    /// <summary>
+    /// Clears <see cref="mInstances"/>
+    /// </summary>
+    public void ClearAllInstances()
+    {
+        mInstances.Clear();
+    }
+    #endregion
+
+    /// <summary>
+    /// Gets rid of any orphaned tile layers
+    /// </summary>
+    public void DestroyOrphanedLayers()
+    {
+        if (Layers == null && TileData != null)
+        {
+            Layers = JsonConvert.DeserializeObject<Dictionary<string, Tile[,]>>(LZ4.UnPickleString(TileData), mJsonSerializerSettings);
+            foreach (var key in Layers.Keys.ToArray())
+            {
+                if (!Options.Instance.MapOpts.Layers.All.Contains(key))
+                {
+                    Layers.Remove(key);
+                }
+            }
+            TileData = LZ4.PickleString(JsonConvert.SerializeObject(Layers, Formatting.None, mJsonSerializerSettings));
+            Layers = null;
+            
+        }
+    }
+
+    /// <summary>
+    /// Removes this map from the database
+    /// </summary>
+    public override void Delete()
+    {
+        Lookup?.Delete(this);
+    }
+
+    /// <summary>
+    /// Get back a list of tiles surrounding a requested tile, with a given distance
+    /// </summary>
+    /// <param name="location">The tile to search for</param>
+    /// <param name="distance">The distance from the requested tile to search out from</param>
+    /// <returns>A dictionary of tiles on their own maps</returns>
+    public Dictionary<MapController, List<int>> FindSurroundingTiles(Point location, int distance)
+    {
+        // Loop through all locations surrounding us to get valid tiles.
+        var locations = new Dictionary<MapController, List<int>>();
+        for (var x = 0 - distance; x <= distance; x++)
+        {
+            for (var y = 0 - distance; y <= distance; y++)
+            {
+                // Use these to keep track of our translation.
+                var currentMap = this;
+                var currentX = location.X + x;
+                var currentY = location.Y + y;
+
+                // Are we on a valid map at all?
+                if (currentMap == null)
+                {
+                    break;
+                }
+
+                // Are we going to the map on our left?
+                if (currentX < 0)
+                {
+                    var oldMap = currentMap;
+                    if (currentMap.Left != Guid.Empty)
+                    {
+                        currentMap = MapController.Get(currentMap.Left);
+                        if (currentMap == null)
+                        {
+                            currentMap = oldMap;
+                            continue;
+                        }
+
+                        currentX = (Options.MapWidth + 1) + x;
+                    }
+                }
+
+                // Are we going to the map on our right?
+                if (currentX >= Options.MapWidth)
+                {
+                    var oldMap = currentMap;
+                    if (currentMap.Right != Guid.Empty)
+                    {
+                        currentMap = MapController.Get(currentMap.Right);
+                        if (currentMap == null)
+                        {
+                            currentMap = oldMap;
+                            continue;
+                        }
+
+                        currentX = -1 + x;
+                    }
+                }
+
+                // Are we going to the map up from us?
+                if (currentY < 0)
+                {
+                    var oldMap = currentMap;
+                    if (currentMap.Up != Guid.Empty)
+                    {
+                        currentMap = MapController.Get(currentMap.Up);
+                        if (currentMap == null)
+                        {
+                            currentMap = oldMap;
+                            continue;
+                        }
+
+                        currentY = (Options.MapHeight + 1) + y;
+                    }
+                }
+
+                // Are we going to the map down from us?
+                if (currentY >= Options.MapHeight)
+                {
+                    var oldMap = currentMap;
+                    if (currentMap.Down != Guid.Empty)
+                    {
+                        currentMap = MapController.Get(currentMap.Down);
+                        if (currentMap == null)
+                        {
+                            currentMap = oldMap;
+                            continue;
+                        }
+
+                        currentY = -1 + y;
+                    }
+                }
+
+                if (currentX < 0 || currentY < 0 || currentX >= Options.MapWidth || currentY >= Options.MapHeight)
+                {
+                    continue;
+                }
+
+                if (!locations.ContainsKey(currentMap))
+                {
+                    locations.Add(currentMap, new List<int>());
+                }
+                locations[currentMap].Add(currentY * Options.MapWidth + currentX);
+            }
+        }
+
+        return locations;
+    }
+
+    /// <summary>
+    /// A destructor, responsible for making sure that if a map controller is removed, all of its instances are as well
+    /// </summary>
+    ~MapController()
+    {
+        ClearAllInstances();
     }
 }

--- a/Intersect.Server.Core/Maps/MapEntityMovements.cs
+++ b/Intersect.Server.Core/Maps/MapEntityMovements.cs
@@ -1,47 +1,46 @@
 using Intersect.Network.Packets.Server;
 using Intersect.Server.Entities;
 
-namespace Intersect.Server.Maps
-{
-    public partial class MapEntityMovements
-    {
-        private Dictionary<Guid, List<EntityMovePacket>> mMovements = new Dictionary<Guid, List<EntityMovePacket>>();
+namespace Intersect.Server.Maps;
 
-        public void Add(Entity en, bool correction, Player forPlayer = null)
+public partial class MapEntityMovements
+{
+    private Dictionary<Guid, List<EntityMovePacket>> mMovements = new Dictionary<Guid, List<EntityMovePacket>>();
+
+    public void Add(Entity en, bool correction, Player forPlayer = null)
+    {
+        lock (mMovements)
+        {
+            var id = forPlayer?.Id ?? Guid.Empty;
+            if (!mMovements.ContainsKey(id))
+            {
+                mMovements.Add(id, new List<EntityMovePacket>());
+            }
+            mMovements[id].Add(new EntityMovePacket(en.Id, en.GetEntityType(), en.MapId, (byte)en.X, (byte)en.Y, (byte)en.Dir, correction));
+        }
+    }
+
+    public void SendPackets(HashSet<Player> nearbyPlayers)
+    {
+        if (mMovements.Count > 0)
         {
             lock (mMovements)
             {
-                var id = forPlayer?.Id ?? Guid.Empty;
-                if (!mMovements.ContainsKey(id))
+                var globalMovements = mMovements.ContainsKey(Guid.Empty) ? mMovements[Guid.Empty].ToArray() : null;
+                foreach (var player in nearbyPlayers)
                 {
-                    mMovements.Add(id, new List<EntityMovePacket>());
-                }
-                mMovements[id].Add(new EntityMovePacket(en.Id, en.GetEntityType(), en.MapId, (byte)en.X, (byte)en.Y, (byte)en.Dir, correction));
-            }
-        }
-
-        public void SendPackets(HashSet<Player> nearbyPlayers)
-        {
-            if (mMovements.Count > 0)
-            {
-                lock (mMovements)
-                {
-                    var globalMovements = mMovements.ContainsKey(Guid.Empty) ? mMovements[Guid.Empty].ToArray() : null;
-                    foreach (var player in nearbyPlayers)
+                    var localMovements = mMovements.ContainsKey(player.Id) ? mMovements[player.Id].ToArray() : null;
+                    if (globalMovements != null || localMovements != null)
                     {
-                        var localMovements = mMovements.ContainsKey(player.Id) ? mMovements[player.Id].ToArray() : null;
-                        if (globalMovements != null || localMovements != null)
+                        var pkt = new EntityMovementPackets()
                         {
-                            var pkt = new EntityMovementPackets()
-                            {
-                                GlobalMovements = globalMovements,
-                                LocalMovements = localMovements
-                            };
-                            player.SendPacket(pkt);
-                        }
+                            GlobalMovements = globalMovements,
+                            LocalMovements = localMovements
+                        };
+                        player.SendPacket(pkt);
                     }
-                    mMovements.Clear();
                 }
+                mMovements.Clear();
             }
         }
     }

--- a/Intersect.Server.Core/Maps/MapInstance.cs
+++ b/Intersect.Server.Core/Maps/MapInstance.cs
@@ -14,1445 +14,1444 @@ using Intersect.Server.Classes.Maps;
 using MapAttribute = Intersect.Enums.MapAttribute;
 using Intersect.Server.Core.MapInstancing;
 
-namespace Intersect.Server.Maps
+namespace Intersect.Server.Maps;
+
+/// <summary>
+/// A <see cref="MapInstance"/> exists to process map updates, but on a "layered" system, where a single map can be processing 
+/// differently for each instance that exists upon it.
+/// <remarks>
+/// <para>
+/// A <see cref="MapController"/> contains a list <see cref="MapController.mInstances"/>, each one responsible for sending the necessary
+/// packet updates to the players that exist on that instance.
+/// </para>
+/// <para>
+/// By taking the processing out of the <see cref="MapController"/> itself, we can support map "Instancing" - ergo, the ability to process
+/// the same map differently for different players/parties. This allows for concepts such as dungeons and personal cutscenes, minigames,
+/// duel arenas, etc etc.
+/// </para>
+/// <para>
+/// A <see cref="Player"/> is the sole creator of MapInstances. A new instance will be created (via a call to <see cref="MapController.TryCreateInstance(Guid, out MapInstance)"/>)
+/// when a player:
+/// <list type="number">
+/// <item>
+/// Warps to a new map, or their <see cref="Entity.MapInstanceId"/> has otherwise changed.
+/// </item> 
+/// <item>
+/// Walks across a map boundary and fetches new maps from <see cref="MapController.GetSurroundingMaps(bool)"/>.
+/// </item>
+/// </list>
+/// </para>
+/// <para>
+/// A <see cref="MapInstance"/> needs to know when it is ready to be cleaned up, if its instance ID is not that of the overworld. A MapController can be marked for cleanup if there are no players on itself
+/// or any of its surrounding layers, and at least <see cref="Options.TimeUntilMapCleanup"/> ms have passed since the last player was on the map/its neighbors.
+/// </para>
+/// </remarks>
+/// </summary>
+public partial class MapInstance : IDisposable
 {
     /// <summary>
-    /// A <see cref="MapInstance"/> exists to process map updates, but on a "layered" system, where a single map can be processing 
-    /// differently for each instance that exists upon it.
+    /// Reference to stay consistent/easy-to-read with overworld behavior
+    /// </summary>
+    public static readonly Guid OverworldInstanceId = Guid.Empty;
+
+    private MapController mMapController;
+
+    /// <summary>
+    /// The last time the instance's properties were updated and packets were sent to players
+    /// </summary>
+    private long mLastUpdateTime;
+
+    /// <summary>
+    /// Used to determine when to process the instance (update properties & send packets to players.
     /// <remarks>
-    /// <para>
-    /// A <see cref="MapController"/> contains a list <see cref="MapController.mInstances"/>, each one responsible for sending the necessary
-    /// packet updates to the players that exist on that instance.
-    /// </para>
-    /// <para>
-    /// By taking the processing out of the <see cref="MapController"/> itself, we can support map "Instancing" - ergo, the ability to process
-    /// the same map differently for different players/parties. This allows for concepts such as dungeons and personal cutscenes, minigames,
-    /// duel arenas, etc etc.
-    /// </para>
-    /// <para>
-    /// A <see cref="Player"/> is the sole creator of MapInstances. A new instance will be created (via a call to <see cref="MapController.TryCreateInstance(Guid, out MapInstance)"/>)
-    /// when a player:
-    /// <list type="number">
-    /// <item>
-    /// Warps to a new map, or their <see cref="Entity.MapInstanceId"/> has otherwise changed.
-    /// </item> 
-    /// <item>
-    /// Walks across a map boundary and fetches new maps from <see cref="MapController.GetSurroundingMaps(bool)"/>.
-    /// </item>
-    /// </list>
-    /// </para>
-    /// <para>
-    /// A <see cref="MapInstance"/> needs to know when it is ready to be cleaned up, if its instance ID is not that of the overworld. A MapController can be marked for cleanup if there are no players on itself
-    /// or any of its surrounding layers, and at least <see cref="Options.TimeUntilMapCleanup"/> ms have passed since the last player was on the map/its neighbors.
-    /// </para>
+    /// This is flipped whenever we have NO players on this or surrounding processing layers.
     /// </remarks>
     /// </summary>
-    public partial class MapInstance : IDisposable
+    private bool mIsProcessing;
+
+    //SyncLock
+    protected object mMapProcessLock = new object();
+
+    /// <summary>
+    /// A unique identifier referring to this processing instance alone.
+    /// <remarks>
+    /// Note that this is NOT the Instance instance identifier - that is <see cref="MapInstanceId"/>
+    /// </remarks>
+    /// </summary>
+    public Guid Id;
+
+    /// <summary>
+    /// An ID referring to which instance this processer belongs to.
+    /// <remarks>
+    /// Entities/Items/Etc with that share an <see cref="Entity.MapInstanceId"/> with <see cref="MapInstance.MapInstanceId"/> 
+    /// will be processed and fed packets by that processer.
+    /// </remarks>
+    /// </summary>
+    public Guid MapInstanceId;
+
+    /// <summary>
+    /// The last time the <see cref="Core.LogicService.LogicThread"/> made a call to <see cref="Update(long)"/>.
+    /// <remarks>
+    /// This is used to determine when enough time has passed to cleanup this instance (remove it from it's parent <see cref="MapController"/>).
+    /// </remarks>
+    /// </summary>
+    public long LastRequestedUpdateTime;
+
+    /// <summary>
+    /// When the <see cref="Core.LogicService.LogicThread"/> started processing this instance.
+    /// </summary>
+    public long UpdateQueueStart = -1;
+
+    // Players & Entities
+    private ConcurrentDictionary<Guid, Player> mPlayers = new ConcurrentDictionary<Guid, Player>();
+    private readonly ConcurrentDictionary<Guid, Entity> mEntities = new ConcurrentDictionary<Guid, Entity>();
+    private Entity[] mCachedEntities = new Entity[0];
+    private MapEntityMovements mEntityMovements = new MapEntityMovements();
+
+    // NPCs
+    public ConcurrentDictionary<NpcSpawn, MapNpcSpawn> NpcSpawnInstances = new ConcurrentDictionary<NpcSpawn, MapNpcSpawn>();
+
+    // Items
+    public ConcurrentDictionary<Guid, MapItemSpawn> ItemRespawns = new ConcurrentDictionary<Guid, MapItemSpawn>();
+    public ConcurrentDictionary<Guid, MapItem>[] TileItems { get; } = new ConcurrentDictionary<Guid, MapItem>[Options.Instance.MapOpts.MapWidth * Options.Instance.MapOpts.MapHeight];
+    public ConcurrentDictionary<Guid, MapItem> AllMapItems { get; } = new ConcurrentDictionary<Guid, MapItem>();
+
+    // Resources
+    public ConcurrentDictionary<ResourceSpawn, MapResourceSpawn> ResourceSpawnInstances = new ConcurrentDictionary<ResourceSpawn, MapResourceSpawn>();
+    public ConcurrentDictionary<Guid, ResourceSpawn> ResourceSpawns { get; set; } = new ConcurrentDictionary<Guid, ResourceSpawn>();
+
+    // Projectiles & Traps
+    public ConcurrentDictionary<Guid, Projectile> MapProjectiles { get; } = new ConcurrentDictionary<Guid, Projectile>();
+    public Projectile[] MapProjectilesCached = new Projectile[0];
+    public long LastProjectileUpdateTime = -1;
+    public ConcurrentDictionary<Guid, MapTrapInstance> MapTraps = new ConcurrentDictionary<Guid, MapTrapInstance>();
+    public MapTrapInstance[] MapTrapsCached = new MapTrapInstance[0];
+
+    // Collision
+    private BytePoint[] mMapBlocks = Array.Empty<BytePoint>();
+    private BytePoint[] mNpcMapBlocks = Array.Empty<BytePoint>();
+
+    // Events
+    /* Processing Layers have Global Events - these are global to the PROCESSING instance, NOT to the MapController.
+     * As of the initial "Add Instancing" refactor, this is what the stock "Is Global?" event tick box in the editor
+     * will enable - an "Instance-Global" event */
+    public ConcurrentDictionary<EventBase, Event> GlobalEventInstances = new ConcurrentDictionary<EventBase, Event>();
+    public List<EventBase> EventsCache = new List<EventBase>();
+
+    // Animations & Text
+    private MapActionMessages mActionMessages = new MapActionMessages();
+    private MapAnimations mMapAnimations = new MapAnimations();
+
+    public MapInstance(MapController map, Guid mapInstanceId, Player creator)
     {
-        /// <summary>
-        /// Reference to stay consistent/easy-to-read with overworld behavior
-        /// </summary>
-        public static readonly Guid OverworldInstanceId = Guid.Empty;
+        mMapController = map;
+        MapInstanceId = mapInstanceId;
+        Id = Guid.NewGuid();
+        _ = InstanceProcessor.TryAddInstanceController(MapInstanceId, creator);
+    }
 
-        private MapController mMapController;
+    public bool IsDisposed { get; protected set; }
 
-        /// <summary>
-        /// The last time the instance's properties were updated and packets were sent to players
-        /// </summary>
-        private long mLastUpdateTime;
-
-        /// <summary>
-        /// Used to determine when to process the instance (update properties & send packets to players.
-        /// <remarks>
-        /// This is flipped whenever we have NO players on this or surrounding processing layers.
-        /// </remarks>
-        /// </summary>
-        private bool mIsProcessing;
-
-        //SyncLock
-        protected object mMapProcessLock = new object();
-
-        /// <summary>
-        /// A unique identifier referring to this processing instance alone.
-        /// <remarks>
-        /// Note that this is NOT the Instance instance identifier - that is <see cref="MapInstanceId"/>
-        /// </remarks>
-        /// </summary>
-        public Guid Id;
-
-        /// <summary>
-        /// An ID referring to which instance this processer belongs to.
-        /// <remarks>
-        /// Entities/Items/Etc with that share an <see cref="Entity.MapInstanceId"/> with <see cref="MapInstance.MapInstanceId"/> 
-        /// will be processed and fed packets by that processer.
-        /// </remarks>
-        /// </summary>
-        public Guid MapInstanceId;
-
-        /// <summary>
-        /// The last time the <see cref="Core.LogicService.LogicThread"/> made a call to <see cref="Update(long)"/>.
-        /// <remarks>
-        /// This is used to determine when enough time has passed to cleanup this instance (remove it from it's parent <see cref="MapController"/>).
-        /// </remarks>
-        /// </summary>
-        public long LastRequestedUpdateTime;
-
-        /// <summary>
-        /// When the <see cref="Core.LogicService.LogicThread"/> started processing this instance.
-        /// </summary>
-        public long UpdateQueueStart = -1;
-
-        // Players & Entities
-        private ConcurrentDictionary<Guid, Player> mPlayers = new ConcurrentDictionary<Guid, Player>();
-        private readonly ConcurrentDictionary<Guid, Entity> mEntities = new ConcurrentDictionary<Guid, Entity>();
-        private Entity[] mCachedEntities = new Entity[0];
-        private MapEntityMovements mEntityMovements = new MapEntityMovements();
-
-        // NPCs
-        public ConcurrentDictionary<NpcSpawn, MapNpcSpawn> NpcSpawnInstances = new ConcurrentDictionary<NpcSpawn, MapNpcSpawn>();
-
-        // Items
-        public ConcurrentDictionary<Guid, MapItemSpawn> ItemRespawns = new ConcurrentDictionary<Guid, MapItemSpawn>();
-        public ConcurrentDictionary<Guid, MapItem>[] TileItems { get; } = new ConcurrentDictionary<Guid, MapItem>[Options.Instance.MapOpts.MapWidth * Options.Instance.MapOpts.MapHeight];
-        public ConcurrentDictionary<Guid, MapItem> AllMapItems { get; } = new ConcurrentDictionary<Guid, MapItem>();
-
-        // Resources
-        public ConcurrentDictionary<ResourceSpawn, MapResourceSpawn> ResourceSpawnInstances = new ConcurrentDictionary<ResourceSpawn, MapResourceSpawn>();
-        public ConcurrentDictionary<Guid, ResourceSpawn> ResourceSpawns { get; set; } = new ConcurrentDictionary<Guid, ResourceSpawn>();
-
-        // Projectiles & Traps
-        public ConcurrentDictionary<Guid, Projectile> MapProjectiles { get; } = new ConcurrentDictionary<Guid, Projectile>();
-        public Projectile[] MapProjectilesCached = new Projectile[0];
-        public long LastProjectileUpdateTime = -1;
-        public ConcurrentDictionary<Guid, MapTrapInstance> MapTraps = new ConcurrentDictionary<Guid, MapTrapInstance>();
-        public MapTrapInstance[] MapTrapsCached = new MapTrapInstance[0];
-
-        // Collision
-        private BytePoint[] mMapBlocks = Array.Empty<BytePoint>();
-        private BytePoint[] mNpcMapBlocks = Array.Empty<BytePoint>();
-
-        // Events
-        /* Processing Layers have Global Events - these are global to the PROCESSING instance, NOT to the MapController.
-         * As of the initial "Add Instancing" refactor, this is what the stock "Is Global?" event tick box in the editor
-         * will enable - an "Instance-Global" event */
-        public ConcurrentDictionary<EventBase, Event> GlobalEventInstances = new ConcurrentDictionary<EventBase, Event>();
-        public List<EventBase> EventsCache = new List<EventBase>();
-
-        // Animations & Text
-        private MapActionMessages mActionMessages = new MapActionMessages();
-        private MapAnimations mMapAnimations = new MapAnimations();
-
-        public MapInstance(MapController map, Guid mapInstanceId, Player creator)
+    /// <summary>
+    /// Initializes the processing instance for processing - called in the constructor. Essentially refreshes the instance
+    /// so that it can give everything it has to offer to the player by the time they arrive in it
+    /// </summary>
+    public void Initialize()
+    {
+        lock (GetLock())
         {
-            mMapController = map;
-            MapInstanceId = mapInstanceId;
-            Id = Guid.NewGuid();
-            _ = InstanceProcessor.TryAddInstanceController(MapInstanceId, creator);
+            mIsProcessing = true;
+
+            CacheMapBlocks();
+            DespawnEverything();
+            RespawnEverything();
         }
+    }
 
-        public bool IsDisposed { get; protected set; }
+    public bool ShouldBeCleaned()
+    {
+        return (MapInstanceId != OverworldInstanceId && !ShouldBeActive());
+    }
 
-        /// <summary>
-        /// Initializes the processing instance for processing - called in the constructor. Essentially refreshes the instance
-        /// so that it can give everything it has to offer to the player by the time they arrive in it
-        /// </summary>
-        public void Initialize()
+    public bool ShouldBeActive()
+    {
+        return (mIsProcessing || LastRequestedUpdateTime <= mLastUpdateTime + Options.Map.TimeUntilMapCleanup);
+    }
+
+    public void RemoveLayerFromController()
+    {
+        lock (GetLock())
         {
-            lock (GetLock())
+            mMapController.DisposeInstanceWithId(MapInstanceId);
+        }
+    }
+
+    public object GetLock()
+    {
+        return mMapProcessLock;
+    }
+
+    /// <summary>
+    /// Gets our _parent's_ map lock.
+    /// </summary>
+    /// <returns>The parent map instance's map lock</returns>
+    public object GetControllerLock()
+    {
+        return mMapController.GetMapLock();
+    }
+
+    public virtual void Dispose()
+    {
+        if (!IsDisposed)
+        {
+            IsDisposed = true;
+        }
+    }
+
+    public MapController GetController()
+    {
+        return mMapController;
+    }
+
+    /// <summary>
+    /// Destroys the processable elements of the instance - RespawnEverything() to bring them back, and begin processing them
+    /// in the update loop once more
+    /// </summary>
+    public void DespawnEverything()
+    {
+        DespawnNpcs();
+        DespawnResources();
+        DespawnProjectiles();
+        DespawnTraps();
+        DespawnItems();
+        DespawnGlobalEvents();
+    }
+
+    /// <summary>
+    /// Respawns everything - if this isn't called, the map will never begin processing anything in it's update loop, as
+    /// it will have nothing to process. Note this also refreshes the event cache - refreshing events, global and local
+    /// alike, when an Instance is refreshed.
+    /// </summary>
+    public void RespawnEverything()
+    {
+        SpawnMapNpcs();
+        SpawnAttributeItems(); // This must be done before spawning items or resources
+        SpawnMapResources();
+        RefreshEventsCache();
+        SpawnGlobalEvents();
+    }
+
+    /// <summary>
+    /// The update loop - runs everytime the job in the LogicThread class executes it. Takes care of:
+    /// - Checking if items need to spawn/be despawned
+    /// - Move/process entity actions, regen
+    /// - Determine if NPCs need respawned/regen'd
+    /// - Determine if Resources need respawned/regen'd
+    /// - Update global event processing
+    /// </summary>
+    /// <param name="timeMs">The current time the update was called. Used for determining updates to things such as respawn timers.</param>
+    public void Update(long timeMs)
+    {
+        lock (GetLock())
+        {
+            if (mIsProcessing)
             {
-                mIsProcessing = true;
-
-                CacheMapBlocks();
-                DespawnEverything();
-                RespawnEverything();
-            }
-        }
-
-        public bool ShouldBeCleaned()
-        {
-            return (MapInstanceId != OverworldInstanceId && !ShouldBeActive());
-        }
-
-        public bool ShouldBeActive()
-        {
-            return (mIsProcessing || LastRequestedUpdateTime <= mLastUpdateTime + Options.Map.TimeUntilMapCleanup);
-        }
-
-        public void RemoveLayerFromController()
-        {
-            lock (GetLock())
-            {
-                mMapController.DisposeInstanceWithId(MapInstanceId);
-            }
-        }
-
-        public object GetLock()
-        {
-            return mMapProcessLock;
-        }
-
-        /// <summary>
-        /// Gets our _parent's_ map lock.
-        /// </summary>
-        /// <returns>The parent map instance's map lock</returns>
-        public object GetControllerLock()
-        {
-            return mMapController.GetMapLock();
-        }
-
-        public virtual void Dispose()
-        {
-            if (!IsDisposed)
-            {
-                IsDisposed = true;
-            }
-        }
-
-        public MapController GetController()
-        {
-            return mMapController;
-        }
-
-        /// <summary>
-        /// Destroys the processable elements of the instance - RespawnEverything() to bring them back, and begin processing them
-        /// in the update loop once more
-        /// </summary>
-        public void DespawnEverything()
-        {
-            DespawnNpcs();
-            DespawnResources();
-            DespawnProjectiles();
-            DespawnTraps();
-            DespawnItems();
-            DespawnGlobalEvents();
-        }
-
-        /// <summary>
-        /// Respawns everything - if this isn't called, the map will never begin processing anything in it's update loop, as
-        /// it will have nothing to process. Note this also refreshes the event cache - refreshing events, global and local
-        /// alike, when an Instance is refreshed.
-        /// </summary>
-        public void RespawnEverything()
-        {
-            SpawnMapNpcs();
-            SpawnAttributeItems(); // This must be done before spawning items or resources
-            SpawnMapResources();
-            RefreshEventsCache();
-            SpawnGlobalEvents();
-        }
-
-        /// <summary>
-        /// The update loop - runs everytime the job in the LogicThread class executes it. Takes care of:
-        /// - Checking if items need to spawn/be despawned
-        /// - Move/process entity actions, regen
-        /// - Determine if NPCs need respawned/regen'd
-        /// - Determine if Resources need respawned/regen'd
-        /// - Update global event processing
-        /// </summary>
-        /// <param name="timeMs">The current time the update was called. Used for determining updates to things such as respawn timers.</param>
-        public void Update(long timeMs)
-        {
-            lock (GetLock())
-            {
-                if (mIsProcessing)
+                if (Options.Instance.Processing.MapUpdateInterval == Options.Instance.Processing.ProjectileUpdateInterval)
                 {
-                    if (Options.Instance.Processing.MapUpdateInterval == Options.Instance.Processing.ProjectileUpdateInterval)
-                    {
-                        UpdateProjectiles(timeMs);
-                    }
-
-                    UpdateItems(timeMs);
-                    UpdateEntities(timeMs);
-                    ProcessNpcRespawns();
-                    ProcessResourceRespawns();
-                    UpdateGlobalEvents(timeMs);
-
-                    SendBatchedPacketsToPlayers();
-                    mLastUpdateTime = timeMs;
+                    UpdateProjectiles(timeMs);
                 }
 
-                // If there are no players on this or surrounding processing layers, stop processing updates.
-                mIsProcessing = GetPlayers(true).Any();
-                LastRequestedUpdateTime = timeMs;
-            }
-        }
+                UpdateItems(timeMs);
+                UpdateEntities(timeMs);
+                ProcessNpcRespawns();
+                ProcessResourceRespawns();
+                UpdateGlobalEvents(timeMs);
 
-        /// <summary>
-        /// Adds an entity to the MapInstance so that the instance knows to process them.
-        /// </summary>
-        /// <param name="en">The entity to add.</param>
-        public void AddEntity(Entity en)
+                SendBatchedPacketsToPlayers();
+                mLastUpdateTime = timeMs;
+            }
+
+            // If there are no players on this or surrounding processing layers, stop processing updates.
+            mIsProcessing = GetPlayers(true).Any();
+            LastRequestedUpdateTime = timeMs;
+        }
+    }
+
+    /// <summary>
+    /// Adds an entity to the MapInstance so that the instance knows to process them.
+    /// </summary>
+    /// <param name="en">The entity to add.</param>
+    public void AddEntity(Entity en)
+    {
+        if (en != null && !en.IsDead() && en.MapInstanceId == MapInstanceId)
         {
-            if (en != null && !en.IsDead() && en.MapInstanceId == MapInstanceId)
+            if (!mEntities.ContainsKey(en.Id))
             {
-                if (!mEntities.ContainsKey(en.Id))
+                mEntities.TryAdd(en.Id, en);
+                if (en is Player plyr)
                 {
-                    mEntities.TryAdd(en.Id, en);
-                    if (en is Player plyr)
-                    {
-                        mPlayers.TryAdd(plyr.Id, plyr);
-                    }
-                    mCachedEntities = mEntities.Values.ToArray();
+                    mPlayers.TryAdd(plyr.Id, plyr);
                 }
+                mCachedEntities = mEntities.Values.ToArray();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Removes an entity. After removal, that entity will no longer be updated by the processing instance.
+    /// If this entity is a player, they will experience a complete desync from the server, as the map
+    /// would not be sending them update packets any longer - so be mindful of what you're removing and when.
+    /// </summary>
+    /// <param name="en">The entity to remove.</param>
+    public void RemoveEntity(Entity en)
+    {
+        mEntities.TryRemove(en.Id, out var result);
+        if (mPlayers.ContainsKey(en.Id))
+        {
+            mPlayers.TryRemove(en.Id, out var pResult);
+        }
+        mCachedEntities = mEntities.Values.ToArray();
+    }
+
+    /// <summary>
+    /// Returns a list of all the entities (NPCs, Resources, Players, EventPageInstances, Projectiles) being processed by this map.
+    /// </summary>
+    /// <param name="includeSurroundingMaps">Whether we should look at surrounding maps with a shared processing ID
+    /// while acquiring this list.</param>
+    /// <returns>A list of Entities</returns>
+    public List<Entity> GetEntities(bool includeSurroundingMaps = false)
+    {
+        var entities = new List<Entity>(mEntities.Values.ToList());
+
+        // ReSharper disable once InvertIf
+        if (includeSurroundingMaps)
+        {
+            foreach (var mapInstance in MapController.GetSurroundingMapInstances(mMapController.Id, MapInstanceId, false))
+            {
+                entities.AddRange(mapInstance.GetEntities());
             }
         }
 
-        /// <summary>
-        /// Removes an entity. After removal, that entity will no longer be updated by the processing instance.
-        /// If this entity is a player, they will experience a complete desync from the server, as the map
-        /// would not be sending them update packets any longer - so be mindful of what you're removing and when.
-        /// </summary>
-        /// <param name="en">The entity to remove.</param>
-        public void RemoveEntity(Entity en)
+        return entities;
+    }
+
+    /// <summary>
+    /// Sends all the information a Player must receive when they've entered this Instance.
+    /// </summary>
+    /// <param name="player">The player who's entered</param>
+    public void PlayerEnteredMap(Player player)
+    {
+        //Send Entity Info to Everyone and Everyone to the Entity
+        player.Client?.SentMaps?.Clear();
+        PacketSender.SendMapItems(player, mMapController.Id);
+
+        AddEntity(player);
+        player.LastMapEntered = mMapController.Id;
+
+        // Send the entities/items of this current MapInstance to the player
+        SendMapEntitiesTo(player);
+
+        // send the entities/items of the SURROUNDING maps on this instance to the player
+        foreach (var surroundingMapInstance in MapController.GetSurroundingMapInstances(mMapController.Id, MapInstanceId, false))
         {
-            mEntities.TryRemove(en.Id, out var result);
-            if (mPlayers.ContainsKey(en.Id))
-            {
-                mPlayers.TryRemove(en.Id, out var pResult);
-            }
-            mCachedEntities = mEntities.Values.ToArray();
+            surroundingMapInstance.SendMapEntitiesTo(player);
+            PacketSender.SendMapItems(player, surroundingMapInstance.GetController().Id);
         }
+        PacketSender.SendEntityDataToProximity(player, player);
+    }
 
-        /// <summary>
-        /// Returns a list of all the entities (NPCs, Resources, Players, EventPageInstances, Projectiles) being processed by this map.
-        /// </summary>
-        /// <param name="includeSurroundingMaps">Whether we should look at surrounding maps with a shared processing ID
-        /// while acquiring this list.</param>
-        /// <returns>A list of Entities</returns>
-        public List<Entity> GetEntities(bool includeSurroundingMaps = false)
+    /// <summary>
+    /// Sends entities on the map to some player.
+    /// </summary>
+    /// <param name="player">The player to send entities to</param>
+    public void SendMapEntitiesTo(Player player)
+    {
+        if (player != null)
         {
-            var entities = new List<Entity>(mEntities.Values.ToList());
-
-            // ReSharper disable once InvertIf
-            if (includeSurroundingMaps)
+            PacketSender.SendMapEntitiesTo(player, mEntities);
+            if (player.MapId == mMapController.Id && player.MapInstanceId == MapInstanceId)
             {
-                foreach (var mapInstance in MapController.GetSurroundingMapInstances(mMapController.Id, MapInstanceId, false))
+                player.SendEvents();
+            }
+        }
+    }
+
+    #region Players
+    /// <summary>
+    /// Gets all the players on a map instance
+    /// </summary>
+    /// <param name="includeSurrounding"></param>
+    /// <returns></returns>
+    public ICollection<Player> GetPlayers(bool includeSurrounding = false)
+    {
+        var allPlayers = new List<Player>(mPlayers.Values);
+
+        if (includeSurrounding)
+        {
+            foreach (var mapInstance in MapController.GetSurroundingMapInstances(mMapController.Id, MapInstanceId, false))
+            {
+                var adjoiningPlayers = mapInstance.GetPlayers(false);
+                if (adjoiningPlayers != null)
                 {
-                    entities.AddRange(mapInstance.GetEntities());
-                }
-            }
-
-            return entities;
-        }
-
-        /// <summary>
-        /// Sends all the information a Player must receive when they've entered this Instance.
-        /// </summary>
-        /// <param name="player">The player who's entered</param>
-        public void PlayerEnteredMap(Player player)
-        {
-            //Send Entity Info to Everyone and Everyone to the Entity
-            player.Client?.SentMaps?.Clear();
-            PacketSender.SendMapItems(player, mMapController.Id);
-
-            AddEntity(player);
-            player.LastMapEntered = mMapController.Id;
-
-            // Send the entities/items of this current MapInstance to the player
-            SendMapEntitiesTo(player);
-
-            // send the entities/items of the SURROUNDING maps on this instance to the player
-            foreach (var surroundingMapInstance in MapController.GetSurroundingMapInstances(mMapController.Id, MapInstanceId, false))
-            {
-                surroundingMapInstance.SendMapEntitiesTo(player);
-                PacketSender.SendMapItems(player, surroundingMapInstance.GetController().Id);
-            }
-            PacketSender.SendEntityDataToProximity(player, player);
-        }
-
-        /// <summary>
-        /// Sends entities on the map to some player.
-        /// </summary>
-        /// <param name="player">The player to send entities to</param>
-        public void SendMapEntitiesTo(Player player)
-        {
-            if (player != null)
-            {
-                PacketSender.SendMapEntitiesTo(player, mEntities);
-                if (player.MapId == mMapController.Id && player.MapInstanceId == MapInstanceId)
-                {
-                    player.SendEvents();
+                    allPlayers.AddRange(adjoiningPlayers);
                 }
             }
         }
 
-        #region Players
-        /// <summary>
-        /// Gets all the players on a map instance
-        /// </summary>
-        /// <param name="includeSurrounding"></param>
-        /// <returns></returns>
-        public ICollection<Player> GetPlayers(bool includeSurrounding = false)
+        return allPlayers;
+    }
+    #endregion
+
+    #region NPCs
+    /// <summary>
+    /// Spawn map NPCs that the MapController has in it's list of spawns
+    /// </summary>
+    private void SpawnMapNpcs()
+    {
+        var spawns = mMapController.Spawns;
+        for (var i = 0; i < spawns.Count; i++)
         {
-            var allPlayers = new List<Player>(mPlayers.Values);
-
-            if (includeSurrounding)
-            {
-                foreach (var mapInstance in MapController.GetSurroundingMapInstances(mMapController.Id, MapInstanceId, false))
-                {
-                    var adjoiningPlayers = mapInstance.GetPlayers(false);
-                    if (adjoiningPlayers != null)
-                    {
-                        allPlayers.AddRange(adjoiningPlayers);
-                    }
-                }
-            }
-
-            return allPlayers;
+            SpawnMapNpc(spawns[i]);
         }
-        #endregion
+    }
 
-        #region NPCs
-        /// <summary>
-        /// Spawn map NPCs that the MapController has in it's list of spawns
-        /// </summary>
-        private void SpawnMapNpcs()
+    private void SpawnMapNpc(NpcSpawn spawn)
+    {
+        if (spawn == default)
         {
-            var spawns = mMapController.Spawns;
-            for (var i = 0; i < spawns.Count; i++)
-            {
-                SpawnMapNpc(spawns[i]);
-            }
+            return;
         }
 
-        private void SpawnMapNpc(NpcSpawn spawn)
+        var npcBase = NpcBase.Get(spawn.NpcId);
+        if (npcBase != null)
         {
-            if (spawn == default)
+            if (!NpcSpawnInstances.TryGetValue(spawn, out var npcSpawnInstance))
             {
-                return;
+                npcSpawnInstance = new MapNpcSpawn();
+                _ = NpcSpawnInstances.TryAdd(spawn, npcSpawnInstance);
             }
 
-            var npcBase = NpcBase.Get(spawn.NpcId);
-            if (npcBase != null)
-            {
-                if (!NpcSpawnInstances.TryGetValue(spawn, out var npcSpawnInstance))
-                {
-                    npcSpawnInstance = new MapNpcSpawn();
-                    _ = NpcSpawnInstances.TryAdd(spawn, npcSpawnInstance);
-                }
+            FindNpcSpawnLocation(spawn, out var x, out var y, out Direction dir);
 
-                FindNpcSpawnLocation(spawn, out var x, out var y, out Direction dir);
+            npcSpawnInstance.Entity = SpawnNpc((byte) x, (byte) y, dir, spawn.NpcId);
+        }
+    }
 
-                npcSpawnInstance.Entity = SpawnNpc((byte) x, (byte) y, dir, spawn.NpcId);
-            }
+    /// <summary>
+    /// Finds the requested spawn of an NPC based on its controller's properties
+    /// </summary>
+    /// <param name="spawn">The <see cref="NpcSpawn"/> to spawn</param>
+    /// <param name="x">The X-coordinate to spawn at; out</param>
+    /// <param name="y">The Y-coordinate to spawn at; out</param>
+    /// <param name="dir">The direction to spawn at; out</param>
+    private void FindNpcSpawnLocation(NpcSpawn spawn, out int x, out int y, out Direction dir)
+    {
+        dir = 0;
+        x = 0;
+        y = 0;
+
+        if (spawn.Direction != NpcSpawnDirection.Random)
+        {
+            dir = (Direction)(spawn.Direction - 1);
+        }
+        else
+        {
+            dir = Randomization.NextDirection();
         }
 
-        /// <summary>
-        /// Finds the requested spawn of an NPC based on its controller's properties
-        /// </summary>
-        /// <param name="spawn">The <see cref="NpcSpawn"/> to spawn</param>
-        /// <param name="x">The X-coordinate to spawn at; out</param>
-        /// <param name="y">The Y-coordinate to spawn at; out</param>
-        /// <param name="dir">The direction to spawn at; out</param>
-        private void FindNpcSpawnLocation(NpcSpawn spawn, out int x, out int y, out Direction dir)
+        if (spawn.X >= 0 && spawn.Y >= 0)
         {
-            dir = 0;
-            x = 0;
-            y = 0;
-
-            if (spawn.Direction != NpcSpawnDirection.Random)
-            {
-                dir = (Direction)(spawn.Direction - 1);
-            }
-            else
-            {
-                dir = Randomization.NextDirection();
-            }
-
-            if (spawn.X >= 0 && spawn.Y >= 0)
-            {
-                x = spawn.X;
-                y = spawn.Y;
-            }
-            else
-            {
-                for (var n = 0; n < 100; n++)
-                {
-                    x = (byte)Randomization.Next(0, Options.MapWidth);
-                    y = (byte)Randomization.Next(0, Options.MapHeight);
-                    if (mMapController.Attributes[x, y] == null || mMapController.Attributes[x, y].Type == (int)MapAttribute.Walkable)
-                    {
-                        break;
-                    }
-
-                    x = 0;
-                    y = 0;
-                }
-            }
+            x = spawn.X;
+            y = spawn.Y;
         }
-
-        /// <summary>
-        /// Physically places an NPC on our map instance
-        /// </summary>
-        /// <param name="tileX">X Spawn Co-ordinate</param>
-        /// <param name="tileY">Y Spawn Co-ordinate</param>
-        /// <param name="dir">Direction to face after spawn</param>
-        /// <param name="npcId">NPC Entity ID to spawn</param>
-        /// <param name="despawnable">Whether or not this NPC can be despawned (for example, if spawned via event command)</param>
-        /// <returns></returns>
-        public Npc SpawnNpc(byte tileX, byte tileY, Direction dir, Guid npcId, bool despawnable = false)
+        else
         {
-            var npcBase = NpcBase.Get(npcId);
-            if (npcBase != null)
+            for (var n = 0; n < 100; n++)
             {
-                var processLayer = this.MapInstanceId;
-                var npc = new Npc(npcBase, despawnable)
+                x = (byte)Randomization.Next(0, Options.MapWidth);
+                y = (byte)Randomization.Next(0, Options.MapHeight);
+                if (mMapController.Attributes[x, y] == null || mMapController.Attributes[x, y].Type == (int)MapAttribute.Walkable)
                 {
-                    MapId = mMapController.Id,
-                    X = tileX,
-                    Y = tileY,
-                    Dir = dir,
-                    MapInstanceId = processLayer
-                };
-
-                AddEntity(npc);
-                PacketSender.SendEntityDataToProximity(npc);
-
-                return npc;
-            }
-
-            return null;
-        }
-
-        /// <summary>
-        /// Forcibly reset all Npcs originating from this map.
-        /// </summary>
-        public void ResetNpcSpawns()
-        {
-            //Kill all npcs spawned from this map
-            lock (GetLock())
-            {
-                foreach (var npcSpawn in NpcSpawnInstances)
-                {
-                    lock (npcSpawn.Value.Entity.EntityLock)
-                    {
-                        var npc = npcSpawn.Value.Entity as Npc;
-                        if (!npc.Dead)
-                        {
-                            // If we keep track of reset radiuses, just reset it to that value.
-                            if (Options.Npc.AllowResetRadius)
-                            {
-                                npc.Reset();
-                            }
-                            // If we don't.. Kill and respawn the Npc assuming it's in combat.
-                            else
-                            {
-                                if (npc.Target != null || npc.CombatTimer > Timing.Global.Milliseconds)
-                                {
-                                    npc.Die(false);
-                                    FindNpcSpawnLocation(npcSpawn.Key, out var x, out var y, out var dir);
-                                    npcSpawn.Value.Entity = SpawnNpc((byte)x, (byte)y, dir, npcSpawn.Key.NpcId);
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        /// <summary>
-        /// Despawns all NPCs, and removes them from our dictionary of Spawn Instances.
-        /// </summary>
-        private void DespawnNpcs()
-        {
-            //Kill all npcs spawned from this map
-            lock (GetLock())
-            {
-                foreach (var npcSpawn in NpcSpawnInstances)
-                {
-                    lock (npcSpawn.Value.Entity.EntityLock)
-                    {
-                        npcSpawn.Value.Entity.Die(false);
-                    }
+                    break;
                 }
 
-                NpcSpawnInstances.Clear();
-
-                //Kill any other npcs on this map (only players should remain)
-                foreach (var entity in mEntities)
-                {
-                    if (entity.Value is Npc npc)
-                    {
-                        lock (npc.EntityLock)
-                        {
-                            npc.Die(false);
-                        }
-                    }
-                }
+                x = 0;
+                y = 0;
             }
         }
+    }
 
-        /// <summary>
-        /// Clears the given entity of any targets that an NPC has on them. For AI purposes.
-        /// </summary>
-        /// <param name="en">The entitiy to clear targets of.</param>
-        public void ClearEntityTargetsOf(Entity en)
+    /// <summary>
+    /// Physically places an NPC on our map instance
+    /// </summary>
+    /// <param name="tileX">X Spawn Co-ordinate</param>
+    /// <param name="tileY">Y Spawn Co-ordinate</param>
+    /// <param name="dir">Direction to face after spawn</param>
+    /// <param name="npcId">NPC Entity ID to spawn</param>
+    /// <param name="despawnable">Whether or not this NPC can be despawned (for example, if spawned via event command)</param>
+    /// <returns></returns>
+    public Npc SpawnNpc(byte tileX, byte tileY, Direction dir, Guid npcId, bool despawnable = false)
+    {
+        var npcBase = NpcBase.Get(npcId);
+        if (npcBase != null)
         {
-            foreach (var entity in mEntities)
+            var processLayer = this.MapInstanceId;
+            var npc = new Npc(npcBase, despawnable)
             {
-                if (entity.Value is Npc npc && npc.Target == en)
-                {
-                    npc.RemoveTarget();
-                }
-            }
-        }
-        #endregion
-
-        #region Resources
-        /// <summary>
-        /// Spawns a map resource attribute at its editor-given location
-        /// </summary>
-        /// <param name="x">X co-ordinate to spawn at</param>
-        /// <param name="y">Y co-ordinate to spawn at</param>
-        private void SpawnAttributeResource(byte x, byte y)
-        {
-            var tempResource = new ResourceSpawn()
-            {
-                ResourceId = ((MapResourceAttribute)mMapController.Attributes[x, y]).ResourceId,
-                X = x,
-                Y = y,
-                Z = ((MapResourceAttribute)mMapController.Attributes[x, y]).SpawnLevel
+                MapId = mMapController.Id,
+                X = tileX,
+                Y = tileY,
+                Dir = dir,
+                MapInstanceId = processLayer
             };
 
-            ResourceSpawns.TryAdd(tempResource.Id, tempResource);
+            AddEntity(npc);
+            PacketSender.SendEntityDataToProximity(npc);
+
+            return npc;
         }
 
-        /// <summary>
-        /// Freshly spawns all map resources within our list of Resource Spawns.
-        /// </summary>
-        private void SpawnMapResources()
+        return null;
+    }
+
+    /// <summary>
+    /// Forcibly reset all Npcs originating from this map.
+    /// </summary>
+    public void ResetNpcSpawns()
+    {
+        //Kill all npcs spawned from this map
+        lock (GetLock())
         {
-            foreach (var spawn in ResourceSpawns)
+            foreach (var npcSpawn in NpcSpawnInstances)
             {
-                SpawnMapResource(spawn.Value);
-            }
-        }
-
-        /// <summary>
-        /// Spawns the given resource, and adds it to our list for processing
-        /// </summary>
-        /// <param name="spawn"></param>
-        private void SpawnMapResource(ResourceSpawn spawn)
-        {
-            if (spawn == default)
-            {
-                return;
-            }
-
-            var id = Guid.Empty;
-            if (!ResourceSpawnInstances.TryGetValue(spawn, out var resourceSpawnInstance))
-            {
-                resourceSpawnInstance = new MapResourceSpawn();
-                _ = ResourceSpawnInstances.TryAdd(spawn, resourceSpawnInstance);
-            }
-
-            if (resourceSpawnInstance.Entity == default)
-            {
-                if (ResourceBase.TryGet(spawn.ResourceId, out var resourceDescriptor))
+                lock (npcSpawn.Value.Entity.EntityLock)
                 {
-                    var res = new Resource(resourceDescriptor)
+                    var npc = npcSpawn.Value.Entity as Npc;
+                    if (!npc.Dead)
                     {
-                        X = spawn.X,
-                        Y = spawn.Y,
-                        Z = spawn.Z,
-                        MapId = mMapController.Id,
-                        MapInstanceId = MapInstanceId
-                    };
-                    id = res.Id;
-                    resourceSpawnInstance.Entity = res;
-                    AddEntity(res);
-                }
-            }
-            else
-            {
-                id = resourceSpawnInstance.Entity.Id;
-            }
-
-            if (id != Guid.Empty)
-            {
-                resourceSpawnInstance.Entity.Spawn();
-            }
-        }
-
-        /// <summary>
-        /// Despawns all resources, and clears our list of spawn instances
-        /// </summary>
-        private void DespawnResources()
-        {
-            //Kill all resources spawned from this map
-            lock (GetLock())
-            {
-                foreach (var resourceSpawn in ResourceSpawnInstances)
-                {
-                    if (resourceSpawn.Value != null && resourceSpawn.Value.Entity != null)
-                    {
-                        resourceSpawn.Value.Entity.Destroy();
-                        RemoveEntity(resourceSpawn.Value.Entity);
+                        // If we keep track of reset radiuses, just reset it to that value.
+                        if (Options.Npc.AllowResetRadius)
+                        {
+                            npc.Reset();
+                        }
+                        // If we don't.. Kill and respawn the Npc assuming it's in combat.
+                        else
+                        {
+                            if (npc.Target != null || npc.CombatTimer > Timing.Global.Milliseconds)
+                            {
+                                npc.Die(false);
+                                FindNpcSpawnLocation(npcSpawn.Key, out var x, out var y, out var dir);
+                                npcSpawn.Value.Entity = SpawnNpc((byte)x, (byte)y, dir, npcSpawn.Key.NpcId);
+                            }
+                        }
                     }
                 }
-
-                ResourceSpawnInstances.Clear();
             }
         }
-        #endregion
+    }
 
-        #region Items
-        /// <summary>
-        /// Add a map item to this map.
-        /// </summary>
-        /// <param name="x">The X location of this item.</param>
-        /// <param name="y">The Y location of this item.</param>
-        /// <param name="item">The <see cref="MapItem"/> to add to the map.</param>
-        private void AddItem(MapItem item)
+    /// <summary>
+    /// Despawns all NPCs, and removes them from our dictionary of Spawn Instances.
+    /// </summary>
+    private void DespawnNpcs()
+    {
+        //Kill all npcs spawned from this map
+        lock (GetLock())
         {
-            AllMapItems.TryAdd(item.UniqueId, item);
-
-            if (TileItems[item.TileIndex] == null)
+            foreach (var npcSpawn in NpcSpawnInstances)
             {
-                TileItems[item.TileIndex] = new ConcurrentDictionary<Guid, MapItem>();
-            }
-
-            TileItems[item.TileIndex]?.TryAdd(item.UniqueId, item);
-        }
-
-        /// <summary>
-        /// Spawn an item to this map instance.
-        /// </summary>
-        /// <param name="x">The horizontal location of this item</param>
-        /// <param name="y">The vertical location of this item.</param>
-        /// <param name="item">The <see cref="Item"/> to spawn on the map.</param>
-        /// <param name="amount">The amount of times to spawn this item to the map. Set to the <see cref="Item"/> quantity, overwrites quantity if stackable!</param>
-        public void SpawnItem(int x, int y, Item item, int amount) => SpawnItem(x, y, item, amount, Guid.Empty);
-
-        /// <summary>
-        /// Spawn an item to this map instance.
-        /// </summary>
-        /// <param name="x">The horizontal location of this item</param>
-        /// <param name="y">The vertical location of this item.</param>
-        /// <param name="item">The <see cref="Item"/> to spawn on the map.</param>
-        /// <param name="amount">The amount of times to spawn this item to the map. Set to the <see cref="Item"/> quantity, overwrites quantity if stackable!</param>
-        /// <param name="owner">The player Id that will be the temporary owner of this item.</param>
-        public void SpawnItem(int x, int y, Item item, int amount, Guid owner, bool sendUpdate = true)
-        {
-            if (item == null)
-            {
-                Log.Warn($"Tried to spawn {amount} of a null item at ({x}, {y}) in map {Id}.");
-
-                return;
-            }
-
-            var itemDescriptor = ItemBase.Get(item.ItemId);
-            if (itemDescriptor == null)
-            {
-                Log.Warn($"No item found for {item.ItemId}.");
-
-                return;
-            }
-
-            // if we can stack this item or the user configured to drop items consolidated, simply spawn a single stack of it.
-            // Does not count for Equipment and bags, these are ALWAYS their own separate item spawn. We don't want to lose data on that!
-            if ((itemDescriptor.ItemType != ItemType.Equipment && itemDescriptor.ItemType != ItemType.Bag) &&
-                (itemDescriptor.Stackable || Options.Loot.ConsolidateMapDrops))
-            {
-                // Does this item already exist on this tile? If so, get its value so we can simply consolidate the stack.
-                var existingCount = 0;
-                var existingItems = FindItemsAt(y * Options.MapWidth + x);
-                var toRemove = new List<MapItem>();
-                foreach (var exItem in existingItems)
+                lock (npcSpawn.Value.Entity.EntityLock)
                 {
-                    // If the Id and Owner matches, get its quantity and remove the item so we don't get multiple stacks.
-                    if (exItem.ItemId == item.ItemId && exItem.Owner == owner)
+                    npcSpawn.Value.Entity.Die(false);
+                }
+            }
+
+            NpcSpawnInstances.Clear();
+
+            //Kill any other npcs on this map (only players should remain)
+            foreach (var entity in mEntities)
+            {
+                if (entity.Value is Npc npc)
+                {
+                    lock (npc.EntityLock)
                     {
-                        existingCount += exItem.Quantity;
-                        toRemove.Add(exItem);
+                        npc.Die(false);
                     }
                 }
+            }
+        }
+    }
 
-                var mapItem = new MapItem(item.ItemId, amount + existingCount, x, y, item.BagId, item.Bag)
+    /// <summary>
+    /// Clears the given entity of any targets that an NPC has on them. For AI purposes.
+    /// </summary>
+    /// <param name="en">The entitiy to clear targets of.</param>
+    public void ClearEntityTargetsOf(Entity en)
+    {
+        foreach (var entity in mEntities)
+        {
+            if (entity.Value is Npc npc && npc.Target == en)
+            {
+                npc.RemoveTarget();
+            }
+        }
+    }
+    #endregion
+
+    #region Resources
+    /// <summary>
+    /// Spawns a map resource attribute at its editor-given location
+    /// </summary>
+    /// <param name="x">X co-ordinate to spawn at</param>
+    /// <param name="y">Y co-ordinate to spawn at</param>
+    private void SpawnAttributeResource(byte x, byte y)
+    {
+        var tempResource = new ResourceSpawn()
+        {
+            ResourceId = ((MapResourceAttribute)mMapController.Attributes[x, y]).ResourceId,
+            X = x,
+            Y = y,
+            Z = ((MapResourceAttribute)mMapController.Attributes[x, y]).SpawnLevel
+        };
+
+        ResourceSpawns.TryAdd(tempResource.Id, tempResource);
+    }
+
+    /// <summary>
+    /// Freshly spawns all map resources within our list of Resource Spawns.
+    /// </summary>
+    private void SpawnMapResources()
+    {
+        foreach (var spawn in ResourceSpawns)
+        {
+            SpawnMapResource(spawn.Value);
+        }
+    }
+
+    /// <summary>
+    /// Spawns the given resource, and adds it to our list for processing
+    /// </summary>
+    /// <param name="spawn"></param>
+    private void SpawnMapResource(ResourceSpawn spawn)
+    {
+        if (spawn == default)
+        {
+            return;
+        }
+
+        var id = Guid.Empty;
+        if (!ResourceSpawnInstances.TryGetValue(spawn, out var resourceSpawnInstance))
+        {
+            resourceSpawnInstance = new MapResourceSpawn();
+            _ = ResourceSpawnInstances.TryAdd(spawn, resourceSpawnInstance);
+        }
+
+        if (resourceSpawnInstance.Entity == default)
+        {
+            if (ResourceBase.TryGet(spawn.ResourceId, out var resourceDescriptor))
+            {
+                var res = new Resource(resourceDescriptor)
                 {
-                    DespawnTime = Timing.Global.Milliseconds + (itemDescriptor.DespawnTime <= 0 ? Options.Loot.ItemDespawnTime : itemDescriptor.DespawnTime),
+                    X = spawn.X,
+                    Y = spawn.Y,
+                    Z = spawn.Z,
+                    MapId = mMapController.Id,
+                    MapInstanceId = MapInstanceId
+                };
+                id = res.Id;
+                resourceSpawnInstance.Entity = res;
+                AddEntity(res);
+            }
+        }
+        else
+        {
+            id = resourceSpawnInstance.Entity.Id;
+        }
+
+        if (id != Guid.Empty)
+        {
+            resourceSpawnInstance.Entity.Spawn();
+        }
+    }
+
+    /// <summary>
+    /// Despawns all resources, and clears our list of spawn instances
+    /// </summary>
+    private void DespawnResources()
+    {
+        //Kill all resources spawned from this map
+        lock (GetLock())
+        {
+            foreach (var resourceSpawn in ResourceSpawnInstances)
+            {
+                if (resourceSpawn.Value != null && resourceSpawn.Value.Entity != null)
+                {
+                    resourceSpawn.Value.Entity.Destroy();
+                    RemoveEntity(resourceSpawn.Value.Entity);
+                }
+            }
+
+            ResourceSpawnInstances.Clear();
+        }
+    }
+    #endregion
+
+    #region Items
+    /// <summary>
+    /// Add a map item to this map.
+    /// </summary>
+    /// <param name="x">The X location of this item.</param>
+    /// <param name="y">The Y location of this item.</param>
+    /// <param name="item">The <see cref="MapItem"/> to add to the map.</param>
+    private void AddItem(MapItem item)
+    {
+        AllMapItems.TryAdd(item.UniqueId, item);
+
+        if (TileItems[item.TileIndex] == null)
+        {
+            TileItems[item.TileIndex] = new ConcurrentDictionary<Guid, MapItem>();
+        }
+
+        TileItems[item.TileIndex]?.TryAdd(item.UniqueId, item);
+    }
+
+    /// <summary>
+    /// Spawn an item to this map instance.
+    /// </summary>
+    /// <param name="x">The horizontal location of this item</param>
+    /// <param name="y">The vertical location of this item.</param>
+    /// <param name="item">The <see cref="Item"/> to spawn on the map.</param>
+    /// <param name="amount">The amount of times to spawn this item to the map. Set to the <see cref="Item"/> quantity, overwrites quantity if stackable!</param>
+    public void SpawnItem(int x, int y, Item item, int amount) => SpawnItem(x, y, item, amount, Guid.Empty);
+
+    /// <summary>
+    /// Spawn an item to this map instance.
+    /// </summary>
+    /// <param name="x">The horizontal location of this item</param>
+    /// <param name="y">The vertical location of this item.</param>
+    /// <param name="item">The <see cref="Item"/> to spawn on the map.</param>
+    /// <param name="amount">The amount of times to spawn this item to the map. Set to the <see cref="Item"/> quantity, overwrites quantity if stackable!</param>
+    /// <param name="owner">The player Id that will be the temporary owner of this item.</param>
+    public void SpawnItem(int x, int y, Item item, int amount, Guid owner, bool sendUpdate = true)
+    {
+        if (item == null)
+        {
+            Log.Warn($"Tried to spawn {amount} of a null item at ({x}, {y}) in map {Id}.");
+
+            return;
+        }
+
+        var itemDescriptor = ItemBase.Get(item.ItemId);
+        if (itemDescriptor == null)
+        {
+            Log.Warn($"No item found for {item.ItemId}.");
+
+            return;
+        }
+
+        // if we can stack this item or the user configured to drop items consolidated, simply spawn a single stack of it.
+        // Does not count for Equipment and bags, these are ALWAYS their own separate item spawn. We don't want to lose data on that!
+        if ((itemDescriptor.ItemType != ItemType.Equipment && itemDescriptor.ItemType != ItemType.Bag) &&
+            (itemDescriptor.Stackable || Options.Loot.ConsolidateMapDrops))
+        {
+            // Does this item already exist on this tile? If so, get its value so we can simply consolidate the stack.
+            var existingCount = 0;
+            var existingItems = FindItemsAt(y * Options.MapWidth + x);
+            var toRemove = new List<MapItem>();
+            foreach (var exItem in existingItems)
+            {
+                // If the Id and Owner matches, get its quantity and remove the item so we don't get multiple stacks.
+                if (exItem.ItemId == item.ItemId && exItem.Owner == owner)
+                {
+                    existingCount += exItem.Quantity;
+                    toRemove.Add(exItem);
+                }
+            }
+
+            var mapItem = new MapItem(item.ItemId, amount + existingCount, x, y, item.BagId, item.Bag)
+            {
+                DespawnTime = Timing.Global.Milliseconds + (itemDescriptor.DespawnTime <= 0 ? Options.Loot.ItemDespawnTime : itemDescriptor.DespawnTime),
+                Owner = owner,
+                OwnershipTime = Timing.Global.Milliseconds + Options.Loot.ItemOwnershipTime,
+                VisibleToAll = Options.Loot.ShowUnownedItems || owner == Guid.Empty
+            };
+
+            if (mapItem.TileIndex > Options.MapHeight * Options.MapWidth || mapItem.TileIndex < 0)
+            {
+                return;
+            }
+
+            // Remove existing items if we need to.
+            foreach (var reItem in toRemove)
+            {
+                RemoveItem(reItem);
+                if (sendUpdate)
+                {
+                    PacketSender.SendMapItemUpdate(mMapController.Id, MapInstanceId, reItem, true);
+                }
+            }
+
+            // Drop the new item.
+            AddItem(mapItem);
+            if (sendUpdate)
+            {
+                PacketSender.SendMapItemUpdate(mMapController.Id, MapInstanceId, mapItem, false);
+            }
+        }
+        else
+        {
+            // Oh boy here we go! Set quantity to 1 and drop multiple!
+            for (var i = 0; i < amount; i++)
+            {
+                var mapItem = new MapItem(item.ItemId, amount, x, y, item.BagId, item.Bag)
+                {
+                    DespawnTime = Timing.Global.Milliseconds + Options.Loot.ItemDespawnTime,
                     Owner = owner,
                     OwnershipTime = Timing.Global.Milliseconds + Options.Loot.ItemOwnershipTime,
                     VisibleToAll = Options.Loot.ShowUnownedItems || owner == Guid.Empty
                 };
+
+                // If this is a piece of equipment, set up the stat buffs for it.
+                if (itemDescriptor.ItemType == ItemType.Equipment)
+                {
+                    mapItem.SetupStatBuffs(item);
+                }
 
                 if (mapItem.TileIndex > Options.MapHeight * Options.MapWidth || mapItem.TileIndex < 0)
                 {
                     return;
                 }
 
-                // Remove existing items if we need to.
-                foreach (var reItem in toRemove)
-                {
-                    RemoveItem(reItem);
-                    if (sendUpdate)
-                    {
-                        PacketSender.SendMapItemUpdate(mMapController.Id, MapInstanceId, reItem, true);
-                    }
-                }
-
-                // Drop the new item.
                 AddItem(mapItem);
-                if (sendUpdate)
-                {
-                    PacketSender.SendMapItemUpdate(mMapController.Id, MapInstanceId, mapItem, false);
-                }
             }
-            else
+            PacketSender.SendMapItemsToProximity(mMapController.Id, this);
+        }
+    }
+
+    /// <summary>
+    /// Find a Map Item on this map based on its Unique Id;
+    /// </summary>
+    /// <param name="uniqueId">The Unique Id of the Map Item to look for.</param>
+    /// <returns>Returns a <see cref="MapItem"/> if one is found with the desired Unique Id.</returns>
+    public MapItem FindItem(Guid uniqueId)
+    {
+        if (AllMapItems.TryGetValue(uniqueId, out MapItem item))
+        {
+            return item;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// /// Find all map items at a specificed location.
+    /// </summary>
+    /// <param name="tileIndex">The integer value representation of the tile.</param>
+    /// <returns>Returns a <see cref="ICollection"/> of <see cref="MapItem"/></returns>
+    public ICollection<MapItem> FindItemsAt(int tileIndex)
+    {
+        if (tileIndex < 0 || tileIndex >= Options.MapWidth * Options.MapHeight || TileItems[tileIndex] == null)
+        {
+            return Array.Empty<MapItem>();
+        }
+        return TileItems[tileIndex].Values;
+    }
+
+    /// <summary>
+    /// Removes some item from this processing instance
+    /// </summary>
+    /// <param name="item">The item to remove from the instance</param>
+    /// <param name="respawn">Whether or not this item will respawn</param>
+    public void RemoveItem(MapItem item, bool respawn = true)
+    {
+        if (item != null)
+        {
+            // Only try to handle respawns for items that have attribute spawn locations.
+            if (item.AttributeSpawnX > -1)
             {
-                // Oh boy here we go! Set quantity to 1 and drop multiple!
-                for (var i = 0; i < amount; i++)
+                if (respawn)
                 {
-                    var mapItem = new MapItem(item.ItemId, amount, x, y, item.BagId, item.Bag)
+                    var spawn = new MapItemSpawn()
                     {
-                        DespawnTime = Timing.Global.Milliseconds + Options.Loot.ItemDespawnTime,
-                        Owner = owner,
-                        OwnershipTime = Timing.Global.Milliseconds + Options.Loot.ItemOwnershipTime,
-                        VisibleToAll = Options.Loot.ShowUnownedItems || owner == Guid.Empty
+                        AttributeSpawnX = item.X,
+                        AttributeSpawnY = item.Y,
+                        RespawnTime = Timing.Global.Milliseconds + (item.AttributeRespawnTime <= 0 ? Options.Map.ItemAttributeRespawnTime : item.AttributeRespawnTime)
                     };
+                    ItemRespawns.TryAdd(spawn.Id, spawn);
+                }
+            }
 
-                    // If this is a piece of equipment, set up the stat buffs for it.
-                    if (itemDescriptor.ItemType == ItemType.Equipment)
+            var oldOwner = item.Owner;
+            AllMapItems.TryRemove(item.UniqueId, out MapItem removed);
+            TileItems[item.TileIndex]?.TryRemove(item.UniqueId, out MapItem tileRemoved);
+            if (TileItems[item.TileIndex]?.IsEmpty ?? false)
+            {
+                TileItems[item.TileIndex] = null;
+            }
+            PacketSender.SendMapItemUpdate(mMapController.Id, MapInstanceId, item, true, item.VisibleToAll, oldOwner);
+        }
+    }
+
+    /// <summary>
+    /// Despawns all items, and removes them from our list of them.
+    /// </summary>
+    public void DespawnItems()
+    {
+        //Kill all items resting on map
+        ItemRespawns.Clear();
+        foreach (var item in AllMapItems.Values)
+        {
+            RemoveItem(item);
+        }
+
+        AllMapItems.Clear();
+    }
+
+    /// <summary>
+    /// Spawns an item that was placed via editor Item map attribute
+    /// </summary>
+    /// <param name="x">X co-ordinate to spawn</param>
+    /// <param name="y">Y co-ordinate to spawn</param>
+    private void SpawnAttributeItem(int x, int y)
+    {
+        var item = ItemBase.Get(((MapItemAttribute)mMapController.Attributes[x, y]).ItemId);
+        if (item != null)
+        {
+            var mapItem = new MapItem(item.Id, ((MapItemAttribute)mMapController.Attributes[x, y]).Quantity, x, y, ((MapItemAttribute)mMapController.Attributes[x, y]).RespawnTime);
+            mapItem.DespawnTime = -1;
+            mapItem.AttributeSpawnX = x;
+            mapItem.AttributeSpawnY = y;
+            if (item.ItemType == ItemType.Equipment)
+            {
+                mapItem.Quantity = 1;
+            }
+            AddItem(mapItem);
+            PacketSender.SendMapItemUpdate(mMapController.Id, MapInstanceId, mapItem, false);
+        }
+    }
+
+    /// <summary>
+    /// Spawns map atribute items/resources
+    /// </summary>
+    private void SpawnAttributeItems()
+    {
+        ResourceSpawns.Clear();
+        for (byte x = 0; x < Options.MapWidth; x++)
+        {
+            for (byte y = 0; y < Options.MapHeight; y++)
+            {
+                if (mMapController.Attributes[x, y] != null)
+                {
+                    if (mMapController.Attributes[x, y].Type == MapAttribute.Item)
                     {
-                        mapItem.SetupStatBuffs(item);
+                        SpawnAttributeItem(x, y);
                     }
-
-                    if (mapItem.TileIndex > Options.MapHeight * Options.MapWidth || mapItem.TileIndex < 0)
+                    else if (mMapController.Attributes[x, y].Type == MapAttribute.Resource)
                     {
-                        return;
-                    }
-
-                    AddItem(mapItem);
-                }
-                PacketSender.SendMapItemsToProximity(mMapController.Id, this);
-            }
-        }
-
-        /// <summary>
-        /// Find a Map Item on this map based on its Unique Id;
-        /// </summary>
-        /// <param name="uniqueId">The Unique Id of the Map Item to look for.</param>
-        /// <returns>Returns a <see cref="MapItem"/> if one is found with the desired Unique Id.</returns>
-        public MapItem FindItem(Guid uniqueId)
-        {
-            if (AllMapItems.TryGetValue(uniqueId, out MapItem item))
-            {
-                return item;
-            }
-            return null;
-        }
-
-        /// <summary>
-        /// /// Find all map items at a specificed location.
-        /// </summary>
-        /// <param name="tileIndex">The integer value representation of the tile.</param>
-        /// <returns>Returns a <see cref="ICollection"/> of <see cref="MapItem"/></returns>
-        public ICollection<MapItem> FindItemsAt(int tileIndex)
-        {
-            if (tileIndex < 0 || tileIndex >= Options.MapWidth * Options.MapHeight || TileItems[tileIndex] == null)
-            {
-                return Array.Empty<MapItem>();
-            }
-            return TileItems[tileIndex].Values;
-        }
-
-        /// <summary>
-        /// Removes some item from this processing instance
-        /// </summary>
-        /// <param name="item">The item to remove from the instance</param>
-        /// <param name="respawn">Whether or not this item will respawn</param>
-        public void RemoveItem(MapItem item, bool respawn = true)
-        {
-            if (item != null)
-            {
-                // Only try to handle respawns for items that have attribute spawn locations.
-                if (item.AttributeSpawnX > -1)
-                {
-                    if (respawn)
-                    {
-                        var spawn = new MapItemSpawn()
-                        {
-                            AttributeSpawnX = item.X,
-                            AttributeSpawnY = item.Y,
-                            RespawnTime = Timing.Global.Milliseconds + (item.AttributeRespawnTime <= 0 ? Options.Map.ItemAttributeRespawnTime : item.AttributeRespawnTime)
-                        };
-                        ItemRespawns.TryAdd(spawn.Id, spawn);
-                    }
-                }
-
-                var oldOwner = item.Owner;
-                AllMapItems.TryRemove(item.UniqueId, out MapItem removed);
-                TileItems[item.TileIndex]?.TryRemove(item.UniqueId, out MapItem tileRemoved);
-                if (TileItems[item.TileIndex]?.IsEmpty ?? false)
-                {
-                    TileItems[item.TileIndex] = null;
-                }
-                PacketSender.SendMapItemUpdate(mMapController.Id, MapInstanceId, item, true, item.VisibleToAll, oldOwner);
-            }
-        }
-
-        /// <summary>
-        /// Despawns all items, and removes them from our list of them.
-        /// </summary>
-        public void DespawnItems()
-        {
-            //Kill all items resting on map
-            ItemRespawns.Clear();
-            foreach (var item in AllMapItems.Values)
-            {
-                RemoveItem(item);
-            }
-
-            AllMapItems.Clear();
-        }
-
-        /// <summary>
-        /// Spawns an item that was placed via editor Item map attribute
-        /// </summary>
-        /// <param name="x">X co-ordinate to spawn</param>
-        /// <param name="y">Y co-ordinate to spawn</param>
-        private void SpawnAttributeItem(int x, int y)
-        {
-            var item = ItemBase.Get(((MapItemAttribute)mMapController.Attributes[x, y]).ItemId);
-            if (item != null)
-            {
-                var mapItem = new MapItem(item.Id, ((MapItemAttribute)mMapController.Attributes[x, y]).Quantity, x, y, ((MapItemAttribute)mMapController.Attributes[x, y]).RespawnTime);
-                mapItem.DespawnTime = -1;
-                mapItem.AttributeSpawnX = x;
-                mapItem.AttributeSpawnY = y;
-                if (item.ItemType == ItemType.Equipment)
-                {
-                    mapItem.Quantity = 1;
-                }
-                AddItem(mapItem);
-                PacketSender.SendMapItemUpdate(mMapController.Id, MapInstanceId, mapItem, false);
-            }
-        }
-
-        /// <summary>
-        /// Spawns map atribute items/resources
-        /// </summary>
-        private void SpawnAttributeItems()
-        {
-            ResourceSpawns.Clear();
-            for (byte x = 0; x < Options.MapWidth; x++)
-            {
-                for (byte y = 0; y < Options.MapHeight; y++)
-                {
-                    if (mMapController.Attributes[x, y] != null)
-                    {
-                        if (mMapController.Attributes[x, y].Type == MapAttribute.Item)
-                        {
-                            SpawnAttributeItem(x, y);
-                        }
-                        else if (mMapController.Attributes[x, y].Type == MapAttribute.Resource)
-                        {
-                            SpawnAttributeResource(x, y);
-                        }
+                        SpawnAttributeResource(x, y);
                     }
                 }
             }
         }
-        #endregion
+    }
+    #endregion
 
-        #region Projectiles & Traps
-        /// <summary>
-        /// Spawn a projectile on the map instance
-        /// </summary>
-        /// <param name="owner">Who spawned the projectile</param>
-        /// <param name="projectile">Which projectile to spawn</param>
-        /// <param name="parentSpell">If the projectile was spawned via spell</param>
-        /// <param name="parentItem">If the projectile was spawned via item</param>
-        /// <param name="mapId">What MapController the projectile was spawned on</param>
-        /// <param name="x">X co-ordinate to spawn at</param>
-        /// <param name="y">Y co-ordinate ot spawn at</param>
-        /// <param name="z">Z co-ordinate to spawn at, if enabled in config</param>
-        /// <param name="direction">Direction in which to spawn</param>
-        /// <param name="target">The target of the projectil</param>
-        public void SpawnMapProjectile(
-            Entity owner,
-            ProjectileBase projectile,
-            SpellBase parentSpell,
-            ItemBase parentItem,
-            Guid mapId,
-            byte x,
-            byte y,
-            byte z,
-            Direction direction,
-            Entity target
-        )
+    #region Projectiles & Traps
+    /// <summary>
+    /// Spawn a projectile on the map instance
+    /// </summary>
+    /// <param name="owner">Who spawned the projectile</param>
+    /// <param name="projectile">Which projectile to spawn</param>
+    /// <param name="parentSpell">If the projectile was spawned via spell</param>
+    /// <param name="parentItem">If the projectile was spawned via item</param>
+    /// <param name="mapId">What MapController the projectile was spawned on</param>
+    /// <param name="x">X co-ordinate to spawn at</param>
+    /// <param name="y">Y co-ordinate ot spawn at</param>
+    /// <param name="z">Z co-ordinate to spawn at, if enabled in config</param>
+    /// <param name="direction">Direction in which to spawn</param>
+    /// <param name="target">The target of the projectil</param>
+    public void SpawnMapProjectile(
+        Entity owner,
+        ProjectileBase projectile,
+        SpellBase parentSpell,
+        ItemBase parentItem,
+        Guid mapId,
+        byte x,
+        byte y,
+        byte z,
+        Direction direction,
+        Entity target
+    )
+    {
+        var proj = new Projectile(owner, parentSpell, parentItem, projectile, mMapController.Id, x, y, z, direction, target);
+        proj.MapInstanceId = MapInstanceId;
+        MapProjectiles.TryAdd(proj.Id, proj);
+        MapProjectilesCached = MapProjectiles.Values.ToArray();
+        PacketSender.SendEntityDataToProximity(proj);
+    }
+
+    /// <summary>
+    /// Despawns all projectiles on the instance.
+    /// </summary>
+    public void DespawnProjectiles()
+    {
+        var guids = new List<Guid>();
+        foreach (var proj in MapProjectiles)
         {
-            var proj = new Projectile(owner, parentSpell, parentItem, projectile, mMapController.Id, x, y, z, direction, target);
-            proj.MapInstanceId = MapInstanceId;
-            MapProjectiles.TryAdd(proj.Id, proj);
-            MapProjectilesCached = MapProjectiles.Values.ToArray();
-            PacketSender.SendEntityDataToProximity(proj);
+            if (proj.Value != null)
+            {
+                guids.Add(proj.Value.Id);
+                proj.Value.Die();
+            }
+        }
+        PacketSender.SendRemoveProjectileSpawns(mMapController.Id, MapInstanceId, guids.ToArray(), null);
+        MapProjectiles.Clear();
+        MapProjectilesCached = new Projectile[0];
+    }
+
+    public void RemoveProjectile(Projectile en)
+    {
+        MapProjectiles.TryRemove(en.Id, out Projectile removed);
+        MapProjectilesCached = MapProjectiles.Values.ToArray();
+    }
+
+    public void SpawnTrap(Entity owner, SpellBase parentSpell, byte x, byte y, byte z)
+    {
+        var trap = new MapTrapInstance(owner, parentSpell, mMapController.Id, MapInstanceId, x, y, z);
+        MapTraps.TryAdd(trap.Id, trap);
+        MapTrapsCached = MapTraps.Values.ToArray();
+    }
+
+    public void DespawnTraps()
+    {
+        MapTraps.Clear();
+        MapTrapsCached = new MapTrapInstance[0];
+    }
+
+    public void RemoveTrap(MapTrapInstance trap)
+    {
+        MapTraps.TryRemove(trap.Id, out MapTrapInstance removed);
+        MapTrapsCached = MapTraps.Values.ToArray();
+    }
+
+    #endregion
+
+    #region Events
+    private void SpawnGlobalEvents()
+    {
+        GlobalEventInstances.Clear();
+        foreach (var id in mMapController.EventIds)
+        {
+            var evt = EventBase.Get(id);
+            if (evt != null && evt.Global)
+            {
+                GlobalEventInstances.TryAdd(evt, new Event(evt.Id, evt, mMapController, MapInstanceId));
+            }
+        }
+    }
+
+    private void DespawnGlobalEvents()
+    {
+        //Kill global events on map (make sure processing stops for online players)
+        //Gonna rely on GC for now
+        foreach (var evt in GlobalEventInstances.ToArray())
+        {
+            foreach (var player in GetPlayers(true))
+            {
+                player.RemoveEvent(evt.Value.BaseEvent.Id);
+            }
         }
 
-        /// <summary>
-        /// Despawns all projectiles on the instance.
-        /// </summary>
-        public void DespawnProjectiles()
+        GlobalEventInstances.Clear();
+    }
+
+    public Event GetGlobalEventInstance(EventBase baseEvent)
+    {
+        if (GlobalEventInstances.ContainsKey(baseEvent))
         {
-            var guids = new List<Guid>();
-            foreach (var proj in MapProjectiles)
+            return GlobalEventInstances[baseEvent];
+        }
+
+        return null;
+    }
+
+    public bool FindEvent(EventBase baseEvent, EventPageInstance globalClone)
+    {
+        if (GlobalEventInstances.ContainsKey(baseEvent))
+        {
+            for (var i = 0; i < GlobalEventInstances[baseEvent].GlobalPageInstance.Length; i++)
             {
-                if (proj.Value != null)
+                if (GlobalEventInstances[baseEvent].GlobalPageInstance[i] == globalClone)
                 {
-                    guids.Add(proj.Value.Id);
-                    proj.Value.Die();
+                    return true;
                 }
             }
-            PacketSender.SendRemoveProjectileSpawns(mMapController.Id, MapInstanceId, guids.ToArray(), null);
-            MapProjectiles.Clear();
-            MapProjectilesCached = new Projectile[0];
         }
 
-        public void RemoveProjectile(Projectile en)
-        {
-            MapProjectiles.TryRemove(en.Id, out Projectile removed);
-            MapProjectilesCached = MapProjectiles.Values.ToArray();
-        }
+        return false;
+    }
 
-        public void SpawnTrap(Entity owner, SpellBase parentSpell, byte x, byte y, byte z)
+    public void RefreshEventsCache()
+    {
+        var events = new List<EventBase>();
+        foreach (var evt in mMapController.EventIds)
         {
-            var trap = new MapTrapInstance(owner, parentSpell, mMapController.Id, MapInstanceId, x, y, z);
-            MapTraps.TryAdd(trap.Id, trap);
-            MapTrapsCached = MapTraps.Values.ToArray();
-        }
-
-        public void DespawnTraps()
-        {
-            MapTraps.Clear();
-            MapTrapsCached = new MapTrapInstance[0];
-        }
-
-        public void RemoveTrap(MapTrapInstance trap)
-        {
-            MapTraps.TryRemove(trap.Id, out MapTrapInstance removed);
-            MapTrapsCached = MapTraps.Values.ToArray();
-        }
-
-        #endregion
-
-        #region Events
-        private void SpawnGlobalEvents()
-        {
-            GlobalEventInstances.Clear();
-            foreach (var id in mMapController.EventIds)
+            var itm = EventBase.Get(evt);
+            if (itm != null)
             {
-                var evt = EventBase.Get(id);
-                if (evt != null && evt.Global)
+                events.Add(itm);
+            }
+        }
+        EventsCache = events;
+    }
+    #endregion
+
+    #region Collision
+    public bool TileBlocked(int x, int y)
+    {
+        if (mMapController.Attributes == null ||
+            x < 0 || x >= mMapController.Attributes.GetLength(0) ||
+            y < 0 || y >= mMapController.Attributes.GetLength(1))
+        {
+            return true;
+        }
+
+        //Check if tile is a blocked attribute
+        if (mMapController.Attributes[x, y] != null && (mMapController.Attributes[x, y].Type == MapAttribute.Blocked ||
+            mMapController.Attributes[x, y].Type == MapAttribute.Animation && ((MapAnimationAttribute)mMapController.Attributes[x, y]).IsBlock))
+        {
+            return true;
+        }
+
+        //See if there are any entities in the way
+        var entities = GetEntities();
+        for (var i = 0; i < entities.Count; i++)
+        {
+            if (entities[i] != null && !(entities[i] is Projectile))
+            {
+                //If Npc or Player then blocked.. if resource then check
+                if (!entities[i].Passable && entities[i].X == x && entities[i].Y == y)
                 {
-                    GlobalEventInstances.TryAdd(evt, new Event(evt.Id, evt, mMapController, MapInstanceId));
+                    return true;
                 }
             }
         }
 
-        private void DespawnGlobalEvents()
+        //Check Global Events
+        foreach (var globalEvent in GlobalEventInstances)
         {
-            //Kill global events on map (make sure processing stops for online players)
-            //Gonna rely on GC for now
-            foreach (var evt in GlobalEventInstances.ToArray())
+            if (globalEvent.Value != null && globalEvent.Value.PageInstance != null)
             {
-                foreach (var player in GetPlayers(true))
+                if (!globalEvent.Value.PageInstance.Passable &&
+                    globalEvent.Value.PageInstance.X == x &&
+                    globalEvent.Value.PageInstance.Y == y)
                 {
-                    player.RemoveEvent(evt.Value.BaseEvent.Id);
+                    return true;
                 }
             }
-
-            GlobalEventInstances.Clear();
         }
 
-        public Event GetGlobalEventInstance(EventBase baseEvent)
-        {
-            if (GlobalEventInstances.ContainsKey(baseEvent))
-            {
-                return GlobalEventInstances[baseEvent];
-            }
+        return false;
+    }
+    #endregion
 
-            return null;
-        }
+    #region Packet Batching
+    public void AddBatchedAnimation(PlayAnimationPacket packet)
+    {
+        mMapAnimations.Add(packet);
+    }
 
-        public bool FindEvent(EventBase baseEvent, EventPageInstance globalClone)
+    public void AddBatchedMovement(Entity en, bool correction, Player forPlayer)
+    {
+        mEntityMovements.Add(en, correction, forPlayer);
+    }
+
+    public void AddBatchedActionMessage(ActionMsgPacket packet)
+    {
+        mActionMessages.Add(packet);
+    }
+    #endregion
+
+    #region Caching
+    public void CacheMapBlocks()
+    {
+        var blocks = new List<BytePoint>();
+        var npcBlocks = new List<BytePoint>();
+        for (byte x = 0; x < Options.MapWidth; x++)
         {
-            if (GlobalEventInstances.ContainsKey(baseEvent))
+            for (byte y = 0; y < Options.MapHeight; y++)
             {
-                for (var i = 0; i < GlobalEventInstances[baseEvent].GlobalPageInstance.Length; i++)
+                if (mMapController.Attributes[x, y] != null)
                 {
-                    if (GlobalEventInstances[baseEvent].GlobalPageInstance[i] == globalClone)
+                    if (mMapController.Attributes[x, y].Type == MapAttribute.Blocked ||
+                        mMapController.Attributes[x, y].Type == MapAttribute.GrappleStone ||
+                        mMapController.Attributes[x, y].Type == MapAttribute.Animation && ((MapAnimationAttribute)mMapController.Attributes[x, y]).IsBlock)
                     {
-                        return true;
+                        blocks.Add(new BytePoint(x, y));
+                        npcBlocks.Add(new BytePoint(x, y));
+                    }
+                    else if (mMapController.Attributes[x, y].Type == MapAttribute.NpcAvoid)
+                    {
+                        npcBlocks.Add(new BytePoint(x, y));
+                    }
+                }
+            }
+        }
+
+        mMapBlocks = blocks.ToArray();
+        mNpcMapBlocks = npcBlocks.ToArray();
+    }
+
+    public Entity[] GetCachedEntities()
+    {
+        return mCachedEntities;
+    }
+
+    public BytePoint[] GetCachedBlocks(bool isPlayer)
+    {
+        return isPlayer ? mMapBlocks : mNpcMapBlocks;
+    }
+    #endregion
+
+    #region Updates
+    private void UpdateEntities(long timeMs)
+    {
+        var surrMaps = mMapController.GetSurroundingMaps(true);
+
+        // Keep a list of all entities with changed vitals and statusses.
+        var vitalUpdates = new List<Entity>();
+        var statusUpdates = new List<Entity>();
+
+        foreach (var en in mEntities)
+        {
+            //Let's see if and how long this map has been inactive, if longer than X seconds, regenerate everything on the map
+            if (timeMs > mLastUpdateTime + Options.Map.TimeUntilMapCleanup)
+            {
+                //Regen Everything & Forget Targets
+                if (en.Value is Resource || en.Value is Npc)
+                {
+                    en.Value.RestoreVital(Vital.Health);
+                    en.Value.RestoreVital(Vital.Mana);
+
+                    if (en.Value is Npc npc)
+                    {
+                        npc.AssignTarget(null);
+                    }
+                    else
+                    {
+                        en.Value.Target = null;
                     }
                 }
             }
 
-            return false;
-        }
+            en.Value.Update(timeMs);
 
-        public void RefreshEventsCache()
-        {
-            var events = new List<EventBase>();
-            foreach (var evt in mMapController.EventIds)
+            // Check to see if we need to send any entity vital and status updates for this entity.
+            if (en.Value.VitalsUpdated)
             {
-                var itm = EventBase.Get(evt);
-                if (itm != null)
+                vitalUpdates.Add(en.Value);
+
+                // Send a party update if we're a player with a party.
+                if (en.Value is Player player)
                 {
-                    events.Add(itm);
-                }
-            }
-            EventsCache = events;
-        }
-        #endregion
-
-        #region Collision
-        public bool TileBlocked(int x, int y)
-        {
-            if (mMapController.Attributes == null ||
-                x < 0 || x >= mMapController.Attributes.GetLength(0) ||
-                y < 0 || y >= mMapController.Attributes.GetLength(1))
-            {
-                return true;
-            }
-
-            //Check if tile is a blocked attribute
-            if (mMapController.Attributes[x, y] != null && (mMapController.Attributes[x, y].Type == MapAttribute.Blocked ||
-                mMapController.Attributes[x, y].Type == MapAttribute.Animation && ((MapAnimationAttribute)mMapController.Attributes[x, y]).IsBlock))
-            {
-                return true;
-            }
-
-            //See if there are any entities in the way
-            var entities = GetEntities();
-            for (var i = 0; i < entities.Count; i++)
-            {
-                if (entities[i] != null && !(entities[i] is Projectile))
-                {
-                    //If Npc or Player then blocked.. if resource then check
-                    if (!entities[i].Passable && entities[i].X == x && entities[i].Y == y)
+                    for (var i = 0; i < player.Party.Count; i++)
                     {
-                        return true;
-                    }
-                }
-            }
-
-            //Check Global Events
-            foreach (var globalEvent in GlobalEventInstances)
-            {
-                if (globalEvent.Value != null && globalEvent.Value.PageInstance != null)
-                {
-                    if (!globalEvent.Value.PageInstance.Passable &&
-                        globalEvent.Value.PageInstance.X == x &&
-                        globalEvent.Value.PageInstance.Y == y)
-                    {
-                        return true;
-                    }
-                }
-            }
-
-            return false;
-        }
-        #endregion
-
-        #region Packet Batching
-        public void AddBatchedAnimation(PlayAnimationPacket packet)
-        {
-            mMapAnimations.Add(packet);
-        }
-
-        public void AddBatchedMovement(Entity en, bool correction, Player forPlayer)
-        {
-            mEntityMovements.Add(en, correction, forPlayer);
-        }
-
-        public void AddBatchedActionMessage(ActionMsgPacket packet)
-        {
-            mActionMessages.Add(packet);
-        }
-        #endregion
-
-        #region Caching
-        public void CacheMapBlocks()
-        {
-            var blocks = new List<BytePoint>();
-            var npcBlocks = new List<BytePoint>();
-            for (byte x = 0; x < Options.MapWidth; x++)
-            {
-                for (byte y = 0; y < Options.MapHeight; y++)
-                {
-                    if (mMapController.Attributes[x, y] != null)
-                    {
-                        if (mMapController.Attributes[x, y].Type == MapAttribute.Blocked ||
-                            mMapController.Attributes[x, y].Type == MapAttribute.GrappleStone ||
-                            mMapController.Attributes[x, y].Type == MapAttribute.Animation && ((MapAnimationAttribute)mMapController.Attributes[x, y]).IsBlock)
-                        {
-                            blocks.Add(new BytePoint(x, y));
-                            npcBlocks.Add(new BytePoint(x, y));
-                        }
-                        else if (mMapController.Attributes[x, y].Type == MapAttribute.NpcAvoid)
-                        {
-                            npcBlocks.Add(new BytePoint(x, y));
-                        }
-                    }
-                }
-            }
-
-            mMapBlocks = blocks.ToArray();
-            mNpcMapBlocks = npcBlocks.ToArray();
-        }
-
-        public Entity[] GetCachedEntities()
-        {
-            return mCachedEntities;
-        }
-
-        public BytePoint[] GetCachedBlocks(bool isPlayer)
-        {
-            return isPlayer ? mMapBlocks : mNpcMapBlocks;
-        }
-        #endregion
-
-        #region Updates
-        private void UpdateEntities(long timeMs)
-        {
-            var surrMaps = mMapController.GetSurroundingMaps(true);
-
-            // Keep a list of all entities with changed vitals and statusses.
-            var vitalUpdates = new List<Entity>();
-            var statusUpdates = new List<Entity>();
-
-            foreach (var en in mEntities)
-            {
-                //Let's see if and how long this map has been inactive, if longer than X seconds, regenerate everything on the map
-                if (timeMs > mLastUpdateTime + Options.Map.TimeUntilMapCleanup)
-                {
-                    //Regen Everything & Forget Targets
-                    if (en.Value is Resource || en.Value is Npc)
-                    {
-                        en.Value.RestoreVital(Vital.Health);
-                        en.Value.RestoreVital(Vital.Mana);
-
-                        if (en.Value is Npc npc)
-                        {
-                            npc.AssignTarget(null);
-                        }
-                        else
-                        {
-                            en.Value.Target = null;
-                        }
+                        PacketSender.SendPartyUpdateTo(player.Party[i], player);
                     }
                 }
 
-                en.Value.Update(timeMs);
+                en.Value.VitalsUpdated = false;
+            }
 
-                // Check to see if we need to send any entity vital and status updates for this entity.
-                if (en.Value.VitalsUpdated)
-                {
-                    vitalUpdates.Add(en.Value);
+            if (en.Value.StatusesUpdated)
+            {
+                statusUpdates.Add(en.Value);
 
-                    // Send a party update if we're a player with a party.
-                    if (en.Value is Player player)
-                    {
-                        for (var i = 0; i < player.Party.Count; i++)
-                        {
-                            PacketSender.SendPartyUpdateTo(player.Party[i], player);
-                        }
-                    }
+                en.Value.StatusesUpdated = false;
+            }
 
-                    en.Value.VitalsUpdated = false;
-                }
-
-                if (en.Value.StatusesUpdated)
+            foreach (var status in en.Value.CachedStatuses)
+            {
+                if (status.Type == SpellEffect.Shield)
                 {
                     statusUpdates.Add(en.Value);
-
-                    en.Value.StatusesUpdated = false;
                 }
-
-                foreach (var status in en.Value.CachedStatuses)
-                {
-                    if (status.Type == SpellEffect.Shield)
-                    {
-                        statusUpdates.Add(en.Value);
-                    }
-                }
-            }
-
-            if (vitalUpdates.Count > 0)
-            {
-                PacketSender.SendMapEntityVitalUpdate(mMapController, vitalUpdates.ToArray(), MapInstanceId);
-            }
-
-            if (statusUpdates.Count > 0)
-            {
-                PacketSender.SendMapEntityStatusUpdate(mMapController, statusUpdates.ToArray(), MapInstanceId);
             }
         }
 
-        private void ProcessNpcRespawns()
+        if (vitalUpdates.Count > 0)
         {
-            var spawns = mMapController.Spawns;
-            for (var i = 0; i < spawns.Count; i++)
+            PacketSender.SendMapEntityVitalUpdate(mMapController, vitalUpdates.ToArray(), MapInstanceId);
+        }
+
+        if (statusUpdates.Count > 0)
+        {
+            PacketSender.SendMapEntityStatusUpdate(mMapController, statusUpdates.ToArray(), MapInstanceId);
+        }
+    }
+
+    private void ProcessNpcRespawns()
+    {
+        var spawns = mMapController.Spawns;
+        for (var i = 0; i < spawns.Count; i++)
+        {
+            var spawn = spawns[i];
+            if (!NpcSpawnInstances.TryGetValue(spawn, out var spawnInstance) || spawnInstance?.Entity?.Base == default || !spawnInstance.Entity.Dead)
             {
-                var spawn = spawns[i];
-                if (!NpcSpawnInstances.TryGetValue(spawn, out var spawnInstance) || spawnInstance?.Entity?.Base == default || !spawnInstance.Entity.Dead)
+                continue;
+            }
+
+            if (spawnInstance.RespawnTime < 0)
+            {
+                spawnInstance.RespawnTime = mLastUpdateTime + (spawnInstance.Entity.Base?.SpawnDuration ?? 0);
+            }
+            else if (spawnInstance.RespawnTime < Timing.Global.Milliseconds)
+            {
+                SpawnMapNpc(spawn);
+                spawnInstance.RespawnTime = -1;
+            }
+        }
+    }
+
+    private void ProcessResourceRespawns()
+    {
+        foreach (var spawn in ResourceSpawns)
+        {
+            if (!ResourceSpawnInstances.TryGetValue(spawn.Value, out var spawnInstance) || spawnInstance?.Entity?.Base == default || !spawnInstance.Entity.Dead)
+            {
+                continue;
+            }
+
+            var now = Timing.Global.Milliseconds;
+            if (spawnInstance.RespawnTime < 0)
+            {
+                spawnInstance.RespawnTime = now + (spawnInstance.Entity.Base?.SpawnDuration ?? 0);
+            }
+            else if (spawnInstance.RespawnTime < now)
+            {
+                // Check to see if this resource can be respawned, if there's an Npc or Player on it we shouldn't let it respawn yet..
+                // Unless of course the resource is walkable regardless.
+                var canSpawn = false;
+                if (spawnInstance.Entity.Base.WalkableBefore)
                 {
-                    continue;
+                    canSpawn = true;
+                }
+                else
+                {
+                    // Check if this resource is currently stepped on
+                    var spawnBlockers = GetEntities().Where(x => x is Player || x is Npc).ToArray();
+                    if (!spawnBlockers.Any(e => e.X == spawnInstance.Entity.X && e.Y == spawnInstance.Entity.Y))
+                    {
+                        canSpawn = true;
+                    }
                 }
 
-                if (spawnInstance.RespawnTime < 0)
+                if (canSpawn)
                 {
-                    spawnInstance.RespawnTime = mLastUpdateTime + (spawnInstance.Entity.Base?.SpawnDuration ?? 0);
-                }
-                else if (spawnInstance.RespawnTime < Timing.Global.Milliseconds)
-                {
-                    SpawnMapNpc(spawn);
+                    SpawnMapResource(spawn.Value);
                     spawnInstance.RespawnTime = -1;
                 }
             }
         }
-
-        private void ProcessResourceRespawns()
-        {
-            foreach (var spawn in ResourceSpawns)
-            {
-                if (!ResourceSpawnInstances.TryGetValue(spawn.Value, out var spawnInstance) || spawnInstance?.Entity?.Base == default || !spawnInstance.Entity.Dead)
-                {
-                    continue;
-                }
-
-                var now = Timing.Global.Milliseconds;
-                if (spawnInstance.RespawnTime < 0)
-                {
-                    spawnInstance.RespawnTime = now + (spawnInstance.Entity.Base?.SpawnDuration ?? 0);
-                }
-                else if (spawnInstance.RespawnTime < now)
-                {
-                    // Check to see if this resource can be respawned, if there's an Npc or Player on it we shouldn't let it respawn yet..
-                    // Unless of course the resource is walkable regardless.
-                    var canSpawn = false;
-                    if (spawnInstance.Entity.Base.WalkableBefore)
-                    {
-                        canSpawn = true;
-                    }
-                    else
-                    {
-                        // Check if this resource is currently stepped on
-                        var spawnBlockers = GetEntities().Where(x => x is Player || x is Npc).ToArray();
-                        if (!spawnBlockers.Any(e => e.X == spawnInstance.Entity.X && e.Y == spawnInstance.Entity.Y))
-                        {
-                            canSpawn = true;
-                        }
-                    }
-
-                    if (canSpawn)
-                    {
-                        SpawnMapResource(spawn.Value);
-                        spawnInstance.RespawnTime = -1;
-                    }
-                }
-            }
-        }
-
-        public void UpdateProjectiles(long timeMs)
-        {
-            var spawnDeaths = new List<KeyValuePair<Guid, int>>();
-            var projDeaths = new List<Guid>();
-
-            //Process all of the projectiles
-            foreach (var proj in MapProjectilesCached)
-            {
-                proj.Update(projDeaths, spawnDeaths);
-            }
-
-            if (projDeaths.Count > 0 || spawnDeaths.Count > 0)
-            {
-                PacketSender.SendRemoveProjectileSpawns(mMapController.Id, MapInstanceId, projDeaths.ToArray(), spawnDeaths.ToArray());
-            }
-
-            //Process all of the traps
-            foreach (var trap in MapTrapsCached)
-            {
-                trap.Update();
-            }
-
-            LastProjectileUpdateTime = timeMs;
-        }
-
-        public void UpdateItems(long timeMs)
-        {
-            foreach (var mapItem in AllMapItems.Values)
-            {
-                // Should this item be visible to everyone now?
-                if (!mapItem.VisibleToAll && mapItem.OwnershipTime < timeMs)
-                {
-                    mapItem.VisibleToAll = true;
-                    PacketSender.SendMapItemUpdate(mMapController.Id, MapInstanceId, mapItem, false);
-                }
-
-                // Do we need to delete this item?
-                if (mapItem.DespawnTime != -1 && mapItem.DespawnTime < timeMs)
-                {
-                    RemoveItem(mapItem);
-                }
-            }
-
-            foreach (var itemRespawn in ItemRespawns.Values)
-            {
-                if (itemRespawn.RespawnTime < timeMs)
-                {
-                    SpawnAttributeItem(itemRespawn.AttributeSpawnX, itemRespawn.AttributeSpawnY);
-                    ItemRespawns.TryRemove(itemRespawn.Id, out MapItemSpawn spawn);
-                }
-            }
-        }
-
-        private void UpdateGlobalEvents(long timeMs)
-        {
-            var evts = GlobalEventInstances.Values.ToList();
-            for (var i = 0; i < evts.Count; i++)
-            {
-                //Only do movement processing on the first page.
-                //This is because global events need to keep all of their pages at the same tile
-                //Think about a global event moving randomly that needed to turn into a warewolf and back (separate pages)
-                //If they were in different tiles the transition would make the event jump
-                //Something like described here: https://www.ascensiongamedev.com/community/bug_tracker/intersect/events-randomly-appearing-and-disappearing-r983/
-                for (var x = 0; x < evts[i].GlobalPageInstance.Length; x++)
-                {
-                    //Gotta figure out if any players are interacting with this event.
-                    var active = false;
-                    foreach (var player in GetPlayers(true))
-                    {
-                        var eventInstance = player.FindGlobalEventInstance(evts[i].GlobalPageInstance[x]);
-                        if (eventInstance != null && eventInstance.CallStack.Count > 0)
-                        {
-                            active = true;
-                        }
-                    }
-
-                    evts[i].GlobalPageInstance[x].Update(active, timeMs);
-                }
-            }
-        }
-
-        private void SendBatchedPacketsToPlayers()
-        {
-            var nearbyPlayers = new HashSet<Player>();
-
-            // Get all players in surrounding and current maps
-            foreach (var mapInstance in MapController.GetSurroundingMapInstances(mMapController.Id, MapInstanceId, true)) 
-            {
-                foreach (var plyr in mapInstance.GetPlayers())
-                {
-                    nearbyPlayers.Add(plyr);
-                }
-            }
-
-            // And send batched packets out to all nearby players
-            mEntityMovements.SendPackets(nearbyPlayers);
-            mActionMessages.SendPackets(nearbyPlayers);
-            mMapAnimations.SendPackets(nearbyPlayers);
-        }
-        #endregion
     }
+
+    public void UpdateProjectiles(long timeMs)
+    {
+        var spawnDeaths = new List<KeyValuePair<Guid, int>>();
+        var projDeaths = new List<Guid>();
+
+        //Process all of the projectiles
+        foreach (var proj in MapProjectilesCached)
+        {
+            proj.Update(projDeaths, spawnDeaths);
+        }
+
+        if (projDeaths.Count > 0 || spawnDeaths.Count > 0)
+        {
+            PacketSender.SendRemoveProjectileSpawns(mMapController.Id, MapInstanceId, projDeaths.ToArray(), spawnDeaths.ToArray());
+        }
+
+        //Process all of the traps
+        foreach (var trap in MapTrapsCached)
+        {
+            trap.Update();
+        }
+
+        LastProjectileUpdateTime = timeMs;
+    }
+
+    public void UpdateItems(long timeMs)
+    {
+        foreach (var mapItem in AllMapItems.Values)
+        {
+            // Should this item be visible to everyone now?
+            if (!mapItem.VisibleToAll && mapItem.OwnershipTime < timeMs)
+            {
+                mapItem.VisibleToAll = true;
+                PacketSender.SendMapItemUpdate(mMapController.Id, MapInstanceId, mapItem, false);
+            }
+
+            // Do we need to delete this item?
+            if (mapItem.DespawnTime != -1 && mapItem.DespawnTime < timeMs)
+            {
+                RemoveItem(mapItem);
+            }
+        }
+
+        foreach (var itemRespawn in ItemRespawns.Values)
+        {
+            if (itemRespawn.RespawnTime < timeMs)
+            {
+                SpawnAttributeItem(itemRespawn.AttributeSpawnX, itemRespawn.AttributeSpawnY);
+                ItemRespawns.TryRemove(itemRespawn.Id, out MapItemSpawn spawn);
+            }
+        }
+    }
+
+    private void UpdateGlobalEvents(long timeMs)
+    {
+        var evts = GlobalEventInstances.Values.ToList();
+        for (var i = 0; i < evts.Count; i++)
+        {
+            //Only do movement processing on the first page.
+            //This is because global events need to keep all of their pages at the same tile
+            //Think about a global event moving randomly that needed to turn into a warewolf and back (separate pages)
+            //If they were in different tiles the transition would make the event jump
+            //Something like described here: https://www.ascensiongamedev.com/community/bug_tracker/intersect/events-randomly-appearing-and-disappearing-r983/
+            for (var x = 0; x < evts[i].GlobalPageInstance.Length; x++)
+            {
+                //Gotta figure out if any players are interacting with this event.
+                var active = false;
+                foreach (var player in GetPlayers(true))
+                {
+                    var eventInstance = player.FindGlobalEventInstance(evts[i].GlobalPageInstance[x]);
+                    if (eventInstance != null && eventInstance.CallStack.Count > 0)
+                    {
+                        active = true;
+                    }
+                }
+
+                evts[i].GlobalPageInstance[x].Update(active, timeMs);
+            }
+        }
+    }
+
+    private void SendBatchedPacketsToPlayers()
+    {
+        var nearbyPlayers = new HashSet<Player>();
+
+        // Get all players in surrounding and current maps
+        foreach (var mapInstance in MapController.GetSurroundingMapInstances(mMapController.Id, MapInstanceId, true)) 
+        {
+            foreach (var plyr in mapInstance.GetPlayers())
+            {
+                nearbyPlayers.Add(plyr);
+            }
+        }
+
+        // And send batched packets out to all nearby players
+        mEntityMovements.SendPackets(nearbyPlayers);
+        mActionMessages.SendPackets(nearbyPlayers);
+        mMapAnimations.SendPackets(nearbyPlayers);
+    }
+    #endregion
 }

--- a/Intersect.Server.Core/Maps/MapItemInstance.cs
+++ b/Intersect.Server.Core/Maps/MapItemInstance.cs
@@ -3,77 +3,75 @@ using Intersect.Server.Database.PlayerData.Players;
 
 using Newtonsoft.Json;
 
-namespace Intersect.Server.Maps
+namespace Intersect.Server.Maps;
+
+
+public partial class MapItem : Item
 {
 
-    public partial class MapItem : Item
+    [JsonIgnore] public int AttributeSpawnX = -1;
+
+    [JsonIgnore] public int AttributeSpawnY = -1;
+
+    [JsonIgnore] public long AttributeRespawnTime = Options.Instance.MapOpts.ItemAttributeRespawnTime;
+
+    [JsonIgnore] public long DespawnTime;
+
+    public int X { get; private set; }
+
+    public int Y { get; private set; } 
+
+    [JsonIgnore] public int TileIndex => Y * Options.MapWidth + X;
+
+    /// <summary>
+    /// The Unique Id of this particular MapItemInstance so we can refer to it elsewhere.
+    /// </summary>
+    public Guid UniqueId { get; private set; }
+
+    public Guid Owner;
+
+    [JsonIgnore] public long OwnershipTime;
+
+    // We need this mostly for the client-side.. They can't keep track of our timer after all!
+    public bool VisibleToAll = true;
+
+    public MapItem(Guid itemId, int quantity, int x, int y, long respawnTime = 0) : base(itemId, quantity)
     {
+        UniqueId = Guid.NewGuid();
+        X = x;
+        Y = y;
 
-        [JsonIgnore] public int AttributeSpawnX = -1;
-
-        [JsonIgnore] public int AttributeSpawnY = -1;
-
-        [JsonIgnore] public long AttributeRespawnTime = Options.Instance.MapOpts.ItemAttributeRespawnTime;
-
-        [JsonIgnore] public long DespawnTime;
-
-        public int X { get; private set; }
-
-        public int Y { get; private set; } 
-
-        [JsonIgnore] public int TileIndex => Y * Options.MapWidth + X;
-
-        /// <summary>
-        /// The Unique Id of this particular MapItemInstance so we can refer to it elsewhere.
-        /// </summary>
-        public Guid UniqueId { get; private set; }
-
-        public Guid Owner;
-
-        [JsonIgnore] public long OwnershipTime;
-
-        // We need this mostly for the client-side.. They can't keep track of our timer after all!
-        public bool VisibleToAll = true;
-
-        public MapItem(Guid itemId, int quantity, int x, int y, long respawnTime = 0) : base(itemId, quantity)
+        if (respawnTime > 0)
         {
-            UniqueId = Guid.NewGuid();
-            X = x;
-            Y = y;
+            AttributeRespawnTime = respawnTime;
+        }
+    }
 
-            if (respawnTime > 0)
+    public MapItem(Guid itemId, int quantity, int x, int y, Guid? bagId, Bag bag) : base(itemId, quantity, bagId, bag)
+    {
+        UniqueId = Guid.NewGuid();
+        X = x;
+        Y = y;
+    }
+
+    public string Data()
+    {
+        return JsonConvert.SerializeObject(this);
+    }
+
+    /// <summary>
+    /// Sets up the Stat Buffs on this map item from a supplied item.
+    /// </summary>
+    /// <param name="item">The item to take the Stat Buffs from and apply them to this MapItem.</param>
+    public void SetupStatBuffs(Item item)
+    {
+        if (Properties.StatModifiers != null && item.Properties.StatModifiers != null)
+        {
+            for (var i = 0; i < Properties.StatModifiers.Length; ++i)
             {
-                AttributeRespawnTime = respawnTime;
+                Properties.StatModifiers[i] = item.Properties.StatModifiers.Length > i ? item.Properties.StatModifiers[i] : 0;
             }
         }
-
-        public MapItem(Guid itemId, int quantity, int x, int y, Guid? bagId, Bag bag) : base(itemId, quantity, bagId, bag)
-        {
-            UniqueId = Guid.NewGuid();
-            X = x;
-            Y = y;
-        }
-
-        public string Data()
-        {
-            return JsonConvert.SerializeObject(this);
-        }
-
-        /// <summary>
-        /// Sets up the Stat Buffs on this map item from a supplied item.
-        /// </summary>
-        /// <param name="item">The item to take the Stat Buffs from and apply them to this MapItem.</param>
-        public void SetupStatBuffs(Item item)
-        {
-            if (Properties.StatModifiers != null && item.Properties.StatModifiers != null)
-            {
-                for (var i = 0; i < Properties.StatModifiers.Length; ++i)
-                {
-                    Properties.StatModifiers[i] = item.Properties.StatModifiers.Length > i ? item.Properties.StatModifiers[i] : 0;
-                }
-            }
-        }
-
     }
 
 }

--- a/Intersect.Server.Core/Maps/MapItemSpawn.cs
+++ b/Intersect.Server.Core/Maps/MapItemSpawn.cs
@@ -1,16 +1,14 @@
-namespace Intersect.Server.Maps
+namespace Intersect.Server.Maps;
+
+
+public partial class MapItemSpawn
 {
+    public Guid Id { get; } = Guid.NewGuid();
 
-    public partial class MapItemSpawn
-    {
-        public Guid Id { get; } = Guid.NewGuid();
+    public int AttributeSpawnX = -1;
 
-        public int AttributeSpawnX = -1;
+    public int AttributeSpawnY = -1;
 
-        public int AttributeSpawnY = -1;
-
-        public long RespawnTime = -1;
-
-    }
+    public long RespawnTime = -1;
 
 }

--- a/Intersect.Server.Core/Maps/MapNpcSpawn.cs
+++ b/Intersect.Server.Core/Maps/MapNpcSpawn.cs
@@ -1,11 +1,10 @@
 using Intersect.Server.Entities;
 
-namespace Intersect.Server.Maps
-{
-    public partial class MapNpcSpawn
-    {
-        public Npc Entity { get; set; }
+namespace Intersect.Server.Maps;
 
-        public long RespawnTime { get; set; } = -1;
-    }
+public partial class MapNpcSpawn
+{
+    public Npc Entity { get; set; }
+
+    public long RespawnTime { get; set; } = -1;
 }

--- a/Intersect.Server.Core/Maps/MapResourceSpawn.cs
+++ b/Intersect.Server.Core/Maps/MapResourceSpawn.cs
@@ -1,17 +1,15 @@
 ﻿using Intersect.Server.Entities;
 
-namespace Intersect.Server.Maps
+namespace Intersect.Server.Maps;
+
+
+public partial class MapResourceSpawn
 {
 
-    public partial class MapResourceSpawn
-    {
+    public Resource Entity;
 
-        public Resource Entity;
+    public int EntityIndex = -1;
 
-        public int EntityIndex = -1;
-
-        public long RespawnTime = -1;
-
-    }
+    public long RespawnTime = -1;
 
 }

--- a/Intersect.Server.Core/Maps/MapTileLoc.cs
+++ b/Intersect.Server.Core/Maps/MapTileLoc.cs
@@ -1,37 +1,36 @@
-namespace Intersect.Server.Maps
+namespace Intersect.Server.Maps;
+
+public partial struct MapTileLoc
 {
-    public partial struct MapTileLoc
+    public readonly Guid MapId;
+    public readonly int X;
+    public readonly int Y;
+
+    public MapTileLoc(Guid id, int x, int y)
     {
-        public readonly Guid MapId;
-        public readonly int X;
-        public readonly int Y;
+        MapId = id;
+        X = x;
+        Y = y;
+    }
 
-        public MapTileLoc(Guid id, int x, int y)
+    public override int GetHashCode()
+    {
+        unchecked
         {
-            MapId = id;
-            X = x;
-            Y = y;
+            return MapId.GetHashCode() + (Y * Options.MapHeight) + X;
         }
+    }
 
-        public override int GetHashCode()
+    public override bool Equals(object obj)
+    {
+        if (obj is MapTileLoc loc)
         {
-            unchecked
+            if (X == loc.X && Y == loc.Y && MapId == loc.MapId)
             {
-                return MapId.GetHashCode() + (Y * Options.MapHeight) + X;
+                return true;
             }
         }
 
-        public override bool Equals(object obj)
-        {
-            if (obj is MapTileLoc loc)
-            {
-                if (X == loc.X && Y == loc.Y && MapId == loc.MapId)
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
+        return false;
     }
 }

--- a/Intersect.Server.Core/Maps/MapTrapInstance.cs
+++ b/Intersect.Server.Core/Maps/MapTrapInstance.cs
@@ -4,88 +4,86 @@ using Intersect.Server.Entities.Events;
 using Intersect.Server.Maps;
 using Intersect.Utilities;
 
-namespace Intersect.Server.Classes.Maps
+namespace Intersect.Server.Classes.Maps;
+
+
+public partial class MapTrapInstance
 {
+    public Guid Id { get; } = Guid.NewGuid();
 
-    public partial class MapTrapInstance
+    private long Duration;
+
+    public Guid MapId;
+    
+    public Guid MapInstanceId;
+
+    public Entity Owner;
+
+    public SpellBase ParentSpell;
+
+    public bool Triggered = false;
+
+    public byte X;
+
+    public byte Y;
+
+    public byte Z;
+
+    public MapTrapInstance(Entity owner, SpellBase parentSpell, Guid mapId, Guid mapInstanceId, byte x, byte y, byte z)
     {
-        public Guid Id { get; } = Guid.NewGuid();
+        Owner = owner;
+        ParentSpell = parentSpell;
+        Duration = Timing.Global.Milliseconds + ParentSpell.Combat.TrapDuration;
+        MapId = mapId;
+        MapInstanceId = mapInstanceId;
+        X = x;
+        Y = y;
+        Z = z;
+    }
 
-        private long Duration;
-
-        public Guid MapId;
-        
-        public Guid MapInstanceId;
-
-        public Entity Owner;
-
-        public SpellBase ParentSpell;
-
-        public bool Triggered = false;
-
-        public byte X;
-
-        public byte Y;
-
-        public byte Z;
-
-        public MapTrapInstance(Entity owner, SpellBase parentSpell, Guid mapId, Guid mapInstanceId, byte x, byte y, byte z)
+    public void CheckEntityHasDetonatedTrap(Entity entity)
+    {
+        if (!Triggered)
         {
-            Owner = owner;
-            ParentSpell = parentSpell;
-            Duration = Timing.Global.Milliseconds + ParentSpell.Combat.TrapDuration;
-            MapId = mapId;
-            MapInstanceId = mapInstanceId;
-            X = x;
-            Y = y;
-            Z = z;
-        }
-
-        public void CheckEntityHasDetonatedTrap(Entity entity)
-        {
-            if (!Triggered)
+            if (entity.MapId == MapId && entity.X == X && entity.Y == Y && entity.Z == Z)
             {
-                if (entity.MapId == MapId && entity.X == X && entity.Y == Y && entity.Z == Z)
+                if (entity is Player entityPlayer && Owner is Player ownerPlayer)
                 {
-                    if (entity is Player entityPlayer && Owner is Player ownerPlayer)
+                    //Don't detonate on yourself and party members on non-friendly spells!
+                    if (Owner == entity || ownerPlayer.InParty(entityPlayer))
                     {
-                        //Don't detonate on yourself and party members on non-friendly spells!
-                        if (Owner == entity || ownerPlayer.InParty(entityPlayer))
+                        if (!ParentSpell.Combat.Friendly)
                         {
-                            if (!ParentSpell.Combat.Friendly)
-                            {
-                                return;
-                            }
+                            return;
                         }
                     }
-
-                    if (entity is EventPageInstance)
-                    {
-                        return;
-                    }
-
-                    Owner.TryAttack(entity, ParentSpell, false, true);
-                    Triggered = true;
                 }
+
+                if (entity is EventPageInstance)
+                {
+                    return;
+                }
+
+                Owner.TryAttack(entity, ParentSpell, false, true);
+                Triggered = true;
             }
         }
+    }
 
-        public void Update()
+    public void Update()
+    {
+        if (MapController.TryGetInstanceFromMap(MapId, MapInstanceId, out var mapInstance))
         {
-            if (MapController.TryGetInstanceFromMap(MapId, MapInstanceId, out var mapInstance))
+            if (Triggered)
             {
-                if (Triggered)
-                {
-                    mapInstance.RemoveTrap(this);
-                }
+                mapInstance.RemoveTrap(this);
+            }
 
-                if (Timing.Global.Milliseconds > Duration)
-                {
-                    mapInstance.RemoveTrap(this);
-                }
+            if (Timing.Global.Milliseconds > Duration)
+            {
+                mapInstance.RemoveTrap(this);
             }
         }
-
     }
 
 }

--- a/Intersect.Server.Core/Maps/TileHelper.cs
+++ b/Intersect.Server.Core/Maps/TileHelper.cs
@@ -1,217 +1,215 @@
 using Intersect.Enums;
 using Intersect.Server.Database;
 
-namespace Intersect.Server.Maps
+namespace Intersect.Server.Maps;
+
+
+public partial class TileHelper
 {
 
-    public partial class TileHelper
+    private Guid mMapId;
+
+    private int mTileX;
+
+    private int mTileY;
+
+    /// <summary>
+    ///     Creates a new tile helper instance in a position given.
+    /// </summary>
+    /// <param name="mapId"></param>
+    /// <param name="tileX"></param>
+    /// <param name="tileY"></param>
+    public TileHelper(Guid mapId, int tileX, int tileY)
     {
+        mMapId = mapId;
+        mTileX = tileX;
+        mTileY = tileY;
+    }
 
-        private Guid mMapId;
+    /// <summary>
+    ///     Moves our tile and then attempts to adjust the map location of we walked out of bounds. Will return true if the
+    ///     position is valid. False if not.
+    /// </summary>
+    /// <param name="xOffset"></param>
+    /// <param name="yOffset"></param>
+    /// <returns></returns>
+    public bool Translate(int xOffset, int yOffset)
+    {
+        mTileX += xOffset;
+        mTileY += yOffset;
 
-        private int mTileX;
+        return TryFix();
+    }
 
-        private int mTileY;
-
-        /// <summary>
-        ///     Creates a new tile helper instance in a position given.
-        /// </summary>
-        /// <param name="mapId"></param>
-        /// <param name="tileX"></param>
-        /// <param name="tileY"></param>
-        public TileHelper(Guid mapId, int tileX, int tileY)
+    public bool TryFix()
+    {
+        var oldTileX = mTileX;
+        var oldTileY = mTileY;
+        if (Fix())
         {
-            mMapId = mapId;
-            mTileX = tileX;
-            mTileY = tileY;
-        }
-
-        /// <summary>
-        ///     Moves our tile and then attempts to adjust the map location of we walked out of bounds. Will return true if the
-        ///     position is valid. False if not.
-        /// </summary>
-        /// <param name="xOffset"></param>
-        /// <param name="yOffset"></param>
-        /// <returns></returns>
-        public bool Translate(int xOffset, int yOffset)
-        {
-            mTileX += xOffset;
-            mTileY += yOffset;
-
-            return TryFix();
-        }
-
-        public bool TryFix()
-        {
-            var oldTileX = mTileX;
-            var oldTileY = mTileY;
-            if (Fix())
-            {
-                return true;
-            }
-
-            mTileX = oldTileX;
-            mTileY = oldTileY;
-
-            return false;
-        }
-
-        public bool Matches(TileHelper other)
-        {
-            if (GetMapId() == other.GetMapId() && GetX() == other.GetX() && GetY() == other.GetY())
-            {
-                return true;
-            }
-
-            return false;
-        }
-
-        private bool TransitionMaps(int direction)
-        {
-            var map = MapController.Get(mMapId);
-            if (map == null)
-            {
-                return false;
-            }
-
-            var grid = DbInterface.GetGrid(map.MapGrid);
-            if (grid == null)
-            {
-                return false;
-            }
-
-            var gridX = map.MapGridX;
-            var gridY = map.MapGridY;
-            switch (direction)
-            {
-                case (int) Direction.Up:
-                    if (gridY > 0 && grid.MapIdGrid[gridX, gridY - 1] != Guid.Empty)
-                    {
-                        mMapId = grid.MapIdGrid[gridX, gridY - 1];
-                        mTileY += Options.MapHeight;
-
-                        return true;
-                    }
-
-                    return false;
-                case (int) Direction.Down:
-                    if (gridY + 1 < grid.Height && grid.MapIdGrid[gridX, gridY + 1] != Guid.Empty)
-                    {
-                        mMapId = grid.MapIdGrid[gridX, gridY + 1];
-                        mTileY -= Options.MapHeight;
-
-                        return true;
-                    }
-
-                    return false;
-                case (int) Direction.Left:
-                    if (gridX > 0 && grid.MapIdGrid[gridX - 1, gridY] != Guid.Empty)
-                    {
-                        mMapId = grid.MapIdGrid[gridX - 1, gridY];
-                        mTileX += Options.MapWidth;
-
-                        return true;
-                    }
-
-                    return false;
-                case (int) Direction.Right:
-                    if (gridX + 1 < grid.Width && grid.MapIdGrid[gridX + 1, gridY] != Guid.Empty)
-                    {
-                        mMapId = grid.MapIdGrid[gridX + 1, gridY];
-                        mTileX -= Options.MapWidth;
-
-                        return true;
-                    }
-
-                    return false;
-                default:
-                    return false;
-            }
-        }
-
-        private bool Fix()
-        {
-            if (!MapController.Lookup.Keys.Contains(mMapId))
-            {
-                return false;
-            }
-
-            var curMap = MapController.Get(mMapId);
-            while (mTileX < 0)
-            {
-                if (!TransitionMaps((int) Direction.Left))
-                {
-                    return false;
-                }
-            }
-
-            while (mTileY < 0)
-            {
-                if (!TransitionMaps((int) Direction.Up))
-                {
-                    return false;
-                }
-            }
-
-            while (mTileX >= Options.MapWidth)
-            {
-                if (!TransitionMaps((int) Direction.Right))
-                {
-                    return false;
-                }
-            }
-
-            while (mTileY >= Options.MapHeight)
-            {
-                if (!TransitionMaps((int) Direction.Down))
-                {
-                    return false;
-                }
-            }
-
             return true;
         }
 
-        public Guid GetMapId()
+        mTileX = oldTileX;
+        mTileY = oldTileY;
+
+        return false;
+    }
+
+    public bool Matches(TileHelper other)
+    {
+        if (GetMapId() == other.GetMapId() && GetX() == other.GetX() && GetY() == other.GetY())
         {
-            return mMapId;
-        }
-
-        public MapController GetMap()
-        {
-            return MapController.Get(mMapId);
-        }
-
-        public byte GetX()
-        {
-            return (byte) mTileX;
-        }
-
-        public byte GetY()
-        {
-            return (byte) mTileY;
-        }
-
-        public static bool IsTileValid(Guid mapId, int tileX, int tileY)
-        {
-            if (!MapController.Lookup.Keys.Contains(mapId))
-            {
-                return false;
-            }
-
-            if (tileX < 0 || tileX >= Options.MapWidth)
-            {
-                return false;
-            }
-
-            if (tileY < 0 || tileY >= Options.MapHeight)
-            {
-                return false;
-            }
-
             return true;
         }
 
+        return false;
+    }
+
+    private bool TransitionMaps(int direction)
+    {
+        var map = MapController.Get(mMapId);
+        if (map == null)
+        {
+            return false;
+        }
+
+        var grid = DbInterface.GetGrid(map.MapGrid);
+        if (grid == null)
+        {
+            return false;
+        }
+
+        var gridX = map.MapGridX;
+        var gridY = map.MapGridY;
+        switch (direction)
+        {
+            case (int) Direction.Up:
+                if (gridY > 0 && grid.MapIdGrid[gridX, gridY - 1] != Guid.Empty)
+                {
+                    mMapId = grid.MapIdGrid[gridX, gridY - 1];
+                    mTileY += Options.MapHeight;
+
+                    return true;
+                }
+
+                return false;
+            case (int) Direction.Down:
+                if (gridY + 1 < grid.Height && grid.MapIdGrid[gridX, gridY + 1] != Guid.Empty)
+                {
+                    mMapId = grid.MapIdGrid[gridX, gridY + 1];
+                    mTileY -= Options.MapHeight;
+
+                    return true;
+                }
+
+                return false;
+            case (int) Direction.Left:
+                if (gridX > 0 && grid.MapIdGrid[gridX - 1, gridY] != Guid.Empty)
+                {
+                    mMapId = grid.MapIdGrid[gridX - 1, gridY];
+                    mTileX += Options.MapWidth;
+
+                    return true;
+                }
+
+                return false;
+            case (int) Direction.Right:
+                if (gridX + 1 < grid.Width && grid.MapIdGrid[gridX + 1, gridY] != Guid.Empty)
+                {
+                    mMapId = grid.MapIdGrid[gridX + 1, gridY];
+                    mTileX -= Options.MapWidth;
+
+                    return true;
+                }
+
+                return false;
+            default:
+                return false;
+        }
+    }
+
+    private bool Fix()
+    {
+        if (!MapController.Lookup.Keys.Contains(mMapId))
+        {
+            return false;
+        }
+
+        var curMap = MapController.Get(mMapId);
+        while (mTileX < 0)
+        {
+            if (!TransitionMaps((int) Direction.Left))
+            {
+                return false;
+            }
+        }
+
+        while (mTileY < 0)
+        {
+            if (!TransitionMaps((int) Direction.Up))
+            {
+                return false;
+            }
+        }
+
+        while (mTileX >= Options.MapWidth)
+        {
+            if (!TransitionMaps((int) Direction.Right))
+            {
+                return false;
+            }
+        }
+
+        while (mTileY >= Options.MapHeight)
+        {
+            if (!TransitionMaps((int) Direction.Down))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public Guid GetMapId()
+    {
+        return mMapId;
+    }
+
+    public MapController GetMap()
+    {
+        return MapController.Get(mMapId);
+    }
+
+    public byte GetX()
+    {
+        return (byte) mTileX;
+    }
+
+    public byte GetY()
+    {
+        return (byte) mTileY;
+    }
+
+    public static bool IsTileValid(Guid mapId, int tileX, int tileY)
+    {
+        if (!MapController.Lookup.Keys.Contains(mapId))
+        {
+            return false;
+        }
+
+        if (tileX < 0 || tileX >= Options.MapWidth)
+        {
+            return false;
+        }
+
+        if (tileY < 0 || tileY >= Options.MapHeight)
+        {
+            return false;
+        }
+
+        return true;
     }
 
 }

--- a/Intersect.Server.Core/Metrics/Controllers/ApplicationMetricsController.cs
+++ b/Intersect.Server.Core/Metrics/Controllers/ApplicationMetricsController.cs
@@ -1,17 +1,16 @@
-namespace Intersect.Server.Metrics.Controllers
+namespace Intersect.Server.Metrics.Controllers;
+
+public partial class ApplicationMetricsController : MetricsController
 {
-    public partial class ApplicationMetricsController : MetricsController
+    private const string CONTEXT = "Application";
+
+    public Histogram Cpu { get; private set; }
+
+    public Histogram Memory { get; private set; }
+
+    public ApplicationMetricsController() : base(CONTEXT)
     {
-        private const string CONTEXT = "Application";
-
-        public Histogram Cpu { get; private set; }
-
-        public Histogram Memory { get; private set; }
-
-        public ApplicationMetricsController() : base(CONTEXT)
-        {
-            Cpu = new Histogram(nameof(Cpu), this);
-            Memory = new Histogram(nameof(Memory), this);
-        }
+        Cpu = new Histogram(nameof(Cpu), this);
+        Memory = new Histogram(nameof(Memory), this);
     }
 }

--- a/Intersect.Server.Core/Metrics/Controllers/GameMetricsController.cs
+++ b/Intersect.Server.Core/Metrics/Controllers/GameMetricsController.cs
@@ -1,44 +1,43 @@
-namespace Intersect.Server.Metrics.Controllers
+namespace Intersect.Server.Metrics.Controllers;
+
+public partial class GameMetricsController : MetricsController
 {
-    public partial class GameMetricsController : MetricsController
+    private const string CONTEXT = "Game";
+
+    public Histogram Cps { get; private set; }
+
+    public Histogram Players { get; private set; }
+
+    public Histogram ActiveMaps { get; private set; }
+
+    public Histogram ActiveEntities { get; private set; }
+
+    public Histogram ActiveEvents { get; private set; }
+
+    public Histogram AutorunEvents { get; private set; }
+
+    public Histogram ProcessingEvents { get; private set; }
+
+    public Histogram MapQueueUpdateOffset { get; private set; }
+
+    public Histogram MapUpdateQueuedTime { get; private set; }
+
+    public Histogram MapUpdateProcessingTime { get; private set; }
+
+    public Histogram MapTotalUpdateTime { get; private set; }
+
+    public GameMetricsController() : base(CONTEXT)
     {
-        private const string CONTEXT = "Game";
-
-        public Histogram Cps { get; private set; }
-
-        public Histogram Players { get; private set; }
-
-        public Histogram ActiveMaps { get; private set; }
-
-        public Histogram ActiveEntities { get; private set; }
-
-        public Histogram ActiveEvents { get; private set; }
-
-        public Histogram AutorunEvents { get; private set; }
-
-        public Histogram ProcessingEvents { get; private set; }
-
-        public Histogram MapQueueUpdateOffset { get; private set; }
-
-        public Histogram MapUpdateQueuedTime { get; private set; }
-
-        public Histogram MapUpdateProcessingTime { get; private set; }
-
-        public Histogram MapTotalUpdateTime { get; private set; }
-
-        public GameMetricsController() : base(CONTEXT)
-        {
-            Cps = new Histogram(nameof(Cps), this);
-            Players = new Histogram(nameof(Players), this);
-            ActiveMaps = new Histogram(nameof(ActiveMaps), this);
-            ActiveEntities = new Histogram(nameof(ActiveEntities), this);
-            ActiveEvents = new Histogram(nameof(ActiveEvents), this);
-            AutorunEvents = new Histogram(nameof(AutorunEvents), this);
-            ProcessingEvents = new Histogram(nameof(ProcessingEvents), this);
-            MapQueueUpdateOffset = new Histogram(nameof(MapQueueUpdateOffset), this);
-            MapUpdateQueuedTime = new Histogram(nameof(MapUpdateQueuedTime), this);
-            MapUpdateProcessingTime = new Histogram(nameof(MapUpdateProcessingTime), this);
-            MapTotalUpdateTime = new Histogram(nameof(MapTotalUpdateTime), this);
-        }
+        Cps = new Histogram(nameof(Cps), this);
+        Players = new Histogram(nameof(Players), this);
+        ActiveMaps = new Histogram(nameof(ActiveMaps), this);
+        ActiveEntities = new Histogram(nameof(ActiveEntities), this);
+        ActiveEvents = new Histogram(nameof(ActiveEvents), this);
+        AutorunEvents = new Histogram(nameof(AutorunEvents), this);
+        ProcessingEvents = new Histogram(nameof(ProcessingEvents), this);
+        MapQueueUpdateOffset = new Histogram(nameof(MapQueueUpdateOffset), this);
+        MapUpdateQueuedTime = new Histogram(nameof(MapUpdateQueuedTime), this);
+        MapUpdateProcessingTime = new Histogram(nameof(MapUpdateProcessingTime), this);
+        MapTotalUpdateTime = new Histogram(nameof(MapTotalUpdateTime), this);
     }
 }

--- a/Intersect.Server.Core/Metrics/Controllers/MetricsController.cs
+++ b/Intersect.Server.Core/Metrics/Controllers/MetricsController.cs
@@ -1,43 +1,40 @@
-﻿using System.Collections.Generic;
+﻿namespace Intersect.Server.Metrics.Controllers;
 
-namespace Intersect.Server.Metrics.Controllers
+public abstract partial class MetricsController
 {
-    public abstract partial class MetricsController
+    private int _allocations;
+
+    protected MetricsController(string context)
     {
-        private int _allocations;
+        Context = context;
+    }
 
-        protected MetricsController(string context)
+    public string Context { get; }
+
+    public List<Histogram> Measurements { get; } = new List<Histogram>();
+
+    public virtual void Clear()
+    {
+        for (var i = 0; i < Measurements.Count; i++)
         {
-            Context = context;
+            Measurements[i].Clear();
         }
+    }
 
-        public string Context { get; }
+    public IDictionary<string, object> Data() {
+        var data = InternalData();
+        _allocations = data.Count;
+        return data;
+    }
 
-        public List<Histogram> Measurements { get; } = new List<Histogram>();
-
-        public virtual void Clear()
+    protected virtual IDictionary<string, object> InternalData()
+    {
+        var data = new Dictionary<string, object>(_allocations);
+        for (var i = 0; i < Measurements.Count; i++)
         {
-            for (var i = 0; i < Measurements.Count; i++)
-            {
-                Measurements[i].Clear();
-            }
+            var histogram = Measurements[i];
+            data[histogram.Name] = histogram;
         }
-
-        public IDictionary<string, object> Data() {
-            var data = InternalData();
-            _allocations = data.Count;
-            return data;
-        }
-
-        protected virtual IDictionary<string, object> InternalData()
-        {
-            var data = new Dictionary<string, object>(_allocations);
-            for (var i = 0; i < Measurements.Count; i++)
-            {
-                var histogram = Measurements[i];
-                data[histogram.Name] = histogram;
-            }
-            return data;
-        }
+        return data;
     }
 }

--- a/Intersect.Server.Core/Metrics/Controllers/NetworkMetricsController.cs
+++ b/Intersect.Server.Core/Metrics/Controllers/NetworkMetricsController.cs
@@ -1,66 +1,62 @@
-using System.Collections.Generic;
-using System.Linq;
-
 using Intersect.Server.Networking;
 
-namespace Intersect.Server.Metrics.Controllers
+namespace Intersect.Server.Metrics.Controllers;
+
+public partial class NetworkMetricsController : MetricsController
 {
-    public partial class NetworkMetricsController : MetricsController
+    private const string CONTEXT = "Network";
+
+    public Histogram Clients { get; private set; }
+
+    public Histogram TotalBandwidth { get; private set; }
+
+    public Histogram SentBytes { get; private set; }
+
+    public Histogram SentPackets { get; private set; }
+
+    public Histogram ReceivedBytes { get; private set; }
+
+    public Histogram ReceivedPackets { get; private set; }
+
+    public Histogram AcceptedBytes { get; private set; }
+
+    public Histogram AcceptedPackets { get; private set; }
+
+    public Histogram DroppedBytes { get; private set; }
+
+    public Histogram DroppedPackets { get; private set; }
+
+    public Histogram TotalReceivedPacketHandlingTime { get; private set; }
+
+    public Histogram TotalSentPacketProcessingTime { get; private set; }
+
+    public NetworkMetricsController() : base(CONTEXT)
     {
-        private const string CONTEXT = "Network";
+        Clients = new Histogram(nameof(Clients), this);
+        TotalBandwidth = new Histogram(nameof(TotalBandwidth), this);
+        SentBytes = new Histogram(nameof(SentBytes), this);
+        SentPackets = new Histogram(nameof(SentPackets), this);
+        ReceivedBytes = new Histogram(nameof(ReceivedBytes), this);
+        ReceivedPackets = new Histogram(nameof(ReceivedPackets), this);
+        AcceptedBytes = new Histogram(nameof(AcceptedBytes), this);
+        AcceptedPackets = new Histogram(nameof(AcceptedPackets), this);
+        DroppedBytes = new Histogram(nameof(DroppedBytes), this);
+        DroppedPackets = new Histogram(nameof(DroppedPackets), this);
+        TotalReceivedPacketHandlingTime = new Histogram(nameof(TotalReceivedPacketHandlingTime), this);
+        TotalSentPacketProcessingTime = new Histogram(nameof(TotalSentPacketProcessingTime), this);
 
-        public Histogram Clients { get; private set; }
+    }
 
-        public Histogram TotalBandwidth { get; private set; }
+    protected override IDictionary<string, object> InternalData()
+    {
+        var res = base.InternalData();
 
-        public Histogram SentBytes { get; private set; }
+        var top10Sent = PacketSender.SentPacketTypes.Where(pair => pair.Value > 0).OrderByDescending(pair => pair.Value).Take(10).ToArray();
+        var top10Received = PacketHandler.AcceptedPacketTypes.Where(pair => pair.Value > 0).OrderByDescending(pair => pair.Value).Take(10).ToArray();
 
-        public Histogram SentPackets { get; private set; }
+        res.Add("MostSentPackets", top10Sent);
+        res.Add("MostReceivedPackets", top10Received);
 
-        public Histogram ReceivedBytes { get; private set; }
-
-        public Histogram ReceivedPackets { get; private set; }
-
-        public Histogram AcceptedBytes { get; private set; }
-
-        public Histogram AcceptedPackets { get; private set; }
-
-        public Histogram DroppedBytes { get; private set; }
-
-        public Histogram DroppedPackets { get; private set; }
-
-        public Histogram TotalReceivedPacketHandlingTime { get; private set; }
-
-        public Histogram TotalSentPacketProcessingTime { get; private set; }
-
-        public NetworkMetricsController() : base(CONTEXT)
-        {
-            Clients = new Histogram(nameof(Clients), this);
-            TotalBandwidth = new Histogram(nameof(TotalBandwidth), this);
-            SentBytes = new Histogram(nameof(SentBytes), this);
-            SentPackets = new Histogram(nameof(SentPackets), this);
-            ReceivedBytes = new Histogram(nameof(ReceivedBytes), this);
-            ReceivedPackets = new Histogram(nameof(ReceivedPackets), this);
-            AcceptedBytes = new Histogram(nameof(AcceptedBytes), this);
-            AcceptedPackets = new Histogram(nameof(AcceptedPackets), this);
-            DroppedBytes = new Histogram(nameof(DroppedBytes), this);
-            DroppedPackets = new Histogram(nameof(DroppedPackets), this);
-            TotalReceivedPacketHandlingTime = new Histogram(nameof(TotalReceivedPacketHandlingTime), this);
-            TotalSentPacketProcessingTime = new Histogram(nameof(TotalSentPacketProcessingTime), this);
-
-        }
-
-        protected override IDictionary<string, object> InternalData()
-        {
-            var res = base.InternalData();
-
-            var top10Sent = PacketSender.SentPacketTypes.Where(pair => pair.Value > 0).OrderByDescending(pair => pair.Value).Take(10).ToArray();
-            var top10Received = PacketHandler.AcceptedPacketTypes.Where(pair => pair.Value > 0).OrderByDescending(pair => pair.Value).Take(10).ToArray();
-
-            res.Add("MostSentPackets", top10Sent);
-            res.Add("MostReceivedPackets", top10Received);
-
-            return res;
-        }
+        return res;
     }
 }

--- a/Intersect.Server.Core/Metrics/Controllers/ThreadingMetricsController.cs
+++ b/Intersect.Server.Core/Metrics/Controllers/ThreadingMetricsController.cs
@@ -1,85 +1,81 @@
-using System.Collections.Generic;
-using System.Threading;
+namespace Intersect.Server.Metrics.Controllers;
 
-namespace Intersect.Server.Metrics.Controllers
+public partial class ThreadingMetricsController : MetricsController
 {
-    public partial class ThreadingMetricsController : MetricsController
+    private const string CONTEXT = "Threading";
+
+    private int mMaxSystemThreadPoolThreads = 0;
+    private int mMaxSystemThreadPoolIOThreads = 0;
+    private int mMinSystemThreadPoolThreads = 0;
+    private int mMinSystemThreadPoolIOThreads = 0;
+
+    public Histogram LogicPoolActiveThreads { get; private set; }
+
+    public Histogram LogicPoolInUseThreads { get; private set; }
+
+    public Histogram LogicPoolWorkItemsCount { get; private set; }
+
+    public Histogram NetworkPoolActiveThreads { get; private set; }
+
+    public Histogram NetworkPoolInUseThreads { get; private set; }
+
+    public Histogram NetworkPoolWorkItemsCount { get; private set; }
+
+    public Histogram DatabasePoolActiveThreads { get; private set; }
+
+    public Histogram DatabasePoolInUseThreads { get; private set; }
+
+    public Histogram DatabasePoolWorkItemsCount { get; private set; }
+
+    public Histogram SystemPoolInUseWorkerThreads { get; private set; }
+
+    public Histogram SystemPoolInUseIOThreads { get; private set; }
+
+
+    public ThreadingMetricsController() : base(CONTEXT)
     {
-        private const string CONTEXT = "Threading";
+        ThreadPool.GetMaxThreads(out mMaxSystemThreadPoolThreads, out mMaxSystemThreadPoolIOThreads);
+        ThreadPool.GetMinThreads(out mMinSystemThreadPoolThreads, out mMinSystemThreadPoolIOThreads);
 
-        private int mMaxSystemThreadPoolThreads = 0;
-        private int mMaxSystemThreadPoolIOThreads = 0;
-        private int mMinSystemThreadPoolThreads = 0;
-        private int mMinSystemThreadPoolIOThreads = 0;
+        LogicPoolActiveThreads = new Histogram(nameof(LogicPoolActiveThreads), this);
+        LogicPoolInUseThreads = new Histogram(nameof(LogicPoolInUseThreads), this);
+        LogicPoolWorkItemsCount = new Histogram(nameof(LogicPoolWorkItemsCount), this);
+        NetworkPoolActiveThreads = new Histogram(nameof(NetworkPoolActiveThreads), this);
+        NetworkPoolInUseThreads = new Histogram(nameof(NetworkPoolInUseThreads), this);
+        NetworkPoolWorkItemsCount = new Histogram(nameof(NetworkPoolWorkItemsCount), this);
+        DatabasePoolActiveThreads = new Histogram(nameof(DatabasePoolActiveThreads), this);
+        DatabasePoolInUseThreads = new Histogram(nameof(DatabasePoolInUseThreads), this);
+        DatabasePoolWorkItemsCount = new Histogram(nameof(DatabasePoolWorkItemsCount), this);
+        SystemPoolInUseWorkerThreads = new Histogram(nameof(SystemPoolInUseWorkerThreads), this);
+        SystemPoolInUseIOThreads = new Histogram(nameof(SystemPoolInUseIOThreads), this);
+    }
 
-        public Histogram LogicPoolActiveThreads { get; private set; }
+    protected override IDictionary<string, object> InternalData()
+    {
+        var res = base.InternalData();
 
-        public Histogram LogicPoolInUseThreads { get; private set; }
+        res.Add("LogicPoolMaxThreads", Options.Instance.Processing.MaxLogicThreads);
+        res.Add("LogicPoolMinThreads", Options.Instance.Processing.MinLogicThreads);
 
-        public Histogram LogicPoolWorkItemsCount { get; private set; }
+        res.Add("NetworkPoolMaxThreads", Options.Instance.Processing.MaxNetworkThreads);
+        res.Add("NetworkPoolMinThreads", Options.Instance.Processing.MinNetworkThreads);
 
-        public Histogram NetworkPoolActiveThreads { get; private set; }
+        res.Add("DatabasePoolMaxThreads", Options.Instance.Processing.MaxDatabaseThreads);
+        res.Add("DatabasePoolMinThreads", Options.Instance.Processing.MinDatabaseThreads);
 
-        public Histogram NetworkPoolInUseThreads { get; private set; }
+        res.Add("SystemPoolDefaultMaxThreads", mMaxSystemThreadPoolThreads);
+        res.Add("SystemPoolDefaultMaxIOThreads", mMaxSystemThreadPoolIOThreads);
+        res.Add("SystemPoolDefaultMinThreads", mMinSystemThreadPoolThreads);
+        res.Add("SystemPoolDefaultMinIOThreads", mMinSystemThreadPoolIOThreads);
 
-        public Histogram NetworkPoolWorkItemsCount { get; private set; }
+        ThreadPool.GetMaxThreads(out int maxWorkerThreads, out int maxIOThreads);
+        ThreadPool.GetMinThreads(out int minWorkerThreads, out int minIOThreads);
 
-        public Histogram DatabasePoolActiveThreads { get; private set; }
+        res.Add("SystemPoolMaxThreads", maxWorkerThreads);
+        res.Add("SystemPoolMinThreads", minWorkerThreads);
+        res.Add("SystemPoolMaxIOThreads", maxIOThreads);
+        res.Add("SystemPoolMinIOThreads", minIOThreads);
 
-        public Histogram DatabasePoolInUseThreads { get; private set; }
-
-        public Histogram DatabasePoolWorkItemsCount { get; private set; }
-
-        public Histogram SystemPoolInUseWorkerThreads { get; private set; }
-
-        public Histogram SystemPoolInUseIOThreads { get; private set; }
-
-
-        public ThreadingMetricsController() : base(CONTEXT)
-        {
-            ThreadPool.GetMaxThreads(out mMaxSystemThreadPoolThreads, out mMaxSystemThreadPoolIOThreads);
-            ThreadPool.GetMinThreads(out mMinSystemThreadPoolThreads, out mMinSystemThreadPoolIOThreads);
-
-            LogicPoolActiveThreads = new Histogram(nameof(LogicPoolActiveThreads), this);
-            LogicPoolInUseThreads = new Histogram(nameof(LogicPoolInUseThreads), this);
-            LogicPoolWorkItemsCount = new Histogram(nameof(LogicPoolWorkItemsCount), this);
-            NetworkPoolActiveThreads = new Histogram(nameof(NetworkPoolActiveThreads), this);
-            NetworkPoolInUseThreads = new Histogram(nameof(NetworkPoolInUseThreads), this);
-            NetworkPoolWorkItemsCount = new Histogram(nameof(NetworkPoolWorkItemsCount), this);
-            DatabasePoolActiveThreads = new Histogram(nameof(DatabasePoolActiveThreads), this);
-            DatabasePoolInUseThreads = new Histogram(nameof(DatabasePoolInUseThreads), this);
-            DatabasePoolWorkItemsCount = new Histogram(nameof(DatabasePoolWorkItemsCount), this);
-            SystemPoolInUseWorkerThreads = new Histogram(nameof(SystemPoolInUseWorkerThreads), this);
-            SystemPoolInUseIOThreads = new Histogram(nameof(SystemPoolInUseIOThreads), this);
-        }
-
-        protected override IDictionary<string, object> InternalData()
-        {
-            var res = base.InternalData();
-
-            res.Add("LogicPoolMaxThreads", Options.Instance.Processing.MaxLogicThreads);
-            res.Add("LogicPoolMinThreads", Options.Instance.Processing.MinLogicThreads);
-
-            res.Add("NetworkPoolMaxThreads", Options.Instance.Processing.MaxNetworkThreads);
-            res.Add("NetworkPoolMinThreads", Options.Instance.Processing.MinNetworkThreads);
-
-            res.Add("DatabasePoolMaxThreads", Options.Instance.Processing.MaxDatabaseThreads);
-            res.Add("DatabasePoolMinThreads", Options.Instance.Processing.MinDatabaseThreads);
-
-            res.Add("SystemPoolDefaultMaxThreads", mMaxSystemThreadPoolThreads);
-            res.Add("SystemPoolDefaultMaxIOThreads", mMaxSystemThreadPoolIOThreads);
-            res.Add("SystemPoolDefaultMinThreads", mMinSystemThreadPoolThreads);
-            res.Add("SystemPoolDefaultMinIOThreads", mMinSystemThreadPoolIOThreads);
-
-            ThreadPool.GetMaxThreads(out int maxWorkerThreads, out int maxIOThreads);
-            ThreadPool.GetMinThreads(out int minWorkerThreads, out int minIOThreads);
-
-            res.Add("SystemPoolMaxThreads", maxWorkerThreads);
-            res.Add("SystemPoolMinThreads", minWorkerThreads);
-            res.Add("SystemPoolMaxIOThreads", maxIOThreads);
-            res.Add("SystemPoolMinIOThreads", minIOThreads);
-
-            return res;
-        }
+        return res;
     }
 }

--- a/Intersect.Server.Core/Metrics/Histogram.cs
+++ b/Intersect.Server.Core/Metrics/Histogram.cs
@@ -2,51 +2,50 @@
 
 using Newtonsoft.Json;
 
-namespace Intersect.Server.Metrics
+namespace Intersect.Server.Metrics;
+
+public partial class Histogram
 {
-    public partial class Histogram
+    [JsonIgnore]
+    public string Name { get; private set; }
+
+    public long Min { get; private set; }
+
+    public long Max { get; private set; }
+
+    public long Count { get; private set; }
+
+    public long Sum { get; private set; }
+
+    public double Mean => Count > 0 ? Sum / (double)Count : 0;
+
+    public Histogram(string name, MetricsController controller)
     {
-        [JsonIgnore]
-        public string Name { get; private set; }
+        Name = name;
+        controller.Measurements.Add(this);
+    }
 
-        public long Min { get; private set; }
-
-        public long Max { get; private set; }
-
-        public long Count { get; private set; }
-
-        public long Sum { get; private set; }
-
-        public double Mean => Count > 0 ? Sum / (double)Count : 0;
-
-        public Histogram(string name, MetricsController controller)
+    public void Record(long val)
+    {
+        if (val < Min || Count == 0)
         {
-            Name = name;
-            controller.Measurements.Add(this);
+            Min = val;
         }
 
-        public void Record(long val)
+        if (val > Max || Count == 0)
         {
-            if (val < Min || Count == 0)
-            {
-                Min = val;
-            }
-
-            if (val > Max || Count == 0)
-            {
-                Max = val;
-            }
-
-            Sum += val;
-            Count++;
+            Max = val;
         }
 
-        public void Clear()
-        {
-            Min = 0;
-            Max = 0;
-            Sum = 0;
-            Count = 0;
-        }
+        Sum += val;
+        Count++;
+    }
+
+    public void Clear()
+    {
+        Min = 0;
+        Max = 0;
+        Sum = 0;
+        Count = 0;
     }
 }

--- a/Intersect.Server.Core/Metrics/MetricsRoot.cs
+++ b/Intersect.Server.Core/Metrics/MetricsRoot.cs
@@ -1,100 +1,96 @@
-using System;
-using System.Collections.Generic;
-
 using Intersect.Server.Metrics.Controllers;
 using Intersect.Utilities;
 
 using Newtonsoft.Json;
 
-namespace Intersect.Server.Metrics
+namespace Intersect.Server.Metrics;
+
+public partial class MetricsRoot
 {
-    public partial class MetricsRoot
+    private const string EmptyJson = "{}";
+
+    private readonly List<MetricsController> MetricsControllers;
+
+    public GameMetricsController Game { get; private set; } = new GameMetricsController();
+
+    public ApplicationMetricsController Application { get; private set; } = new ApplicationMetricsController();
+
+    public NetworkMetricsController Network { get; private set; } = new NetworkMetricsController();
+
+    public ThreadingMetricsController Threading { get; private set; } = new ThreadingMetricsController();
+
+    public string Metrics => mLatestSnapshot == default ? EmptyJson : JsonConvert.SerializeObject(mLatestSnapshot);
+
+    private IDictionary<string, object> mLatestSnapshot;
+
+    /// <summary>
+    /// Creates and configures metric tracking for our various controllers
+    /// </summary>
+    private MetricsRoot()
     {
-        private const string EmptyJson = "{}";
-
-        private readonly List<MetricsController> MetricsControllers;
-
-        public GameMetricsController Game { get; private set; } = new GameMetricsController();
-
-        public ApplicationMetricsController Application { get; private set; } = new ApplicationMetricsController();
-
-        public NetworkMetricsController Network { get; private set; } = new NetworkMetricsController();
-
-        public ThreadingMetricsController Threading { get; private set; } = new ThreadingMetricsController();
-
-        public string Metrics => mLatestSnapshot == default ? EmptyJson : JsonConvert.SerializeObject(mLatestSnapshot);
-
-        private IDictionary<string, object> mLatestSnapshot;
-
-        /// <summary>
-        /// Creates and configures metric tracking for our various controllers
-        /// </summary>
-        private MetricsRoot()
+        MetricsControllers = new List<MetricsController>(4)
         {
-            MetricsControllers = new List<MetricsController>(4)
-            {
-                Application,
-                Game,
-                Network,
-                Threading
-            };
+            Application,
+            Game,
+            Network,
+            Threading
+        };
+    }
+
+    /// <summary>
+    /// Serverwide metrics collecting instance
+    /// </summary>
+    public static MetricsRoot Instance { get; private set; }
+
+    /// <summary>
+    /// Setup our metric counters/histograms if metrics are enabled in the server config
+    /// </summary>
+    public static void Init()
+    {
+        Console.WriteLine("Initializing metrics logger...");
+
+        Instance = new MetricsRoot();
+    }
+
+    /// <summary>
+    /// Clears our cached metrics dump so that the api returns an empty object while metrics are disabled.
+    /// </summary>
+    public void Disable()
+    {
+        mLatestSnapshot = default;
+    }
+
+    public void Capture()
+    {
+        mLatestSnapshot = Data();
+        Clear();
+    }
+
+    public void Clear()
+    {
+        for (var i = 0; i < MetricsControllers.Count; i++)
+        {
+            var controller = MetricsControllers[i];
+            controller.Clear();
+        }
+    }
+
+    private IDictionary<string, object> Data()
+    {
+        var result = new Dictionary<string, object>(MetricsControllers.Count);
+        for (var i = 0; i < MetricsControllers.Count; i++)
+        {
+            var controller = MetricsControllers[i];
+            result[controller.Context] = controller.Data();
         }
 
-        /// <summary>
-        /// Serverwide metrics collecting instance
-        /// </summary>
-        public static MetricsRoot Instance { get; private set; }
-
-        /// <summary>
-        /// Setup our metric counters/histograms if metrics are enabled in the server config
-        /// </summary>
-        public static void Init()
+        var data = new Dictionary<string, object>(3)
         {
-            Console.WriteLine("Initializing metrics logger...");
+            ["uptime"] = Timing.Global.Milliseconds,
+            ["datetime"] = DateTime.UtcNow,
+            ["metrics"] = result
+        };
 
-            Instance = new MetricsRoot();
-        }
-
-        /// <summary>
-        /// Clears our cached metrics dump so that the api returns an empty object while metrics are disabled.
-        /// </summary>
-        public void Disable()
-        {
-            mLatestSnapshot = default;
-        }
-
-        public void Capture()
-        {
-            mLatestSnapshot = Data();
-            Clear();
-        }
-
-        public void Clear()
-        {
-            for (var i = 0; i < MetricsControllers.Count; i++)
-            {
-                var controller = MetricsControllers[i];
-                controller.Clear();
-            }
-        }
-
-        private IDictionary<string, object> Data()
-        {
-            var result = new Dictionary<string, object>(MetricsControllers.Count);
-            for (var i = 0; i < MetricsControllers.Count; i++)
-            {
-                var controller = MetricsControllers[i];
-                result[controller.Context] = controller.Data();
-            }
-
-            var data = new Dictionary<string, object>(3)
-            {
-                ["uptime"] = Timing.Global.Milliseconds,
-                ["datetime"] = DateTime.UtcNow,
-                ["metrics"] = result
-            };
-
-            return data;
-        }
+        return data;
     }
 }

--- a/Intersect.Server.Core/Networking/Client.cs
+++ b/Intersect.Server.Core/Networking/Client.cs
@@ -1,5 +1,4 @@
 using System.Collections.Concurrent;
-using Amib.Threading;
 using Intersect.ErrorHandling;
 
 using Intersect.Core;
@@ -13,506 +12,504 @@ using Intersect.Server.Entities;
 using Intersect.Server.General;
 using Intersect.Server.Metrics;
 using Intersect.Utilities;
-using Microsoft.NET.StringTools;
 using Strings = Intersect.Server.Localization.Strings;
 
-namespace Intersect.Server.Networking
+namespace Intersect.Server.Networking;
+
+
+public partial class Client : IPacketSender
 {
 
-    public partial class Client : IPacketSender
+    public Guid EditorMap = Guid.Empty;
+
+    private bool _crashing;
+
+    //Client Properties
+    public bool IsEditor;
+
+    //Network Variables
+    public IConnection Connection { get; private set; }
+
+    private long mConnectionTimeout;
+
+    private long mConnectTime;
+
+    private bool mDebugPackets = false;
+
+    private int mPacketCount = 0;
+
+    private ConcurrentQueue<Tuple<IPacket, TransmissionMode, long>> mSendPacketQueue = new ConcurrentQueue<Tuple<IPacket, TransmissionMode, long>>();
+    public ConcurrentQueue<IPacket> HandlePacketQueue = new ConcurrentQueue<IPacket>();
+    public ConcurrentQueue<IPacket> RecentPackets = new ConcurrentQueue<IPacket>();
+    public bool PacketHandlingQueued = false;
+    public bool PacketSendingQueued = false;
+    public Config.FloodThreshholds PacketFloodingThreshholds { get; set; } = Options.Instance.SecurityOpts?.PacketOpts.Threshholds;
+    public long LastPing { get; set; } = -1;
+
+    protected long mTimeout = 20000; //20 seconds
+
+    private bool mBanChecked;
+
+    //Sent Maps
+    public Dictionary<Guid, Tuple<long, int>> SentMaps = new Dictionary<Guid, Tuple<long, int>>();
+
+    private Client(IApplicationContext applicationContext, INetwork network, IConnection connection = null)
     {
+        ApplicationContext = applicationContext;
+        Network = network;
 
-        public Guid EditorMap = Guid.Empty;
+        Connection = connection;
+        mConnectTime = Timing.Global.Milliseconds;
+        mConnectionTimeout = Timing.Global.Milliseconds + mTimeout;
 
-        private bool _crashing;
+        PacketSender.SendServerConfig(this);
+    }
 
-        //Client Properties
-        public bool IsEditor;
+    //Game Incorperation Variables
+    public string Name => User?.Name;
 
-        //Network Variables
-        public IConnection Connection { get; private set; }
+    public string Email => User?.Email;
 
-        private long mConnectionTimeout;
+    public Guid Id => User?.Id ?? Guid.Empty;
 
-        private long mConnectTime;
+    public string Password => User?.Password;
 
-        private bool mDebugPackets = false;
+    public string Salt => User?.Salt;
 
-        private int mPacketCount = 0;
+    public bool Banned { get; set; }
 
-        private ConcurrentQueue<Tuple<IPacket, TransmissionMode, long>> mSendPacketQueue = new ConcurrentQueue<Tuple<IPacket, TransmissionMode, long>>();
-        public ConcurrentQueue<IPacket> HandlePacketQueue = new ConcurrentQueue<IPacket>();
-        public ConcurrentQueue<IPacket> RecentPackets = new ConcurrentQueue<IPacket>();
-        public bool PacketHandlingQueued = false;
-        public bool PacketSendingQueued = false;
-        public Config.FloodThreshholds PacketFloodingThreshholds { get; set; } = Options.Instance.SecurityOpts?.PacketOpts.Threshholds;
-        public long LastPing { get; set; } = -1;
+    //Security/Flooding Variables
+    public long AccountAttempts { get; set; }
 
-        protected long mTimeout = 20000; //20 seconds
+    public long Ping => Connection.Statistics.Ping;
 
-        private bool mBanChecked;
+    /// <summary>
+    /// Number of "grace" packets that the client has remaining if speedhacking is accidentally detected.
+    /// </summary>
+    public int TimedBufferPacketsRemaining { get; set; }
 
-        //Sent Maps
-        public Dictionary<Guid, Tuple<long, int>> SentMaps = new Dictionary<Guid, Tuple<long, int>>();
+    public long TimeoutMs { get; set; }
 
-        private Client(IApplicationContext applicationContext, INetwork network, IConnection connection = null)
+    public long PacketTimer { get; set; }
+
+    public bool PacketFloodDetect { get; set; }
+
+    public long PacketCount { get; set; }
+
+    public long FloodDetects { get; set; }
+
+    public bool FloodKicked { get; set; }
+
+    public long TotalFloodDetects { get; set; }
+
+    public long LastPacketDesyncForgiven { get; set; }
+
+    public UserRights Power
+    {
+        get => User?.Power ?? UserRights.None;
+        set
         {
-            ApplicationContext = applicationContext;
-            Network = network;
+            if (User == null)
+            {
+                return;
+            }
 
-            Connection = connection;
-            mConnectTime = Timing.Global.Milliseconds;
+            User.Power = value;
+        }
+    }
+
+    public User User { get; private set; }
+
+    public List<Player> Characters => User?.Players;
+
+    public Player Entity { get; set; }
+
+    public IApplicationContext ApplicationContext { get; }
+
+    public INetwork Network { get; }
+
+    public void SetUser(User user)
+    {
+        if (user == null)
+        {
+            User?.TryLogout();
+        }
+
+        if (user != null && user != User)
+        {
+            User.Login(user, Connection?.Ip);
+        }
+
+        User = user;
+    }
+
+    public void LoadCharacter(Player character)
+    {
+        //Entity = new Player(Id, this, character);
+        Entity = character;
+
+        if (Entity == null)
+        {
+            return;
+        }
+
+        Entity.LastOnline = DateTime.Now;
+        Entity.Client = this;
+    }
+
+
+    public void Pinged()
+    {
+        if (Connection != null)
+        {
             mConnectionTimeout = Timing.Global.Milliseconds + mTimeout;
-
-            PacketSender.SendServerConfig(this);
         }
-
-        //Game Incorperation Variables
-        public string Name => User?.Name;
-
-        public string Email => User?.Email;
-
-        public Guid Id => User?.Id ?? Guid.Empty;
-
-        public string Password => User?.Password;
-
-        public string Salt => User?.Salt;
-
-        public bool Banned { get; set; }
-
-        //Security/Flooding Variables
-        public long AccountAttempts { get; set; }
-
-        public long Ping => Connection.Statistics.Ping;
-
-        /// <summary>
-        /// Number of "grace" packets that the client has remaining if speedhacking is accidentally detected.
-        /// </summary>
-        public int TimedBufferPacketsRemaining { get; set; }
-
-        public long TimeoutMs { get; set; }
-
-        public long PacketTimer { get; set; }
-
-        public bool PacketFloodDetect { get; set; }
-
-        public long PacketCount { get; set; }
-
-        public long FloodDetects { get; set; }
-
-        public bool FloodKicked { get; set; }
-
-        public long TotalFloodDetects { get; set; }
-
-        public long LastPacketDesyncForgiven { get; set; }
-
-        public UserRights Power
-        {
-            get => User?.Power ?? UserRights.None;
-            set
-            {
-                if (User == null)
-                {
-                    return;
-                }
-
-                User.Power = value;
-            }
-        }
-
-        public User User { get; private set; }
-
-        public List<Player> Characters => User?.Players;
-
-        public Player Entity { get; set; }
-
-        public IApplicationContext ApplicationContext { get; }
-
-        public INetwork Network { get; }
-
-        public void SetUser(User user)
-        {
-            if (user == null)
-            {
-                User?.TryLogout();
-            }
-
-            if (user != null && user != User)
-            {
-                User.Login(user, Connection?.Ip);
-            }
-
-            User = user;
-        }
-
-        public void LoadCharacter(Player character)
-        {
-            //Entity = new Player(Id, this, character);
-            Entity = character;
-
-            if (Entity == null)
-            {
-                return;
-            }
-
-            Entity.LastOnline = DateTime.Now;
-            Entity.Client = this;
-        }
-
-
-        public void Pinged()
-        {
-            if (Connection != null)
-            {
-                mConnectionTimeout = Timing.Global.Milliseconds + mTimeout;
-            }
-        }
-
-        public void Disconnect(string? reason = default, bool shutdown = false, bool loggingOut = false)
-        {
-            lock (Globals.ClientLock)
-            {
-                if (Connection == null)
-                {
-                    return;
-                }
-
-                if (!loggingOut)
-                {
-                    Logout(shutdown);
-                }
-
-                Globals.Clients.Remove(this);
-                Globals.ClientArray = Globals.Clients.ToArray();
-                if (Connection != default)
-                {
-                    Globals.ClientLookup.Remove(Connection.Guid);
-
-                    if (!Connection.CanDisconnect)
-                    {
-                        return;
-                    }
-                }
-
-                Connection?.Disconnect(reason);
-                Connection?.Dispose();
-                Connection = default;
-            }
-        }
-
-        public bool IsConnected()
-        {
-            return Connection?.IsConnected ?? false;
-        }
-
-        public string? Ip
-        {
-            get
-            {
-                try
-                {
-                    return Connection?.Ip;
-                }
-                catch (Exception exception)
-                {
-                    Log.Warn(exception, $"Failed to get IP for user {User.Id}");
-                    return default;
-                }
-            }
-        }
-
-        public static Client CreateBeta4Client(IApplicationContext context, INetwork network, IConnection connection)
-        {
-            var client = new Client(context, network, connection);
-            lock (Globals.ClientLock)
-            {
-                Globals.Clients.Add(client);
-                Globals.ClientArray = Globals.Clients.ToArray();
-                Globals.ClientLookup.Add(connection.Guid, client);
-            }
-
-            return client;
-        }
-
-        public void Logout(bool force = false)
-        {
-            var entity = Entity;
-            entity?.TryLogout();
-            Entity = null;
-
-            if (User != null && User.LoginTime != null)
-            {
-                User.PlayTimeSeconds += (ulong)(DateTime.UtcNow - (DateTime)User.LoginTime).TotalSeconds;
-                User.LoginTime = null;
-            }
-
-            if (!force && !IsEditor)
-            {
-                if (User?.Save() == UserSaveResult.DatabaseFailure)
-                {
-                    LogAndDisconnect(Entity?.Id ?? default, nameof(Logout));
-                    return;
-                }
-            }
-
-            SetUser(null);
-
-            Disconnect("logout", loggingOut: true);
-        }
-
-        public static void RemoveBeta4Client(IConnection connection)
-        {
-            if (connection == null)
-            {
-                return;
-            }
-
-            var client = FindBeta4Client(connection);
-            if (client == null)
-            {
-                return;
-            }
-
-            Log.Debug(
-                string.IsNullOrWhiteSpace(client.Name)
-
-                    //? $"Client disconnected ({(client.IsEditor ? "[editor]" : "[client]")})"
-                    // TODO: Transmit client information on network start so we can determine editor vs client
-                    ? $"Client disconnected ([menu])"
-                    : $"Client disconnected ({client.Name}->{client.Entity?.Name ?? "[editor]"})"
-            );
-
-            client.Disconnect();
-        }
-
-        public static Client FindBeta4Client(IConnection connection)
-        {
-            lock (Globals.ClientLock)
-            {
-                return Globals.Clients.Find(client => client?.Connection == connection);
-            }
-        }
-
-        public void FailedAttempt()
-        {
-            AccountAttempts++;
-            ResetTimeout();
-        }
-
-        public void ResetTimeout()
-        {
-            TimeoutMs = Timing.Global.Milliseconds + 5000;
-            if (AccountAttempts > 3)
-            {
-                TimeoutMs += 1000 * AccountAttempts;
-            }
-        }
-
-        public void SendPackets()
-        {
-            while (mSendPacketQueue.TryDequeue(out Tuple<IPacket, TransmissionMode, long> tuple))
-            {
-                if (Connection != null)
-                {
-                    var packet = tuple.Item1;
-                    var mode = tuple.Item2;
-
-                    try
-                    {
-                        if (packet is AbstractTimedPacket timedPacket)
-                        {
-                            timedPacket.UpdateTiming();
-                        }
-                        Connection?.Send(packet, mode);
-                        if (Options.Instance.Metrics.Enable)
-                        {
-                            if (!PacketSender.SentPacketTypes.ContainsKey(packet.GetType().Name))
-                            {
-                                PacketSender.SentPacketTypes.TryAdd(packet.GetType().Name, 0);
-                            }
-                            PacketSender.SentPacketTypes[packet.GetType().Name]++;
-                            PacketSender.SentPackets++;
-                            PacketSender.SentBytes += packet.Data.Length;
-                            MetricsRoot.Instance.Network.TotalSentPacketProcessingTime.Record(Timing.Global.Milliseconds - tuple.Item3);
-                        }
-                    }
-                    catch (Exception exception)
-                    {
-                        var packetType = packet.GetType().Name;
-                        var packetMessage =
-                            $"Sending Packet Error! [Packet: {packetType} | User: {this.Name ?? ""} | Player: {this.Entity?.Name ?? ""} | IP {this.Ip}]";
-
-                        // TODO: Re-combine these once we figure out how to prevent the OutOfMemoryException that happens occasionally
-                        Log.Error(packetMessage);
-                        Log.Error(new ExceptionInfo(exception));
-                        if (exception.InnerException != null)
-                        {
-                            Log.Error(new ExceptionInfo(exception.InnerException));
-                        }
-
-                        // Make the call that triggered the OOME in the first place so that we know when it stops happening
-                        Log.Error(exception, packetMessage);
-
-#if DIAGNOSTIC
-                            this.Disconnect($"Error processing packet type '{packetType}'.");
-#else
-                        this.Disconnect($"Error sending packet.");
-#endif
-                        break;
-                    }
-                }
-            }
-            lock (mSendPacketQueue)
-            {
-                PacketSendingQueued = false;
-            }
-        }
-
-        public void HandlePackets()
-        {
-            if (_crashing)
-            {
-                return;
-            }
-
-            var banned = false;
-            if (Connection != null)
-            {
-                if (!mBanChecked)
-                {
-                    if (string.IsNullOrEmpty(Connection?.Ip))
-                    {
-                        banned = true;
-                    }
-                    if (!banned && !string.IsNullOrEmpty(Database.PlayerData.Ban.CheckBan(Connection.Ip.Trim())) && Options.Instance.SecurityOpts.CheckIp(Connection.Ip.Trim()))
-                    {
-                        banned = true;
-                    }
-                    if (banned)
-                    {
-                        Disconnect("Banned");
-                    }
-
-                    mBanChecked = true;
-                }
-
-                if (banned)
-                {
-                    return;
-                }
-
-                while (HandlePacketQueue.TryDequeue(out IPacket packet))
-                {
-                    if (_crashing)
-                    {
-                        return;
-                    }
-
-                    if (Connection == null)
-                    {
-                        continue;
-                    }
-
-                    try
-                    {
-                        PacketHandler.Instance.ProcessPacket(packet, this);
-                        if (Options.Instance.Metrics.Enable)
-                        {
-                            MetricsRoot.Instance.Network.TotalReceivedPacketHandlingTime.Record(
-                                Timing.Global.Milliseconds - packet.ReceiveTime
-                            );
-                        }
-                    }
-                    catch (Exception exception)
-                    {
-                        var packetType = packet.GetType().Name;
-                        var packetMessage =
-                            $"Client Packet Error! [Packet: {packetType} | User: {this.Name ?? ""} | Player: {this.Entity?.Name ?? ""} | IP {this.Ip}]";
-
-                        // TODO: Re-combine these once we figure out how to prevent the OutOfMemoryException that happens occasionally
-                        Log.Error(packetMessage);
-                        Log.Error(new ExceptionInfo(exception));
-                        if (exception.InnerException != null)
-                        {
-                            Log.Error(new ExceptionInfo(exception.InnerException));
-                        }
-
-                        // Make the call that triggered the OOME in the first place so that we know when it stops happening
-                        Log.Error(exception, packetMessage);
-
-#if DIAGNOSTIC
-                            this.Disconnect($"Error processing packet type '{packetType}'.");
-#else
-                        this.Disconnect($"Error processing packet.");
-#endif
-                        break;
-                    }
-                }
-            }
-            lock (HandlePacketQueue)
-            {
-                PacketHandlingQueued = false;
-            }
-        }
-
-        public async Task LogAndDisconnect(Guid? playerId, string? meta = default)
-        {
-            _crashing = true;
-            HandlePacketQueue.Clear();
-
-            var history = await UserActivityHistory.LogActivityAsync(
-                User?.Id ?? default,
-                playerId ?? Entity?.Id ?? default,
-                Ip,
-                IsEditor ? UserActivityHistory.PeerType.Editor : UserActivityHistory.PeerType.Client,
-                UserActivityHistory.UserAction.DisconnectDatabaseFailure,
-                meta
-            );
-
-            var message = history?.Id.ToString();
-            if (message == default)
-            {
-                Log.Error($"Failed to record crash for {User?.Id.ToString() ?? "N/A"}");
-            }
-
-            Disconnect(message ?? Strings.Networking.ServerFull, loggingOut: true);
-        }
-
-        #region Implementation of IPacketSender
-
-        /// <inheritdoc />
-        public bool Send(IPacket packet) => Send(packet, TransmissionMode.All);
-
-        /// <inheritdoc />
-        public bool Send(IPacket packet, TransmissionMode mode)
+    }
+
+    public void Disconnect(string? reason = default, bool shutdown = false, bool loggingOut = false)
+    {
+        lock (Globals.ClientLock)
         {
             if (Connection == null)
             {
-                return false;
+                return;
             }
 
-            if (packet == default)
+            if (!loggingOut)
             {
-                return false;
+                Logout(shutdown);
             }
 
-            mSendPacketQueue.Enqueue(new Tuple<IPacket, TransmissionMode, long>(packet, mode, Timing.Global.Milliseconds));
-            lock (mSendPacketQueue)
+            Globals.Clients.Remove(this);
+            Globals.ClientArray = Globals.Clients.ToArray();
+            if (Connection != default)
             {
-                if (PacketSendingQueued)
+                Globals.ClientLookup.Remove(Connection.Guid);
+
+                if (!Connection.CanDisconnect)
                 {
-                    return true;
+                    return;
                 }
-
-                PacketSendingQueued = true;
-                EnqueueNetworkTask.Invoke(SendPackets);
             }
 
-            return true;
+            Connection?.Disconnect(reason);
+            Connection?.Dispose();
+            Connection = default;
+        }
+    }
+
+    public bool IsConnected()
+    {
+        return Connection?.IsConnected ?? false;
+    }
+
+    public string? Ip
+    {
+        get
+        {
+            try
+            {
+                return Connection?.Ip;
+            }
+            catch (Exception exception)
+            {
+                Log.Warn(exception, $"Failed to get IP for user {User.Id}");
+                return default;
+            }
+        }
+    }
+
+    public static Client CreateBeta4Client(IApplicationContext context, INetwork network, IConnection connection)
+    {
+        var client = new Client(context, network, connection);
+        lock (Globals.ClientLock)
+        {
+            Globals.Clients.Add(client);
+            Globals.ClientArray = Globals.Clients.ToArray();
+            Globals.ClientLookup.Add(connection.Guid, client);
         }
 
-        #endregion
-
-        public static Action<Action> EnqueueNetworkTask { get; set; } = action => action();
+        return client;
     }
+
+    public void Logout(bool force = false)
+    {
+        var entity = Entity;
+        entity?.TryLogout();
+        Entity = null;
+
+        if (User != null && User.LoginTime != null)
+        {
+            User.PlayTimeSeconds += (ulong)(DateTime.UtcNow - (DateTime)User.LoginTime).TotalSeconds;
+            User.LoginTime = null;
+        }
+
+        if (!force && !IsEditor)
+        {
+            if (User?.Save() == UserSaveResult.DatabaseFailure)
+            {
+                LogAndDisconnect(Entity?.Id ?? default, nameof(Logout));
+                return;
+            }
+        }
+
+        SetUser(null);
+
+        Disconnect("logout", loggingOut: true);
+    }
+
+    public static void RemoveBeta4Client(IConnection connection)
+    {
+        if (connection == null)
+        {
+            return;
+        }
+
+        var client = FindBeta4Client(connection);
+        if (client == null)
+        {
+            return;
+        }
+
+        Log.Debug(
+            string.IsNullOrWhiteSpace(client.Name)
+
+                //? $"Client disconnected ({(client.IsEditor ? "[editor]" : "[client]")})"
+                // TODO: Transmit client information on network start so we can determine editor vs client
+                ? $"Client disconnected ([menu])"
+                : $"Client disconnected ({client.Name}->{client.Entity?.Name ?? "[editor]"})"
+        );
+
+        client.Disconnect();
+    }
+
+    public static Client FindBeta4Client(IConnection connection)
+    {
+        lock (Globals.ClientLock)
+        {
+            return Globals.Clients.Find(client => client?.Connection == connection);
+        }
+    }
+
+    public void FailedAttempt()
+    {
+        AccountAttempts++;
+        ResetTimeout();
+    }
+
+    public void ResetTimeout()
+    {
+        TimeoutMs = Timing.Global.Milliseconds + 5000;
+        if (AccountAttempts > 3)
+        {
+            TimeoutMs += 1000 * AccountAttempts;
+        }
+    }
+
+    public void SendPackets()
+    {
+        while (mSendPacketQueue.TryDequeue(out Tuple<IPacket, TransmissionMode, long> tuple))
+        {
+            if (Connection != null)
+            {
+                var packet = tuple.Item1;
+                var mode = tuple.Item2;
+
+                try
+                {
+                    if (packet is AbstractTimedPacket timedPacket)
+                    {
+                        timedPacket.UpdateTiming();
+                    }
+                    Connection?.Send(packet, mode);
+                    if (Options.Instance.Metrics.Enable)
+                    {
+                        if (!PacketSender.SentPacketTypes.ContainsKey(packet.GetType().Name))
+                        {
+                            PacketSender.SentPacketTypes.TryAdd(packet.GetType().Name, 0);
+                        }
+                        PacketSender.SentPacketTypes[packet.GetType().Name]++;
+                        PacketSender.SentPackets++;
+                        PacketSender.SentBytes += packet.Data.Length;
+                        MetricsRoot.Instance.Network.TotalSentPacketProcessingTime.Record(Timing.Global.Milliseconds - tuple.Item3);
+                    }
+                }
+                catch (Exception exception)
+                {
+                    var packetType = packet.GetType().Name;
+                    var packetMessage =
+                        $"Sending Packet Error! [Packet: {packetType} | User: {this.Name ?? ""} | Player: {this.Entity?.Name ?? ""} | IP {this.Ip}]";
+
+                    // TODO: Re-combine these once we figure out how to prevent the OutOfMemoryException that happens occasionally
+                    Log.Error(packetMessage);
+                    Log.Error(new ExceptionInfo(exception));
+                    if (exception.InnerException != null)
+                    {
+                        Log.Error(new ExceptionInfo(exception.InnerException));
+                    }
+
+                    // Make the call that triggered the OOME in the first place so that we know when it stops happening
+                    Log.Error(exception, packetMessage);
+
+#if DIAGNOSTIC
+                        this.Disconnect($"Error processing packet type '{packetType}'.");
+#else
+                    this.Disconnect($"Error sending packet.");
+#endif
+                    break;
+                }
+            }
+        }
+        lock (mSendPacketQueue)
+        {
+            PacketSendingQueued = false;
+        }
+    }
+
+    public void HandlePackets()
+    {
+        if (_crashing)
+        {
+            return;
+        }
+
+        var banned = false;
+        if (Connection != null)
+        {
+            if (!mBanChecked)
+            {
+                if (string.IsNullOrEmpty(Connection?.Ip))
+                {
+                    banned = true;
+                }
+                if (!banned && !string.IsNullOrEmpty(Database.PlayerData.Ban.CheckBan(Connection.Ip.Trim())) && Options.Instance.SecurityOpts.CheckIp(Connection.Ip.Trim()))
+                {
+                    banned = true;
+                }
+                if (banned)
+                {
+                    Disconnect("Banned");
+                }
+
+                mBanChecked = true;
+            }
+
+            if (banned)
+            {
+                return;
+            }
+
+            while (HandlePacketQueue.TryDequeue(out IPacket packet))
+            {
+                if (_crashing)
+                {
+                    return;
+                }
+
+                if (Connection == null)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    PacketHandler.Instance.ProcessPacket(packet, this);
+                    if (Options.Instance.Metrics.Enable)
+                    {
+                        MetricsRoot.Instance.Network.TotalReceivedPacketHandlingTime.Record(
+                            Timing.Global.Milliseconds - packet.ReceiveTime
+                        );
+                    }
+                }
+                catch (Exception exception)
+                {
+                    var packetType = packet.GetType().Name;
+                    var packetMessage =
+                        $"Client Packet Error! [Packet: {packetType} | User: {this.Name ?? ""} | Player: {this.Entity?.Name ?? ""} | IP {this.Ip}]";
+
+                    // TODO: Re-combine these once we figure out how to prevent the OutOfMemoryException that happens occasionally
+                    Log.Error(packetMessage);
+                    Log.Error(new ExceptionInfo(exception));
+                    if (exception.InnerException != null)
+                    {
+                        Log.Error(new ExceptionInfo(exception.InnerException));
+                    }
+
+                    // Make the call that triggered the OOME in the first place so that we know when it stops happening
+                    Log.Error(exception, packetMessage);
+
+#if DIAGNOSTIC
+                        this.Disconnect($"Error processing packet type '{packetType}'.");
+#else
+                    this.Disconnect($"Error processing packet.");
+#endif
+                    break;
+                }
+            }
+        }
+        lock (HandlePacketQueue)
+        {
+            PacketHandlingQueued = false;
+        }
+    }
+
+    public async Task LogAndDisconnect(Guid? playerId, string? meta = default)
+    {
+        _crashing = true;
+        HandlePacketQueue.Clear();
+
+        var history = await UserActivityHistory.LogActivityAsync(
+            User?.Id ?? default,
+            playerId ?? Entity?.Id ?? default,
+            Ip,
+            IsEditor ? UserActivityHistory.PeerType.Editor : UserActivityHistory.PeerType.Client,
+            UserActivityHistory.UserAction.DisconnectDatabaseFailure,
+            meta
+        );
+
+        var message = history?.Id.ToString();
+        if (message == default)
+        {
+            Log.Error($"Failed to record crash for {User?.Id.ToString() ?? "N/A"}");
+        }
+
+        Disconnect(message ?? Strings.Networking.ServerFull, loggingOut: true);
+    }
+
+    #region Implementation of IPacketSender
+
+    /// <inheritdoc />
+    public bool Send(IPacket packet) => Send(packet, TransmissionMode.All);
+
+    /// <inheritdoc />
+    public bool Send(IPacket packet, TransmissionMode mode)
+    {
+        if (Connection == null)
+        {
+            return false;
+        }
+
+        if (packet == default)
+        {
+            return false;
+        }
+
+        mSendPacketQueue.Enqueue(new Tuple<IPacket, TransmissionMode, long>(packet, mode, Timing.Global.Milliseconds));
+        lock (mSendPacketQueue)
+        {
+            if (PacketSendingQueued)
+            {
+                return true;
+            }
+
+            PacketSendingQueued = true;
+            EnqueueNetworkTask.Invoke(SendPackets);
+        }
+
+        return true;
+    }
+
+    #endregion
+
+    public static Action<Action> EnqueueNetworkTask { get; set; } = action => action();
 }

--- a/Intersect.Server.Core/Networking/PacketHandler.cs
+++ b/Intersect.Server.Core/Networking/PacketHandler.cs
@@ -28,93 +28,110 @@ using PartyInvitePacket = Intersect.Network.Packets.Client.PartyInvitePacket;
 using PingPacket = Intersect.Network.Packets.Client.PingPacket;
 using TradeRequestPacket = Intersect.Network.Packets.Client.TradeRequestPacket;
 
-namespace Intersect.Server.Networking
+namespace Intersect.Server.Networking;
+
+internal sealed partial class PacketHandler
 {
-    internal sealed partial class PacketHandler
+    public IServerContext Context { get; }
+
+    public Logger Logger => Context.Logger;
+
+    public PacketHandlerRegistry Registry { get; }
+
+    public static PacketHandler Instance { get; private set; }
+
+    public static long ReceivedBytes => AcceptedBytes + DroppedBytes;
+
+    public static long ReceivedPackets => AcceptedPackets + DroppedPackets;
+
+    public static ConcurrentDictionary<string, long> AcceptedPacketTypes = new ConcurrentDictionary<string, long>();
+
+    public static long AcceptedBytes { get; set; }
+
+    public static long DroppedBytes { get; set; }
+
+    public static long AcceptedPackets { get; set; }
+
+    public static long DroppedPackets { get; set; }
+
+    public static void ResetMetrics()
     {
-        public IServerContext Context { get; }
+        AcceptedBytes = 0;
+        AcceptedPackets = 0;
+        DroppedBytes = 0;
+        DroppedPackets = 0;
+    }
 
-        public Logger Logger => Context.Logger;
+    public PacketHandler(IServerContext context, PacketHandlerRegistry packetHandlerRegistry)
+    {
+        Context = context ?? throw new ArgumentNullException(nameof(context));
+        Registry = packetHandlerRegistry ?? throw new ArgumentNullException(nameof(packetHandlerRegistry));
 
-        public PacketHandlerRegistry Registry { get; }
-
-        public static PacketHandler Instance { get; private set; }
-
-        public static long ReceivedBytes => AcceptedBytes + DroppedBytes;
-
-        public static long ReceivedPackets => AcceptedPackets + DroppedPackets;
-
-        public static ConcurrentDictionary<string, long> AcceptedPacketTypes = new ConcurrentDictionary<string, long>();
-
-        public static long AcceptedBytes { get; set; }
-
-        public static long DroppedBytes { get; set; }
-
-        public static long AcceptedPackets { get; set; }
-
-        public static long DroppedPackets { get; set; }
-
-        public static void ResetMetrics()
+        if (!Registry.TryRegisterAvailableMethodHandlers(GetType(), this, false) || Registry.IsEmpty)
         {
-            AcceptedBytes = 0;
-            AcceptedPackets = 0;
-            DroppedBytes = 0;
-            DroppedPackets = 0;
+            throw new InvalidOperationException("Failed to register method handlers, see logs for more details.");
         }
 
-        public PacketHandler(IServerContext context, PacketHandlerRegistry packetHandlerRegistry)
+        if (!Registry.TryRegisterAvailableTypeHandlers(GetType().Assembly))
         {
-            Context = context ?? throw new ArgumentNullException(nameof(context));
-            Registry = packetHandlerRegistry ?? throw new ArgumentNullException(nameof(packetHandlerRegistry));
-
-            if (!Registry.TryRegisterAvailableMethodHandlers(GetType(), this, false) || Registry.IsEmpty)
-            {
-                throw new InvalidOperationException("Failed to register method handlers, see logs for more details.");
-            }
-
-            if (!Registry.TryRegisterAvailableTypeHandlers(GetType().Assembly))
-            {
-                throw new InvalidOperationException("Failed to register type handlers, see logs for more details.");
-            }
-
-            Instance = this;
+            throw new InvalidOperationException("Failed to register type handlers, see logs for more details.");
         }
 
-        public bool PreProcessPacket(IConnection connection, long pSize)
+        Instance = this;
+    }
+
+    public bool PreProcessPacket(IConnection connection, long pSize)
+    {
+        if (ShouldAcceptPacket(connection, pSize))
         {
-            if (ShouldAcceptPacket(connection, pSize))
-            {
-                AcceptedPackets++;
-                AcceptedBytes += pSize;
-                return true;
-            }
-            DroppedPackets++;
-            DroppedBytes += pSize;
+            AcceptedPackets++;
+            AcceptedBytes += pSize;
+            return true;
+        }
+        DroppedPackets++;
+        DroppedBytes += pSize;
+        return false;
+    }
+
+    public bool ShouldAcceptPacket(IConnection connection, long pSize)
+    {
+        var client = Client.FindBeta4Client(connection);
+        if (client == null)
+        {
             return false;
         }
 
-        public bool ShouldAcceptPacket(IConnection connection, long pSize)
+        if (client.Banned || client.FloodKicked)
         {
-            var client = Client.FindBeta4Client(connection);
-            if (client == null)
-            {
-                return false;
-            }
+            return false;
+        }
 
-            if (client.Banned || client.FloodKicked)
-            {
-                return false;
-            }
-
-            var packetOptions = Options.Instance.SecurityOpts?.PacketOpts;
-            var thresholds = client.PacketFloodingThreshholds;
+        var packetOptions = Options.Instance.SecurityOpts?.PacketOpts;
+        var thresholds = client.PacketFloodingThreshholds;
 
 
-            if (pSize > thresholds.MaxPacketSize)
+        if (pSize > thresholds.MaxPacketSize)
+        {
+            Log.Error(
+                Strings.Errors.floodsize.ToString(
+                    pSize, client?.User?.Name ?? "", client?.Entity?.Name ?? "", client.Ip
+                )
+            );
+
+            client.FloodKicked = true;
+            client.Disconnect("Flooding detected.");
+
+            return false;
+        }
+
+        if (client.PacketTimer > Timing.Global.Milliseconds)
+        {
+            client.PacketCount++;
+            if (client.PacketCount > thresholds.MaxPacketPerSec)
             {
                 Log.Error(
-                    Strings.Errors.floodsize.ToString(
-                        pSize, client?.User?.Name ?? "", client?.Entity?.Name ?? "", client.Ip
+                    Strings.Errors.floodburst.ToString(
+                        client.PacketCount, client?.User?.Name ?? "", client?.Entity?.Name ?? "", client.Ip
                     )
                 );
 
@@ -123,2831 +140,2813 @@ namespace Intersect.Server.Networking
 
                 return false;
             }
-
-            if (client.PacketTimer > Timing.Global.Milliseconds)
+            else if (client.PacketCount > thresholds.KickAvgPacketPerSec && !client.PacketFloodDetect)
             {
-                client.PacketCount++;
-                if (client.PacketCount > thresholds.MaxPacketPerSec)
+                client.FloodDetects++;
+                client.TotalFloodDetects++;
+                client.PacketFloodDetect = true;
+
+                if (client.FloodDetects > 3)
                 {
-                    Log.Error(
-                        Strings.Errors.floodburst.ToString(
-                            client.PacketCount, client?.User?.Name ?? "", client?.Entity?.Name ?? "", client.Ip
-                        )
-                    );
+                    //Log.Error(
+                    //    Strings.Errors.floodaverage.ToString(
+                    //        client.TotalFloodDetects, client?.User?.Name ?? "", client?.Entity?.Name ?? "",
+                    //        client.GetIp()
+                    //    )
+                    //);
 
                     client.FloodKicked = true;
                     client.Disconnect("Flooding detected.");
 
                     return false;
                 }
-                else if (client.PacketCount > thresholds.KickAvgPacketPerSec && !client.PacketFloodDetect)
+
+                //TODO: Make this check a rolling average somehow to prevent constant flooding right below the threshholds.
+                if (client.TotalFloodDetects > 10)
                 {
-                    client.FloodDetects++;
-                    client.TotalFloodDetects++;
-                    client.PacketFloodDetect = true;
-
-                    if (client.FloodDetects > 3)
-                    {
-                        //Log.Error(
-                        //    Strings.Errors.floodaverage.ToString(
-                        //        client.TotalFloodDetects, client?.User?.Name ?? "", client?.Entity?.Name ?? "",
-                        //        client.GetIp()
-                        //    )
-                        //);
-
-                        client.FloodKicked = true;
-                        client.Disconnect("Flooding detected.");
-
-                        return false;
-                    }
-
-                    //TODO: Make this check a rolling average somehow to prevent constant flooding right below the threshholds.
-                    if (client.TotalFloodDetects > 10)
-                    {
-                        //Log.Error(string.Format("[Flood]: Total Detections: {00} [User: {01} | Player: {02} | IP {03}]", client.TotalFloodDetects, client?.User?.Name ?? "", client?.Entity?.Name ?? "", client.GetIp()));
-                        //client.Disconnect("Flooding detected.");
-                        //return false;
-                    }
-                }
-                else if (client.PacketCount < thresholds.KickAvgPacketPerSec / 2)
-                {
-                    if (client.FloodDetects > 1)
-                    {
-                        client.FloodDetects--;
-                    }
+                    //Log.Error(string.Format("[Flood]: Total Detections: {00} [User: {01} | Player: {02} | IP {03}]", client.TotalFloodDetects, client?.User?.Name ?? "", client?.Entity?.Name ?? "", client.GetIp()));
+                    //client.Disconnect("Flooding detected.");
+                    //return false;
                 }
             }
-            else
+            else if (client.PacketCount < thresholds.KickAvgPacketPerSec / 2)
             {
-                if (client.PacketFloodDetect)
+                if (client.FloodDetects > 1)
                 {
-                    Log.Diagnostic(string.Format("Possible Flood Detected: Packets in last second {00} [User: {01} | Player: {02} | IP {03}]", client.PacketCount, client?.User?.Name ?? "", client?.Entity?.Name ?? "", client.Ip));
+                    client.FloodDetects--;
                 }
-
-                client.PacketCount = 0;
-                client.PacketTimer = Timing.Global.Milliseconds + 1000;
-                client.PacketFloodDetect = false;
+            }
+        }
+        else
+        {
+            if (client.PacketFloodDetect)
+            {
+                Log.Diagnostic(string.Format("Possible Flood Detected: Packets in last second {00} [User: {01} | Player: {02} | IP {03}]", client.PacketCount, client?.User?.Name ?? "", client?.Entity?.Name ?? "", client.Ip));
             }
 
-            return true;
+            client.PacketCount = 0;
+            client.PacketTimer = Timing.Global.Milliseconds + 1000;
+            client.PacketFloodDetect = false;
         }
 
-        public bool HandlePacket(IConnection connection, IPacket packet)
+        return true;
+    }
+
+    public bool HandlePacket(IConnection connection, IPacket packet)
+    {
+        packet.ReceiveTime = Timing.Global.Milliseconds;
+
+        var client = Client.FindBeta4Client(connection);
+        if (client == null)
         {
-            packet.ReceiveTime = Timing.Global.Milliseconds;
+            Log.Error("Client was null when packet was being handled.");
+            return false;
+        }
 
-            var client = Client.FindBeta4Client(connection);
-            if (client == null)
-            {
-                Log.Error("Client was null when packet was being handled.");
+        while (client.RecentPackets.Count > 75)
+        {
+            client.RecentPackets.TryDequeue(out IPacket pkt);
+        }
+
+        client.RecentPackets.Enqueue(packet);
+
+        if (client.Banned)
+        {
+            return false;
+        }
+
+        switch (packet)
+        {
+            case Network.Packets.EditorPacket _ when !client.IsEditor:
                 return false;
-            }
 
-            while (client.RecentPackets.Count > 75)
-            {
-                client.RecentPackets.TryDequeue(out IPacket pkt);
-            }
-
-            client.RecentPackets.Enqueue(packet);
-
-            if (client.Banned)
-            {
-                return false;
-            }
-
-            switch (packet)
-            {
-                case Network.Packets.EditorPacket _ when !client.IsEditor:
-                    return false;
-
-                case null:
-                    Log.Error($@"Received null packet from {client.Id} ({client.Name}).");
-                    client.Disconnect("Error processing packet.");
-
-                    return true;
-            }
-
-            if (!packet.IsValid)
-            {
-                return false;
-            }
-
-            try
-            {
-                var sanitizedFields = packet.Sanitize();
-                if (sanitizedFields != null)
-                {
-                    var sanitizationBuilder = new StringBuilder(256, 8192);
-                    sanitizationBuilder.Append("Received out-of-bounds values in '");
-                    sanitizationBuilder.Append(packet.GetType().Name);
-                    sanitizationBuilder.Append("' packet from '");
-                    sanitizationBuilder.Append(client.Ip);
-                    sanitizationBuilder.Append("', '");
-                    sanitizationBuilder.Append(client.Name);
-                    sanitizationBuilder.AppendLine("': ");
-
-                    foreach (var field in sanitizedFields)
-                    {
-                        sanitizationBuilder.Append(field.Key);
-                        sanitizationBuilder.Append(" = ");
-                        sanitizationBuilder.Append(field.Value.Before);
-                        sanitizationBuilder.Append(" => ");
-                        sanitizationBuilder.Append(field.Value.After);
-                        sanitizationBuilder.AppendLine();
-                    }
-
-                    Log.Warn(sanitizationBuilder.ToString());
-                }
-            }
-            catch (Exception exception)
-            {
-                Log.Error(
-                    $"Client Packet Error! [Packet: {packet.GetType().Name} | User: {client.Name ?? ""} | Player: {client.Entity?.Name ?? ""} | IP {client.Ip}]"
-                );
-
-                Log.Error(exception);
+            case null:
+                Log.Error($@"Received null packet from {client.Id} ({client.Name}).");
                 client.Disconnect("Error processing packet.");
 
-                return false;
+                return true;
+        }
+
+        if (!packet.IsValid)
+        {
+            return false;
+        }
+
+        try
+        {
+            var sanitizedFields = packet.Sanitize();
+            if (sanitizedFields != null)
+            {
+                var sanitizationBuilder = new StringBuilder(256, 8192);
+                sanitizationBuilder.Append("Received out-of-bounds values in '");
+                sanitizationBuilder.Append(packet.GetType().Name);
+                sanitizationBuilder.Append("' packet from '");
+                sanitizationBuilder.Append(client.Ip);
+                sanitizationBuilder.Append("', '");
+                sanitizationBuilder.Append(client.Name);
+                sanitizationBuilder.AppendLine("': ");
+
+                foreach (var field in sanitizedFields)
+                {
+                    sanitizationBuilder.Append(field.Key);
+                    sanitizationBuilder.Append(" = ");
+                    sanitizationBuilder.Append(field.Value.Before);
+                    sanitizationBuilder.Append(" => ");
+                    sanitizationBuilder.Append(field.Value.After);
+                    sanitizationBuilder.AppendLine();
+                }
+
+                Log.Warn(sanitizationBuilder.ToString());
+            }
+        }
+        catch (Exception exception)
+        {
+            Log.Error(
+                $"Client Packet Error! [Packet: {packet.GetType().Name} | User: {client.Name ?? ""} | Player: {client.Entity?.Name ?? ""} | IP {client.Ip}]"
+            );
+
+            Log.Error(exception);
+            client.Disconnect("Error processing packet.");
+
+            return false;
+        }
+
+        if (packet is AbstractTimedPacket timedPacket)
+        {
+            var ping = connection.Statistics.Ping;
+
+            var localAdjusted = Timing.Global.Ticks;
+            var localAdjustedMs = localAdjusted / TimeSpan.TicksPerMillisecond;
+            var localOffsetMs = Timing.Global.MillisecondsOffset;
+            var localUtcMs = localOffsetMs + localAdjustedMs;
+
+            var remoteAdjusted = timedPacket.Adjusted;
+            var remoteAdjustedMs = remoteAdjusted / TimeSpan.TicksPerMillisecond;
+            var remoteUtcMs = timedPacket.UTC / TimeSpan.TicksPerMillisecond;
+            var remoteOffsetMs = timedPacket.Offset / TimeSpan.TicksPerMillisecond;
+
+            var deltaAdjusted = localAdjustedMs - remoteAdjustedMs;
+            var deltaWithPing = deltaAdjusted - ping;
+
+            var configurableMininumPing = Options.Instance.SecurityOpts.PacketOpts.MinimumPing;
+            var configurableErrorMarginFactor = Options.Instance.SecurityOpts.PacketOpts.ErrorMarginFactor;
+            var configurableNaturalLowerMargin = Options.Instance.SecurityOpts.PacketOpts.NaturalLowerMargin;
+            var configurableNaturalUpperMargin = Options.Instance.SecurityOpts.PacketOpts.NaturalUpperMargin;
+            var configurableAllowedSpikePackets = Options.Instance.SecurityOpts.PacketOpts.AllowedSpikePackets;
+            var configurableBaseDesyncForgiveness = Options.Instance.SecurityOpts.PacketOpts.BaseDesyncForegiveness;
+            var configurablePingDesyncForgivenessFactor =
+                Options.Instance.SecurityOpts.PacketOpts.DesyncForgivenessFactor;
+
+            var configurablePacketDesyncForgivenessInternal =
+                Options.Instance.SecurityOpts.PacketOpts.DesyncForgivenessInterval;
+
+            var errorMargin = Math.Max(ping, configurableMininumPing) * configurableErrorMarginFactor;
+            var errorRangeMinimum = ping - errorMargin;
+            var errorRangeMaximum = ping + errorMargin;
+
+            var deltaWithErrorMinimum = deltaAdjusted - errorRangeMinimum;
+            var deltaWithErrorMaximum = deltaAdjusted - errorRangeMaximum;
+
+            var natural = configurableNaturalLowerMargin < deltaAdjusted &&
+                          deltaAdjusted < configurableNaturalUpperMargin;
+
+            var naturalWithErrorMinimum = configurableNaturalLowerMargin < deltaWithErrorMinimum &&
+                                          deltaWithErrorMinimum < configurableNaturalUpperMargin;
+
+            var naturalWithErrorMaximum = configurableNaturalLowerMargin < deltaWithErrorMaximum &&
+                                          deltaWithErrorMaximum < configurableNaturalUpperMargin;
+
+            var naturalWithPing = configurableNaturalLowerMargin < deltaWithPing &&
+                                  deltaWithPing < configurableNaturalUpperMargin;
+
+            var adjustedDesync = Math.Abs(deltaAdjusted);
+            var timeDesync = adjustedDesync >
+                             configurableBaseDesyncForgiveness +
+                             errorRangeMaximum * configurablePingDesyncForgivenessFactor;
+
+            if (timeDesync && Timing.Global.MillisecondsUtc > client.LastPacketDesyncForgiven)
+            {
+                client.LastPacketDesyncForgiven =
+                    Timing.Global.MillisecondsUtc + configurablePacketDesyncForgivenessInternal;
+
+                PacketSender.SendPing(client, false);
+                timeDesync = false;
             }
 
-            if (packet is AbstractTimedPacket timedPacket)
-            {
-                var ping = connection.Statistics.Ping;
-
-                var localAdjusted = Timing.Global.Ticks;
-                var localAdjustedMs = localAdjusted / TimeSpan.TicksPerMillisecond;
-                var localOffsetMs = Timing.Global.MillisecondsOffset;
-                var localUtcMs = localOffsetMs + localAdjustedMs;
-
-                var remoteAdjusted = timedPacket.Adjusted;
-                var remoteAdjustedMs = remoteAdjusted / TimeSpan.TicksPerMillisecond;
-                var remoteUtcMs = timedPacket.UTC / TimeSpan.TicksPerMillisecond;
-                var remoteOffsetMs = timedPacket.Offset / TimeSpan.TicksPerMillisecond;
-
-                var deltaAdjusted = localAdjustedMs - remoteAdjustedMs;
-                var deltaWithPing = deltaAdjusted - ping;
-
-                var configurableMininumPing = Options.Instance.SecurityOpts.PacketOpts.MinimumPing;
-                var configurableErrorMarginFactor = Options.Instance.SecurityOpts.PacketOpts.ErrorMarginFactor;
-                var configurableNaturalLowerMargin = Options.Instance.SecurityOpts.PacketOpts.NaturalLowerMargin;
-                var configurableNaturalUpperMargin = Options.Instance.SecurityOpts.PacketOpts.NaturalUpperMargin;
-                var configurableAllowedSpikePackets = Options.Instance.SecurityOpts.PacketOpts.AllowedSpikePackets;
-                var configurableBaseDesyncForgiveness = Options.Instance.SecurityOpts.PacketOpts.BaseDesyncForegiveness;
-                var configurablePingDesyncForgivenessFactor =
-                    Options.Instance.SecurityOpts.PacketOpts.DesyncForgivenessFactor;
-
-                var configurablePacketDesyncForgivenessInternal =
-                    Options.Instance.SecurityOpts.PacketOpts.DesyncForgivenessInterval;
-
-                var errorMargin = Math.Max(ping, configurableMininumPing) * configurableErrorMarginFactor;
-                var errorRangeMinimum = ping - errorMargin;
-                var errorRangeMaximum = ping + errorMargin;
-
-                var deltaWithErrorMinimum = deltaAdjusted - errorRangeMinimum;
-                var deltaWithErrorMaximum = deltaAdjusted - errorRangeMaximum;
-
-                var natural = configurableNaturalLowerMargin < deltaAdjusted &&
-                              deltaAdjusted < configurableNaturalUpperMargin;
-
-                var naturalWithErrorMinimum = configurableNaturalLowerMargin < deltaWithErrorMinimum &&
-                                              deltaWithErrorMinimum < configurableNaturalUpperMargin;
-
-                var naturalWithErrorMaximum = configurableNaturalLowerMargin < deltaWithErrorMaximum &&
-                                              deltaWithErrorMaximum < configurableNaturalUpperMargin;
-
-                var naturalWithPing = configurableNaturalLowerMargin < deltaWithPing &&
-                                      deltaWithPing < configurableNaturalUpperMargin;
-
-                var adjustedDesync = Math.Abs(deltaAdjusted);
-                var timeDesync = adjustedDesync >
-                                 configurableBaseDesyncForgiveness +
-                                 errorRangeMaximum * configurablePingDesyncForgivenessFactor;
-
-                if (timeDesync && Timing.Global.MillisecondsUtc > client.LastPacketDesyncForgiven)
-                {
-                    client.LastPacketDesyncForgiven =
-                        Timing.Global.MillisecondsUtc + configurablePacketDesyncForgivenessInternal;
-
-                    PacketSender.SendPing(client, false);
-                    timeDesync = false;
-                }
-
-                var logDiagnostics = Debugger.IsAttached;
+            var logDiagnostics = Debugger.IsAttached;
 #if !DIAGNOSTIC
-                if (packet is PingPacket)
-                {
-                    logDiagnostics = false;
-                }
+            if (packet is PingPacket)
+            {
+                logDiagnostics = false;
+            }
 #endif
 
-                if (logDiagnostics)
-                {
-                    Log.Debug(
-                        "\n\t" +
-                        $"Ping[Connection={ping}, Error={Math.Abs(ping)}]\n\t" +
-                        $"Error[G={Math.Abs(localAdjustedMs - remoteAdjustedMs)}, R={Math.Abs(localUtcMs - remoteUtcMs)}, O={Math.Abs(localOffsetMs - remoteOffsetMs)}]\n\t" +
-                        $"Delta[Adjusted={deltaAdjusted}, AWP={deltaWithPing}, AWEN={deltaWithErrorMinimum}, AWEX={deltaWithErrorMaximum}]\n\t" +
-                        $"Natural[A={natural} WP={naturalWithPing}, WEN={naturalWithErrorMinimum}, WEX={naturalWithErrorMaximum}]\n\t" +
-                        $"Time Desync[{timeDesync}]\n\t" +
-                        $"Packet[{packet.ToString()}]"
-                    );
-                }
-
-                var naturalWithError = naturalWithErrorMinimum || naturalWithErrorMaximum;
-
-                if (!(natural || naturalWithError || naturalWithPing) || timeDesync)
-                {
-                    //No matter what, let's send the ping to resync time.
-                    PacketSender.SendPing(client, false);
-
-                    if (client.TimedBufferPacketsRemaining-- < 1 || timeDesync)
-                    {
-                        //if (!(packet is PingPacket))
-                        //{
-                        //    Log.Warn(
-                        //        "Dropping Packet. Time desync? Debug Info:\n\t" +
-                        //        $"Ping[Connection={ping}, NetConnection={ncPing}, Error={Math.Abs(ncPing - ping)}]\n\t" +
-                        //        $"Server Time[Ticks={Timing.Global.Ticks}, AdjustedMs={localAdjustedMs}, TicksUTC={Timing.Global.TicksUTC}, Offset={Timing.Global.TicksOffset}]\n\t" +
-                        //        $"Client Time[Ticks={timedPacket.Adjusted}, AdjustedMs={remoteAdjustedMs}, TicksUTC={timedPacket.UTC}, Offset={timedPacket.Offset}]\n\t" +
-                        //        $"Error[G={Math.Abs(localAdjustedMs - remoteAdjustedMs)}, R={Math.Abs(localUtcMs - remoteUtcMs)}, O={Math.Abs(localOffsetMs - remoteOffsetMs)}]\n\t" +
-                        //        $"Delta[Adjusted={deltaAdjusted}, AWP={deltaWithPing}, AWEN={deltaWithErrorMinimum}, AWEX={deltaWithErrorMaximum}]\n\t" +
-                        //        $"Natural[A={natural} WP={naturalWithPing}, WEN={naturalWithErrorMinimum}, WEX={naturalWithErrorMaximum}]\n\t" +
-                        //        $"Time Desync[{timeDesync}]\n\t" +
-                        //        $"Packet[{packet}]"
-                        //    );
-                        //}
-
-                        try
-                        {
-                            HandleDroppedPacket(client, packet);
-                        }
-                        catch (Exception exception)
-                        {
-                            Log.Debug(
-                                exception,
-                                $"Exception thrown dropping packet ({packet.GetType().Name}/{client.Ip}/{client.Name ?? ""}/{client.Entity?.Name ?? ""})"
-                            );
-                        }
-
-                        return false;
-                    }
-                }
-                else if (natural && naturalWithPing && naturalWithError)
-                {
-                    client.TimedBufferPacketsRemaining = configurableAllowedSpikePackets;
-                }
-                else if (natural && naturalWithPing ||
-                         naturalWithPing && naturalWithError ||
-                         naturalWithError && natural)
-                {
-                    client.TimedBufferPacketsRemaining += (int)Math.Ceiling(
-                        (configurableAllowedSpikePackets - client.TimedBufferPacketsRemaining) / 2.0
-                    );
-                }
-                else
-                {
-                    client.TimedBufferPacketsRemaining = Math.Min(configurableAllowedSpikePackets, client.TimedBufferPacketsRemaining++);
-                }
+            if (logDiagnostics)
+            {
+                Log.Debug(
+                    "\n\t" +
+                    $"Ping[Connection={ping}, Error={Math.Abs(ping)}]\n\t" +
+                    $"Error[G={Math.Abs(localAdjustedMs - remoteAdjustedMs)}, R={Math.Abs(localUtcMs - remoteUtcMs)}, O={Math.Abs(localOffsetMs - remoteOffsetMs)}]\n\t" +
+                    $"Delta[Adjusted={deltaAdjusted}, AWP={deltaWithPing}, AWEN={deltaWithErrorMinimum}, AWEX={deltaWithErrorMaximum}]\n\t" +
+                    $"Natural[A={natural} WP={naturalWithPing}, WEN={naturalWithErrorMinimum}, WEX={naturalWithErrorMaximum}]\n\t" +
+                    $"Time Desync[{timeDesync}]\n\t" +
+                    $"Packet[{packet.ToString()}]"
+                );
             }
 
-            if (!AcceptedPacketTypes.ContainsKey(packet.GetType().Name))
+            var naturalWithError = naturalWithErrorMinimum || naturalWithErrorMaximum;
+
+            if (!(natural || naturalWithError || naturalWithPing) || timeDesync)
             {
-                AcceptedPacketTypes.TryAdd(packet.GetType().Name, 0);
-            }
-            AcceptedPacketTypes[packet.GetType().Name]++;
-
-            client.HandlePacketQueue.Enqueue(packet);
-            lock (client.HandlePacketQueue)
-            {
-                if (!client.PacketHandlingQueued)
-                {
-                    client.PacketHandlingQueued = true;
-                    Client.EnqueueNetworkTask(client.HandlePackets);
-                }
-            }
-
-            return true;
-        }
-
-        public bool ProcessPacket(IPacket packet, Client client)
-        {
-            if (!Registry.TryGetHandler(packet, out HandlePacketGeneric handler))
-            {
-                Logger.Error($"No registered handler for {packet.GetType().FullName}!");
-
-                return false;
-            }
-
-            if (Registry.TryGetPreprocessors(packet, out var preprocessors))
-            {
-                if (!preprocessors.All(preprocessor => preprocessor.Handle(client, packet)))
-                {
-                    // Preprocessors are intended to be silent filter functions
-                    return false;
-                }
-            }
-
-            if (Registry.TryGetPreHooks(packet, out var preHooks))
-            {
-                if (!preHooks.All(hook => hook.Handle(client, packet)))
-                {
-                    // Hooks should not fail, if they do that's an error
-                    Logger.Error($"PreHook handler failed for {packet.GetType().FullName}.");
-                    return false;
-                }
-            }
-
-            if (!handler(client, packet))
-            {
-                return false;
-            }
-
-            if (Registry.TryGetPostHooks(packet, out var postHooks))
-            {
-                if (!postHooks.All(hook => hook.Handle(client, packet)))
-                {
-                    // Hooks should not fail, if they do that's an error
-                    Logger.Error($"PostHook handler failed for {packet.GetType().FullName}.");
-                    return false;
-                }
-            }
-
-            return true;
-        }
-
-        #region "Client Packets"
-
-        public void HandleDroppedPacket(Client client, IPacket packet)
-        {
-            switch (packet)
-            {
-                case MovePacket _:
-                    PacketSender.SendEntityPositionTo(client, client.Entity);
-
-                    break;
-            }
-        }
-
-        //PingPacket
-        public void HandlePacket(Client client, PingPacket packet)
-        {
-            client.Pinged();
-            if (!packet.Responding)
-            {
+                //No matter what, let's send the ping to resync time.
                 PacketSender.SendPing(client, false);
+
+                if (client.TimedBufferPacketsRemaining-- < 1 || timeDesync)
+                {
+                    //if (!(packet is PingPacket))
+                    //{
+                    //    Log.Warn(
+                    //        "Dropping Packet. Time desync? Debug Info:\n\t" +
+                    //        $"Ping[Connection={ping}, NetConnection={ncPing}, Error={Math.Abs(ncPing - ping)}]\n\t" +
+                    //        $"Server Time[Ticks={Timing.Global.Ticks}, AdjustedMs={localAdjustedMs}, TicksUTC={Timing.Global.TicksUTC}, Offset={Timing.Global.TicksOffset}]\n\t" +
+                    //        $"Client Time[Ticks={timedPacket.Adjusted}, AdjustedMs={remoteAdjustedMs}, TicksUTC={timedPacket.UTC}, Offset={timedPacket.Offset}]\n\t" +
+                    //        $"Error[G={Math.Abs(localAdjustedMs - remoteAdjustedMs)}, R={Math.Abs(localUtcMs - remoteUtcMs)}, O={Math.Abs(localOffsetMs - remoteOffsetMs)}]\n\t" +
+                    //        $"Delta[Adjusted={deltaAdjusted}, AWP={deltaWithPing}, AWEN={deltaWithErrorMinimum}, AWEX={deltaWithErrorMaximum}]\n\t" +
+                    //        $"Natural[A={natural} WP={naturalWithPing}, WEN={naturalWithErrorMinimum}, WEX={naturalWithErrorMaximum}]\n\t" +
+                    //        $"Time Desync[{timeDesync}]\n\t" +
+                    //        $"Packet[{packet}]"
+                    //    );
+                    //}
+
+                    try
+                    {
+                        HandleDroppedPacket(client, packet);
+                    }
+                    catch (Exception exception)
+                    {
+                        Log.Debug(
+                            exception,
+                            $"Exception thrown dropping packet ({packet.GetType().Name}/{client.Ip}/{client.Name ?? ""}/{client.Entity?.Name ?? ""})"
+                        );
+                    }
+
+                    return false;
+                }
+            }
+            else if (natural && naturalWithPing && naturalWithError)
+            {
+                client.TimedBufferPacketsRemaining = configurableAllowedSpikePackets;
+            }
+            else if (natural && naturalWithPing ||
+                     naturalWithPing && naturalWithError ||
+                     naturalWithError && natural)
+            {
+                client.TimedBufferPacketsRemaining += (int)Math.Ceiling(
+                    (configurableAllowedSpikePackets - client.TimedBufferPacketsRemaining) / 2.0
+                );
+            }
+            else
+            {
+                client.TimedBufferPacketsRemaining = Math.Min(configurableAllowedSpikePackets, client.TimedBufferPacketsRemaining++);
             }
         }
 
-        //LoginPacket
-        public void HandlePacket(Client client, LoginPacket packet)
+        if (!AcceptedPacketTypes.ContainsKey(packet.GetType().Name))
         {
-            if (client.AccountAttempts > 3 && client.TimeoutMs > Timing.Global.Milliseconds)
+            AcceptedPacketTypes.TryAdd(packet.GetType().Name, 0);
+        }
+        AcceptedPacketTypes[packet.GetType().Name]++;
+
+        client.HandlePacketQueue.Enqueue(packet);
+        lock (client.HandlePacketQueue)
+        {
+            if (!client.PacketHandlingQueued)
             {
-                PacketSender.SendError(client, Strings.Errors.errortimeout);
-                client.ResetTimeout();
-
-                return;
+                client.PacketHandlingQueued = true;
+                Client.EnqueueNetworkTask(client.HandlePackets);
             }
+        }
 
+        return true;
+    }
 
+    public bool ProcessPacket(IPacket packet, Client client)
+    {
+        if (!Registry.TryGetHandler(packet, out HandlePacketGeneric handler))
+        {
+            Logger.Error($"No registered handler for {packet.GetType().FullName}!");
+
+            return false;
+        }
+
+        if (Registry.TryGetPreprocessors(packet, out var preprocessors))
+        {
+            if (!preprocessors.All(preprocessor => preprocessor.Handle(client, packet)))
+            {
+                // Preprocessors are intended to be silent filter functions
+                return false;
+            }
+        }
+
+        if (Registry.TryGetPreHooks(packet, out var preHooks))
+        {
+            if (!preHooks.All(hook => hook.Handle(client, packet)))
+            {
+                // Hooks should not fail, if they do that's an error
+                Logger.Error($"PreHook handler failed for {packet.GetType().FullName}.");
+                return false;
+            }
+        }
+
+        if (!handler(client, packet))
+        {
+            return false;
+        }
+
+        if (Registry.TryGetPostHooks(packet, out var postHooks))
+        {
+            if (!postHooks.All(hook => hook.Handle(client, packet)))
+            {
+                // Hooks should not fail, if they do that's an error
+                Logger.Error($"PostHook handler failed for {packet.GetType().FullName}.");
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    #region "Client Packets"
+
+    public void HandleDroppedPacket(Client client, IPacket packet)
+    {
+        switch (packet)
+        {
+            case MovePacket _:
+                PacketSender.SendEntityPositionTo(client, client.Entity);
+
+                break;
+        }
+    }
+
+    //PingPacket
+    public void HandlePacket(Client client, PingPacket packet)
+    {
+        client.Pinged();
+        if (!packet.Responding)
+        {
+            PacketSender.SendPing(client, false);
+        }
+    }
+
+    //LoginPacket
+    public void HandlePacket(Client client, LoginPacket packet)
+    {
+        if (client.AccountAttempts > 3 && client.TimeoutMs > Timing.Global.Milliseconds)
+        {
+            PacketSender.SendError(client, Strings.Errors.errortimeout);
             client.ResetTimeout();
 
-            // Are we at capacity yet, or can this user still log in?
-            if (Globals.OnlineList.Count >= Options.MaxLoggedinUsers)
-            {
-                PacketSender.SendError(client, Strings.Networking.ServerFull);
-
-                return;
-            }
-
-            var user = User.TryLogin(packet.Username, packet.Password);
-            if (user == null)
-            {
-                UserActivityHistory.LogActivity(Guid.Empty, Guid.Empty, client?.Ip, UserActivityHistory.PeerType.Client, UserActivityHistory.UserAction.FailedLogin, packet.Username);
-
-                client.FailedAttempt();
-                PacketSender.SendError(client, Strings.Account.badlogin);
-
-                return;
-            }
-
-            lock (Globals.ClientLock)
-            {
-                foreach (var cli in Globals.Clients.ToArray())
-                {
-                    if (cli == client)
-                    {
-                        continue;
-                    }
-
-                    if (cli?.IsEditor ?? false)
-                    {
-                        continue;
-                    }
-
-                    if (!string.Equals(cli?.Name, packet.Username, StringComparison.InvariantCultureIgnoreCase))
-                    {
-                        continue;
-                    }
-
-                    cli?.Disconnect();
-                }
-            }
-
-            client.SetUser(user);
-
-            if (client.User != null)
-            {
-                //Logged In
-                client.PacketFloodingThreshholds = Options.Instance.SecurityOpts.PacketOpts.PlayerThreshholds;
-
-                if (client.User.Power.IsAdmin || client.User.Power.IsModerator)
-                {
-                    client.PacketFloodingThreshholds = Options.Instance.SecurityOpts.PacketOpts.ModAdminThreshholds;
-                }
-            }
-
-            //Check for ban
-            var isBanned = Ban.CheckBan(client.User, client.Ip);
-            if (isBanned != null)
-            {
-                client.SetUser(null);
-                client.Banned = true;
-                PacketSender.SendError(client, isBanned);
-
-                return;
-            }
-
-            //Check that server is in admin only mode
-            if (Options.AdminOnly)
-            {
-                if (client.Power == UserRights.None)
-                {
-                    PacketSender.SendError(client, Strings.Account.adminonly);
-
-                    return;
-                }
-            }
-
-            //Check Mute Status and Load into user property
-            Mute.FindMuteReason(client.User, client.Ip);
-
-            UserActivityHistory.LogActivity(user?.Id ?? Guid.Empty, Guid.Empty, client?.Ip, UserActivityHistory.PeerType.Client, UserActivityHistory.UserAction.Login, null);
-
-            // PacketSender.SendServerConfig(client); // TODO: We already send this when the client is initialized, why do we send it again here?
-
-            //Check if we already have a player online/stuck in combat.. if so we will login straight to him
-            foreach (var chr in client.Characters)
-            {
-                if (Player.FindOnline(chr.Id) != null)
-                {
-                    client.LoadCharacter(chr);
-                    client.Entity.SetOnline();
-
-                    PacketSender.SendJoinGame(client);
-                    return;
-                }
-            }
-
-            // Send newly accounts with 0 characters thru the character creation menu.
-            if (client.Characters == default || client.Characters.Count < 1)
-            {
-                PacketSender.SendGameObjects(client, GameObjectType.Class);
-                PacketSender.SendCreateCharacter(client);
-                return;
-            }
-
-            // Show character select menu or login right away by following configuration preferences.
-            if (Options.MaxCharacters > 1 || !Options.Instance.PlayerOpts.SkipCharacterSelect)
-            {
-                PacketSender.SendPlayerCharacters(client);
-            }
-            else
-            {
-                var character = DbInterface.GetUserCharacter(
-                    client.User,
-                    client.Characters.First().Id,
-                    explicitLoad: true
-                );
-                client.LoadCharacter(character);
-                client.Entity.SetOnline();
-                PacketSender.SendJoinGame(client);
-            }
+            return;
         }
 
-        //LogoutPacket
-        public void HandlePacket(Client client, LogoutPacket packet)
+
+        client.ResetTimeout();
+
+        // Are we at capacity yet, or can this user still log in?
+        if (Globals.OnlineList.Count >= Options.MaxLoggedinUsers)
         {
-            if (client == null)
-            {
-                return;
-            }
+            PacketSender.SendError(client, Strings.Networking.ServerFull);
 
-            UserActivityHistory.LogActivity(client.User?.Id ?? Guid.Empty, Guid.Empty, client.Ip,
-                UserActivityHistory.PeerType.Client,
-                packet.ReturningToCharSelect
-                    ? UserActivityHistory.UserAction.SwitchPlayer
-                    : UserActivityHistory.UserAction.DisconnectLogout, $"{client.Name},{client.Entity?.Name}");
-
-            if (packet.ReturningToCharSelect &&
-                (Options.MaxCharacters > 1 || !Options.Instance.PlayerOpts.SkipCharacterSelect))
-            {
-                Log.Debug($"[{nameof(LogoutPacket)}] Returning to character select from player {client.Entity?.Id} ({client.User?.Id})");
-                client.Entity?.TryLogout(false, true);
-                client.Entity = default;
-                PacketSender.SendPlayerCharacters(client, skipLoadingRelationships: true);
-            }
-            else
-            {
-                client.Logout();
-            }
+            return;
         }
 
-        //NeedMapPacket
-        public void HandlePacket(Client client, GetObjectData<MapBase> packet)
+        var user = User.TryLogin(packet.Username, packet.Password);
+        if (user == null)
         {
-            var player = client?.Entity;
+            UserActivityHistory.LogActivity(Guid.Empty, Guid.Empty, client?.Ip, UserActivityHistory.PeerType.Client, UserActivityHistory.UserAction.FailedLogin, packet.Username);
 
-            if (player == default)
+            client.FailedAttempt();
+            PacketSender.SendError(client, Strings.Account.badlogin);
+
+            return;
+        }
+
+        lock (Globals.ClientLock)
+        {
+            foreach (var cli in Globals.Clients.ToArray())
             {
-                return;
-            }
-
-            if (!MapController.TryGet(player.MapId, out var playerMapController))
-            {
-                return;
-            }
-
-            var playerMapGrid = DbInterface.GetGrid(playerMapController.MapGrid);
-            var validKeys = packet.CacheKeys.Where(
-                    key => playerMapGrid.MapIds.Contains(key.Id.Guid) && MapController.Lookup.Keys.Contains(key.Id.Guid)
-                )
-                .ToArray();
-
-            if (validKeys.Any(key => key.Id.Guid == player.MapId))
-            {
-                PacketSender.SendMapGrid(client, playerMapGrid);
-            }
-
-            foreach (var cacheKey in validKeys)
-            {
-                if (!MapController.TryGet(cacheKey.Id.Guid, out var descriptor))
+                if (cli == client)
                 {
                     continue;
                 }
 
-                var version = MapPacket.ComputeCacheVersion(descriptor.Id, descriptor.Revision);
+                if (cli?.IsEditor ?? false)
+                {
+                    continue;
+                }
 
-                var checksumToCompare = string.Equals(cacheKey.Version, version, StringComparison.Ordinal)
-                    ? cacheKey.Checksum
-                    : default;
+                if (!string.Equals(cli?.Name, packet.Username, StringComparison.InvariantCultureIgnoreCase))
+                {
+                    continue;
+                }
 
-                PacketSender.SendMap(client, cacheKey.Id.Guid, checksum: checksumToCompare);
+                cli?.Disconnect();
             }
         }
 
-        //MovePacket
-        public void HandlePacket(Client client, MovePacket packet)
+        client.SetUser(user);
+
+        if (client.User != null)
         {
-            var player = client?.Entity;
-            if (player == null)
+            //Logged In
+            client.PacketFloodingThreshholds = Options.Instance.SecurityOpts.PacketOpts.PlayerThreshholds;
+
+            if (client.User.Power.IsAdmin || client.User.Power.IsModerator)
+            {
+                client.PacketFloodingThreshholds = Options.Instance.SecurityOpts.PacketOpts.ModAdminThreshholds;
+            }
+        }
+
+        //Check for ban
+        var isBanned = Ban.CheckBan(client.User, client.Ip);
+        if (isBanned != null)
+        {
+            client.SetUser(null);
+            client.Banned = true;
+            PacketSender.SendError(client, isBanned);
+
+            return;
+        }
+
+        //Check that server is in admin only mode
+        if (Options.AdminOnly)
+        {
+            if (client.Power == UserRights.None)
+            {
+                PacketSender.SendError(client, Strings.Account.adminonly);
+
+                return;
+            }
+        }
+
+        //Check Mute Status and Load into user property
+        Mute.FindMuteReason(client.User, client.Ip);
+
+        UserActivityHistory.LogActivity(user?.Id ?? Guid.Empty, Guid.Empty, client?.Ip, UserActivityHistory.PeerType.Client, UserActivityHistory.UserAction.Login, null);
+
+        // PacketSender.SendServerConfig(client); // TODO: We already send this when the client is initialized, why do we send it again here?
+
+        //Check if we already have a player online/stuck in combat.. if so we will login straight to him
+        foreach (var chr in client.Characters)
+        {
+            if (Player.FindOnline(chr.Id) != null)
+            {
+                client.LoadCharacter(chr);
+                client.Entity.SetOnline();
+
+                PacketSender.SendJoinGame(client);
+                return;
+            }
+        }
+
+        // Send newly accounts with 0 characters thru the character creation menu.
+        if (client.Characters == default || client.Characters.Count < 1)
+        {
+            PacketSender.SendGameObjects(client, GameObjectType.Class);
+            PacketSender.SendCreateCharacter(client);
+            return;
+        }
+
+        // Show character select menu or login right away by following configuration preferences.
+        if (Options.MaxCharacters > 1 || !Options.Instance.PlayerOpts.SkipCharacterSelect)
+        {
+            PacketSender.SendPlayerCharacters(client);
+        }
+        else
+        {
+            var character = DbInterface.GetUserCharacter(
+                client.User,
+                client.Characters.First().Id,
+                explicitLoad: true
+            );
+            client.LoadCharacter(character);
+            client.Entity.SetOnline();
+            PacketSender.SendJoinGame(client);
+        }
+    }
+
+    //LogoutPacket
+    public void HandlePacket(Client client, LogoutPacket packet)
+    {
+        if (client == null)
+        {
+            return;
+        }
+
+        UserActivityHistory.LogActivity(client.User?.Id ?? Guid.Empty, Guid.Empty, client.Ip,
+            UserActivityHistory.PeerType.Client,
+            packet.ReturningToCharSelect
+                ? UserActivityHistory.UserAction.SwitchPlayer
+                : UserActivityHistory.UserAction.DisconnectLogout, $"{client.Name},{client.Entity?.Name}");
+
+        if (packet.ReturningToCharSelect &&
+            (Options.MaxCharacters > 1 || !Options.Instance.PlayerOpts.SkipCharacterSelect))
+        {
+            Log.Debug($"[{nameof(LogoutPacket)}] Returning to character select from player {client.Entity?.Id} ({client.User?.Id})");
+            client.Entity?.TryLogout(false, true);
+            client.Entity = default;
+            PacketSender.SendPlayerCharacters(client, skipLoadingRelationships: true);
+        }
+        else
+        {
+            client.Logout();
+        }
+    }
+
+    //NeedMapPacket
+    public void HandlePacket(Client client, GetObjectData<MapBase> packet)
+    {
+        var player = client?.Entity;
+
+        if (player == default)
+        {
+            return;
+        }
+
+        if (!MapController.TryGet(player.MapId, out var playerMapController))
+        {
+            return;
+        }
+
+        var playerMapGrid = DbInterface.GetGrid(playerMapController.MapGrid);
+        var validKeys = packet.CacheKeys.Where(
+                key => playerMapGrid.MapIds.Contains(key.Id.Guid) && MapController.Lookup.Keys.Contains(key.Id.Guid)
+            )
+            .ToArray();
+
+        if (validKeys.Any(key => key.Id.Guid == player.MapId))
+        {
+            PacketSender.SendMapGrid(client, playerMapGrid);
+        }
+
+        foreach (var cacheKey in validKeys)
+        {
+            if (!MapController.TryGet(cacheKey.Id.Guid, out var descriptor))
+            {
+                continue;
+            }
+
+            var version = MapPacket.ComputeCacheVersion(descriptor.Id, descriptor.Revision);
+
+            var checksumToCompare = string.Equals(cacheKey.Version, version, StringComparison.Ordinal)
+                ? cacheKey.Checksum
+                : default;
+
+            PacketSender.SendMap(client, cacheKey.Id.Guid, checksum: checksumToCompare);
+        }
+    }
+
+    //MovePacket
+    public void HandlePacket(Client client, MovePacket packet)
+    {
+        var player = client?.Entity;
+        if (player == null)
+        {
+            return;
+        }
+
+        //check if player is stunned or snared, if so don't let them move.
+        foreach (var status in player.CachedStatuses)
+        {
+            if (status.Type == SpellEffect.Stun ||
+                status.Type == SpellEffect.Snare ||
+                status.Type == SpellEffect.Sleep)
             {
                 return;
             }
+        }
 
-            //check if player is stunned or snared, if so don't let them move.
-            foreach (var status in player.CachedStatuses)
+        if (!TileHelper.IsTileValid(packet.MapId, packet.X, packet.Y))
+        {
+            //POSSIBLE HACKING ATTEMPT!
+            PacketSender.SendEntityPositionTo(client, client.Entity);
+
+            return;
+        }
+
+        var clientTime = packet.Adjusted / TimeSpan.TicksPerMillisecond;
+        if (player.ClientMoveTimer <= clientTime &&
+            (Options.Instance.PlayerOpts.AllowCombatMovement || player.ClientAttackTimer <= clientTime))
+        {
+            if (
+                (player.CanMoveInDirection(packet.Dir, out var blockerType, out _) || blockerType == MovementBlockerType.Slide)
+                && client.Entity.MoveRoute == default
+            )
             {
-                if (status.Type == SpellEffect.Stun ||
-                    status.Type == SpellEffect.Snare ||
-                    status.Type == SpellEffect.Sleep)
+                player.Move(packet.Dir, player, false);
+                var utcDeltaMs = (Timing.Global.TicksUtc - packet.UTC) / TimeSpan.TicksPerMillisecond;
+                var latencyAdjustmentMs = -(client.Ping + Math.Max(0, utcDeltaMs));
+                var currentMs = packet.ReceiveTime;
+                if (player.MoveTimer > currentMs)
                 {
-                    return;
-                }
-            }
-
-            if (!TileHelper.IsTileValid(packet.MapId, packet.X, packet.Y))
-            {
-                //POSSIBLE HACKING ATTEMPT!
-                PacketSender.SendEntityPositionTo(client, client.Entity);
-
-                return;
-            }
-
-            var clientTime = packet.Adjusted / TimeSpan.TicksPerMillisecond;
-            if (player.ClientMoveTimer <= clientTime &&
-                (Options.Instance.PlayerOpts.AllowCombatMovement || player.ClientAttackTimer <= clientTime))
-            {
-                if (
-                    (player.CanMoveInDirection(packet.Dir, out var blockerType, out _) || blockerType == MovementBlockerType.Slide)
-                    && client.Entity.MoveRoute == default
-                )
-                {
-                    player.Move(packet.Dir, player, false);
-                    var utcDeltaMs = (Timing.Global.TicksUtc - packet.UTC) / TimeSpan.TicksPerMillisecond;
-                    var latencyAdjustmentMs = -(client.Ping + Math.Max(0, utcDeltaMs));
-                    var currentMs = packet.ReceiveTime;
-                    if (player.MoveTimer > currentMs)
-                    {
-                        player.MoveTimer = currentMs + latencyAdjustmentMs + (long)(player.GetMovementTime() * .75f);
-                        player.ClientMoveTimer = clientTime + (long)player.GetMovementTime();
-                    }
-                }
-                else
-                {
-                    PacketSender.SendEntityPositionTo(client, client.Entity);
-                    return;
+                    player.MoveTimer = currentMs + latencyAdjustmentMs + (long)(player.GetMovementTime() * .75f);
+                    player.ClientMoveTimer = clientTime + (long)player.GetMovementTime();
                 }
             }
             else
             {
                 PacketSender.SendEntityPositionTo(client, client.Entity);
-
                 return;
-            }
-
-            if (packet.MapId != client.Entity.MapId || packet.X != client.Entity.X || packet.Y != client.Entity.Y)
-            {
-                PacketSender.SendEntityPositionTo(client, client.Entity);
             }
         }
-
-        //ChatMsgPacket
-        public void HandlePacket(Client client, ChatMsgPacket packet)
+        else
         {
-            var player = client?.Entity;
+            PacketSender.SendEntityPositionTo(client, client.Entity);
 
-            if (player == null)
+            return;
+        }
+
+        if (packet.MapId != client.Entity.MapId || packet.X != client.Entity.X || packet.Y != client.Entity.Y)
+        {
+            PacketSender.SendEntityPositionTo(client, client.Entity);
+        }
+    }
+
+    //ChatMsgPacket
+    public void HandlePacket(Client client, ChatMsgPacket packet)
+    {
+        var player = client?.Entity;
+
+        if (player == null)
+        {
+            return;
+        }
+
+        var msg = packet.Message;
+        var channel = packet.Channel;
+
+        if (string.IsNullOrWhiteSpace(msg))
+        {
+            return;
+        }
+
+        if (client?.User.IsMuted ?? false) //Don't let the tongueless toxic kids speak.
+        {
+            PacketSender.SendChatMsg(player, client?.User?.Mute?.Reason, ChatMessageType.Notice);
+
+            return;
+        }
+
+        if (player.LastChatTime > Timing.Global.MillisecondsUtc)
+        {
+            PacketSender.SendChatMsg(player, Strings.Chat.toofast, ChatMessageType.Notice);
+            player.LastChatTime = Timing.Global.MillisecondsUtc + Options.MinChatInterval;
+
+            return;
+        }
+
+        if (packet.Message.Length > Options.MaxChatLength)
+        {
+            return;
+        }
+
+        //If no /command, then use the designated channel.
+        var cmd = "";
+        if (!msg.StartsWith("/"))
+        {
+            switch (channel)
+            {
+                case 0: //local
+                    cmd = Strings.Chat.localcmd;
+
+                    break;
+
+                case 1: //global
+                    cmd = Strings.Chat.allcmd;
+
+                    break;
+
+                case 2: //party
+                    cmd = Strings.Chat.partycmd;
+
+                    break;
+
+                case 3:
+                    cmd = Strings.Guilds.guildcmd;
+                    break;
+
+                case 4: //admin
+                    cmd = Strings.Chat.admincmd;
+
+                    break;
+
+                case 5: //private
+                    PacketSender.SendChatMsg(player, msg, ChatMessageType.Local);
+
+                    return;
+            }
+        }
+        else
+        {
+            cmd = msg.Split()[0].ToLower();
+            msg = msg.Remove(0, cmd.Length);
+        }
+
+        var msgSplit = msg.Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+
+        if (cmd == Strings.Chat.localcmd)
+        {
+            if (msg.Trim().Length == 0)
             {
                 return;
             }
 
-            var msg = packet.Message;
-            var channel = packet.Channel;
+            var chatColor = CustomColors.Chat.LocalChat;
 
-            if (string.IsNullOrWhiteSpace(msg))
+            if (client?.Power.IsAdmin ?? false)
+            {
+                chatColor = CustomColors.Chat.AdminLocalChat;
+            }
+            else if (client?.Power.IsModerator ?? false)
+            {
+                chatColor = CustomColors.Chat.ModLocalChat;
+            }
+
+            PacketSender.SendProximityMsgToLayer(
+                Strings.Chat.local.ToString(player.Name, msg), ChatMessageType.Local, player.MapId, player.MapInstanceId, chatColor,
+                player.Name
+            );
+            PacketSender.SendChatBubble(player.Id, player.MapInstanceId, (int)EntityType.GlobalEntity, msg, player.MapId);
+            ChatHistory.LogMessage(player, msg.Trim(), ChatMessageType.Local, Guid.Empty);
+        }
+        else if (cmd == Strings.Chat.allcmd || cmd == Strings.Chat.globalcmd)
+        {
+            if (msg.Trim().Length == 0)
             {
                 return;
             }
 
-            if (client?.User.IsMuted ?? false) //Don't let the tongueless toxic kids speak.
+            var chatColor = CustomColors.Chat.GlobalChat;
+            if (client?.Power.IsAdmin ?? false)
             {
-                PacketSender.SendChatMsg(player, client?.User?.Mute?.Reason, ChatMessageType.Notice);
+                chatColor = CustomColors.Chat.AdminGlobalChat;
+            }
+            else if (client?.Power.IsModerator ?? false)
+            {
+                chatColor = CustomColors.Chat.ModGlobalChat;
+            }
 
+            PacketSender.SendGlobalMsg(Strings.Chat.Global.ToString(player.Name, msg), chatColor, player.Name);
+            ChatHistory.LogMessage(player, msg.Trim(), ChatMessageType.Global, Guid.Empty);
+        }
+        else if (cmd == Strings.Chat.partycmd)
+        {
+            if (msg.Trim().Length == 0)
+            {
                 return;
             }
 
-            if (player.LastChatTime > Timing.Global.MillisecondsUtc)
+            if (player.InParty(player))
             {
-                PacketSender.SendChatMsg(player, Strings.Chat.toofast, ChatMessageType.Notice);
-                player.LastChatTime = Timing.Global.MillisecondsUtc + Options.MinChatInterval;
-
-                return;
-            }
-
-            if (packet.Message.Length > Options.MaxChatLength)
-            {
-                return;
-            }
-
-            //If no /command, then use the designated channel.
-            var cmd = "";
-            if (!msg.StartsWith("/"))
-            {
-                switch (channel)
-                {
-                    case 0: //local
-                        cmd = Strings.Chat.localcmd;
-
-                        break;
-
-                    case 1: //global
-                        cmd = Strings.Chat.allcmd;
-
-                        break;
-
-                    case 2: //party
-                        cmd = Strings.Chat.partycmd;
-
-                        break;
-
-                    case 3:
-                        cmd = Strings.Guilds.guildcmd;
-                        break;
-
-                    case 4: //admin
-                        cmd = Strings.Chat.admincmd;
-
-                        break;
-
-                    case 5: //private
-                        PacketSender.SendChatMsg(player, msg, ChatMessageType.Local);
-
-                        return;
-                }
+                PacketSender.SendPartyMsg(
+                    player, Strings.Chat.party.ToString(player.Name, msg), CustomColors.Chat.PartyChat, player.Name
+                );
+                ChatHistory.LogMessage(player, msg.Trim(), ChatMessageType.Party, Guid.Empty);
             }
             else
             {
-                cmd = msg.Split()[0].ToLower();
-                msg = msg.Remove(0, cmd.Length);
+                PacketSender.SendChatMsg(player, Strings.Parties.notinparty, ChatMessageType.Party, CustomColors.Alerts.Error);
+            }
+        }
+        else if (cmd == Strings.Chat.admincmd)
+        {
+            if (msg.Trim().Length == 0)
+            {
+                return;
             }
 
-            var msgSplit = msg.Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
-
-            if (cmd == Strings.Chat.localcmd)
+            if (client?.Power.IsModerator ?? false)
             {
-                if (msg.Trim().Length == 0)
-                {
-                    return;
-                }
+                PacketSender.SendAdminMsg(
+                    Strings.Chat.admin.ToString(player.Name, msg), CustomColors.Chat.AdminChat, player.Name
+                );
+                ChatHistory.LogMessage(player, msg.Trim(), ChatMessageType.Admin, Guid.Empty);
+            }
+        }
+        else if (cmd == Strings.Guilds.guildcmd)
+        {
+            if (player.Guild == null)
+            {
+                PacketSender.SendChatMsg(player, Strings.Guilds.NotInGuild, ChatMessageType.Guild, CustomColors.Alerts.Error);
+                return;
+            }
 
-                var chatColor = CustomColors.Chat.LocalChat;
+            if (msg.Trim().Length == 0)
+            {
+                return;
+            }
 
-                if (client?.Power.IsAdmin ?? false)
-                {
-                    chatColor = CustomColors.Chat.AdminLocalChat;
-                }
-                else if (client?.Power.IsModerator ?? false)
-                {
-                    chatColor = CustomColors.Chat.ModLocalChat;
-                }
+            //Normalize Rank
+            var rank = Options.Instance.Guild.Ranks[Math.Max(0, Math.Min(player.GuildRank, Options.Instance.Guild.Ranks.Length - 1))].Title;
+            PacketSender.SendGuildMsg(player, Strings.Guilds.guildchat.ToString(rank, player.Name, msg), CustomColors.Chat.GuildChat);
+            ChatHistory.LogMessage(player, msg.Trim(), ChatMessageType.Guild, player.Guild.Id);
 
-                PacketSender.SendProximityMsgToLayer(
-                    Strings.Chat.local.ToString(player.Name, msg), ChatMessageType.Local, player.MapId, player.MapInstanceId, chatColor,
+        }
+        else if (cmd == Strings.Chat.announcementcmd)
+        {
+            if (msg.Trim().Length == 0)
+            {
+                return;
+            }
+
+            if (client?.Power.IsModerator ?? false)
+            {
+                PacketSender.SendGlobalMsg(
+                    Strings.Chat.announcement.ToString(player.Name, msg), CustomColors.Chat.AnnouncementChat,
                     player.Name
                 );
-                PacketSender.SendChatBubble(player.Id, player.MapInstanceId, (int)EntityType.GlobalEntity, msg, player.MapId);
-                ChatHistory.LogMessage(player, msg.Trim(), ChatMessageType.Local, Guid.Empty);
+
+                // Show an announcement banner if configured to do so as well!
+                if (Options.Chat.ShowAnnouncementBanners)
+                {
+                    // TODO: Make the duration configurable through chat?
+                    PacketSender.SendGameAnnouncement(msg, Options.Chat.AnnouncementDisplayDuration);
+                }
+
+                ChatHistory.LogMessage(player, msg.Trim(), ChatMessageType.Notice, Guid.Empty);
             }
-            else if (cmd == Strings.Chat.allcmd || cmd == Strings.Chat.globalcmd)
+        }
+        else if (cmd == Strings.Chat.pmcmd || cmd == Strings.Chat.messagecmd)
+        {
+            if (msgSplit.Length < 2)
             {
-                if (msg.Trim().Length == 0)
-                {
-                    return;
-                }
-
-                var chatColor = CustomColors.Chat.GlobalChat;
-                if (client?.Power.IsAdmin ?? false)
-                {
-                    chatColor = CustomColors.Chat.AdminGlobalChat;
-                }
-                else if (client?.Power.IsModerator ?? false)
-                {
-                    chatColor = CustomColors.Chat.ModGlobalChat;
-                }
-
-                PacketSender.SendGlobalMsg(Strings.Chat.Global.ToString(player.Name, msg), chatColor, player.Name);
-                ChatHistory.LogMessage(player, msg.Trim(), ChatMessageType.Global, Guid.Empty);
+                return;
             }
-            else if (cmd == Strings.Chat.partycmd)
-            {
-                if (msg.Trim().Length == 0)
-                {
-                    return;
-                }
 
-                if (player.InParty(player))
-                {
-                    PacketSender.SendPartyMsg(
-                        player, Strings.Chat.party.ToString(player.Name, msg), CustomColors.Chat.PartyChat, player.Name
-                    );
-                    ChatHistory.LogMessage(player, msg.Trim(), ChatMessageType.Party, Guid.Empty);
-                }
-                else
-                {
-                    PacketSender.SendChatMsg(player, Strings.Parties.notinparty, ChatMessageType.Party, CustomColors.Alerts.Error);
-                }
+            msg = msg.Remove(0, msgSplit[0].Length + 1); //Chop off the player name parameter
+
+            if (msg.Trim().Length == 0)
+            {
+                return;
             }
-            else if (cmd == Strings.Chat.admincmd)
-            {
-                if (msg.Trim().Length == 0)
-                {
-                    return;
-                }
 
-                if (client?.Power.IsModerator ?? false)
-                {
-                    PacketSender.SendAdminMsg(
-                        Strings.Chat.admin.ToString(player.Name, msg), CustomColors.Chat.AdminChat, player.Name
-                    );
-                    ChatHistory.LogMessage(player, msg.Trim(), ChatMessageType.Admin, Guid.Empty);
-                }
+            var target = Player.FindOnline(msgSplit[0].ToLower());
+
+            if (target == player)
+            {
+                return;
             }
-            else if (cmd == Strings.Guilds.guildcmd)
+
+            if (target != null)
             {
-                if (player.Guild == null)
-                {
-                    PacketSender.SendChatMsg(player, Strings.Guilds.NotInGuild, ChatMessageType.Guild, CustomColors.Alerts.Error);
-                    return;
-                }
+                PacketSender.SendChatMsg(
+                    player, Strings.Chat.PrivateTo.ToString(target.Name, msg), ChatMessageType.PM, CustomColors.Chat.PrivateChatTo,
+                    player.Name
+                );
 
-                if (msg.Trim().Length == 0)
-                {
-                    return;
-                }
+                PacketSender.SendChatMsg(
+                    target, Strings.Chat.PrivateFrom.ToString(player.Name, msg), ChatMessageType.PM,
+                    CustomColors.Chat.PrivateChatFrom, player.Name
+                );
 
-                //Normalize Rank
-                var rank = Options.Instance.Guild.Ranks[Math.Max(0, Math.Min(player.GuildRank, Options.Instance.Guild.Ranks.Length - 1))].Title;
-                PacketSender.SendGuildMsg(player, Strings.Guilds.guildchat.ToString(rank, player.Name, msg), CustomColors.Chat.GuildChat);
-                ChatHistory.LogMessage(player, msg.Trim(), ChatMessageType.Guild, player.Guild.Id);
-
-            }
-            else if (cmd == Strings.Chat.announcementcmd)
-            {
-                if (msg.Trim().Length == 0)
-                {
-                    return;
-                }
-
-                if (client?.Power.IsModerator ?? false)
-                {
-                    PacketSender.SendGlobalMsg(
-                        Strings.Chat.announcement.ToString(player.Name, msg), CustomColors.Chat.AnnouncementChat,
-                        player.Name
-                    );
-
-                    // Show an announcement banner if configured to do so as well!
-                    if (Options.Chat.ShowAnnouncementBanners)
-                    {
-                        // TODO: Make the duration configurable through chat?
-                        PacketSender.SendGameAnnouncement(msg, Options.Chat.AnnouncementDisplayDuration);
-                    }
-
-                    ChatHistory.LogMessage(player, msg.Trim(), ChatMessageType.Notice, Guid.Empty);
-                }
-            }
-            else if (cmd == Strings.Chat.pmcmd || cmd == Strings.Chat.messagecmd)
-            {
-                if (msgSplit.Length < 2)
-                {
-                    return;
-                }
-
-                msg = msg.Remove(0, msgSplit[0].Length + 1); //Chop off the player name parameter
-
-                if (msg.Trim().Length == 0)
-                {
-                    return;
-                }
-
-                var target = Player.FindOnline(msgSplit[0].ToLower());
-
-                if (target == player)
-                {
-                    return;
-                }
-
-                if (target != null)
-                {
-                    PacketSender.SendChatMsg(
-                        player, Strings.Chat.PrivateTo.ToString(target.Name, msg), ChatMessageType.PM, CustomColors.Chat.PrivateChatTo,
-                        player.Name
-                    );
-
-                    PacketSender.SendChatMsg(
-                        target, Strings.Chat.PrivateFrom.ToString(player.Name, msg), ChatMessageType.PM,
-                        CustomColors.Chat.PrivateChatFrom, player.Name
-                    );
-
-                    target.ChatTarget = player;
-                    player.ChatTarget = target;
-                    ChatHistory.LogMessage(player, msg.Trim(), ChatMessageType.PM, target?.Id ?? Guid.Empty);
-                }
-                else
-                {
-                    PacketSender.SendChatMsg(player, Strings.Player.offline, ChatMessageType.PM, CustomColors.Alerts.Error);
-                }
-            }
-            else if (cmd == Strings.Chat.replycmd || cmd == Strings.Chat.rcmd)
-            {
-                if (msg.Trim().Length == 0)
-                {
-                    return;
-                }
-
-                if (player.ChatTarget != null && Player.FindOnline(player.ChatTarget.Id) != null)
-                {
-                    PacketSender.SendChatMsg(
-                        player, Strings.Chat.PrivateTo.ToString(player.ChatTarget.Name, msg), ChatMessageType.PM, CustomColors.Chat.PrivateChatTo,
-                        player.Name
-                    );
-
-                    PacketSender.SendChatMsg(
-                        player.ChatTarget, Strings.Chat.PrivateFrom.ToString(player.Name, msg), ChatMessageType.PM,
-                        CustomColors.Chat.PrivateChatFrom, player.Name
-                    );
-
-                    player.ChatTarget.ChatTarget = player;
-                    ChatHistory.LogMessage(player, msg.Trim(), ChatMessageType.PM, player.ChatTarget?.Id ?? Guid.Empty);
-                }
-                else
-                {
-                    PacketSender.SendChatMsg(player, Strings.Player.offline, ChatMessageType.PM, CustomColors.Alerts.Error);
-                }
+                target.ChatTarget = player;
+                player.ChatTarget = target;
+                ChatHistory.LogMessage(player, msg.Trim(), ChatMessageType.PM, target?.Id ?? Guid.Empty);
             }
             else
             {
-                //Search for command activated events and run them
-                foreach (var evt in EventBase.Lookup)
-                {
-                    var eventDescriptor = evt.Value as EventBase;
-                    if (eventDescriptor == default)
-                    {
-                        continue;
-                    }
+                PacketSender.SendChatMsg(player, Strings.Player.offline, ChatMessageType.PM, CustomColors.Alerts.Error);
+            }
+        }
+        else if (cmd == Strings.Chat.replycmd || cmd == Strings.Chat.rcmd)
+        {
+            if (msg.Trim().Length == 0)
+            {
+                return;
+            }
 
-                    if (client.Entity.UnsafeStartCommonEvent(eventDescriptor, CommonEventTrigger.SlashCommand, cmd.TrimStart('/'), msg))
-                    {
-                        return; //Found our /command, exit now :)
-                    }
+            if (player.ChatTarget != null && Player.FindOnline(player.ChatTarget.Id) != null)
+            {
+                PacketSender.SendChatMsg(
+                    player, Strings.Chat.PrivateTo.ToString(player.ChatTarget.Name, msg), ChatMessageType.PM, CustomColors.Chat.PrivateChatTo,
+                    player.Name
+                );
+
+                PacketSender.SendChatMsg(
+                    player.ChatTarget, Strings.Chat.PrivateFrom.ToString(player.Name, msg), ChatMessageType.PM,
+                    CustomColors.Chat.PrivateChatFrom, player.Name
+                );
+
+                player.ChatTarget.ChatTarget = player;
+                ChatHistory.LogMessage(player, msg.Trim(), ChatMessageType.PM, player.ChatTarget?.Id ?? Guid.Empty);
+            }
+            else
+            {
+                PacketSender.SendChatMsg(player, Strings.Player.offline, ChatMessageType.PM, CustomColors.Alerts.Error);
+            }
+        }
+        else
+        {
+            //Search for command activated events and run them
+            foreach (var evt in EventBase.Lookup)
+            {
+                var eventDescriptor = evt.Value as EventBase;
+                if (eventDescriptor == default)
+                {
+                    continue;
                 }
 
-                //No common event /command, invalid command.
-                PacketSender.SendChatMsg(player, Strings.Commands.invalid, ChatMessageType.Error, CustomColors.Alerts.Error);
+                if (client.Entity.UnsafeStartCommonEvent(eventDescriptor, CommonEventTrigger.SlashCommand, cmd.TrimStart('/'), msg))
+                {
+                    return; //Found our /command, exit now :)
+                }
+            }
+
+            //No common event /command, invalid command.
+            PacketSender.SendChatMsg(player, Strings.Commands.invalid, ChatMessageType.Error, CustomColors.Alerts.Error);
+        }
+    }
+
+    //BlockPacket
+    public void HandlePacket(Client client, BlockPacket packet)
+    {
+        var player = client?.Entity;
+        if (player == null)
+        {
+            return;
+        }
+
+        //check if player is stunned or sleeping
+        var statuses = client.Entity.Statuses.Values.ToArray();
+        foreach (var status in statuses)
+        {
+            if (status.Type == SpellEffect.Stun)
+            {
+                PacketSender.SendChatMsg(player, Strings.Combat.stunblocking, ChatMessageType.Combat);
+
+                return;
+            }
+
+            if (status.Type == SpellEffect.Sleep)
+            {
+                PacketSender.SendChatMsg(player, Strings.Combat.sleepblocking, ChatMessageType.Combat);
+
+                return;
             }
         }
 
-        //BlockPacket
-        public void HandlePacket(Client client, BlockPacket packet)
+        client.Entity.TryBlock(packet.Blocking);
+    }
+
+    //BumpPacket
+    public void HandlePacket(Client client, BumpPacket packet)
+    {
+        var player = client?.Entity;
+        if (player == null)
         {
-            var player = client?.Entity;
-            if (player == null)
-            {
-                return;
-            }
-
-            //check if player is stunned or sleeping
-            var statuses = client.Entity.Statuses.Values.ToArray();
-            foreach (var status in statuses)
-            {
-                if (status.Type == SpellEffect.Stun)
-                {
-                    PacketSender.SendChatMsg(player, Strings.Combat.stunblocking, ChatMessageType.Combat);
-
-                    return;
-                }
-
-                if (status.Type == SpellEffect.Sleep)
-                {
-                    PacketSender.SendChatMsg(player, Strings.Combat.sleepblocking, ChatMessageType.Combat);
-
-                    return;
-                }
-            }
-
-            client.Entity.TryBlock(packet.Blocking);
+            return;
         }
 
-        //BumpPacket
-        public void HandlePacket(Client client, BumpPacket packet)
-        {
-            var player = client?.Entity;
-            if (player == null)
-            {
-                return;
-            }
+        player.TryBumpEvent(packet.MapId, packet.EventId);
+    }
 
-            player.TryBumpEvent(packet.MapId, packet.EventId);
+    //AttackPacket
+    public void HandlePacket(Client client, AttackPacket packet)
+    {
+        var player = client?.Entity;
+        if (player == null)
+        {
+            return;
         }
 
-        //AttackPacket
-        public void HandlePacket(Client client, AttackPacket packet)
+        var unequippedAttack = false;
+        var target = packet.Target;
+
+        var clientTime = packet.Adjusted / TimeSpan.TicksPerMillisecond;
+        if (player.ClientAttackTimer > clientTime ||
+            (!Options.Instance.PlayerOpts.AllowCombatMovement && player.ClientMoveTimer > clientTime))
         {
-            var player = client?.Entity;
-            if (player == null)
+            return;
+        }
+
+        if (player.IsAttacking)
+        {
+            return;
+        }
+
+        if (player.IsCasting)
+        {
+            if (Options.Combat.EnableCombatChatMessages)
             {
-                return;
+                PacketSender.SendChatMsg(player, Strings.Combat.channelingnoattack, ChatMessageType.Combat);
             }
 
-            var unequippedAttack = false;
-            var target = packet.Target;
+            return;
+        }
 
-            var clientTime = packet.Adjusted / TimeSpan.TicksPerMillisecond;
-            if (player.ClientAttackTimer > clientTime ||
-                (!Options.Instance.PlayerOpts.AllowCombatMovement && player.ClientMoveTimer > clientTime))
-            {
-                return;
-            }
+        var utcDeltaMs = (Timing.Global.TicksUtc - packet.UTC) / TimeSpan.TicksPerMillisecond;
+        var latencyAdjustmentMs = -(client.Ping + Math.Max(0, utcDeltaMs));
 
-            if (player.IsAttacking)
-            {
-                return;
-            }
-
-            if (player.IsCasting)
+        //check if player is blinded or stunned or in stealth mode
+        foreach (var status in player.CachedStatuses)
+        {
+            if (status.Type == SpellEffect.Stun)
             {
                 if (Options.Combat.EnableCombatChatMessages)
                 {
-                    PacketSender.SendChatMsg(player, Strings.Combat.channelingnoattack, ChatMessageType.Combat);
+                    PacketSender.SendChatMsg(player, Strings.Combat.stunattacking, ChatMessageType.Combat);
                 }
 
                 return;
             }
 
-            var utcDeltaMs = (Timing.Global.TicksUtc - packet.UTC) / TimeSpan.TicksPerMillisecond;
-            var latencyAdjustmentMs = -(client.Ping + Math.Max(0, utcDeltaMs));
-
-            //check if player is blinded or stunned or in stealth mode
-            foreach (var status in player.CachedStatuses)
+            if (status.Type == SpellEffect.Sleep)
             {
-                if (status.Type == SpellEffect.Stun)
+                if (Options.Combat.EnableCombatChatMessages)
                 {
-                    if (Options.Combat.EnableCombatChatMessages)
-                    {
-                        PacketSender.SendChatMsg(player, Strings.Combat.stunattacking, ChatMessageType.Combat);
-                    }
-
-                    return;
+                    PacketSender.SendChatMsg(player, Strings.Combat.sleepattacking, ChatMessageType.Combat);
                 }
 
-                if (status.Type == SpellEffect.Sleep)
-                {
-                    if (Options.Combat.EnableCombatChatMessages)
-                    {
-                        PacketSender.SendChatMsg(player, Strings.Combat.sleepattacking, ChatMessageType.Combat);
-                    }
-
-                    return;
-                }
-
-                if (status.Type == SpellEffect.Blind)
-                {
-                    PacketSender.SendActionMsg(player, Strings.Combat.miss, CustomColors.Combat.Missed);
-
-                    return;
-                }
-
-                //Remove stealth status.
-                if (status.Type == SpellEffect.Stealth)
-                {
-                    status.RemoveStatus();
-                }
+                return;
             }
 
-            var attackingTile = new TileHelper(player.MapId, player.X, player.Y);
-            switch (player.Dir)
+            if (status.Type == SpellEffect.Blind)
             {
-                case Direction.Up:
-                    attackingTile.Translate(0, -1);
-                    break;
+                PacketSender.SendActionMsg(player, Strings.Combat.miss, CustomColors.Combat.Missed);
 
-                case Direction.Down:
-                    attackingTile.Translate(0, 1);
-                    break;
-
-                case Direction.Left:
-                    attackingTile.Translate(-1, 0);
-                    break;
-
-                case Direction.Right:
-                    attackingTile.Translate(1, 0);
-                    break;
-
-                case Direction.UpLeft:
-                    attackingTile.Translate(-1, -1);
-                    break;
-
-                case Direction.UpRight:
-                    attackingTile.Translate(1, -1);
-                    break;
-
-                case Direction.DownLeft:
-                    attackingTile.Translate(-1, 1);
-                    break;
-
-                case Direction.DownRight:
-                    attackingTile.Translate(1, 1);
-                    break;
+                return;
             }
 
-            PacketSender.SendEntityAttack(player, player.CalculateAttackTime());
-
-            player.ClientAttackTimer = clientTime + player.CalculateAttackTime();
-
-            //Fire projectile instead if weapon has it
-
-            if (player.TryGetEquippedItem(Options.WeaponIndex, out var equippedWeapon))
+            //Remove stealth status.
+            if (status.Type == SpellEffect.Stealth)
             {
-                var weaponItem = equippedWeapon.Descriptor;
+                status.RemoveStatus();
+            }
+        }
 
-                //Check for animation
-                var attackAnim = weaponItem.AttackAnimation;
+        var attackingTile = new TileHelper(player.MapId, player.X, player.Y);
+        switch (player.Dir)
+        {
+            case Direction.Up:
+                attackingTile.Translate(0, -1);
+                break;
 
-                if (attackAnim != null && attackingTile.TryFix())
+            case Direction.Down:
+                attackingTile.Translate(0, 1);
+                break;
+
+            case Direction.Left:
+                attackingTile.Translate(-1, 0);
+                break;
+
+            case Direction.Right:
+                attackingTile.Translate(1, 0);
+                break;
+
+            case Direction.UpLeft:
+                attackingTile.Translate(-1, -1);
+                break;
+
+            case Direction.UpRight:
+                attackingTile.Translate(1, -1);
+                break;
+
+            case Direction.DownLeft:
+                attackingTile.Translate(-1, 1);
+                break;
+
+            case Direction.DownRight:
+                attackingTile.Translate(1, 1);
+                break;
+        }
+
+        PacketSender.SendEntityAttack(player, player.CalculateAttackTime());
+
+        player.ClientAttackTimer = clientTime + player.CalculateAttackTime();
+
+        //Fire projectile instead if weapon has it
+
+        if (player.TryGetEquippedItem(Options.WeaponIndex, out var equippedWeapon))
+        {
+            var weaponItem = equippedWeapon.Descriptor;
+
+            //Check for animation
+            var attackAnim = weaponItem.AttackAnimation;
+
+            if (attackAnim != null && attackingTile.TryFix())
+            {
+                PacketSender.SendAnimationToProximity(
+                    attackAnim.Id, -1, player.Id, attackingTile.GetMapId(), attackingTile.GetX(),
+                    attackingTile.GetY(), player.Dir, player.MapInstanceId
+                );
+            }
+
+            var projectileBase = ProjectileBase.Get(weaponItem?.ProjectileId ?? Guid.Empty);
+
+            if (projectileBase != null)
+            {
+                if (projectileBase.AmmoItemId != Guid.Empty)
                 {
-                    PacketSender.SendAnimationToProximity(
-                        attackAnim.Id, -1, player.Id, attackingTile.GetMapId(), attackingTile.GetX(),
-                        attackingTile.GetY(), player.Dir, player.MapInstanceId
+                    var itemSlot = player.FindInventoryItemSlot(
+                        projectileBase.AmmoItemId, projectileBase.AmmoRequired
                     );
-                }
 
-                var projectileBase = ProjectileBase.Get(weaponItem?.ProjectileId ?? Guid.Empty);
-
-                if (projectileBase != null)
-                {
-                    if (projectileBase.AmmoItemId != Guid.Empty)
+                    if (itemSlot == null)
                     {
-                        var itemSlot = player.FindInventoryItemSlot(
-                            projectileBase.AmmoItemId, projectileBase.AmmoRequired
+                        PacketSender.SendChatMsg(
+                            player,
+                            Strings.Items.notenough.ToString(ItemBase.GetName(projectileBase.AmmoItemId)),
+                            ChatMessageType.Inventory,
+                            CustomColors.Combat.NoAmmo
                         );
 
-                        if (itemSlot == null)
-                        {
-                            PacketSender.SendChatMsg(
-                                player,
-                                Strings.Items.notenough.ToString(ItemBase.GetName(projectileBase.AmmoItemId)),
-                                ChatMessageType.Inventory,
-                                CustomColors.Combat.NoAmmo
-                            );
-
-                            return;
-                        }
-#if INTERSECT_DIAGNOSTIC
-                                PacketSender.SendPlayerMsg(client,
-                                    Strings.Get("items", "notenough", $"REGISTERED_AMMO ({projectileBase.Ammo}:'{ItemBase.GetName(projectileBase.Ammo)}':{projectileBase.AmmoRequired})"),
-                                    ChatMessageType.Inventory, CustomColors.NoAmmo);
-#endif
-                        if (!player.TryTakeItem(projectileBase.AmmoItemId, projectileBase.AmmoRequired))
-                        {
-#if INTERSECT_DIAGNOSTIC
-                                    PacketSender.SendPlayerMsg(client,
-                                        Strings.Get("items", "notenough", "FAILED_TO_DEDUCT_AMMO"),
-                                        CustomColors.NoAmmo);
-                                    PacketSender.SendPlayerMsg(client,
-                                        Strings.Get("items", "notenough", $"FAILED_TO_DEDUCT_AMMO {client.Entity.CountItems(projectileBase.Ammo)}"),
-                                        ChatMessageType.Inventory, CustomColors.NoAmmo);
-#endif
-                        }
+                        return;
                     }
 #if INTERSECT_DIAGNOSTIC
-                            else
-                            {
-                                PacketSender.SendPlayerMsg(client,
-                                    Strings.Get("items", "notenough", "NO_REGISTERED_AMMO"),
-                                    ChatMessageType.Inventory, CustomColors.NoAmmo);
-                            }
+                            PacketSender.SendPlayerMsg(client,
+                                Strings.Get("items", "notenough", $"REGISTERED_AMMO ({projectileBase.Ammo}:'{ItemBase.GetName(projectileBase.Ammo)}':{projectileBase.AmmoRequired})"),
+                                ChatMessageType.Inventory, CustomColors.NoAmmo);
 #endif
-                    if (MapController.TryGetInstanceFromMap(player.MapId, player.MapInstanceId, out var mapInstance))
+                    if (!player.TryTakeItem(projectileBase.AmmoItemId, projectileBase.AmmoRequired))
                     {
-                        mapInstance
-                            .SpawnMapProjectile(
-                                player, projectileBase, null, weaponItem, player.MapId,
-                                (byte)player.X, (byte)player.Y, (byte)player.Z, player.Dir, null);
-
-                        player.AttackTimer = Timing.Global.Milliseconds +
-                                             latencyAdjustmentMs +
-                                             player.CalculateAttackTime();
+#if INTERSECT_DIAGNOSTIC
+                                PacketSender.SendPlayerMsg(client,
+                                    Strings.Get("items", "notenough", "FAILED_TO_DEDUCT_AMMO"),
+                                    CustomColors.NoAmmo);
+                                PacketSender.SendPlayerMsg(client,
+                                    Strings.Get("items", "notenough", $"FAILED_TO_DEDUCT_AMMO {client.Entity.CountItems(projectileBase.Ammo)}"),
+                                    ChatMessageType.Inventory, CustomColors.NoAmmo);
+#endif
                     }
-
-                    return;
                 }
 #if INTERSECT_DIAGNOSTIC
                         else
                         {
                             PacketSender.SendPlayerMsg(client,
-                                Strings.Get("items", "notenough", "NONPROJECTILE"),
+                                Strings.Get("items", "notenough", "NO_REGISTERED_AMMO"),
                                 ChatMessageType.Inventory, CustomColors.NoAmmo);
-                            return;
                         }
 #endif
-            }
-            else
-            {
-                unequippedAttack = true;
-            }
-
-            if (unequippedAttack)
-            {
-                var classBase = ClassBase.Get(player.ClassId);
-                if (classBase != null)
+                if (MapController.TryGetInstanceFromMap(player.MapId, player.MapInstanceId, out var mapInstance))
                 {
-                    //Check for animation
-                    if (classBase.AttackAnimation != null)
+                    mapInstance
+                        .SpawnMapProjectile(
+                            player, projectileBase, null, weaponItem, player.MapId,
+                            (byte)player.X, (byte)player.Y, (byte)player.Z, player.Dir, null);
+
+                    player.AttackTimer = Timing.Global.Milliseconds +
+                                         latencyAdjustmentMs +
+                                         player.CalculateAttackTime();
+                }
+
+                return;
+            }
+#if INTERSECT_DIAGNOSTIC
+                    else
                     {
-                        PacketSender.SendAnimationToProximity(
-                            classBase.AttackAnimationId, -1, player.Id, attackingTile.GetMapId(), attackingTile.GetX(),
-                            attackingTile.GetY(), player.Dir, player.MapInstanceId
-                        );
+                        PacketSender.SendPlayerMsg(client,
+                            Strings.Get("items", "notenough", "NONPROJECTILE"),
+                            ChatMessageType.Inventory, CustomColors.NoAmmo);
+                        return;
                     }
+#endif
+        }
+        else
+        {
+            unequippedAttack = true;
+        }
+
+        if (unequippedAttack)
+        {
+            var classBase = ClassBase.Get(player.ClassId);
+            if (classBase != null)
+            {
+                //Check for animation
+                if (classBase.AttackAnimation != null)
+                {
+                    PacketSender.SendAnimationToProximity(
+                        classBase.AttackAnimationId, -1, player.Id, attackingTile.GetMapId(), attackingTile.GetX(),
+                        attackingTile.GetY(), player.Dir, player.MapInstanceId
+                    );
                 }
             }
+        }
 
-            foreach (var mapInstance in MapController.GetSurroundingMapInstances(player.Map.Id, player.MapInstanceId, true))
+        foreach (var mapInstance in MapController.GetSurroundingMapInstances(player.Map.Id, player.MapInstanceId, true))
+        {
+            foreach (var entity in mapInstance.GetEntities())
             {
-                foreach (var entity in mapInstance.GetEntities())
+                if (entity.Id == target)
                 {
-                    if (entity.Id == target)
-                    {
-                        player.TryAttack(entity);
+                    player.TryAttack(entity);
 
-                        break;
-                    }
+                    break;
                 }
             }
-
-            if (player.IsAttacking)
-            {
-                player.AttackTimer = Timing.Global.Milliseconds + latencyAdjustmentMs + player.CalculateAttackTime();
-            }
         }
 
-        //DirectionPacket
-        public void HandlePacket(Client client, DirectionPacket packet)
+        if (player.IsAttacking)
         {
-            var player = client?.Entity;
+            player.AttackTimer = Timing.Global.Milliseconds + latencyAdjustmentMs + player.CalculateAttackTime();
+        }
+    }
 
-            player?.ChangeDir(packet.Direction);
+    //DirectionPacket
+    public void HandlePacket(Client client, DirectionPacket packet)
+    {
+        var player = client?.Entity;
+
+        player?.ChangeDir(packet.Direction);
+    }
+
+    //EnterGamePacket
+    public void HandlePacket(Client client, EnterGamePacket packet)
+    {
+    }
+
+    //ActivateEventPacket
+    public void HandlePacket(Client client, ActivateEventPacket packet)
+    {
+        var player = client?.Entity;
+        if (player == null)
+        {
+            return;
         }
 
-        //EnterGamePacket
-        public void HandlePacket(Client client, EnterGamePacket packet)
+        player.TryActivateEvent(packet.EventId);
+    }
+
+    //EventResponsePacket
+    public void HandlePacket(Client client, EventResponsePacket packet)
+    {
+        var player = client?.Entity;
+        if (player == null)
         {
+            return;
         }
 
-        //ActivateEventPacket
-        public void HandlePacket(Client client, ActivateEventPacket packet)
+        player.RespondToEvent(packet.EventId, packet.Response);
+    }
+
+    //EventInputVariablePacket
+    public void HandlePacket(Client client, EventInputVariablePacket packet)
+    {
+        client.Entity.RespondToEventInput(
+            packet.EventId, packet.Value, packet.StringValue, packet.Canceled
+        );
+    }
+
+    //CreateAccountPacket
+    public void HandlePacket(Client client, CreateAccountPacket packet)
+    {
+        if (client.TimeoutMs > Timing.Global.Milliseconds)
         {
-            var player = client?.Entity;
-            if (player == null)
-            {
-                return;
-            }
-
-            player.TryActivateEvent(packet.EventId);
-        }
-
-        //EventResponsePacket
-        public void HandlePacket(Client client, EventResponsePacket packet)
-        {
-            var player = client?.Entity;
-            if (player == null)
-            {
-                return;
-            }
-
-            player.RespondToEvent(packet.EventId, packet.Response);
-        }
-
-        //EventInputVariablePacket
-        public void HandlePacket(Client client, EventInputVariablePacket packet)
-        {
-            client.Entity.RespondToEventInput(
-                packet.EventId, packet.Value, packet.StringValue, packet.Canceled
-            );
-        }
-
-        //CreateAccountPacket
-        public void HandlePacket(Client client, CreateAccountPacket packet)
-        {
-            if (client.TimeoutMs > Timing.Global.Milliseconds)
-            {
-                PacketSender.SendError(client, Strings.Errors.errortimeout);
-                client.ResetTimeout();
-
-                return;
-            }
-
+            PacketSender.SendError(client, Strings.Errors.errortimeout);
             client.ResetTimeout();
 
-            if (Options.BlockClientRegistrations)
+            return;
+        }
+
+        client.ResetTimeout();
+
+        if (Options.BlockClientRegistrations)
+        {
+            PacketSender.SendError(client, Strings.Account.registrationsblocked);
+
+            return;
+        }
+
+        if (!FieldChecking.IsValidUsername(packet.Username, Strings.Regex.username))
+        {
+            PacketSender.SendError(client, Strings.Account.invalidname);
+
+            return;
+        }
+
+        if (!FieldChecking.IsWellformedEmailAddress(packet.Email, Strings.Regex.email))
+        {
+            PacketSender.SendError(client, Strings.Account.invalidemail);
+
+            return;
+        }
+
+        //Check for ban
+        var isBanned = Ban.CheckBan(client.Ip);
+        if (isBanned != null)
+        {
+            PacketSender.SendError(client, isBanned);
+
+            return;
+        }
+
+        if (User.UserExists(packet.Username))
+        {
+            PacketSender.SendError(client, Strings.Account.exists);
+        }
+        else
+        {
+            if (User.UserExists(packet.Email))
             {
-                PacketSender.SendError(client, Strings.Account.registrationsblocked);
-
-                return;
-            }
-
-            if (!FieldChecking.IsValidUsername(packet.Username, Strings.Regex.username))
-            {
-                PacketSender.SendError(client, Strings.Account.invalidname);
-
-                return;
-            }
-
-            if (!FieldChecking.IsWellformedEmailAddress(packet.Email, Strings.Regex.email))
-            {
-                PacketSender.SendError(client, Strings.Account.invalidemail);
-
-                return;
-            }
-
-            //Check for ban
-            var isBanned = Ban.CheckBan(client.Ip);
-            if (isBanned != null)
-            {
-                PacketSender.SendError(client, isBanned);
-
-                return;
-            }
-
-            if (User.UserExists(packet.Username))
-            {
-                PacketSender.SendError(client, Strings.Account.exists);
+                PacketSender.SendError(client, Strings.Account.emailexists);
             }
             else
             {
-                if (User.UserExists(packet.Email))
+
+                UserActivityHistory.LogActivity(client.User?.Id ?? Guid.Empty, Guid.Empty, client?.Ip, UserActivityHistory.PeerType.Client, UserActivityHistory.UserAction.Create, client?.Name);
+
+                DbInterface.CreateAccount(client, packet.Username, packet.Password, packet.Email);
+
+                if (client.User != null)
                 {
-                    PacketSender.SendError(client, Strings.Account.emailexists);
+                    //Logged In
+                    client.PacketFloodingThreshholds = Options.Instance.SecurityOpts.PacketOpts.PlayerThreshholds;
+
+                    if (client.User.Power.IsAdmin || client.User.Power.IsModerator)
+                    {
+                        client.PacketFloodingThreshholds = Options.Instance.SecurityOpts.PacketOpts.ModAdminThreshholds;
+                    }
                 }
-                else
+
+                // PacketSender.SendServerConfig(client); // TODO: We already send this when the client is initialized, why do we send it again here?
+
+                //Check that server is in admin only mode
+                if (Options.AdminOnly)
                 {
-
-                    UserActivityHistory.LogActivity(client.User?.Id ?? Guid.Empty, Guid.Empty, client?.Ip, UserActivityHistory.PeerType.Client, UserActivityHistory.UserAction.Create, client?.Name);
-
-                    DbInterface.CreateAccount(client, packet.Username, packet.Password, packet.Email);
-
-                    if (client.User != null)
+                    if (client.Power == UserRights.None)
                     {
-                        //Logged In
-                        client.PacketFloodingThreshholds = Options.Instance.SecurityOpts.PacketOpts.PlayerThreshholds;
+                        PacketSender.SendError(client, Strings.Account.adminonly);
 
-                        if (client.User.Power.IsAdmin || client.User.Power.IsModerator)
-                        {
-                            client.PacketFloodingThreshholds = Options.Instance.SecurityOpts.PacketOpts.ModAdminThreshholds;
-                        }
+                        return;
                     }
-
-                    // PacketSender.SendServerConfig(client); // TODO: We already send this when the client is initialized, why do we send it again here?
-
-                    //Check that server is in admin only mode
-                    if (Options.AdminOnly)
-                    {
-                        if (client.Power == UserRights.None)
-                        {
-                            PacketSender.SendError(client, Strings.Account.adminonly);
-
-                            return;
-                        }
-                    }
-
-                    //Start the character creation process for the newly created account.
-                    PacketSender.SendGameObjects(client, GameObjectType.Class);
-                    PacketSender.SendCreateCharacter(client);
                 }
+
+                //Start the character creation process for the newly created account.
+                PacketSender.SendGameObjects(client, GameObjectType.Class);
+                PacketSender.SendCreateCharacter(client);
+            }
+        }
+    }
+
+    //CreateCharacterPacket
+    public void HandlePacket(Client client, CreateCharacterPacket packet)
+    {
+        if (client.User == null)
+        {
+            return;
+        }
+
+        if (!FieldChecking.IsValidUsername(packet.Name, Strings.Regex.username))
+        {
+            PacketSender.SendError(client, Strings.Account.invalidname);
+
+            return;
+        }
+
+        var index = client.Id;
+        var classBase = ClassBase.Get(packet.ClassId);
+        if (classBase == null || classBase.Locked)
+        {
+            PacketSender.SendError(client, Strings.Account.invalidclass);
+
+            return;
+        }
+
+        if (Player.PlayerExists(packet.Name))
+        {
+            PacketSender.SendError(client, Strings.Account.characterexists);
+            return;
+        }
+
+        Player newChar = new()
+        {
+            Id = Guid.NewGuid(),
+        };
+
+        newChar.ValidateLists();
+        for (var i = 0; i < Options.EquipmentSlots.Count; i++)
+        {
+            newChar.Equipment[i] = -1;
+        }
+
+        newChar.Name = packet.Name;
+        newChar.ClassId = packet.ClassId;
+        newChar.Level = 1;
+
+        if (classBase.Sprites.Count > 0)
+        {
+            var spriteIndex = Math.Max(0, Math.Min(classBase.Sprites.Count, packet.Sprite));
+            newChar.Sprite = classBase.Sprites[spriteIndex].Sprite;
+            newChar.Face = classBase.Sprites[spriteIndex].Face;
+            newChar.Gender = classBase.Sprites[spriteIndex].Gender;
+        }
+
+        client.LoadCharacter(newChar);
+
+        newChar.SetVital(Vital.Health, classBase.BaseVital[(int)Vital.Health]);
+        newChar.SetVital(Vital.Mana, classBase.BaseVital[(int)Vital.Mana]);
+
+        for (var i = 0; i < Enum.GetValues<Stat>().Length; i++)
+        {
+            newChar.Stat[i].BaseStat = 0;
+        }
+
+        newChar.StatPoints = classBase.BasePoints;
+
+        for (var i = 0; i < classBase.Spells.Count; i++)
+        {
+            if (classBase.Spells[i].Level <= 1)
+            {
+                var tempSpell = new Spell(classBase.Spells[i].Id);
+                newChar.TryTeachSpell(tempSpell, false);
             }
         }
 
-        //CreateCharacterPacket
-        public void HandlePacket(Client client, CreateCharacterPacket packet)
+        foreach (var item in classBase.Items)
         {
-            if (client.User == null)
+            if (ItemBase.Get(item.Id) != null)
             {
-                return;
+                var tempItem = new Item(item.Id, item.Quantity);
+                newChar.TryGiveItem(tempItem, ItemHandling.Normal, false, -1, false);
             }
-
-            if (!FieldChecking.IsValidUsername(packet.Name, Strings.Regex.username))
-            {
-                PacketSender.SendError(client, Strings.Account.invalidname);
-
-                return;
-            }
-
-            var index = client.Id;
-            var classBase = ClassBase.Get(packet.ClassId);
-            if (classBase == null || classBase.Locked)
-            {
-                PacketSender.SendError(client, Strings.Account.invalidclass);
-
-                return;
-            }
-
-            if (Player.PlayerExists(packet.Name))
-            {
-                PacketSender.SendError(client, Strings.Account.characterexists);
-                return;
-            }
-
-            Player newChar = new()
-            {
-                Id = Guid.NewGuid(),
-            };
-
-            newChar.ValidateLists();
-            for (var i = 0; i < Options.EquipmentSlots.Count; i++)
-            {
-                newChar.Equipment[i] = -1;
-            }
-
-            newChar.Name = packet.Name;
-            newChar.ClassId = packet.ClassId;
-            newChar.Level = 1;
-
-            if (classBase.Sprites.Count > 0)
-            {
-                var spriteIndex = Math.Max(0, Math.Min(classBase.Sprites.Count, packet.Sprite));
-                newChar.Sprite = classBase.Sprites[spriteIndex].Sprite;
-                newChar.Face = classBase.Sprites[spriteIndex].Face;
-                newChar.Gender = classBase.Sprites[spriteIndex].Gender;
-            }
-
-            client.LoadCharacter(newChar);
-
-            newChar.SetVital(Vital.Health, classBase.BaseVital[(int)Vital.Health]);
-            newChar.SetVital(Vital.Mana, classBase.BaseVital[(int)Vital.Mana]);
-
-            for (var i = 0; i < Enum.GetValues<Stat>().Length; i++)
-            {
-                newChar.Stat[i].BaseStat = 0;
-            }
-
-            newChar.StatPoints = classBase.BasePoints;
-
-            for (var i = 0; i < classBase.Spells.Count; i++)
-            {
-                if (classBase.Spells[i].Level <= 1)
-                {
-                    var tempSpell = new Spell(classBase.Spells[i].Id);
-                    newChar.TryTeachSpell(tempSpell, false);
-                }
-            }
-
-            foreach (var item in classBase.Items)
-            {
-                if (ItemBase.Get(item.Id) != null)
-                {
-                    var tempItem = new Item(item.Id, item.Quantity);
-                    newChar.TryGiveItem(tempItem, ItemHandling.Normal, false, -1, false);
-                }
-            }
-
-            UserActivityHistory.LogActivity(client?.User?.Id ?? Guid.Empty, client?.Entity?.Id ?? Guid.Empty, client?.Ip, UserActivityHistory.PeerType.Client, UserActivityHistory.UserAction.CreatePlayer, $"{client?.Name},{client?.Entity?.Name}");
-
-            if (!client.User.TryAddCharacter(newChar))
-            {
-                client.LogAndDisconnect(newChar.Id);
-                return;
-            }
-
-            newChar.SetOnline();
-
-            PacketSender.SendJoinGame(client);
         }
 
-        //PickupItemPacket
-        public void HandlePacket(Client client, PickupItemPacket packet)
+        UserActivityHistory.LogActivity(client?.User?.Id ?? Guid.Empty, client?.Entity?.Id ?? Guid.Empty, client?.Ip, UserActivityHistory.PeerType.Client, UserActivityHistory.UserAction.CreatePlayer, $"{client?.Name},{client?.Entity?.Name}");
+
+        if (!client.User.TryAddCharacter(newChar))
         {
-            var player = client.Entity;
-            if (player == null || packet.TileIndex < 0 || packet.TileIndex >= Options.MapWidth * Options.MapHeight)
-            {
-                return;
-            }
+            client.LogAndDisconnect(newChar.Id);
+            return;
+        }
 
-            if (!MapController.TryGetInstanceFromMap(packet.MapId, player.MapInstanceId, out var playerMapInstance))
-            {
-                return;
-            }
+        newChar.SetOnline();
 
-            var playerMapController = playerMapInstance.GetController();
+        PacketSender.SendJoinGame(client);
+    }
 
-            var lootDistance = Math.Min(
-                Math.Min(Options.Instance.MapOpts.MapWidth, Options.Instance.MapOpts.MapHeight),
-                Options.Loot.MaximumLootWindowDistance
-            );
+    //PickupItemPacket
+    public void HandlePacket(Client client, PickupItemPacket packet)
+    {
+        var player = client.Entity;
+        if (player == null || packet.TileIndex < 0 || packet.TileIndex >= Options.MapWidth * Options.MapHeight)
+        {
+            return;
+        }
 
-            // Is our user within range of the item they are trying to pick up?
-            if (player.GetDistanceTo(playerMapController, packet.TileIndex % Options.MapWidth, (int)Math.Floor(packet.TileIndex / (float)Options.MapWidth)) > lootDistance)
-            {
-                return;
-            }
+        if (!MapController.TryGetInstanceFromMap(packet.MapId, player.MapInstanceId, out var playerMapInstance))
+        {
+            return;
+        }
 
-            var giveItems = new Dictionary<MapController, List<MapItem>>();
-            // Are we trying to pick up everything on this location or one specific item?
-            if (packet.UniqueId == Guid.Empty)
-            {
-                // GET IT ALL! BE GREEDY!
-                foreach (var (mapWithItems, value) in playerMapController.FindSurroundingTiles(new Point(player.X, player.Y), lootDistance))
-                {
-                    if (!mapWithItems.TryGetInstance(player.MapInstanceId, out var mapInstanceWithItems))
-                    {
-                        continue;
-                    }
+        var playerMapController = playerMapInstance.GetController();
 
-                    if (!giveItems.TryGetValue(mapWithItems, out var itemsFromMap))
-                    {
-                        itemsFromMap = new List<MapItem>();
-                        giveItems[mapWithItems] = itemsFromMap;
-                    }
+        var lootDistance = Math.Min(
+            Math.Min(Options.Instance.MapOpts.MapWidth, Options.Instance.MapOpts.MapHeight),
+            Options.Loot.MaximumLootWindowDistance
+        );
 
-                    itemsFromMap.AddRange(value.SelectMany(itemLoc => mapInstanceWithItems.FindItemsAt(itemLoc)));
-                }
-            }
-            else
-            {
-                // One specific item.
-                giveItems.Add(playerMapController, new List<MapItem> { playerMapInstance.FindItem(packet.UniqueId) });
-            }
+        // Is our user within range of the item they are trying to pick up?
+        if (player.GetDistanceTo(playerMapController, packet.TileIndex % Options.MapWidth, (int)Math.Floor(packet.TileIndex / (float)Options.MapWidth)) > lootDistance)
+        {
+            return;
+        }
 
-            // Go through each item we're trying to give our player and see if we can do so.
-            foreach (var (mapWithItems, value) in giveItems)
+        var giveItems = new Dictionary<MapController, List<MapItem>>();
+        // Are we trying to pick up everything on this location or one specific item?
+        if (packet.UniqueId == Guid.Empty)
+        {
+            // GET IT ALL! BE GREEDY!
+            foreach (var (mapWithItems, value) in playerMapController.FindSurroundingTiles(new Point(player.X, player.Y), lootDistance))
             {
                 if (!mapWithItems.TryGetInstance(player.MapInstanceId, out var mapInstanceWithItems))
                 {
                     continue;
                 }
 
-                // Remove null or missing map items from the list
-                var validMapItems = value.Where(
-                    mapItem => mapItem != default && mapInstanceWithItems.FindItem(mapItem.UniqueId) != default
-                );
-                foreach (var mapItem in validMapItems)
+                if (!giveItems.TryGetValue(mapWithItems, out var itemsFromMap))
                 {
-                    if (mapItem.Owner != default &&
-                        mapItem.Owner != player.Id &&
-                        Timing.Global.Milliseconds < mapItem.OwnershipTime)
-                    {
-                        continue;
-                    }
-
-                    // Remove the item from the map now, because otherwise the overflow would just add to the existing quantity
-                    mapInstanceWithItems.RemoveItem(mapItem);
-
-                    // Try to give the item to our player.
-                    if (!player.TryGiveItem(mapItem, ItemHandling.Overflow, false, -1, true, mapItem.X, mapItem.Y))
-                    {
-                        // We couldn't give the player their item, notify them.
-                        PacketSender.SendChatMsg(
-                            player,
-                            Strings.Items.InventoryNoSpace,
-                            ChatMessageType.Inventory,
-                            CustomColors.Alerts.Error
-                        );
-                        continue;
-                    }
-
-                    if (ItemBase.TryGet(mapItem.ItemId, out var item))
-                    {
-                        PacketSender.SendActionMsg(player, item.Name, CustomColors.Items.Rarities[item.Rarity]);
-                    }
-                }
-            }
-        }
-
-        //SwapInvItemsPacket
-        public void HandlePacket(Client client, SwapInvItemsPacket packet)
-        {
-            var player = client?.Entity;
-            if (player == null)
-            {
-                return;
-            }
-
-            player.SwapItems(packet.Slot1, packet.Slot2);
-        }
-
-        //DropItemPacket
-        public void HandlePacket(Client client, DropItemPacket packet)
-        {
-            var player = client?.Entity;
-            if (packet == null)
-            {
-                return;
-            }
-
-            player?.DropItemFrom(packet.Slot, packet.Quantity);
-        }
-
-        //UseItemPacket
-        public void HandlePacket(Client client, UseItemPacket packet)
-        {
-            var player = client?.Entity;
-            if (player == null)
-            {
-                return;
-            }
-
-            Entity target = null;
-            if (packet.TargetId != Guid.Empty)
-            {
-                foreach (var mapInstance in MapController.GetSurroundingMapInstances(player.Map.Id, player.MapInstanceId, true))
-                {
-                    foreach (var en in mapInstance.GetEntities())
-                    {
-                        if (en.Id == packet.TargetId)
-                        {
-                            target = en;
-
-                            break;
-                        }
-                    }
-                }
-            }
-
-            player.UseItem(packet.Slot, target);
-        }
-
-        //SwapSpellsPacket
-        public void HandlePacket(Client client, SwapSpellsPacket packet)
-        {
-            var player = client?.Entity;
-            if (player == null || player.IsCasting)
-            {
-                return;
-            }
-
-            player.SwapSpells(packet.Slot1, packet.Slot2);
-        }
-
-        //ForgetSpellPacket
-        public void HandlePacket(Client client, ForgetSpellPacket packet)
-        {
-            var player = client?.Entity;
-            if (player == null)
-            {
-                return;
-            }
-
-            player.ForgetSpell(packet.Slot);
-        }
-
-        //UseSpellPacket
-        public void HandlePacket(Client client, UseSpellPacket packet)
-        {
-            var player = client?.Entity;
-            if (player == null)
-            {
-                return;
-            }
-
-            var casted = false;
-
-            if (packet.TargetId != Guid.Empty)
-            {
-                foreach (var mapInstance in MapController.GetSurroundingMapInstances(player.Map.Id, player.MapInstanceId, true))
-                {
-                    foreach (var en in mapInstance.GetEntities())
-                    {
-                        if (en.Id == packet.TargetId)
-                        {
-                            player.UseSpell(packet.Slot, en);
-                            casted = true;
-
-                            break;
-                        }
-                    }
-                }
-            }
-
-            if (!casted)
-            {
-                player.UseSpell(packet.Slot, null);
-            }
-        }
-
-        //UnequipItemPacket
-        public void HandlePacket(Client client, UnequipItemPacket packet)
-        {
-            var player = client?.Entity;
-            if (player == null)
-            {
-                return;
-            }
-
-            player.UnequipItem(packet.Slot);
-        }
-
-        //UpgradeStatPacket
-        public void HandlePacket(Client client, UpgradeStatPacket packet)
-        {
-            var player = client?.Entity;
-            if (player == null)
-            {
-                return;
-            }
-
-            player.UpgradeStat(packet.Stat);
-        }
-
-        //HotbarUpdatePacket
-        public void HandlePacket(Client client, HotbarUpdatePacket packet)
-        {
-            var player = client?.Entity;
-            if (player == null)
-            {
-                return;
-            }
-
-            player.HotbarChange(packet.HotbarSlot, packet.Type, packet.Index);
-        }
-
-        //HotbarSwapPacket
-        public void HandlePacket(Client client, HotbarSwapPacket packet)
-        {
-            var player = client?.Entity;
-            if (player == null)
-            {
-                return;
-            }
-
-            player.HotbarSwap(packet.Slot1, packet.Slot2);
-        }
-
-        //BuyItemPacket
-        public void HandlePacket(Client client, BuyItemPacket packet)
-        {
-            var player = client?.Entity;
-            if (player == null)
-            {
-                return;
-            }
-
-            player.BuyItem(packet.Slot, packet.Quantity);
-        }
-
-        //SellItemPacket
-        public void HandlePacket(Client client, SellItemPacket packet)
-        {
-            var player = client?.Entity;
-            if (player == null)
-            {
-                return;
-            }
-
-            player.SellItem(packet.Slot, packet.Quantity);
-        }
-
-        //CloseShopPacket
-        public void HandlePacket(Client client, CloseShopPacket packet)
-        {
-            var player = client?.Entity;
-            if (player == null)
-            {
-                return;
-            }
-
-            player.CloseShop();
-        }
-
-        //CloseCraftingPacket
-        public void HandlePacket(Client client, CloseCraftingPacket packet)
-        {
-            var player = client?.Entity;
-            if (player == null)
-            {
-                return;
-            }
-
-            player.CloseCraftingTable();
-        }
-
-        //CraftItemPacket
-        public void HandlePacket(Client client, CraftItemPacket packet)
-        {
-            var player = client?.Entity;
-            if (player == null)
-            {
-                return;
-            }
-
-            if (player.CraftJournalMode)
-            {
-                PacketSender.SendChatMsg(player, Strings.Crafting.InJournalMode, ChatMessageType.Notice);
-                return;
-            }
-
-            lock (player.EntityLock)
-            {
-                //if player hit stop button in crafting window
-                if (packet.CraftId == default)
-                {
-                    player.CraftingState = default;
-                    return;
+                    itemsFromMap = new List<MapItem>();
+                    giveItems[mapWithItems] = itemsFromMap;
                 }
 
-                if (!CraftBase.TryGet(packet.CraftId, out var craftDescriptor))
+                itemsFromMap.AddRange(value.SelectMany(itemLoc => mapInstanceWithItems.FindItemsAt(itemLoc)));
+            }
+        }
+        else
+        {
+            // One specific item.
+            giveItems.Add(playerMapController, new List<MapItem> { playerMapInstance.FindItem(packet.UniqueId) });
+        }
+
+        // Go through each item we're trying to give our player and see if we can do so.
+        foreach (var (mapWithItems, value) in giveItems)
+        {
+            if (!mapWithItems.TryGetInstance(player.MapInstanceId, out var mapInstanceWithItems))
+            {
+                continue;
+            }
+
+            // Remove null or missing map items from the list
+            var validMapItems = value.Where(
+                mapItem => mapItem != default && mapInstanceWithItems.FindItem(mapItem.UniqueId) != default
+            );
+            foreach (var mapItem in validMapItems)
+            {
+                if (mapItem.Owner != default &&
+                    mapItem.Owner != player.Id &&
+                    Timing.Global.Milliseconds < mapItem.OwnershipTime)
                 {
-                    Log.Warn($"Player {player.Id} tried to craft {packet.CraftId} which does not exist.");
-                    return;
+                    continue;
                 }
 
-                if (player.OpenCraftingTableId == default)
+                // Remove the item from the map now, because otherwise the overflow would just add to the existing quantity
+                mapInstanceWithItems.RemoveItem(mapItem);
+
+                // Try to give the item to our player.
+                if (!player.TryGiveItem(mapItem, ItemHandling.Overflow, false, -1, true, mapItem.X, mapItem.Y))
                 {
-                    Log.Warn($"Player {player.Id} tried to craft {packet.CraftId} without having opened a table yet.");
-                    return;
-                }
-
-                if (player.CraftingState != default)
-                {
-                    PacketSender.SendChatMsg(player, Strings.Crafting.AlreadyCrafting, ChatMessageType.Crafting, CustomColors.Alerts.Error);
-                    return;
-                }
-
-                player.CraftingState = new CraftingState
-                {
-                    Id = packet.CraftId,
-                    CraftCount = packet.Count,
-                    RemainingCount = packet.Count,
-                    DurationPerCraft = craftDescriptor.Time,
-                    NextCraftCompletionTime = Timing.Global.Milliseconds + craftDescriptor.Time
-                };
-            }
-        }
-
-        //CloseBankPacket
-        public void HandlePacket(Client client, CloseBankPacket packet)
-        {
-            var player = client?.Entity;
-            if (player == null)
-            {
-                return;
-            }
-
-            player.CloseBank();
-        }
-
-        //DepositItemPacket
-        public void HandlePacket(Client client, DepositItemPacket packet)
-        {
-            client?.Entity?.BankInterface?.TryDepositItem(default, packet.Slot, packet.Quantity, packet.BankSlot);
-        }
-
-        //WithdrawItemPacket
-        public void HandlePacket(Client client, WithdrawItemPacket packet)
-        {
-            client?.Entity?.BankInterface?.TryWithdrawItem(default, packet.Slot, packet.Quantity, packet.InvSlot);
-        }
-
-        //MoveBankItemPacket
-        public void HandlePacket(Client client, SwapBankItemsPacket packet)
-        {
-            var player = client?.Entity;
-            if (player == null)
-            {
-                return;
-            }
-
-            player?.BankInterface?.SwapBankItems(packet.Slot1, packet.Slot2);
-        }
-
-        //PartyInvitePacket
-        public void HandlePacket(Client client, PartyInvitePacket packet)
-        {
-            var player = client?.Entity;
-            if (player == null)
-            {
-                return;
-            }
-
-            var target = packet.TargetId != Guid.Empty ?
-                Player.FindOnline(packet.TargetId) :
-                Player.FindOnline(packet.Target.Trim());
-
-            if (target != null && target.Id != player.Id)
-            {
-                target.InviteToParty(player);
-
-                return;
-            }
-
-            PacketSender.SendChatMsg(player, Strings.Parties.outofrange, ChatMessageType.Combat, CustomColors.Combat.NoTarget);
-        }
-
-        //PartyInviteResponsePacket
-        public void HandlePacket(Client client, PartyInviteResponsePacket packet)
-        {
-            var player = client?.Entity;
-            if (player == null)
-            {
-                return;
-            }
-
-            var leader = packet.PartyId;
-            if (player.PartyRequester != null && player.PartyRequester.Id == leader)
-            {
-                if (packet.AcceptingInvite)
-                {
-                    if (player.PartyRequester.IsValidPlayer)
-                    {
-                        _ = player.PartyRequester.TryAddParty(player);
-                    }
-                }
-                else
-                {
+                    // We couldn't give the player their item, notify them.
                     PacketSender.SendChatMsg(
-                        player.PartyRequester, Strings.Parties.declined.ToString(client.Entity.Name),
-                        ChatMessageType.Party,
-                        CustomColors.Alerts.Declined
+                        player,
+                        Strings.Items.InventoryNoSpace,
+                        ChatMessageType.Inventory,
+                        CustomColors.Alerts.Error
                     );
-
-                    if (player.PartyRequests.ContainsKey(player.PartyRequester))
-                    {
-                        player.PartyRequests[player.PartyRequester] =
-                            Timing.Global.Milliseconds + Options.RequestTimeout;
-                    }
-                    else
-                    {
-                        player.PartyRequests.Add(
-                            player.PartyRequester, Timing.Global.Milliseconds + Options.RequestTimeout
-                        );
-                    }
+                    continue;
                 }
 
-                player.PartyRequester = null;
+                if (ItemBase.TryGet(mapItem.ItemId, out var item))
+                {
+                    PacketSender.SendActionMsg(player, item.Name, CustomColors.Items.Rarities[item.Rarity]);
+                }
+            }
+        }
+    }
+
+    //SwapInvItemsPacket
+    public void HandlePacket(Client client, SwapInvItemsPacket packet)
+    {
+        var player = client?.Entity;
+        if (player == null)
+        {
+            return;
+        }
+
+        player.SwapItems(packet.Slot1, packet.Slot2);
+    }
+
+    //DropItemPacket
+    public void HandlePacket(Client client, DropItemPacket packet)
+    {
+        var player = client?.Entity;
+        if (packet == null)
+        {
+            return;
+        }
+
+        player?.DropItemFrom(packet.Slot, packet.Quantity);
+    }
+
+    //UseItemPacket
+    public void HandlePacket(Client client, UseItemPacket packet)
+    {
+        var player = client?.Entity;
+        if (player == null)
+        {
+            return;
+        }
+
+        Entity target = null;
+        if (packet.TargetId != Guid.Empty)
+        {
+            foreach (var mapInstance in MapController.GetSurroundingMapInstances(player.Map.Id, player.MapInstanceId, true))
+            {
+                foreach (var en in mapInstance.GetEntities())
+                {
+                    if (en.Id == packet.TargetId)
+                    {
+                        target = en;
+
+                        break;
+                    }
+                }
             }
         }
 
-        //PartyKickPacket
-        public void HandlePacket(Client client, PartyKickPacket packet)
-        {
-            var player = client?.Entity;
-            if (player == null)
-            {
-                return;
-            }
+        player.UseItem(packet.Slot, target);
+    }
 
-            player.KickParty(packet.TargetId);
+    //SwapSpellsPacket
+    public void HandlePacket(Client client, SwapSpellsPacket packet)
+    {
+        var player = client?.Entity;
+        if (player == null || player.IsCasting)
+        {
+            return;
         }
 
-        //PartyLeavePacket
-        public void HandlePacket(Client client, PartyLeavePacket packet)
-        {
-            var player = client?.Entity;
-            if (player == null)
-            {
-                return;
-            }
+        player.SwapSpells(packet.Slot1, packet.Slot2);
+    }
 
-            player.LeaveParty();
+    //ForgetSpellPacket
+    public void HandlePacket(Client client, ForgetSpellPacket packet)
+    {
+        var player = client?.Entity;
+        if (player == null)
+        {
+            return;
         }
 
-        //QuestResponsePacket
-        public void HandlePacket(Client client, QuestResponsePacket packet)
+        player.ForgetSpell(packet.Slot);
+    }
+
+    //UseSpellPacket
+    public void HandlePacket(Client client, UseSpellPacket packet)
+    {
+        var player = client?.Entity;
+        if (player == null)
         {
-            var player = client?.Entity;
-            if (player == null)
+            return;
+        }
+
+        var casted = false;
+
+        if (packet.TargetId != Guid.Empty)
+        {
+            foreach (var mapInstance in MapController.GetSurroundingMapInstances(player.Map.Id, player.MapInstanceId, true))
             {
+                foreach (var en in mapInstance.GetEntities())
+                {
+                    if (en.Id == packet.TargetId)
+                    {
+                        player.UseSpell(packet.Slot, en);
+                        casted = true;
+
+                        break;
+                    }
+                }
+            }
+        }
+
+        if (!casted)
+        {
+            player.UseSpell(packet.Slot, null);
+        }
+    }
+
+    //UnequipItemPacket
+    public void HandlePacket(Client client, UnequipItemPacket packet)
+    {
+        var player = client?.Entity;
+        if (player == null)
+        {
+            return;
+        }
+
+        player.UnequipItem(packet.Slot);
+    }
+
+    //UpgradeStatPacket
+    public void HandlePacket(Client client, UpgradeStatPacket packet)
+    {
+        var player = client?.Entity;
+        if (player == null)
+        {
+            return;
+        }
+
+        player.UpgradeStat(packet.Stat);
+    }
+
+    //HotbarUpdatePacket
+    public void HandlePacket(Client client, HotbarUpdatePacket packet)
+    {
+        var player = client?.Entity;
+        if (player == null)
+        {
+            return;
+        }
+
+        player.HotbarChange(packet.HotbarSlot, packet.Type, packet.Index);
+    }
+
+    //HotbarSwapPacket
+    public void HandlePacket(Client client, HotbarSwapPacket packet)
+    {
+        var player = client?.Entity;
+        if (player == null)
+        {
+            return;
+        }
+
+        player.HotbarSwap(packet.Slot1, packet.Slot2);
+    }
+
+    //BuyItemPacket
+    public void HandlePacket(Client client, BuyItemPacket packet)
+    {
+        var player = client?.Entity;
+        if (player == null)
+        {
+            return;
+        }
+
+        player.BuyItem(packet.Slot, packet.Quantity);
+    }
+
+    //SellItemPacket
+    public void HandlePacket(Client client, SellItemPacket packet)
+    {
+        var player = client?.Entity;
+        if (player == null)
+        {
+            return;
+        }
+
+        player.SellItem(packet.Slot, packet.Quantity);
+    }
+
+    //CloseShopPacket
+    public void HandlePacket(Client client, CloseShopPacket packet)
+    {
+        var player = client?.Entity;
+        if (player == null)
+        {
+            return;
+        }
+
+        player.CloseShop();
+    }
+
+    //CloseCraftingPacket
+    public void HandlePacket(Client client, CloseCraftingPacket packet)
+    {
+        var player = client?.Entity;
+        if (player == null)
+        {
+            return;
+        }
+
+        player.CloseCraftingTable();
+    }
+
+    //CraftItemPacket
+    public void HandlePacket(Client client, CraftItemPacket packet)
+    {
+        var player = client?.Entity;
+        if (player == null)
+        {
+            return;
+        }
+
+        if (player.CraftJournalMode)
+        {
+            PacketSender.SendChatMsg(player, Strings.Crafting.InJournalMode, ChatMessageType.Notice);
+            return;
+        }
+
+        lock (player.EntityLock)
+        {
+            //if player hit stop button in crafting window
+            if (packet.CraftId == default)
+            {
+                player.CraftingState = default;
                 return;
             }
 
-            if (packet.AcceptingQuest)
+            if (!CraftBase.TryGet(packet.CraftId, out var craftDescriptor))
             {
-                player.AcceptQuest(packet.QuestId);
+                Log.Warn($"Player {player.Id} tried to craft {packet.CraftId} which does not exist.");
+                return;
+            }
+
+            if (player.OpenCraftingTableId == default)
+            {
+                Log.Warn($"Player {player.Id} tried to craft {packet.CraftId} without having opened a table yet.");
+                return;
+            }
+
+            if (player.CraftingState != default)
+            {
+                PacketSender.SendChatMsg(player, Strings.Crafting.AlreadyCrafting, ChatMessageType.Crafting, CustomColors.Alerts.Error);
+                return;
+            }
+
+            player.CraftingState = new CraftingState
+            {
+                Id = packet.CraftId,
+                CraftCount = packet.Count,
+                RemainingCount = packet.Count,
+                DurationPerCraft = craftDescriptor.Time,
+                NextCraftCompletionTime = Timing.Global.Milliseconds + craftDescriptor.Time
+            };
+        }
+    }
+
+    //CloseBankPacket
+    public void HandlePacket(Client client, CloseBankPacket packet)
+    {
+        var player = client?.Entity;
+        if (player == null)
+        {
+            return;
+        }
+
+        player.CloseBank();
+    }
+
+    //DepositItemPacket
+    public void HandlePacket(Client client, DepositItemPacket packet)
+    {
+        client?.Entity?.BankInterface?.TryDepositItem(default, packet.Slot, packet.Quantity, packet.BankSlot);
+    }
+
+    //WithdrawItemPacket
+    public void HandlePacket(Client client, WithdrawItemPacket packet)
+    {
+        client?.Entity?.BankInterface?.TryWithdrawItem(default, packet.Slot, packet.Quantity, packet.InvSlot);
+    }
+
+    //MoveBankItemPacket
+    public void HandlePacket(Client client, SwapBankItemsPacket packet)
+    {
+        var player = client?.Entity;
+        if (player == null)
+        {
+            return;
+        }
+
+        player?.BankInterface?.SwapBankItems(packet.Slot1, packet.Slot2);
+    }
+
+    //PartyInvitePacket
+    public void HandlePacket(Client client, PartyInvitePacket packet)
+    {
+        var player = client?.Entity;
+        if (player == null)
+        {
+            return;
+        }
+
+        var target = packet.TargetId != Guid.Empty ?
+            Player.FindOnline(packet.TargetId) :
+            Player.FindOnline(packet.Target.Trim());
+
+        if (target != null && target.Id != player.Id)
+        {
+            target.InviteToParty(player);
+
+            return;
+        }
+
+        PacketSender.SendChatMsg(player, Strings.Parties.outofrange, ChatMessageType.Combat, CustomColors.Combat.NoTarget);
+    }
+
+    //PartyInviteResponsePacket
+    public void HandlePacket(Client client, PartyInviteResponsePacket packet)
+    {
+        var player = client?.Entity;
+        if (player == null)
+        {
+            return;
+        }
+
+        var leader = packet.PartyId;
+        if (player.PartyRequester != null && player.PartyRequester.Id == leader)
+        {
+            if (packet.AcceptingInvite)
+            {
+                if (player.PartyRequester.IsValidPlayer)
+                {
+                    _ = player.PartyRequester.TryAddParty(player);
+                }
             }
             else
             {
-                player.DeclineQuest(packet.QuestId);
-            }
-        }
+                PacketSender.SendChatMsg(
+                    player.PartyRequester, Strings.Parties.declined.ToString(client.Entity.Name),
+                    ChatMessageType.Party,
+                    CustomColors.Alerts.Declined
+                );
 
-        //AbandonQuestPacket
-        public void HandlePacket(Client client, AbandonQuestPacket packet)
-        {
-            var player = client?.Entity;
-            if (player == null)
-            {
-                return;
-            }
-
-            player.CancelQuest(packet.QuestId);
-        }
-
-        //TradeRequestPacket
-        public void HandlePacket(Client client, TradeRequestPacket packet)
-        {
-            var player = client?.Entity;
-            if (player == null)
-            {
-                return;
-            }
-
-            var target = Player.FindOnline(packet.TargetId);
-
-            if (target != null && target.Id != player.Id && player.InRangeOf(target, Options.TradeRange))
-            {
-                if (player.InRangeOf(target, Options.TradeRange))
+                if (player.PartyRequests.ContainsKey(player.PartyRequester))
                 {
-                    target.InviteToTrade(player);
-
-                    return;
+                    player.PartyRequests[player.PartyRequester] =
+                        Timing.Global.Milliseconds + Options.RequestTimeout;
+                }
+                else
+                {
+                    player.PartyRequests.Add(
+                        player.PartyRequester, Timing.Global.Milliseconds + Options.RequestTimeout
+                    );
                 }
             }
 
-            //Player Out of Range Or Offline
-            PacketSender.SendChatMsg(player, Strings.Trading.outofrange.ToString(), ChatMessageType.Trading, CustomColors.Combat.NoTarget);
+            player.PartyRequester = null;
+        }
+    }
+
+    //PartyKickPacket
+    public void HandlePacket(Client client, PartyKickPacket packet)
+    {
+        var player = client?.Entity;
+        if (player == null)
+        {
+            return;
         }
 
-        //TradeRequestResponsePacket
-        public void HandlePacket(Client client, TradeRequestResponsePacket packet)
+        player.KickParty(packet.TargetId);
+    }
+
+    //PartyLeavePacket
+    public void HandlePacket(Client client, PartyLeavePacket packet)
+    {
+        var player = client?.Entity;
+        if (player == null)
         {
-            var player = client?.Entity;
-            if (player == null)
+            return;
+        }
+
+        player.LeaveParty();
+    }
+
+    //QuestResponsePacket
+    public void HandlePacket(Client client, QuestResponsePacket packet)
+    {
+        var player = client?.Entity;
+        if (player == null)
+        {
+            return;
+        }
+
+        if (packet.AcceptingQuest)
+        {
+            player.AcceptQuest(packet.QuestId);
+        }
+        else
+        {
+            player.DeclineQuest(packet.QuestId);
+        }
+    }
+
+    //AbandonQuestPacket
+    public void HandlePacket(Client client, AbandonQuestPacket packet)
+    {
+        var player = client?.Entity;
+        if (player == null)
+        {
+            return;
+        }
+
+        player.CancelQuest(packet.QuestId);
+    }
+
+    //TradeRequestPacket
+    public void HandlePacket(Client client, TradeRequestPacket packet)
+    {
+        var player = client?.Entity;
+        if (player == null)
+        {
+            return;
+        }
+
+        var target = Player.FindOnline(packet.TargetId);
+
+        if (target != null && target.Id != player.Id && player.InRangeOf(target, Options.TradeRange))
+        {
+            if (player.InRangeOf(target, Options.TradeRange))
             {
+                target.InviteToTrade(player);
+
                 return;
             }
+        }
 
-            var target = packet.TradeId;
-            if (player.Trading.Requester != null && player.Trading.Requester.Id == target)
+        //Player Out of Range Or Offline
+        PacketSender.SendChatMsg(player, Strings.Trading.outofrange.ToString(), ChatMessageType.Trading, CustomColors.Combat.NoTarget);
+    }
+
+    //TradeRequestResponsePacket
+    public void HandlePacket(Client client, TradeRequestResponsePacket packet)
+    {
+        var player = client?.Entity;
+        if (player == null)
+        {
+            return;
+        }
+
+        var target = packet.TradeId;
+        if (player.Trading.Requester != null && player.Trading.Requester.Id == target)
+        {
+            if (player.Trading.Requester.IsValidPlayer)
             {
-                if (player.Trading.Requester.IsValidPlayer)
+                if (packet.AcceptingInvite)
                 {
-                    if (packet.AcceptingInvite)
+                    if (player.Trading.Requester.Trading.Counterparty == null
+                    ) //They could have accepted another trade since.
                     {
-                        if (player.Trading.Requester.Trading.Counterparty == null
-                        ) //They could have accepted another trade since.
+                        if (player.InRangeOf(player.Trading.Requester, Options.TradeRange))
                         {
-                            if (player.InRangeOf(player.Trading.Requester, Options.TradeRange))
-                            {
-                                //Check if still in range lolz
-                                player.Trading.Requester.StartTrade(player);
-                            }
-                            else
-                            {
-                                PacketSender.SendChatMsg(
-                                    player, Strings.Trading.outofrange.ToString(), ChatMessageType.Trading, CustomColors.Combat.NoTarget
-                                );
-                            }
+                            //Check if still in range lolz
+                            player.Trading.Requester.StartTrade(player);
                         }
                         else
                         {
                             PacketSender.SendChatMsg(
-                                player, Strings.Trading.busy.ToString(player.Trading.Requester.Name), ChatMessageType.Trading, Color.Red
+                                player, Strings.Trading.outofrange.ToString(), ChatMessageType.Trading, CustomColors.Combat.NoTarget
                             );
                         }
                     }
                     else
                     {
                         PacketSender.SendChatMsg(
-                            player.Trading.Requester, Strings.Trading.declined.ToString(player.Name),
-                            ChatMessageType.Trading,
-                            CustomColors.Alerts.Declined
+                            player, Strings.Trading.busy.ToString(player.Trading.Requester.Name), ChatMessageType.Trading, Color.Red
                         );
-
-                        if (player.Trading.Requests.ContainsKey(player.Trading.Requester))
-                        {
-                            player.Trading.Requests[player.Trading.Requester] =
-                                Timing.Global.Milliseconds + Options.RequestTimeout;
-                        }
-                        else
-                        {
-                            player.Trading.Requests.Add(
-                                player.Trading.Requester, Timing.Global.Milliseconds + Options.RequestTimeout
-                            );
-                        }
-                    }
-                }
-            }
-
-            player.Trading.Requester = null;
-        }
-
-        //OfferTradeItemPacket
-        public void HandlePacket(Client client, OfferTradeItemPacket packet)
-        {
-            var player = client?.Entity;
-            if (player == null || player.Trading.Counterparty == null)
-            {
-                return;
-            }
-
-            player?.OfferItem(packet.Slot, packet.Quantity);
-        }
-
-        //RevokeTradeItemPacket
-        public void HandlePacket(Client client, RevokeTradeItemPacket packet)
-        {
-            var player = client?.Entity;
-            if (player == null || player.Trading.Counterparty == null)
-            {
-                return;
-            }
-
-            if (player.Trading.Counterparty.Trading.Accepted)
-            {
-                PacketSender.SendChatMsg(
-                    player, Strings.Trading.RevokeNotAllowed.ToString(player.Trading.Counterparty.Name), ChatMessageType.Trading,
-                    CustomColors.Alerts.Declined
-                );
-            }
-            else
-            {
-                player?.RevokeItem(packet.Slot, packet.Quantity);
-            }
-        }
-
-        //AcceptTradePacket
-        public void HandlePacket(Client client, AcceptTradePacket packet)
-        {
-            var player = client?.Entity;
-            if (player == null || player.Trading.Counterparty == null)
-            {
-                return;
-            }
-
-            player.Trading.Accepted = true;
-            if (player.Trading.Counterparty.Trading.Accepted)
-            {
-                if (Options.Instance.Logging.Trade)
-                {
-                    //Duplicate the items we are trading because they are messed with in the ReturnTradeItems() function below
-                    var tradeId = Guid.NewGuid();
-                    var ourItems = player.Trading.Offer.Where(i => i != null && i.ItemId != Guid.Empty).Select(i => i.Clone()).ToArray();
-                    var theirItems = player.Trading.Counterparty.Trading.Offer.Where(i => i != null && i.ItemId != Guid.Empty).Select(i => i.Clone()).ToArray();
-                    TradeHistory.LogTrade(tradeId, player, player.Trading.Counterparty, ourItems, theirItems);
-                    TradeHistory.LogTrade(tradeId, player.Trading.Counterparty, player, theirItems, ourItems);
-                }
-                //Swap the trade boxes over, then return the trade boxes to their new owners!
-                var t = player.Trading.Offer;
-                player.Trading.Offer = player.Trading.Counterparty.Trading.Offer;
-                player.Trading.Counterparty.Trading.Offer = t;
-                player.Trading.Counterparty.ReturnTradeItems();
-                player.ReturnTradeItems();
-
-                PacketSender.SendChatMsg(player, Strings.Trading.accepted, ChatMessageType.Trading, CustomColors.Alerts.Accepted);
-                PacketSender.SendChatMsg(
-                    player.Trading.Counterparty, Strings.Trading.accepted, ChatMessageType.Trading, CustomColors.Alerts.Accepted
-                );
-
-                PacketSender.SendTradeClose(player.Trading.Counterparty);
-                PacketSender.SendTradeClose(player);
-                player.Trading.Counterparty.Trading.Counterparty = null;
-                player.Trading.Counterparty = null;
-            }
-            else
-            {
-                PacketSender.SendChatMsg(
-                    player.Trading.Counterparty, Strings.Trading.OfferAccepted.ToString(player.Name), ChatMessageType.Trading, CustomColors.Alerts.Accepted
-                );
-            }
-        }
-
-        //DeclineTradePacket
-        public void HandlePacket(Client client, DeclineTradePacket packet)
-        {
-            var player = client?.Entity;
-            if (player == null)
-            {
-                return;
-            }
-
-            player?.CancelTrade();
-        }
-
-        //CloseBagPacket
-        public void HandlePacket(Client client, CloseBagPacket packet)
-        {
-            var player = client?.Entity;
-            if (player == null)
-            {
-                return;
-            }
-
-            player?.CloseBag();
-        }
-
-        //StoreBagItemPacket
-        public void HandlePacket(Client client, StoreBagItemPacket packet)
-        {
-            var player = client?.Entity;
-            if (player == null)
-            {
-                return;
-            }
-
-            player?.StoreBagItem(packet.Slot, packet.Quantity, packet.BagSlot);
-        }
-
-        //RetrieveBagItemPacket
-        public void HandlePacket(Client client, RetrieveBagItemPacket packet)
-        {
-            var player = client?.Entity;
-            if (player == null)
-            {
-                return;
-            }
-
-            player?.RetrieveBagItem(packet.Slot, packet.Quantity, packet.InventorySlot);
-        }
-
-        //SwapBagItemPacket
-        public void HandlePacket(Client client, SwapBagItemsPacket packet)
-        {
-            var player = client?.Entity;
-            if (player == null)
-            {
-                return;
-            }
-
-            player?.SwapBagItems(packet.Slot1, packet.Slot2);
-        }
-
-        //RequestFriendsPacket
-        public void HandlePacket(Client client, RequestFriendsPacket packet)
-        {
-            var player = client?.Entity;
-            if (player == null)
-            {
-                return;
-            }
-
-            PacketSender.SendFriends(player);
-        }
-
-        //UpdateFriendsPacket
-        public void HandlePacket(Client client, UpdateFriendsPacket packet)
-        {
-            var player = client?.Entity;
-            if (player == null)
-            {
-                return;
-            }
-
-            if (packet.Adding)
-            {
-                //Don't add yourself!
-                if (packet.Name.ToLower() == client.Entity.Name.ToLower())
-                {
-                    return;
-                }
-
-                if (client.Entity.GetFriendId(packet.Name) == Guid.Empty)
-                {
-                    var target = Player.FindOnline(packet.Name);
-                    if (target != null)
-                    {
-                        if (target.CombatTimer < Timing.Global.Milliseconds)
-                        {
-                            target.FriendRequest(client.Entity);
-                        }
-                        else
-                        {
-                            PacketSender.SendChatMsg(player, Strings.Friends.busy.ToString(target.Name), ChatMessageType.Friend);
-                        }
-                    }
-                    else
-                    {
-                        PacketSender.SendChatMsg(player, Strings.Player.offline, ChatMessageType.Friend, CustomColors.Alerts.Error);
                     }
                 }
                 else
                 {
                     PacketSender.SendChatMsg(
-                        player, Strings.Friends.alreadyfriends.ToString(packet.Name), ChatMessageType.Friend, CustomColors.Alerts.Info
+                        player.Trading.Requester, Strings.Trading.declined.ToString(player.Name),
+                        ChatMessageType.Trading,
+                        CustomColors.Alerts.Declined
                     );
+
+                    if (player.Trading.Requests.ContainsKey(player.Trading.Requester))
+                    {
+                        player.Trading.Requests[player.Trading.Requester] =
+                            Timing.Global.Milliseconds + Options.RequestTimeout;
+                    }
+                    else
+                    {
+                        player.Trading.Requests.Add(
+                            player.Trading.Requester, Timing.Global.Milliseconds + Options.RequestTimeout
+                        );
+                    }
+                }
+            }
+        }
+
+        player.Trading.Requester = null;
+    }
+
+    //OfferTradeItemPacket
+    public void HandlePacket(Client client, OfferTradeItemPacket packet)
+    {
+        var player = client?.Entity;
+        if (player == null || player.Trading.Counterparty == null)
+        {
+            return;
+        }
+
+        player?.OfferItem(packet.Slot, packet.Quantity);
+    }
+
+    //RevokeTradeItemPacket
+    public void HandlePacket(Client client, RevokeTradeItemPacket packet)
+    {
+        var player = client?.Entity;
+        if (player == null || player.Trading.Counterparty == null)
+        {
+            return;
+        }
+
+        if (player.Trading.Counterparty.Trading.Accepted)
+        {
+            PacketSender.SendChatMsg(
+                player, Strings.Trading.RevokeNotAllowed.ToString(player.Trading.Counterparty.Name), ChatMessageType.Trading,
+                CustomColors.Alerts.Declined
+            );
+        }
+        else
+        {
+            player?.RevokeItem(packet.Slot, packet.Quantity);
+        }
+    }
+
+    //AcceptTradePacket
+    public void HandlePacket(Client client, AcceptTradePacket packet)
+    {
+        var player = client?.Entity;
+        if (player == null || player.Trading.Counterparty == null)
+        {
+            return;
+        }
+
+        player.Trading.Accepted = true;
+        if (player.Trading.Counterparty.Trading.Accepted)
+        {
+            if (Options.Instance.Logging.Trade)
+            {
+                //Duplicate the items we are trading because they are messed with in the ReturnTradeItems() function below
+                var tradeId = Guid.NewGuid();
+                var ourItems = player.Trading.Offer.Where(i => i != null && i.ItemId != Guid.Empty).Select(i => i.Clone()).ToArray();
+                var theirItems = player.Trading.Counterparty.Trading.Offer.Where(i => i != null && i.ItemId != Guid.Empty).Select(i => i.Clone()).ToArray();
+                TradeHistory.LogTrade(tradeId, player, player.Trading.Counterparty, ourItems, theirItems);
+                TradeHistory.LogTrade(tradeId, player.Trading.Counterparty, player, theirItems, ourItems);
+            }
+            //Swap the trade boxes over, then return the trade boxes to their new owners!
+            var t = player.Trading.Offer;
+            player.Trading.Offer = player.Trading.Counterparty.Trading.Offer;
+            player.Trading.Counterparty.Trading.Offer = t;
+            player.Trading.Counterparty.ReturnTradeItems();
+            player.ReturnTradeItems();
+
+            PacketSender.SendChatMsg(player, Strings.Trading.accepted, ChatMessageType.Trading, CustomColors.Alerts.Accepted);
+            PacketSender.SendChatMsg(
+                player.Trading.Counterparty, Strings.Trading.accepted, ChatMessageType.Trading, CustomColors.Alerts.Accepted
+            );
+
+            PacketSender.SendTradeClose(player.Trading.Counterparty);
+            PacketSender.SendTradeClose(player);
+            player.Trading.Counterparty.Trading.Counterparty = null;
+            player.Trading.Counterparty = null;
+        }
+        else
+        {
+            PacketSender.SendChatMsg(
+                player.Trading.Counterparty, Strings.Trading.OfferAccepted.ToString(player.Name), ChatMessageType.Trading, CustomColors.Alerts.Accepted
+            );
+        }
+    }
+
+    //DeclineTradePacket
+    public void HandlePacket(Client client, DeclineTradePacket packet)
+    {
+        var player = client?.Entity;
+        if (player == null)
+        {
+            return;
+        }
+
+        player?.CancelTrade();
+    }
+
+    //CloseBagPacket
+    public void HandlePacket(Client client, CloseBagPacket packet)
+    {
+        var player = client?.Entity;
+        if (player == null)
+        {
+            return;
+        }
+
+        player?.CloseBag();
+    }
+
+    //StoreBagItemPacket
+    public void HandlePacket(Client client, StoreBagItemPacket packet)
+    {
+        var player = client?.Entity;
+        if (player == null)
+        {
+            return;
+        }
+
+        player?.StoreBagItem(packet.Slot, packet.Quantity, packet.BagSlot);
+    }
+
+    //RetrieveBagItemPacket
+    public void HandlePacket(Client client, RetrieveBagItemPacket packet)
+    {
+        var player = client?.Entity;
+        if (player == null)
+        {
+            return;
+        }
+
+        player?.RetrieveBagItem(packet.Slot, packet.Quantity, packet.InventorySlot);
+    }
+
+    //SwapBagItemPacket
+    public void HandlePacket(Client client, SwapBagItemsPacket packet)
+    {
+        var player = client?.Entity;
+        if (player == null)
+        {
+            return;
+        }
+
+        player?.SwapBagItems(packet.Slot1, packet.Slot2);
+    }
+
+    //RequestFriendsPacket
+    public void HandlePacket(Client client, RequestFriendsPacket packet)
+    {
+        var player = client?.Entity;
+        if (player == null)
+        {
+            return;
+        }
+
+        PacketSender.SendFriends(player);
+    }
+
+    //UpdateFriendsPacket
+    public void HandlePacket(Client client, UpdateFriendsPacket packet)
+    {
+        var player = client?.Entity;
+        if (player == null)
+        {
+            return;
+        }
+
+        if (packet.Adding)
+        {
+            //Don't add yourself!
+            if (packet.Name.ToLower() == client.Entity.Name.ToLower())
+            {
+                return;
+            }
+
+            if (client.Entity.GetFriendId(packet.Name) == Guid.Empty)
+            {
+                var target = Player.FindOnline(packet.Name);
+                if (target != null)
+                {
+                    if (target.CombatTimer < Timing.Global.Milliseconds)
+                    {
+                        target.FriendRequest(client.Entity);
+                    }
+                    else
+                    {
+                        PacketSender.SendChatMsg(player, Strings.Friends.busy.ToString(target.Name), ChatMessageType.Friend);
+                    }
+                }
+                else
+                {
+                    PacketSender.SendChatMsg(player, Strings.Player.offline, ChatMessageType.Friend, CustomColors.Alerts.Error);
                 }
             }
             else
             {
-                //Check if we have this friend
-                var friendId = player.GetFriendId(packet.Name);
-                if (friendId != Guid.Empty)
+                PacketSender.SendChatMsg(
+                    player, Strings.Friends.alreadyfriends.ToString(packet.Name), ChatMessageType.Friend, CustomColors.Alerts.Info
+                );
+            }
+        }
+        else
+        {
+            //Check if we have this friend
+            var friendId = player.GetFriendId(packet.Name);
+            if (friendId != Guid.Empty)
+            {
+                var otherPlayer = Player.FindOnline(friendId);
+                player.CachedFriends.Remove(friendId);
+                PacketSender.SendFriends(player);
+                PacketSender.SendChatMsg(player, Strings.Friends.remove, ChatMessageType.Friend, CustomColors.Alerts.Declined);
+
+                if (otherPlayer?.CachedFriends.ContainsKey(player.Id) ?? false)
                 {
-                    var otherPlayer = Player.FindOnline(friendId);
-                    player.CachedFriends.Remove(friendId);
-                    PacketSender.SendFriends(player);
-                    PacketSender.SendChatMsg(player, Strings.Friends.remove, ChatMessageType.Friend, CustomColors.Alerts.Declined);
+                    otherPlayer.CachedFriends.Remove(player.Id);
+                    PacketSender.SendFriends(otherPlayer);
+                }
 
-                    if (otherPlayer?.CachedFriends.ContainsKey(player.Id) ?? false)
-                    {
-                        otherPlayer.CachedFriends.Remove(player.Id);
-                        PacketSender.SendFriends(otherPlayer);
-                    }
-
-                    if (!Player.TryRemoveFriendship(player.Id, friendId))
-                    {
-                        client.LogAndDisconnect(player.Id, nameof(Player.TryRemoveFriendship));
-                        return;
-                    }
+                if (!Player.TryRemoveFriendship(player.Id, friendId))
+                {
+                    client.LogAndDisconnect(player.Id, nameof(Player.TryRemoveFriendship));
+                    return;
                 }
             }
         }
+    }
 
-        //FriendRequestResponsePacket
-        public void HandlePacket(Client client, FriendRequestResponsePacket packet)
+    //FriendRequestResponsePacket
+    public void HandlePacket(Client client, FriendRequestResponsePacket packet)
+    {
+        var player = client?.Entity;
+        if (player == null)
         {
-            var player = client?.Entity;
-            if (player == null)
-            {
-                return;
-            }
-
-            var target = Player.FindOnline(packet.FriendId);
-
-            if (target == null || target.Id == player.Id)
-            {
-                return;
-            }
-
-            if (packet.AcceptingRequest)
-            {
-                if (!player.CachedFriends.ContainsKey(target.Id)) // Incase one user deleted friend then re-requested
-                {
-                    if (!player.TryAddFriend(target))
-                    {
-                        return;
-                    }
-
-                    PacketSender.SendChatMsg(
-                        player, Strings.Friends.notification.ToString(target.Name), ChatMessageType.Friend, CustomColors.Alerts.Accepted
-                    );
-
-                    PacketSender.SendFriends(player);
-                }
-
-                if (!target.CachedFriends.ContainsKey(player.Id)) // Incase one user deleted friend then re-requested
-                {
-                    if (!target.TryAddFriend(player))
-                    {
-                        return;
-                    }
-
-                    PacketSender.SendChatMsg(
-                        target, Strings.Friends.accept.ToString(player.Name), ChatMessageType.Friend, CustomColors.Alerts.Accepted
-                    );
-
-                    PacketSender.SendFriends(target);
-                }
-            }
-            else
-            {
-                if (player.FriendRequester == target)
-                {
-                    if (player.FriendRequester.IsValidPlayer)
-                    {
-                        if (player.FriendRequests.ContainsKey(player.FriendRequester))
-                        {
-                            player.FriendRequests[player.FriendRequester] =
-                                Timing.Global.Milliseconds + Options.RequestTimeout;
-                        }
-                        else
-                        {
-                            player.FriendRequests.Add(
-                                client.Entity.FriendRequester, Timing.Global.Milliseconds + Options.RequestTimeout
-                            );
-                        }
-                    }
-                }
-            }
-
-            player.FriendRequester = null;
+            return;
         }
 
-        //SelectCharacterPacket
-        public void HandlePacket(Client client, SelectCharacterPacket packet)
+        var target = Player.FindOnline(packet.FriendId);
+
+        if (target == null || target.Id == player.Id)
         {
-            if (client.User == null)
-            {
-                return;
-            }
-
-            var character = DbInterface.GetUserCharacter(client.User, packet.CharacterId, true);
-            if (character == null)
-            {
-                return;
-            }
-
-            client.LoadCharacter(character);
-
-            UserActivityHistory.LogActivity(client.User?.Id ?? Guid.Empty, client?.Entity?.Id ?? Guid.Empty, client?.Ip, UserActivityHistory.PeerType.Client, UserActivityHistory.UserAction.SelectPlayer, $"{client?.Name},{client?.Entity?.Name}");
-
-            try
-            {
-                client.Entity?.SetOnline();
-                PacketSender.SendJoinGame(client);
-            }
-            catch (Exception exception)
-            {
-                Log.Warn(exception);
-                PacketSender.SendError(client, Strings.Account.loadfail);
-                client.Logout();
-            }
+            return;
         }
 
-        //DeleteCharacterPacket
-        public void HandlePacket(Client client, DeleteCharacterPacket packet)
+        if (packet.AcceptingRequest)
         {
-            if (client.User == null)
+            if (!player.CachedFriends.ContainsKey(target.Id)) // Incase one user deleted friend then re-requested
             {
-                return;
-            }
-
-            if (Player.FindOnline(packet.CharacterId) != null)
-            {
-                PacketSender.SendError(client, Strings.Account.deletecharerror, Strings.Account.deletederror);
-                PacketSender.SendPlayerCharacters(client);
-                return;
-            }
-
-            var character = DbInterface.GetUserCharacter(client.User, packet.CharacterId);
-            if (character != null)
-            {
-                character.LoadGuild();
-                if (character.Guild != null && character.GuildRank == 0)
+                if (!player.TryAddFriend(target))
                 {
-                    PacketSender.SendError(client, Strings.Guilds.deleteguildleader, Strings.Account.deleted);
                     return;
                 }
 
-                foreach (var chr in client.Characters.ToArray())
-                {
-                    if (chr.Id == packet.CharacterId)
-                    {
-                        UserActivityHistory.LogActivity(client?.User?.Id ?? Guid.Empty, client?.Entity?.Id ?? Guid.Empty, client?.Ip, UserActivityHistory.PeerType.Client, UserActivityHistory.UserAction.DeletePlayer, $"{client?.Name},{client?.Entity?.Name}");
+                PacketSender.SendChatMsg(
+                    player, Strings.Friends.notification.ToString(target.Name), ChatMessageType.Friend, CustomColors.Alerts.Accepted
+                );
 
-                        if (!client.User.TryDeleteCharacter(chr))
-                        {
-                            client.LogAndDisconnect(chr.Id, nameof(User.TryDeleteCharacter));
-                        }
+                PacketSender.SendFriends(player);
+            }
+
+            if (!target.CachedFriends.ContainsKey(player.Id)) // Incase one user deleted friend then re-requested
+            {
+                if (!target.TryAddFriend(player))
+                {
+                    return;
+                }
+
+                PacketSender.SendChatMsg(
+                    target, Strings.Friends.accept.ToString(player.Name), ChatMessageType.Friend, CustomColors.Alerts.Accepted
+                );
+
+                PacketSender.SendFriends(target);
+            }
+        }
+        else
+        {
+            if (player.FriendRequester == target)
+            {
+                if (player.FriendRequester.IsValidPlayer)
+                {
+                    if (player.FriendRequests.ContainsKey(player.FriendRequester))
+                    {
+                        player.FriendRequests[player.FriendRequester] =
+                            Timing.Global.Milliseconds + Options.RequestTimeout;
+                    }
+                    else
+                    {
+                        player.FriendRequests.Add(
+                            client.Entity.FriendRequester, Timing.Global.Milliseconds + Options.RequestTimeout
+                        );
                     }
                 }
             }
+        }
 
-            PacketSender.SendError(client, Strings.Account.deletechar, Strings.Account.deleted);
+        player.FriendRequester = null;
+    }
+
+    //SelectCharacterPacket
+    public void HandlePacket(Client client, SelectCharacterPacket packet)
+    {
+        if (client.User == null)
+        {
+            return;
+        }
+
+        var character = DbInterface.GetUserCharacter(client.User, packet.CharacterId, true);
+        if (character == null)
+        {
+            return;
+        }
+
+        client.LoadCharacter(character);
+
+        UserActivityHistory.LogActivity(client.User?.Id ?? Guid.Empty, client?.Entity?.Id ?? Guid.Empty, client?.Ip, UserActivityHistory.PeerType.Client, UserActivityHistory.UserAction.SelectPlayer, $"{client?.Name},{client?.Entity?.Name}");
+
+        try
+        {
+            client.Entity?.SetOnline();
+            PacketSender.SendJoinGame(client);
+        }
+        catch (Exception exception)
+        {
+            Log.Warn(exception);
+            PacketSender.SendError(client, Strings.Account.loadfail);
+            client.Logout();
+        }
+    }
+
+    //DeleteCharacterPacket
+    public void HandlePacket(Client client, DeleteCharacterPacket packet)
+    {
+        if (client.User == null)
+        {
+            return;
+        }
+
+        if (Player.FindOnline(packet.CharacterId) != null)
+        {
+            PacketSender.SendError(client, Strings.Account.deletecharerror, Strings.Account.deletederror);
             PacketSender.SendPlayerCharacters(client);
+            return;
         }
 
-        //NewCharacterPacket
-        public void HandlePacket(Client client, NewCharacterPacket packet)
+        var character = DbInterface.GetUserCharacter(client.User, packet.CharacterId);
+        if (character != null)
         {
-            if (client?.Characters?.Count < Options.MaxCharacters)
+            character.LoadGuild();
+            if (character.Guild != null && character.GuildRank == 0)
             {
-                PacketSender.SendGameObjects(client, GameObjectType.Class);
-                PacketSender.SendCreateCharacter(client);
-            }
-            else
-            {
-                PacketSender.SendError(client, Strings.Account.maxchars);
-            }
-        }
-
-        //ResetPasswordPacket
-        public void HandlePacket(Client client, ResetPasswordPacket packet)
-        {
-            //Find account with that name or email
-
-            if (client.TimeoutMs > Timing.Global.Milliseconds)
-            {
-                PacketSender.SendError(client, Strings.Errors.errortimeout);
-                client.ResetTimeout();
-
+                PacketSender.SendError(client, Strings.Guilds.deleteguildleader, Strings.Account.deleted);
                 return;
             }
 
-            var success = false;
-            var user = User.FindFromNameOrEmail(packet.NameOrEmail.Trim());
-            if (user != null)
+            foreach (var chr in client.Characters.ToArray())
             {
-                if (user.PasswordResetCode.ToLower().Trim() == packet.ResetCode.ToLower().Trim() &&
-                    user.PasswordResetTime > DateTime.UtcNow)
+                if (chr.Id == packet.CharacterId)
                 {
-                    user.PasswordResetCode = "";
-                    user.PasswordResetTime = DateTime.MinValue;
-                    DbInterface.ResetPass(user, packet.NewPassword);
-                    success = true;
+                    UserActivityHistory.LogActivity(client?.User?.Id ?? Guid.Empty, client?.Entity?.Id ?? Guid.Empty, client?.Ip, UserActivityHistory.PeerType.Client, UserActivityHistory.UserAction.DeletePlayer, $"{client?.Name},{client?.Entity?.Name}");
+
+                    if (!client.User.TryDeleteCharacter(chr))
+                    {
+                        client.LogAndDisconnect(chr.Id, nameof(User.TryDeleteCharacter));
+                    }
                 }
             }
-
-            PacketSender.SendPasswordResetResult(client, success);
         }
 
-        //RequestGuildPacket
-        public void HandlePacket(Client client, RequestGuildPacket packet)
+        PacketSender.SendError(client, Strings.Account.deletechar, Strings.Account.deleted);
+        PacketSender.SendPlayerCharacters(client);
+    }
+
+    //NewCharacterPacket
+    public void HandlePacket(Client client, NewCharacterPacket packet)
+    {
+        if (client?.Characters?.Count < Options.MaxCharacters)
         {
-            var player = client.Entity;
-            if (player == null)
-            {
-                return;
-            }
-            PacketSender.SendGuild(player);
+            PacketSender.SendGameObjects(client, GameObjectType.Class);
+            PacketSender.SendCreateCharacter(client);
+        }
+        else
+        {
+            PacketSender.SendError(client, Strings.Account.maxchars);
+        }
+    }
+
+    //ResetPasswordPacket
+    public void HandlePacket(Client client, ResetPasswordPacket packet)
+    {
+        //Find account with that name or email
+
+        if (client.TimeoutMs > Timing.Global.Milliseconds)
+        {
+            PacketSender.SendError(client, Strings.Errors.errortimeout);
+            client.ResetTimeout();
+
+            return;
         }
 
-
-        //UpdateGuildMemberPacket
-        public void HandlePacket(Client client, UpdateGuildMemberPacket packet)
+        var success = false;
+        var user = User.FindFromNameOrEmail(packet.NameOrEmail.Trim());
+        if (user != null)
         {
-            var player = client.Entity;
-            if (player == null)
+            if (user.PasswordResetCode.ToLower().Trim() == packet.ResetCode.ToLower().Trim() &&
+                user.PasswordResetTime > DateTime.UtcNow)
             {
-                return;
+                user.PasswordResetCode = "";
+                user.PasswordResetTime = DateTime.MinValue;
+                DbInterface.ResetPass(user, packet.NewPassword);
+                success = true;
             }
+        }
 
-            var guild = player.Guild;
+        PacketSender.SendPasswordResetResult(client, success);
+    }
 
-            // Are we in a guild?
-            if (guild == null)
-            {
-                PacketSender.SendChatMsg(player, Strings.Guilds.NotInGuild, ChatMessageType.Guild, CustomColors.Alerts.Error);
-                return;
-            }
+    //RequestGuildPacket
+    public void HandlePacket(Client client, RequestGuildPacket packet)
+    {
+        var player = client.Entity;
+        if (player == null)
+        {
+            return;
+        }
+        PacketSender.SendGuild(player);
+    }
 
-            var isOwner = player.GuildRank == 0;
-            var rank = Options.Instance.Guild.Ranks[Math.Max(0, Math.Min(player.GuildRank, Options.Instance.Guild.Ranks.Length - 1))];
-            Intersect.Network.Packets.Server.GuildMember member = null;
 
-            // Handle our desired action, assuming we're allowed to of course.
-            switch (packet.Action)
-            {
-                case GuildMemberUpdateAction.Invite:
-                    // Are we allowed to invite players?
-                    var inviteRankIndex = Options.Instance.Guild.Ranks.Length - 1;
-                    var inviteRank = Options.Instance.Guild.Ranks[inviteRankIndex];
-                    if (!rank.Permissions.Invite)
+    //UpdateGuildMemberPacket
+    public void HandlePacket(Client client, UpdateGuildMemberPacket packet)
+    {
+        var player = client.Entity;
+        if (player == null)
+        {
+            return;
+        }
+
+        var guild = player.Guild;
+
+        // Are we in a guild?
+        if (guild == null)
+        {
+            PacketSender.SendChatMsg(player, Strings.Guilds.NotInGuild, ChatMessageType.Guild, CustomColors.Alerts.Error);
+            return;
+        }
+
+        var isOwner = player.GuildRank == 0;
+        var rank = Options.Instance.Guild.Ranks[Math.Max(0, Math.Min(player.GuildRank, Options.Instance.Guild.Ranks.Length - 1))];
+        Intersect.Network.Packets.Server.GuildMember member = null;
+
+        // Handle our desired action, assuming we're allowed to of course.
+        switch (packet.Action)
+        {
+            case GuildMemberUpdateAction.Invite:
+                // Are we allowed to invite players?
+                var inviteRankIndex = Options.Instance.Guild.Ranks.Length - 1;
+                var inviteRank = Options.Instance.Guild.Ranks[inviteRankIndex];
+                if (!rank.Permissions.Invite)
+                {
+                    PacketSender.SendChatMsg(player, Strings.Guilds.NotAllowed, ChatMessageType.Guild, CustomColors.Alerts.Error);
+                    return;
+                }
+
+                if (inviteRank.Limit > -1 && guild.Members.Where(m => m.Value.Rank == inviteRankIndex).Count() >= inviteRank.Limit)
+                {
+                    PacketSender.SendChatMsg(player, Strings.Guilds.RankLimitResponse.ToString(inviteRank.Title, player.Name), ChatMessageType.Guild, CustomColors.Alerts.Error);
+                    return;
+                }
+
+                // Does our target player exist online?
+                var target = Player.FindOnline(packet.Name);
+                if (target != null)
+                {
+                    // Are we already in a guild? or have a pending invite?
+                    if (target.Guild == null && target.GuildInvite == null)
+                    {
+                        // Thank god, we can FINALLY get started!
+                        // Set our invite and send our players the relevant messages.
+                        target.GuildInvite = new Tuple<Player, Guild>(player, player.Guild);
+
+                        PacketSender.SendChatMsg(player, Strings.Guilds.InviteSent.ToString(target.Name, player.Guild.Name), ChatMessageType.Guild, CustomColors.Alerts.Info);
+
+                        PacketSender.SendGuildInvite(target, player);
+                    }
+                    else
+                    {
+                        PacketSender.SendChatMsg(player, Strings.Guilds.InviteAlreadyInGuild, ChatMessageType.Guild, CustomColors.Alerts.Error);
+                    }
+                }
+                else
+                {
+                    PacketSender.SendChatMsg(player, Strings.Guilds.InviteNotOnline, ChatMessageType.Guild, CustomColors.Alerts.Error);
+                }
+                break;
+            case GuildMemberUpdateAction.Remove:
+                if (guild.Members.TryGetValue(packet.Id, out member))
+                {
+                    if ((!rank.Permissions.Kick && !isOwner) || member.Rank <= player.GuildRank)
                     {
                         PacketSender.SendChatMsg(player, Strings.Guilds.NotAllowed, ChatMessageType.Guild, CustomColors.Alerts.Error);
                         return;
                     }
 
-                    if (inviteRank.Limit > -1 && guild.Members.Where(m => m.Value.Rank == inviteRankIndex).Count() >= inviteRank.Limit)
+                    // Start common events for all online guild members that this one left
+                    foreach (var mem in guild.FindOnlineMembers())
                     {
-                        PacketSender.SendChatMsg(player, Strings.Guilds.RankLimitResponse.ToString(inviteRank.Title, player.Name), ChatMessageType.Guild, CustomColors.Alerts.Error);
+                        mem.StartCommonEventsWithTrigger(CommonEventTrigger.GuildMemberKicked, guild.Name, member.Name);
+                    }
+
+                    guild.RemoveMember(packet.Id, default, player, GuildHistory.GuildActivityType.Kicked);
+                }
+                else
+                {
+                    PacketSender.SendChatMsg(player, Strings.Guilds.NoSuchPlayer, ChatMessageType.Guild, CustomColors.Alerts.Error);
+                }
+                break;
+            case GuildMemberUpdateAction.Promote:
+                if (guild.Members.TryGetValue(packet.Id, out member))
+                {
+                    var promotionRankIndex = Math.Max(0, Math.Min(packet.Rank, Options.Instance.Guild.Ranks.Length - 1));
+                    var promotionRank = Options.Instance.Guild.Ranks[promotionRankIndex];
+                    if ((!rank.Permissions.Promote && !isOwner) || member.Rank <= player.GuildRank || packet.Rank <= player.GuildRank || packet.Rank > member.Rank)
+                    {
+                        PacketSender.SendChatMsg(player, Strings.Guilds.NotAllowed, ChatMessageType.Guild, CustomColors.Alerts.Error);
                         return;
                     }
 
-                    // Does our target player exist online?
-                    var target = Player.FindOnline(packet.Name);
-                    if (target != null)
+                    if (promotionRank.Limit > -1 && guild.Members.Where(m => m.Value.Rank == promotionRankIndex).Count() >= promotionRank.Limit)
                     {
-                        // Are we already in a guild? or have a pending invite?
-                        if (target.Guild == null && target.GuildInvite == null)
-                        {
-                            // Thank god, we can FINALLY get started!
-                            // Set our invite and send our players the relevant messages.
-                            target.GuildInvite = new Tuple<Player, Guild>(player, player.Guild);
-
-                            PacketSender.SendChatMsg(player, Strings.Guilds.InviteSent.ToString(target.Name, player.Guild.Name), ChatMessageType.Guild, CustomColors.Alerts.Info);
-
-                            PacketSender.SendGuildInvite(target, player);
-                        }
-                        else
-                        {
-                            PacketSender.SendChatMsg(player, Strings.Guilds.InviteAlreadyInGuild, ChatMessageType.Guild, CustomColors.Alerts.Error);
-                        }
+                        PacketSender.SendChatMsg(player, Strings.Guilds.RankLimitResponse.ToString(promotionRank.Title, player.Name), ChatMessageType.Guild, CustomColors.Alerts.Error);
+                        return;
                     }
-                    else
-                    {
-                        PacketSender.SendChatMsg(player, Strings.Guilds.InviteNotOnline, ChatMessageType.Guild, CustomColors.Alerts.Error);
-                    }
-                    break;
-                case GuildMemberUpdateAction.Remove:
-                    if (guild.Members.TryGetValue(packet.Id, out member))
-                    {
-                        if ((!rank.Permissions.Kick && !isOwner) || member.Rank <= player.GuildRank)
-                        {
-                            PacketSender.SendChatMsg(player, Strings.Guilds.NotAllowed, ChatMessageType.Guild, CustomColors.Alerts.Error);
-                            return;
-                        }
 
-                        // Start common events for all online guild members that this one left
-                        foreach (var mem in guild.FindOnlineMembers())
-                        {
-                            mem.StartCommonEventsWithTrigger(CommonEventTrigger.GuildMemberKicked, guild.Name, member.Name);
-                        }
+                    guild.SetPlayerRank(packet.Id, packet.Rank, player);
 
-                        guild.RemoveMember(packet.Id, default, player, GuildHistory.GuildActivityType.Kicked);
-                    }
-                    else
-                    {
-                        PacketSender.SendChatMsg(player, Strings.Guilds.NoSuchPlayer, ChatMessageType.Guild, CustomColors.Alerts.Error);
-                    }
-                    break;
-                case GuildMemberUpdateAction.Promote:
-                    if (guild.Members.TryGetValue(packet.Id, out member))
-                    {
-                        var promotionRankIndex = Math.Max(0, Math.Min(packet.Rank, Options.Instance.Guild.Ranks.Length - 1));
-                        var promotionRank = Options.Instance.Guild.Ranks[promotionRankIndex];
-                        if ((!rank.Permissions.Promote && !isOwner) || member.Rank <= player.GuildRank || packet.Rank <= player.GuildRank || packet.Rank > member.Rank)
-                        {
-                            PacketSender.SendChatMsg(player, Strings.Guilds.NotAllowed, ChatMessageType.Guild, CustomColors.Alerts.Error);
-                            return;
-                        }
-
-                        if (promotionRank.Limit > -1 && guild.Members.Where(m => m.Value.Rank == promotionRankIndex).Count() >= promotionRank.Limit)
-                        {
-                            PacketSender.SendChatMsg(player, Strings.Guilds.RankLimitResponse.ToString(promotionRank.Title, player.Name), ChatMessageType.Guild, CustomColors.Alerts.Error);
-                            return;
-                        }
-
-                        guild.SetPlayerRank(packet.Id, packet.Rank, player);
-
-                        PacketSender.SendGuildMsg(player, Strings.Guilds.Promoted.ToString(member.Name, promotionRank.Title), CustomColors.Alerts.Success);
-                    }
-                    else
-                    {
-                        PacketSender.SendChatMsg(player, Strings.Guilds.NoSuchPlayer, ChatMessageType.Guild, CustomColors.Alerts.Error);
-                    }
-                    break;
-                case GuildMemberUpdateAction.Demote:
-                    if (guild.Members.TryGetValue(packet.Id, out member))
-                    {
-                        var demotionRankIndex = Math.Max(0, Math.Min(packet.Rank, Options.Instance.Guild.Ranks.Length - 1));
-                        var demotionRank = Options.Instance.Guild.Ranks[demotionRankIndex];
-                        if ((!rank.Permissions.Demote && !isOwner) || member.Rank <= player.GuildRank || packet.Rank <= player.GuildRank || packet.Rank < member.Rank)
-                        {
-                            PacketSender.SendChatMsg(player, Strings.Guilds.NotAllowed, ChatMessageType.Guild, CustomColors.Alerts.Error);
-                            return;
-                        }
-
-                        if (demotionRank.Limit > -1 && guild.Members.Where(m => m.Value.Rank == demotionRankIndex).Count() >= demotionRank.Limit)
-                        {
-                            PacketSender.SendChatMsg(player, Strings.Guilds.RankLimitResponse.ToString(demotionRank.Title, player.Name), ChatMessageType.Guild, CustomColors.Alerts.Error);
-                            return;
-                        }
-
-                        guild.SetPlayerRank(packet.Id, packet.Rank, player);
-
-                        PacketSender.SendGuildMsg(player, Strings.Guilds.Demoted.ToString(member.Name, demotionRank.Title), CustomColors.Alerts.Error);
-                    }
-                    else
-                    {
-                        PacketSender.SendChatMsg(player, Strings.Guilds.NoSuchPlayer, ChatMessageType.Guild, CustomColors.Alerts.Error);
-                    }
-                    break;
-                case GuildMemberUpdateAction.Transfer:
-                    if (guild.Members.TryGetValue(packet.Id, out member))
-                    {
-                        if (!isOwner)
-                        {
-                            PacketSender.SendChatMsg(player, Strings.Guilds.NotAllowed, ChatMessageType.Guild, CustomColors.Alerts.Error);
-                            return;
-                        }
-
-                        guild.TransferOwnership(Player.Find(packet.Id));
-
-                        PacketSender.SendGuildMsg(player, Strings.Guilds.Transferred.ToString(guild.Name, player.Name, member.Name), CustomColors.Alerts.Success);
-                    }
-                    else
-                    {
-                        PacketSender.SendChatMsg(player, Strings.Guilds.NoSuchPlayer, ChatMessageType.Guild, CustomColors.Alerts.Error);
-                    }
-                    break;
-                default:
-                    /// ???
-                    break;
-            }
-
-            player.UnequipInvalidItems();
-        }
-
-        //GuildInviteAcceptPacket
-        public void HandlePacket(Client client, GuildInviteAcceptPacket packet)
-        {
-            var player = client.Entity;
-            if (player == null)
-            {
-                return;
-            }
-
-            var invitor = player?.GuildInvite?.Item1;
-            var guild = player?.GuildInvite?.Item2;
-
-            // Have we received an invite at all?
-            if (guild == null || player.GuildInvite == null)
-            {
-                PacketSender.SendChatMsg(player, Strings.Guilds.NotReceivedInvite, ChatMessageType.Guild, CustomColors.Alerts.Error);
-                return;
-            }
-
-            if (Options.Instance.Guild.Ranks[Options.Instance.Guild.Ranks.Length - 1].Limit > -1 && guild.Members.Where(m => m.Value.Rank == Options.Instance.Guild.Ranks.Length - 1).Count() >= Options.Instance.Guild.Ranks[Options.Instance.Guild.Ranks.Length - 1].Limit)
-            {
-                // Inform the inviter that the guild is full
-                if (player.GuildInvite.Item1 != null)
-                {
-                    var onlinePlayer = Player.FindOnline(player.GuildInvite.Item1.Id);
-                    if (onlinePlayer != null)
-                    {
-                        PacketSender.SendChatMsg(onlinePlayer, Strings.Guilds.RankLimitResponse.ToString(Options.Instance.Guild.Ranks[Options.Instance.Guild.Ranks.Length - 1].Title, player.Name), ChatMessageType.Guild, CustomColors.Alerts.Error);
-                    }
+                    PacketSender.SendGuildMsg(player, Strings.Guilds.Promoted.ToString(member.Name, promotionRank.Title), CustomColors.Alerts.Success);
                 }
+                else
+                {
+                    PacketSender.SendChatMsg(player, Strings.Guilds.NoSuchPlayer, ChatMessageType.Guild, CustomColors.Alerts.Error);
+                }
+                break;
+            case GuildMemberUpdateAction.Demote:
+                if (guild.Members.TryGetValue(packet.Id, out member))
+                {
+                    var demotionRankIndex = Math.Max(0, Math.Min(packet.Rank, Options.Instance.Guild.Ranks.Length - 1));
+                    var demotionRank = Options.Instance.Guild.Ranks[demotionRankIndex];
+                    if ((!rank.Permissions.Demote && !isOwner) || member.Rank <= player.GuildRank || packet.Rank <= player.GuildRank || packet.Rank < member.Rank)
+                    {
+                        PacketSender.SendChatMsg(player, Strings.Guilds.NotAllowed, ChatMessageType.Guild, CustomColors.Alerts.Error);
+                        return;
+                    }
 
-                //Inform the acceptor that they are actually not in the guild
-                PacketSender.SendChatMsg(player, Strings.Guilds.RankLimit.ToString(player.GuildInvite.Item2.Name), ChatMessageType.Guild, CustomColors.Alerts.Error);
+                    if (demotionRank.Limit > -1 && guild.Members.Where(m => m.Value.Rank == demotionRankIndex).Count() >= demotionRank.Limit)
+                    {
+                        PacketSender.SendChatMsg(player, Strings.Guilds.RankLimitResponse.ToString(demotionRank.Title, player.Name), ChatMessageType.Guild, CustomColors.Alerts.Error);
+                        return;
+                    }
 
-                player.GuildInvite = null;
+                    guild.SetPlayerRank(packet.Id, packet.Rank, player);
 
-                return;
-            }
+                    PacketSender.SendGuildMsg(player, Strings.Guilds.Demoted.ToString(member.Name, demotionRank.Title), CustomColors.Alerts.Error);
+                }
+                else
+                {
+                    PacketSender.SendChatMsg(player, Strings.Guilds.NoSuchPlayer, ChatMessageType.Guild, CustomColors.Alerts.Error);
+                }
+                break;
+            case GuildMemberUpdateAction.Transfer:
+                if (guild.Members.TryGetValue(packet.Id, out member))
+                {
+                    if (!isOwner)
+                    {
+                        PacketSender.SendChatMsg(player, Strings.Guilds.NotAllowed, ChatMessageType.Guild, CustomColors.Alerts.Error);
+                        return;
+                    }
 
-            // Accept our invite!
-            guild.AddMember(player, Options.Instance.Guild.Ranks.Length - 1, invitor);
-            player.GuildInvite = null;
+                    guild.TransferOwnership(Player.Find(packet.Id));
 
-            // Start common events for all online guild members that this one left
-            foreach (var member in guild.FindOnlineMembers())
-            {
-                member.StartCommonEventsWithTrigger(CommonEventTrigger.GuildMemberJoined, guild.Name, player.Name);
-            }
-
-            // Send the updated data around.
-            PacketSender.SendEntityDataToProximity(player);
+                    PacketSender.SendGuildMsg(player, Strings.Guilds.Transferred.ToString(guild.Name, player.Name, member.Name), CustomColors.Alerts.Success);
+                }
+                else
+                {
+                    PacketSender.SendChatMsg(player, Strings.Guilds.NoSuchPlayer, ChatMessageType.Guild, CustomColors.Alerts.Error);
+                }
+                break;
+            default:
+                /// ???
+                break;
         }
 
-        //GuildInviteDeclinePacket
-        public void HandlePacket(Client client, GuildInviteDeclinePacket packet)
+        player.UnequipInvalidItems();
+    }
+
+    //GuildInviteAcceptPacket
+    public void HandlePacket(Client client, GuildInviteAcceptPacket packet)
+    {
+        var player = client.Entity;
+        if (player == null)
         {
-            var player = client.Entity;
-            if (player == null)
-            {
-                return;
-            }
+            return;
+        }
 
-            // Have we received an invite at all?
-            if (player.GuildInvite == null)
-            {
-                PacketSender.SendChatMsg(player, Strings.Guilds.NotReceivedInvite, ChatMessageType.Guild, CustomColors.Alerts.Error);
-                return;
-            }
+        var invitor = player?.GuildInvite?.Item1;
+        var guild = player?.GuildInvite?.Item2;
 
-            // Politely decline our invite.
+        // Have we received an invite at all?
+        if (guild == null || player.GuildInvite == null)
+        {
+            PacketSender.SendChatMsg(player, Strings.Guilds.NotReceivedInvite, ChatMessageType.Guild, CustomColors.Alerts.Error);
+            return;
+        }
+
+        if (Options.Instance.Guild.Ranks[Options.Instance.Guild.Ranks.Length - 1].Limit > -1 && guild.Members.Where(m => m.Value.Rank == Options.Instance.Guild.Ranks.Length - 1).Count() >= Options.Instance.Guild.Ranks[Options.Instance.Guild.Ranks.Length - 1].Limit)
+        {
+            // Inform the inviter that the guild is full
             if (player.GuildInvite.Item1 != null)
             {
                 var onlinePlayer = Player.FindOnline(player.GuildInvite.Item1.Id);
                 if (onlinePlayer != null)
                 {
-                    PacketSender.SendChatMsg(onlinePlayer, Strings.Guilds.InviteDeclinedResponse.ToString(player.Name, player.GuildInvite.Item2.Name), ChatMessageType.Guild, CustomColors.Alerts.Info);
-                    PacketSender.SendChatMsg(player, Strings.Guilds.InviteDeclined.ToString(onlinePlayer.Name, player.GuildInvite.Item2.Name), ChatMessageType.Guild, CustomColors.Alerts.Info);
-                }
-                else
-                {
-                    PacketSender.SendChatMsg(player, Strings.Guilds.InviteDeclined.ToString(player.GuildInvite.Item2.Name), ChatMessageType.Guild, CustomColors.Alerts.Info);
-                }
-
-                player.GuildInvite = null;
-            }
-        }
-
-        //GuildLeavePacket
-        public void HandlePacket(Client client, GuildLeavePacket packet)
-        {
-            var player = client.Entity;
-            if (player == null)
-            {
-                return;
-            }
-
-            var guild = player.Guild;
-
-            // Are we in a guild at all?
-            if (guild == null)
-            {
-                return;
-            }
-
-            // Are we the guild master? If so, they're not allowed to leave.
-            if (player.GuildRank == 0)
-            {
-                PacketSender.SendChatMsg(player, Strings.Guilds.GuildLeaderLeave, ChatMessageType.Guild, CustomColors.Alerts.Error);
-                return;
-            }
-
-            // Start common events for all online guild members that this one left
-            foreach (var member in guild.FindOnlineMembers())
-            {
-                member.StartCommonEventsWithTrigger(CommonEventTrigger.GuildMemberLeft, guild.Name, player.Name);
-            }
-
-            guild.RemoveMember(player.Id, player, null, GuildHistory.GuildActivityType.Left);
-
-            // Send the newly updated player information to their surroundings.
-            PacketSender.SendEntityDataToProximity(player);
-            player.UnequipInvalidItems();
-
-        }
-
-
-        //PictureClosedPacket
-        public void HandlePacket(Client client, PictureClosedPacket packet)
-        {
-            var player = client?.Entity;
-            if (player == null)
-            {
-                return;
-            }
-            player.PictureClosed(packet.EventId);
-        }
-
-        public void HandlePacket(Client client, FadeCompletePacket packet)
-        {
-            var player = client?.Entity;
-            if (player == null)
-            {
-                return;
-            }
-            player.IsFading = false;
-        }
-
-        public void HandlePacket(Client client, TargetPacket packet)
-        {
-            var player = client?.Entity;
-            if (player == null)
-            {
-                return;
-            }
-
-            if (packet.TargetId == Guid.Empty)
-            {
-                player.Target = default;
-                return;
-            }
-
-            if (player.Map.TryGetInstance(player.MapInstanceId, out var instance))
-            {
-                var entity = instance.GetEntities(true).Find(e => e.Id == packet.TargetId);
-                if (entity != null)
-                {
-                    player.Target = entity;
+                    PacketSender.SendChatMsg(onlinePlayer, Strings.Guilds.RankLimitResponse.ToString(Options.Instance.Guild.Ranks[Options.Instance.Guild.Ranks.Length - 1].Title, player.Name), ChatMessageType.Guild, CustomColors.Alerts.Error);
                 }
             }
+
+            //Inform the acceptor that they are actually not in the guild
+            PacketSender.SendChatMsg(player, Strings.Guilds.RankLimit.ToString(player.GuildInvite.Item2.Name), ChatMessageType.Guild, CustomColors.Alerts.Error);
+
+            player.GuildInvite = null;
+
+            return;
         }
 
-        #endregion
+        // Accept our invite!
+        guild.AddMember(player, Options.Instance.Guild.Ranks.Length - 1, invitor);
+        player.GuildInvite = null;
+
+        // Start common events for all online guild members that this one left
+        foreach (var member in guild.FindOnlineMembers())
+        {
+            member.StartCommonEventsWithTrigger(CommonEventTrigger.GuildMemberJoined, guild.Name, player.Name);
+        }
+
+        // Send the updated data around.
+        PacketSender.SendEntityDataToProximity(player);
     }
+
+    //GuildInviteDeclinePacket
+    public void HandlePacket(Client client, GuildInviteDeclinePacket packet)
+    {
+        var player = client.Entity;
+        if (player == null)
+        {
+            return;
+        }
+
+        // Have we received an invite at all?
+        if (player.GuildInvite == null)
+        {
+            PacketSender.SendChatMsg(player, Strings.Guilds.NotReceivedInvite, ChatMessageType.Guild, CustomColors.Alerts.Error);
+            return;
+        }
+
+        // Politely decline our invite.
+        if (player.GuildInvite.Item1 != null)
+        {
+            var onlinePlayer = Player.FindOnline(player.GuildInvite.Item1.Id);
+            if (onlinePlayer != null)
+            {
+                PacketSender.SendChatMsg(onlinePlayer, Strings.Guilds.InviteDeclinedResponse.ToString(player.Name, player.GuildInvite.Item2.Name), ChatMessageType.Guild, CustomColors.Alerts.Info);
+                PacketSender.SendChatMsg(player, Strings.Guilds.InviteDeclined.ToString(onlinePlayer.Name, player.GuildInvite.Item2.Name), ChatMessageType.Guild, CustomColors.Alerts.Info);
+            }
+            else
+            {
+                PacketSender.SendChatMsg(player, Strings.Guilds.InviteDeclined.ToString(player.GuildInvite.Item2.Name), ChatMessageType.Guild, CustomColors.Alerts.Info);
+            }
+
+            player.GuildInvite = null;
+        }
+    }
+
+    //GuildLeavePacket
+    public void HandlePacket(Client client, GuildLeavePacket packet)
+    {
+        var player = client.Entity;
+        if (player == null)
+        {
+            return;
+        }
+
+        var guild = player.Guild;
+
+        // Are we in a guild at all?
+        if (guild == null)
+        {
+            return;
+        }
+
+        // Are we the guild master? If so, they're not allowed to leave.
+        if (player.GuildRank == 0)
+        {
+            PacketSender.SendChatMsg(player, Strings.Guilds.GuildLeaderLeave, ChatMessageType.Guild, CustomColors.Alerts.Error);
+            return;
+        }
+
+        // Start common events for all online guild members that this one left
+        foreach (var member in guild.FindOnlineMembers())
+        {
+            member.StartCommonEventsWithTrigger(CommonEventTrigger.GuildMemberLeft, guild.Name, player.Name);
+        }
+
+        guild.RemoveMember(player.Id, player, null, GuildHistory.GuildActivityType.Left);
+
+        // Send the newly updated player information to their surroundings.
+        PacketSender.SendEntityDataToProximity(player);
+        player.UnequipInvalidItems();
+
+    }
+
+
+    //PictureClosedPacket
+    public void HandlePacket(Client client, PictureClosedPacket packet)
+    {
+        var player = client?.Entity;
+        if (player == null)
+        {
+            return;
+        }
+        player.PictureClosed(packet.EventId);
+    }
+
+    public void HandlePacket(Client client, FadeCompletePacket packet)
+    {
+        var player = client?.Entity;
+        if (player == null)
+        {
+            return;
+        }
+        player.IsFading = false;
+    }
+
+    public void HandlePacket(Client client, TargetPacket packet)
+    {
+        var player = client?.Entity;
+        if (player == null)
+        {
+            return;
+        }
+
+        if (packet.TargetId == Guid.Empty)
+        {
+            player.Target = default;
+            return;
+        }
+
+        if (player.Map.TryGetInstance(player.MapInstanceId, out var instance))
+        {
+            var entity = instance.GetEntities(true).Find(e => e.Id == packet.TargetId);
+            if (entity != null)
+            {
+                player.Target = entity;
+            }
+        }
+    }
+
+    #endregion
 }

--- a/Intersect.Server.Core/Networking/PacketSender.cs
+++ b/Intersect.Server.Core/Networking/PacketSender.cs
@@ -20,716 +20,687 @@ using Intersect.Server.Maps;
 using Intersect.Utilities;
 using Newtonsoft.Json;
 
-namespace Intersect.Server.Networking
+namespace Intersect.Server.Networking;
+
+
+public static partial class PacketSender
 {
 
-    public static partial class PacketSender
+    //Cached GameDataPacket that gets sent to clients
+    public static GameDataPacket CachedGameDataPacket = null;
+
+    public static ConcurrentDictionary<string, long> SentPacketTypes = new ConcurrentDictionary<string, long>();
+
+    public static long SentPackets { get; set; }
+
+    public static long SentBytes { get; set; }
+
+    public static void ResetMetrics()
     {
+        SentPackets = 0;
+        SentBytes = 0;
+    }
 
-        //Cached GameDataPacket that gets sent to clients
-        public static GameDataPacket CachedGameDataPacket = null;
-
-        public static ConcurrentDictionary<string, long> SentPacketTypes = new ConcurrentDictionary<string, long>();
-
-        public static long SentPackets { get; set; }
-
-        public static long SentBytes { get; set; }
-
-        public static void ResetMetrics()
+    //PingPacket
+    public static void SendPing(Client client, bool request = true)
+    {
+        if (client != null && client.LastPing + 250 < Timing.Global.Milliseconds)
         {
-            SentPackets = 0;
-            SentBytes = 0;
+            client.Send(new PingPacket(request), TransmissionMode.Any);
+            client.LastPing = Timing.Global.Milliseconds;
+        }
+    }
+
+    //ConfigPacket
+    public static void SendServerConfig(Client client)
+    {
+        client.Send(new ConfigPacket(Options.OptionsData));
+    }
+
+    //EnteringGamePacket
+    public static void SendEnteringGamePacket(Player player)
+    {
+        player.SendPacket(new EnteringGamePacket());
+    }
+
+    //JoinGamePacket
+    public static void SendJoinGame(Client client)
+    {
+        UserActivityHistory.LogActivity(client?.User?.Id ?? Guid.Empty, client?.Entity?.Id ?? Guid.Empty, client?.Ip, UserActivityHistory.PeerType.Client, UserActivityHistory.UserAction.SelectPlayer, $"{client?.Name},{client?.Entity?.Name}");
+
+        if (!client.IsEditor)
+        {
+            SendEnteringGamePacket(client.Entity);
+            SendEntityDataTo(client.Entity, client.Entity);
         }
 
-        //PingPacket
-        public static void SendPing(Client client, bool request = true)
+        client.TimedBufferPacketsRemaining = 5;
+        client.Send(new JoinGamePacket());
+        SendGameData(client);
+
+        if (!client.IsEditor)
         {
-            if (client != null && client.LastPing + 250 < Timing.Global.Milliseconds)
+            var player = client.Entity;
+            player.RecalculateStatsAndPoints();
+            player.UnequipInvalidItems();
+            player.InGame = true;
+
+            SendTimeTo(client);
+
+            if (client.Power.Editor)
             {
-                client.Send(new PingPacket(request), TransmissionMode.Any);
-                client.LastPing = Timing.Global.Milliseconds;
+                SendChatMsg(player, Strings.Player.adminjoined, ChatMessageType.Notice, CustomColors.Alerts.AdminJoined);
             }
+            else if (client.Power.IsModerator)
+            {
+                SendChatMsg(player, Strings.Player.modjoined, ChatMessageType.Notice, CustomColors.Alerts.ModJoined);
+            }
+
+            player.LoginWarp();
+
+            SendEntityDataTo(client.Entity, player);
+
+            //Search for login activated events and run them
+            player.StartCommonEventsWithTrigger(CommonEventTrigger.Login);
+
+            // Send our friend list over so the UI can adjust accordingly without having to open it client-side first.
+            PacketSender.SendFriends(player);
+        }
+    }
+
+    //MapAreaPacket
+    public static void SendAreaPacket(Player player)
+    {
+        var client = player.Client;
+        if (client == null)
+        {
+            return;
         }
 
-        //ConfigPacket
-        public static void SendServerConfig(Client client)
+        MapController? playerMap = player.Map;
+        if (playerMap == default && !MapController.TryGet(player.MapId, out playerMap))
         {
-            client.Send(new ConfigPacket(Options.OptionsData));
+            return;
         }
 
-        //EnteringGamePacket
-        public static void SendEnteringGamePacket(Player player)
+        var surroundingMaps = playerMap.GetSurroundingMaps(true);
+        // var packets = new List<MapPacket>();
+        foreach (var map in surroundingMaps)
         {
-            player.SendPacket(new EnteringGamePacket());
+            // packets.Add(GenerateMapPacket(client, map.Id));
+            GenerateMapPackets(client, map.Id);
         }
+        // player.SendPacket(new MapAreaPacket(packets.ToArray()));
 
-        //JoinGamePacket
-        public static void SendJoinGame(Client client)
+        var surroundingMapIds = surroundingMaps.Select(map => map.Id).ToArray();
+        MapAreaIdsPacket mapAreaIdsPacket = new(surroundingMapIds);
+        player.SendPacket(mapAreaIdsPacket);
+    }
+
+    public static MapPacket GenerateMapPacket(Client client, Guid mapId)
+    {
+        if (client == null)
         {
-            UserActivityHistory.LogActivity(client?.User?.Id ?? Guid.Empty, client?.Entity?.Id ?? Guid.Empty, client?.Ip, UserActivityHistory.PeerType.Client, UserActivityHistory.UserAction.SelectPlayer, $"{client?.Name},{client?.Entity?.Name}");
-
-            if (!client.IsEditor)
-            {
-                SendEnteringGamePacket(client.Entity);
-                SendEntityDataTo(client.Entity, client.Entity);
-            }
-
-            client.TimedBufferPacketsRemaining = 5;
-            client.Send(new JoinGamePacket());
-            SendGameData(client);
-
-            if (!client.IsEditor)
-            {
-                var player = client.Entity;
-                player.RecalculateStatsAndPoints();
-                player.UnequipInvalidItems();
-                player.InGame = true;
-
-                SendTimeTo(client);
-
-                if (client.Power.Editor)
-                {
-                    SendChatMsg(player, Strings.Player.adminjoined, ChatMessageType.Notice, CustomColors.Alerts.AdminJoined);
-                }
-                else if (client.Power.IsModerator)
-                {
-                    SendChatMsg(player, Strings.Player.modjoined, ChatMessageType.Notice, CustomColors.Alerts.ModJoined);
-                }
-
-                player.LoginWarp();
-
-                SendEntityDataTo(client.Entity, player);
-
-                //Search for login activated events and run them
-                player.StartCommonEventsWithTrigger(CommonEventTrigger.Login);
-
-                // Send our friend list over so the UI can adjust accordingly without having to open it client-side first.
-                PacketSender.SendFriends(player);
-            }
-        }
-
-        //MapAreaPacket
-        public static void SendAreaPacket(Player player)
-        {
-            var client = player.Client;
-            if (client == null)
-            {
-                return;
-            }
-
-            MapController? playerMap = player.Map;
-            if (playerMap == default && !MapController.TryGet(player.MapId, out playerMap))
-            {
-                return;
-            }
-
-            var surroundingMaps = playerMap.GetSurroundingMaps(true);
-            // var packets = new List<MapPacket>();
-            foreach (var map in surroundingMaps)
-            {
-                // packets.Add(GenerateMapPacket(client, map.Id));
-                GenerateMapPackets(client, map.Id);
-            }
-            // player.SendPacket(new MapAreaPacket(packets.ToArray()));
-
-            var surroundingMapIds = surroundingMaps.Select(map => map.Id).ToArray();
-            MapAreaIdsPacket mapAreaIdsPacket = new(surroundingMapIds);
-            player.SendPacket(mapAreaIdsPacket);
-        }
-
-        public static MapPacket GenerateMapPacket(Client client, Guid mapId)
-        {
-            if (client == null)
-            {
-                Log.Error("Attempted to send packet to null client.");
-
-                return null;
-            }
-
-            if (!MapController.TryGet(mapId, out var map))
-            {
-                return new MapPacket(mapId, true);
-            }
-
-            if (!client.IsEditor)
-            {
-                var cachedClientPacket = map.CachedMapClientPacket;
-                if (cachedClientPacket != default)
-                {
-                    return cachedClientPacket;
-                }
-            }
-
-            var mapPacket = new MapPacket(
-                mapId,
-                false,
-                map.JsonData,
-                map.TileData,
-                map.AttributeData,
-                map.Revision,
-                map.MapGridX,
-                map.MapGridY,
-                new bool[4]
-            );
-
-            if (client.IsEditor)
-            {
-                foreach (var id in map.EventIds)
-                {
-                    if (EventBase.TryGet(id, out var evt))
-                    {
-                        SendGameObject(client, evt);
-                    }
-                }
-            }
-            else
-            {
-                switch (Options.GameBorderStyle)
-                {
-                    case 1:
-                        mapPacket.CameraHolds = new bool[4] { true, true, true, true };
-
-                        break;
-
-                    case 0:
-                        var grid = DbInterface.GetGrid(map.MapGrid);
-                        if (grid != null)
-                        {
-                            mapPacket.CameraHolds = new bool[4]
-                            {
-                                0 == map.MapGridY, grid.YMax - 1 == map.MapGridY,
-                                0 == map.MapGridX, grid.XMax - 1 == map.MapGridX
-                            };
-                        }
-
-                        break;
-                }
-            }
-
-            if (client.IsEditor)
-            {
-                return mapPacket;
-            }
-
-            map.CachedMapClientPacket = mapPacket;
-
-            return mapPacket;
-        }
-
-        //MapPacket
-        public static (MapPacket, MapEntitiesPacket?, MapItemsPacket?) GenerateMapPackets(Client client, Guid mapId)
-        {
-            if (client == null)
-            {
-                Log.Error("Attempted to send packet to null client.");
-
-                return default;
-            }
-
-            var mapPacket = GenerateMapPacket(client, mapId);
-
-            if (client.IsEditor)
-            {
-                return (mapPacket, default, default);
-            }
-
-            var mapEntitiesPacket = GenerateMapEntitiesPacket(mapId, client.Entity);
-            var mapItemsPacket = GenerateMapItemsPacket(client.Entity, mapId);
-            return (mapPacket, mapEntitiesPacket, mapItemsPacket);
-        }
-
-        //MapPacket
-        public static void SendMap(Client client, Guid mapId, bool allEditors = false, string? checksum = default)
-        {
-            var sentMaps = client?.SentMaps;
-            if (sentMaps == default)
-            {
-                return;
-            }
-
-            if (!MapController.TryGet(mapId, out var map))
-            {
-                return;
-            }
-
-            if (!client.IsEditor)
-            {
-                if (sentMaps.TryGetValue(mapId, out var sentMap))
-                {
-                    if (sentMap.Item1 > Timing.Global.Milliseconds && sentMap.Item2 == map.Revision)
-                    {
-                        return;
-                    }
-
-                    client.SentMaps.Remove(mapId);
-                }
-
-                try
-                {
-                    sentMaps.Add(mapId, new Tuple<long, int>(Timing.Global.Milliseconds + 5000, map.Revision));
-                }
-                catch (Exception exception)
-                {
-                    Log.Error($"Current Map #: {mapId}");
-                    Log.Error($"# Sent maps: {sentMaps.Count}");
-                    Log.Error($"# Maps: {MapController.Lookup.Count}");
-                    Log.Error(exception);
-
-                    throw;
-                }
-            }
-
-            if (client.IsEditor)
-            {
-                var (mapPacket, _, _) = GenerateMapPackets(client, mapId);
-                if (allEditors)
-                {
-                    SendDataToEditors(mapPacket);
-                }
-                else
-                {
-                    client.Send(mapPacket);
-                }
-            }
-            else
-            {
-                var (mapPacket, mapEntitiesPacket, mapItemsPacket) = GenerateMapPackets(client, mapId);
-                var mapIsCached = false;
-                if (!string.IsNullOrWhiteSpace(checksum))
-                {
-                    mapIsCached = string.Equals(checksum, mapPacket.CacheChecksum);
-                }
-
-                if (!mapIsCached)
-                {
-                    client.Send(mapPacket);
-                }
-
-                client.Send(mapEntitiesPacket);
-                client.Send(mapItemsPacket);
-
-                var entity = client.Entity;
-                if (entity != null)
-                {
-                    //TODO: INCLUDE EVENTS IN MAP PACKET
-                    if (mapId == entity.MapId)
-                    {
-                        entity.SendEvents();
-                    }
-                }
-
-                //TODO - Include Aggression and Equipment in ENTITY DATA PACKETS!
-                //SendMapEntityEquipmentTo(client, sendEntities); //Send the equipment of each player
-
-                //foreach (var sendEntity in sendEntities)
-                //{
-                //    if (sendEntity is Npc npc)
-                //    {
-                //        SendNpcAggressionTo(client.Entity, npc);
-                //    }
-                //}
-            }
-        }
-
-        //MapPacket
-        public static void SendMapToEditors(Guid mapId)
-        {
-            MapPacket packet = null;
-            var map = MapController.Get(mapId);
-            if (map == null)
-            {
-                packet = new MapPacket(mapId, true);
-            }
-            else
-            {
-                packet = new MapPacket(
-                    mapId, false, map.JsonData, map.TileData, map.AttributeData, map.Revision, map.MapGridX,
-                    map.MapGridY
-                );
-            }
-
-            SendDataToEditors(packet);
-        }
-
-        //MapEntitiesPacket
-        public static MapEntitiesPacket GenerateMapEntitiesPacket(Guid mapId, Player forPlayer)
-        {
-            if (MapController.TryGetInstanceFromMap(mapId, forPlayer.MapInstanceId, out var mapInstance))
-            {
-                var entities = new List<Entity>();
-                entities.AddRange(mapInstance.GetEntities(false));
-
-                var sendEntities = new List<Entity>();
-                for (var i = 0; i < entities.Count; i++)
-                {
-                    if (entities[i] != null)
-                    {
-                        sendEntities.Add(entities[i]);
-                    }
-                }
-
-                var enPackets = new List<EntityPacket>();
-                for (var i = 0; i < sendEntities.Count; i++)
-                {
-                    enPackets.Add(sendEntities[i].EntityPacket(null, forPlayer));
-                }
-
-                return new MapEntitiesPacket(enPackets.ToArray());
-            }
+            Log.Error("Attempted to send packet to null client.");
 
             return null;
         }
 
-        //EntityPacket
-        public static void SendEntityDataTo(Player player, Entity entity)
+        if (!MapController.TryGet(mapId, out var map))
         {
-            if (entity == null)
+            return new MapPacket(mapId, true);
+        }
+
+        if (!client.IsEditor)
+        {
+            var cachedClientPacket = map.CachedMapClientPacket;
+            if (cachedClientPacket != default)
             {
-                return;
-            }
-
-            var packet = entity.EntityPacket(null, player);
-            packet.IsSelf = entity == player;
-
-            player.SendPacket(packet);
-
-            if (entity == player)
-            {
-                SendExperience(player);
-                SendInventory(player);
-                SendPlayerSpells(player);
-                SendPointsTo(player);
-                SendHotbarSlots(player);
-                SendQuestsProgress(player);
-                SendItemCooldowns(player);
-                SendSpellCooldowns(player);
-            }
-
-            switch (entity)
-            {
-                //If a player, send equipment to all (for paperdolls)
-                case Player entityPlayer:
-                    SendPlayerEquipmentTo(player, entityPlayer);
-                    break;
-
-                case Npc npc:
-                    SendNpcAggressionTo(player, npc);
-                    break;
-
+                return cachedClientPacket;
             }
         }
 
-        //MapEntitiesPacket
-        public static void SendMapEntitiesTo(Player player, ConcurrentDictionary<Guid, Entity> entities)
+        var mapPacket = new MapPacket(
+            mapId,
+            false,
+            map.JsonData,
+            map.TileData,
+            map.AttributeData,
+            map.Revision,
+            map.MapGridX,
+            map.MapGridY,
+            new bool[4]
+        );
+
+        if (client.IsEditor)
         {
-            if (player == null) return;
+            foreach (var id in map.EventIds)
+            {
+                if (EventBase.TryGet(id, out var evt))
+                {
+                    SendGameObject(client, evt);
+                }
+            }
+        }
+        else
+        {
+            switch (Options.GameBorderStyle)
+            {
+                case 1:
+                    mapPacket.CameraHolds = new bool[4] { true, true, true, true };
+
+                    break;
+
+                case 0:
+                    var grid = DbInterface.GetGrid(map.MapGrid);
+                    if (grid != null)
+                    {
+                        mapPacket.CameraHolds = new bool[4]
+                        {
+                            0 == map.MapGridY, grid.YMax - 1 == map.MapGridY,
+                            0 == map.MapGridX, grid.XMax - 1 == map.MapGridX
+                        };
+                    }
+
+                    break;
+            }
+        }
+
+        if (client.IsEditor)
+        {
+            return mapPacket;
+        }
+
+        map.CachedMapClientPacket = mapPacket;
+
+        return mapPacket;
+    }
+
+    //MapPacket
+    public static (MapPacket, MapEntitiesPacket?, MapItemsPacket?) GenerateMapPackets(Client client, Guid mapId)
+    {
+        if (client == null)
+        {
+            Log.Error("Attempted to send packet to null client.");
+
+            return default;
+        }
+
+        var mapPacket = GenerateMapPacket(client, mapId);
+
+        if (client.IsEditor)
+        {
+            return (mapPacket, default, default);
+        }
+
+        var mapEntitiesPacket = GenerateMapEntitiesPacket(mapId, client.Entity);
+        var mapItemsPacket = GenerateMapItemsPacket(client.Entity, mapId);
+        return (mapPacket, mapEntitiesPacket, mapItemsPacket);
+    }
+
+    //MapPacket
+    public static void SendMap(Client client, Guid mapId, bool allEditors = false, string? checksum = default)
+    {
+        var sentMaps = client?.SentMaps;
+        if (sentMaps == default)
+        {
+            return;
+        }
+
+        if (!MapController.TryGet(mapId, out var map))
+        {
+            return;
+        }
+
+        if (!client.IsEditor)
+        {
+            if (sentMaps.TryGetValue(mapId, out var sentMap))
+            {
+                if (sentMap.Item1 > Timing.Global.Milliseconds && sentMap.Item2 == map.Revision)
+                {
+                    return;
+                }
+
+                client.SentMaps.Remove(mapId);
+            }
+
+            try
+            {
+                sentMaps.Add(mapId, new Tuple<long, int>(Timing.Global.Milliseconds + 5000, map.Revision));
+            }
+            catch (Exception exception)
+            {
+                Log.Error($"Current Map #: {mapId}");
+                Log.Error($"# Sent maps: {sentMaps.Count}");
+                Log.Error($"# Maps: {MapController.Lookup.Count}");
+                Log.Error(exception);
+
+                throw;
+            }
+        }
+
+        if (client.IsEditor)
+        {
+            var (mapPacket, _, _) = GenerateMapPackets(client, mapId);
+            if (allEditors)
+            {
+                SendDataToEditors(mapPacket);
+            }
+            else
+            {
+                client.Send(mapPacket);
+            }
+        }
+        else
+        {
+            var (mapPacket, mapEntitiesPacket, mapItemsPacket) = GenerateMapPackets(client, mapId);
+            var mapIsCached = false;
+            if (!string.IsNullOrWhiteSpace(checksum))
+            {
+                mapIsCached = string.Equals(checksum, mapPacket.CacheChecksum);
+            }
+
+            if (!mapIsCached)
+            {
+                client.Send(mapPacket);
+            }
+
+            client.Send(mapEntitiesPacket);
+            client.Send(mapItemsPacket);
+
+            var entity = client.Entity;
+            if (entity != null)
+            {
+                //TODO: INCLUDE EVENTS IN MAP PACKET
+                if (mapId == entity.MapId)
+                {
+                    entity.SendEvents();
+                }
+            }
+
+            //TODO - Include Aggression and Equipment in ENTITY DATA PACKETS!
+            //SendMapEntityEquipmentTo(client, sendEntities); //Send the equipment of each player
+
+            //foreach (var sendEntity in sendEntities)
+            //{
+            //    if (sendEntity is Npc npc)
+            //    {
+            //        SendNpcAggressionTo(client.Entity, npc);
+            //    }
+            //}
+        }
+    }
+
+    //MapPacket
+    public static void SendMapToEditors(Guid mapId)
+    {
+        MapPacket packet = null;
+        var map = MapController.Get(mapId);
+        if (map == null)
+        {
+            packet = new MapPacket(mapId, true);
+        }
+        else
+        {
+            packet = new MapPacket(
+                mapId, false, map.JsonData, map.TileData, map.AttributeData, map.Revision, map.MapGridX,
+                map.MapGridY
+            );
+        }
+
+        SendDataToEditors(packet);
+    }
+
+    //MapEntitiesPacket
+    public static MapEntitiesPacket GenerateMapEntitiesPacket(Guid mapId, Player forPlayer)
+    {
+        if (MapController.TryGetInstanceFromMap(mapId, forPlayer.MapInstanceId, out var mapInstance))
+        {
+            var entities = new List<Entity>();
+            entities.AddRange(mapInstance.GetEntities(false));
 
             var sendEntities = new List<Entity>();
-
-            foreach (var en in entities)
+            for (var i = 0; i < entities.Count; i++)
             {
-                if (en.Value != null && en.Value != player && en.Value.MapInstanceId == player.MapInstanceId)
+                if (entities[i] != null)
                 {
-                    sendEntities.Add(en.Value);
+                    sendEntities.Add(entities[i]);
                 }
             }
 
             var enPackets = new List<EntityPacket>();
             for (var i = 0; i < sendEntities.Count; i++)
             {
-                enPackets.Add(sendEntities[i].EntityPacket(null, player));
+                enPackets.Add(sendEntities[i].EntityPacket(null, forPlayer));
             }
 
-            player.SendPacket(new MapEntitiesPacket(enPackets.ToArray()));
+            return new MapEntitiesPacket(enPackets.ToArray());
+        }
 
-            SendMapEntityEquipmentTo(player, sendEntities); //Send the equipment of each player
+        return null;
+    }
 
-            foreach (var sendEntity in sendEntities)
+    //EntityPacket
+    public static void SendEntityDataTo(Player player, Entity entity)
+    {
+        if (entity == null)
+        {
+            return;
+        }
+
+        var packet = entity.EntityPacket(null, player);
+        packet.IsSelf = entity == player;
+
+        player.SendPacket(packet);
+
+        if (entity == player)
+        {
+            SendExperience(player);
+            SendInventory(player);
+            SendPlayerSpells(player);
+            SendPointsTo(player);
+            SendHotbarSlots(player);
+            SendQuestsProgress(player);
+            SendItemCooldowns(player);
+            SendSpellCooldowns(player);
+        }
+
+        switch (entity)
+        {
+            //If a player, send equipment to all (for paperdolls)
+            case Player entityPlayer:
+                SendPlayerEquipmentTo(player, entityPlayer);
+                break;
+
+            case Npc npc:
+                SendNpcAggressionTo(player, npc);
+                break;
+
+        }
+    }
+
+    //MapEntitiesPacket
+    public static void SendMapEntitiesTo(Player player, ConcurrentDictionary<Guid, Entity> entities)
+    {
+        if (player == null) return;
+
+        var sendEntities = new List<Entity>();
+
+        foreach (var en in entities)
+        {
+            if (en.Value != null && en.Value != player && en.Value.MapInstanceId == player.MapInstanceId)
             {
-                if (sendEntity is Npc npc)
+                sendEntities.Add(en.Value);
+            }
+        }
+
+        var enPackets = new List<EntityPacket>();
+        for (var i = 0; i < sendEntities.Count; i++)
+        {
+            enPackets.Add(sendEntities[i].EntityPacket(null, player));
+        }
+
+        player.SendPacket(new MapEntitiesPacket(enPackets.ToArray()));
+
+        SendMapEntityEquipmentTo(player, sendEntities); //Send the equipment of each player
+
+        foreach (var sendEntity in sendEntities)
+        {
+            if (sendEntity is Npc npc)
+            {
+                SendNpcAggressionTo(player, npc);
+            }
+        }
+    }
+
+    public static void SendMapInstanceChangedPacket(Player player, MapController oldMap, Guid oldLayer)
+    {
+        // Sends a packet to the client telling it that the player has been warped to a new instance and that it should
+        // clear its local entities
+        if (MapController.TryGetInstanceFromMap(oldMap.Id, oldLayer, out var oldMapInstance))
+        {
+            var entitiesToDispose = oldMapInstance.GetEntities(true);
+            var effectedMaps = oldMapInstance.GetController().GetSurroundingMapIds(true);
+
+            var enPackets = new List<EntityPacket>();
+            for (var i = 0; i < entitiesToDispose.Count; i++)
+            {
+                enPackets.Add(entitiesToDispose[i].EntityPacket(null, player));
+            }
+
+            player?.SendPacket(new MapInstanceChangedPacket(enPackets.ToArray(), effectedMaps.ToList()));
+        }
+    }
+
+    public static void SendMapEntityEquipmentTo(Player player, List<Entity> entities)
+    {
+        foreach (var entity in entities)
+        {
+            if (entity != null && entity != player)
+            {
+                //If a player, send equipment to all (for paperdolls)
+                if (entity is Player entityPlayer && player != entity)
                 {
-                    SendNpcAggressionTo(player, npc);
+                    SendPlayerEquipmentTo(player, entityPlayer);
+                }
+            }
+        }
+    }
+
+    //EntityDataPacket
+    public static void SendEntityDataToProximity(Entity en, Player except = null)
+    {
+        if (en == null)
+        {
+            return;
+        }
+
+        if (en is Projectile)
+        {
+            SendDataToProximityOnMapInstance(en.MapId, en.MapInstanceId, en.EntityPacket(null, null), null, TransmissionMode.All);
+        }
+        else
+        {
+            foreach (var map in en.Map.GetSurroundingMaps(true))
+            {
+                foreach (Player entityToSendTo in map.GetPlayersOnSharedInstance(en.MapInstanceId, except))
+                {
+                    SendEntityDataTo(entityToSendTo, en);
                 }
             }
         }
 
-        public static void SendMapInstanceChangedPacket(Player player, MapController oldMap, Guid oldLayer)
-        {
-            // Sends a packet to the client telling it that the player has been warped to a new instance and that it should
-            // clear its local entities
-            if (MapController.TryGetInstanceFromMap(oldMap.Id, oldLayer, out var oldMapInstance))
-            {
-                var entitiesToDispose = oldMapInstance.GetEntities(true);
-                var effectedMaps = oldMapInstance.GetController().GetSurroundingMapIds(true);
+        SendEntityStats(en);
 
-                var enPackets = new List<EntityPacket>();
-                for (var i = 0; i < entitiesToDispose.Count; i++)
+        switch (en)
+        {
+            // If a player, send equipment to all (for paperdolls)
+            case Player player:
+                SendPlayerEquipmentToProximity(player);
+                break;
+
+            case Npc npc:
+                SendNpcAggressionToProximity(npc);
+                break;
+        }
+    }
+
+    //EntityDataPacket
+    public static void SendEntityDataToMap(Entity en, MapController map, Player except = null)
+    {
+        if (en == null || !MapController.TryGetInstanceFromMap(map.Id, en.MapInstanceId, out var mapInstance))
+        {
+            return;
+        }
+
+        if (en is Projectile)
+        {
+            SendDataToMapInstance(map.Id, en.MapInstanceId, en.EntityPacket(null, null), null, TransmissionMode.All);
+        }
+        else
+        {
+            foreach (var player in mapInstance.GetPlayers())
+            {
+                if (player != except)
                 {
-                    enPackets.Add(entitiesToDispose[i].EntityPacket(null, player));
-                }
-
-                player?.SendPacket(new MapInstanceChangedPacket(enPackets.ToArray(), effectedMaps.ToList()));
-            }
-        }
-
-        public static void SendMapEntityEquipmentTo(Player player, List<Entity> entities)
-        {
-            foreach (var entity in entities)
-            {
-                if (entity != null && entity != player)
-                {
-                    //If a player, send equipment to all (for paperdolls)
-                    if (entity is Player entityPlayer && player != entity)
-                    {
-                        SendPlayerEquipmentTo(player, entityPlayer);
-                    }
-                }
-            }
-        }
-
-        //EntityDataPacket
-        public static void SendEntityDataToProximity(Entity en, Player except = null)
-        {
-            if (en == null)
-            {
-                return;
-            }
-
-            if (en is Projectile)
-            {
-                SendDataToProximityOnMapInstance(en.MapId, en.MapInstanceId, en.EntityPacket(null, null), null, TransmissionMode.All);
-            }
-            else
-            {
-                foreach (var map in en.Map.GetSurroundingMaps(true))
-                {
-                    foreach (Player entityToSendTo in map.GetPlayersOnSharedInstance(en.MapInstanceId, except))
-                    {
-                        SendEntityDataTo(entityToSendTo, en);
-                    }
-                }
-            }
-
-            SendEntityStats(en);
-
-            switch (en)
-            {
-                // If a player, send equipment to all (for paperdolls)
-                case Player player:
-                    SendPlayerEquipmentToProximity(player);
-                    break;
-
-                case Npc npc:
-                    SendNpcAggressionToProximity(npc);
-                    break;
-            }
-        }
-
-        //EntityDataPacket
-        public static void SendEntityDataToMap(Entity en, MapController map, Player except = null)
-        {
-            if (en == null || !MapController.TryGetInstanceFromMap(map.Id, en.MapInstanceId, out var mapInstance))
-            {
-                return;
-            }
-
-            if (en is Projectile)
-            {
-                SendDataToMapInstance(map.Id, en.MapInstanceId, en.EntityPacket(null, null), null, TransmissionMode.All);
-            }
-            else
-            {
-                foreach (var player in mapInstance.GetPlayers())
-                {
-                    if (player != except)
-                    {
-                        SendEntityDataTo(player, en);
-                    }
-                }
-            }
-
-            SendEntityStats(en);
-
-            switch (en)
-            {
-                // If a player, send equipment to all (for paperdolls)
-                case Player player:
-                    SendPlayerEquipmentToProximity(player);
-                    break;
-
-                case Npc npc:
-                    SendNpcAggressionToProximity(npc);
-                    break;
-            }
-        }
-
-        //EntityPositionPacket
-        public static void SendEntityPositionTo(Client client, Entity en)
-        {
-            if (en == null)
-            {
-                return;
-            }
-
-            client.Send(
-                new EntityPositionPacket(
-                    en.Id, en.GetEntityType(), en.MapId, (byte)en.X, (byte)en.Y, (byte)en.Dir, en.Passable,
-                    en.HideName
-                )
-            );
-        }
-
-        //EntityPositionPacket
-        public static void SendEntityPositionToAll(Entity en)
-        {
-            if (en == null)
-            {
-                return;
-            }
-
-            SendDataToProximityOnMapInstance(
-                en.MapId, en.MapInstanceId,
-                new EntityPositionPacket(
-                    en.Id, en.GetEntityType(), en.MapId, (byte)en.X, (byte)en.Y, (byte)en.Dir, en.Passable,
-                    en.HideName
-                )
-            );
-        }
-
-        public static void SendNpcAggressionToProximity(Npc en)
-        {
-            if (en == null)
-            {
-                return;
-            }
-
-            foreach (var mapInstance in MapController.GetSurroundingMapInstances(en.Map.Id, en.MapInstanceId, true))
-            {
-                var players = mapInstance.GetPlayers();
-                foreach (var pl in players)
-                {
-                    SendNpcAggressionTo(pl, en);
+                    SendEntityDataTo(player, en);
                 }
             }
         }
 
-        //NpcAggressionPacket
-        public static void SendNpcAggressionTo(Player player, Npc npc)
+        SendEntityStats(en);
+
+        switch (en)
         {
-            if (player == null || npc == null)
+            // If a player, send equipment to all (for paperdolls)
+            case Player player:
+                SendPlayerEquipmentToProximity(player);
+                break;
+
+            case Npc npc:
+                SendNpcAggressionToProximity(npc);
+                break;
+        }
+    }
+
+    //EntityPositionPacket
+    public static void SendEntityPositionTo(Client client, Entity en)
+    {
+        if (en == null)
+        {
+            return;
+        }
+
+        client.Send(
+            new EntityPositionPacket(
+                en.Id, en.GetEntityType(), en.MapId, (byte)en.X, (byte)en.Y, (byte)en.Dir, en.Passable,
+                en.HideName
+            )
+        );
+    }
+
+    //EntityPositionPacket
+    public static void SendEntityPositionToAll(Entity en)
+    {
+        if (en == null)
+        {
+            return;
+        }
+
+        SendDataToProximityOnMapInstance(
+            en.MapId, en.MapInstanceId,
+            new EntityPositionPacket(
+                en.Id, en.GetEntityType(), en.MapId, (byte)en.X, (byte)en.Y, (byte)en.Dir, en.Passable,
+                en.HideName
+            )
+        );
+    }
+
+    public static void SendNpcAggressionToProximity(Npc en)
+    {
+        if (en == null)
+        {
+            return;
+        }
+
+        foreach (var mapInstance in MapController.GetSurroundingMapInstances(en.Map.Id, en.MapInstanceId, true))
+        {
+            var players = mapInstance.GetPlayers();
+            foreach (var pl in players)
             {
-                return;
+                SendNpcAggressionTo(pl, en);
             }
+        }
+    }
 
-            player.SendPacket(new NpcAggressionPacket(npc.Id, npc.GetAggression(player)), TransmissionMode.Any);
+    //NpcAggressionPacket
+    public static void SendNpcAggressionTo(Player player, Npc npc)
+    {
+        if (player == null || npc == null)
+        {
+            return;
         }
 
-        //EntityLeftArea
-        public static void SendEntityLeaveMap(Entity en, Guid leftMap)
+        player.SendPacket(new NpcAggressionPacket(npc.Id, npc.GetAggression(player)), TransmissionMode.Any);
+    }
+
+    //EntityLeftArea
+    public static void SendEntityLeaveMap(Entity en, Guid leftMap)
+    {
+        SendDataToMapInstance(leftMap, en.MapInstanceId, new EntityLeftPacket(en.Id, en.GetEntityType(), en.MapId));
+    }
+
+    //EntityLeftPacket
+    public static void SendEntityLeave(Entity en)
+    {
+        SendDataToProximityOnMapInstance(en.MapId, en.MapInstanceId, new EntityLeftPacket(en.Id, en.GetEntityType(), en.MapId));
+    }
+
+    //EntityLeftPacket
+    public static void SendEntityLeaveLayer(Entity en, Guid mapInstanceId)
+    {
+        SendDataToProximityOnMapInstance(en.MapId, mapInstanceId, new EntityLeftPacket(en.Id, en.GetEntityType(), en.MapId));
+    }
+
+    //EntityLeftPacket
+    public static void SendEntityLeaveInstanceOfMap(Entity en, Guid mapId, Guid mapInstanceId)
+    {
+        SendDataToProximityOnMapInstance(mapId, mapInstanceId, new EntityLeftPacket(en.Id, en.GetEntityType(), en.MapId));
+    }
+
+    //EntityLeavePacket
+    public static void SendEntityLeaveTo(Player player, Entity en)
+    {
+        player.SendPacket(new EntityLeftPacket(en.Id, en.GetEntityType(), en.MapId));
+    }
+
+    //EventLeavePacket
+    public static void SendEntityLeaveTo(Player player, Event evt)
+    {
+        player.SendPacket(new EntityLeftPacket(evt.Id, EntityType.Event, evt.MapId));
+    }
+
+    /// <summary>
+    /// Sends a chat message to the specified player.
+    /// </summary>
+    /// <param name="player">The player to which to send a message.</param>
+    /// <param name="message">The message to send.</param>
+    /// <param name="type">The type of message we are sending.</param>
+    /// <param name="target">The sender of this message, should we decide to respond from the client.</param>
+    public static void SendChatMsg(Player player, string message, ChatMessageType type, string target = "")
+    {
+        SendChatMsg(player, message, type, CustomColors.Chat.PlayerMsg, target);
+    }
+
+    /// <summary>
+    /// Sends a chat message to the specified player.
+    /// </summary>
+    /// <param name="player">The player to which to send a message.</param>
+    /// <param name="message">The message to send.</param>
+    /// <param name="type">The type of message we are sending.</param>
+    /// <param name="color">The color assigned to this message.</param>
+    /// <param name="target">The sender of this message, should we decide to respond from the client.</param>
+    public static void SendChatMsg(Player player, string message, ChatMessageType type, Color color, string target = "")
+    {
+        if (player == null)
         {
-            SendDataToMapInstance(leftMap, en.MapInstanceId, new EntityLeftPacket(en.Id, en.GetEntityType(), en.MapId));
+            return;
         }
 
-        //EntityLeftPacket
-        public static void SendEntityLeave(Entity en)
+        player.SendPacket(new ChatMsgPacket(message, type, color, target), TransmissionMode.All);
+    }
+
+    //GameDataPacket
+    public static void SendGameData(Client client)
+    {
+        if (client == null)
         {
-            SendDataToProximityOnMapInstance(en.MapId, en.MapInstanceId, new EntityLeftPacket(en.Id, en.GetEntityType(), en.MapId));
+            return;
         }
 
-        //EntityLeftPacket
-        public static void SendEntityLeaveLayer(Entity en, Guid mapInstanceId)
+        //If this is an editor, send the shops, events, variables, etc
+        if (client.IsEditor)
         {
-            SendDataToProximityOnMapInstance(en.MapId, mapInstanceId, new EntityLeftPacket(en.Id, en.GetEntityType(), en.MapId));
-        }
-
-        //EntityLeftPacket
-        public static void SendEntityLeaveInstanceOfMap(Entity en, Guid mapId, Guid mapInstanceId)
-        {
-            SendDataToProximityOnMapInstance(mapId, mapInstanceId, new EntityLeftPacket(en.Id, en.GetEntityType(), en.MapId));
-        }
-
-        //EntityLeavePacket
-        public static void SendEntityLeaveTo(Player player, Entity en)
-        {
-            player.SendPacket(new EntityLeftPacket(en.Id, en.GetEntityType(), en.MapId));
-        }
-
-        //EventLeavePacket
-        public static void SendEntityLeaveTo(Player player, Event evt)
-        {
-            player.SendPacket(new EntityLeftPacket(evt.Id, EntityType.Event, evt.MapId));
-        }
-
-        /// <summary>
-        /// Sends a chat message to the specified player.
-        /// </summary>
-        /// <param name="player">The player to which to send a message.</param>
-        /// <param name="message">The message to send.</param>
-        /// <param name="type">The type of message we are sending.</param>
-        /// <param name="target">The sender of this message, should we decide to respond from the client.</param>
-        public static void SendChatMsg(Player player, string message, ChatMessageType type, string target = "")
-        {
-            SendChatMsg(player, message, type, CustomColors.Chat.PlayerMsg, target);
-        }
-
-        /// <summary>
-        /// Sends a chat message to the specified player.
-        /// </summary>
-        /// <param name="player">The player to which to send a message.</param>
-        /// <param name="message">The message to send.</param>
-        /// <param name="type">The type of message we are sending.</param>
-        /// <param name="color">The color assigned to this message.</param>
-        /// <param name="target">The sender of this message, should we decide to respond from the client.</param>
-        public static void SendChatMsg(Player player, string message, ChatMessageType type, Color color, string target = "")
-        {
-            if (player == null)
-            {
-                return;
-            }
-
-            player.SendPacket(new ChatMsgPacket(message, type, color, target), TransmissionMode.All);
-        }
-
-        //GameDataPacket
-        public static void SendGameData(Client client)
-        {
-            if (client == null)
-            {
-                return;
-            }
-
-            //If this is an editor, send the shops, events, variables, etc
-            if (client.IsEditor)
-            {
-                foreach (var val in Enum.GetValues(typeof(GameObjectType)))
-                {
-                    if ((GameObjectType)val == GameObjectType.Map)
-                    {
-                        continue;
-                    }
-
-                    if ((GameObjectType)val == GameObjectType.Shop ||
-                         (GameObjectType)val == GameObjectType.Event ||
-                         (GameObjectType)val == GameObjectType.PlayerVariable ||
-                         (GameObjectType)val == GameObjectType.ServerVariable ||
-                         (GameObjectType)val == GameObjectType.GuildVariable ||
-                         (GameObjectType)val == GameObjectType.UserVariable)
-                    {
-                        SendGameObjects(client, (GameObjectType)val, null);
-                    }
-                }
-            }
-
-            //Now send the cached game data that we send to all clients
-            client.Send(CachedGameDataPacket);
-        }
-
-        //GameDataPacket
-        public static void CacheGameDataPacket()
-        {
-            var gameObjects = new List<GameObjectPacket>();
-
-            //Send massive amounts of game data
             foreach (var val in Enum.GetValues(typeof(GameObjectType)))
             {
                 if ((GameObjectType)val == GameObjectType.Map)
@@ -738,1526 +709,1569 @@ namespace Intersect.Server.Networking
                 }
 
                 if ((GameObjectType)val == GameObjectType.Shop ||
-                    (GameObjectType)val == GameObjectType.Event ||
-                    (GameObjectType)val == GameObjectType.PlayerVariable ||
-                    (GameObjectType)val == GameObjectType.ServerVariable ||
-                    (GameObjectType)val == GameObjectType.GuildVariable ||
-                    (GameObjectType)val == GameObjectType.UserVariable)
+                     (GameObjectType)val == GameObjectType.Event ||
+                     (GameObjectType)val == GameObjectType.PlayerVariable ||
+                     (GameObjectType)val == GameObjectType.ServerVariable ||
+                     (GameObjectType)val == GameObjectType.GuildVariable ||
+                     (GameObjectType)val == GameObjectType.UserVariable)
                 {
-                    continue;
-                }
-
-                SendGameObjects(null, (GameObjectType)val, gameObjects);
-            }
-
-            CachedGameDataPacket = new GameDataPacket(gameObjects.ToArray(), CustomColors.Json());
-        }
-
-        /// <summary>
-        /// Sends a global chat message to every user online.
-        /// </summary>
-        /// <param name="message">The message to send.</param>
-        /// <param name="target">The sender of this message, should we decide to respond from the client.</param>
-        public static void SendGlobalMsg(string message, string target = "")
-        {
-            SendGlobalMsg(message, CustomColors.Chat.AnnouncementChat, target);
-        }
-
-        /// <summary>
-        /// Sends a global chat message to every user online.
-        /// </summary>
-        /// <param name="message">The message to send.</param>
-        /// <param name="color">The color assigned to this message.</param>
-        /// <param name="target">The sender of this message, should we decide to respond from the client.</param>
-        /// <param name="type">The type of message we are sending.</param>
-        public static void SendGlobalMsg(string message, Color color, string target = "", ChatMessageType type = ChatMessageType.Global)
-        {
-            SendDataToAllPlayers(new ChatMsgPacket(message, type, color, target));
-        }
-
-        /// <summary>
-        /// Sends a chat message to the proximity of a specified map.
-        /// </summary>
-        /// <param name="message">The message to send.</param>
-        /// <param name="type">The type of message we are sending.</param>
-        /// <param name="mapId">The Map we are sending this message to (and its surroundings).</param>
-        /// <param name="target">The sender of this message, should we decide to respond from the client.</param>
-        /// <returns>Returns whether or not the message was sent successfully.</returns>
-        public static bool SendProximityMsg(string message, ChatMessageType type, Guid mapId, string target = "")
-        {
-            return SendProximityMsg(message, type, mapId, CustomColors.Chat.ProximityMsg);
-        }
-
-        /// <summary>
-        /// Sends a chat message to the proximity of a specified map.
-        /// </summary>
-        /// <param name="message">The message to send.</param>
-        /// <param name="type">The type of message we are sending.</param>
-        /// <param name="mapId">The Map we are sending this message to (and its surroundings).</param>
-        /// <param name="color">The color assigned to this message.</param>
-        /// <param name="target">The sender of this message, should we decide to respond from the client.</param>
-        /// <returns></returns>
-        public static bool SendProximityMsg(string message, ChatMessageType type, Guid mapId, Color color, string target = "")
-        {
-            return SendDataAcrossMapInstancesInProximity(mapId, new ChatMsgPacket(message, type, color, target));
-        }
-
-        /// <summary>
-        /// Sends a chat message to the proximity of a specified map.
-        /// </summary>
-        /// <param name="message">The message to send.</param>
-        /// <param name="type">The type of message we are sending.</param>
-        /// <param name="mapId">The Map we are sending this message to (and its surroundings).</param>
-        /// <param name="mapInstanceId">The ID of the map instance to send the message to.</param>
-        /// <param name="color">The color assigned to this message.</param>
-        /// <param name="target">The sender of this message, should we decide to respond from the client.</param>
-        /// <returns></returns>
-        public static bool SendProximityMsgToLayer(string message, ChatMessageType type, Guid mapId, Guid mapInstanceId, Color color, string target = "")
-        {
-            return SendDataToProximityOnMapInstance(mapId, mapInstanceId, new ChatMsgPacket(message, type, color, target));
-        }
-
-        /// <summary>
-        /// Sends a message to all online staff members.
-        /// </summary>
-        /// <param name="message">The message to send.</param>
-        /// <param name="color">The color assigned to this message.</param>
-        /// <param name="target">The sender of this message, should we decide to respond from the client.</param>
-        public static void SendAdminMsg(string message, Color color, string target = "")
-        {
-            foreach (var player in Globals.OnlineList)
-            {
-                if (player != null)
-                {
-                    if (player.Power != UserRights.None)
-                    {
-                        SendChatMsg(player, message, ChatMessageType.Admin, color, target);
-                    }
+                    SendGameObjects(client, (GameObjectType)val, null);
                 }
             }
         }
 
-        /// <summary>
-        /// Sends a message to our player's party.
-        /// </summary>
-        /// <param name="player">The player of which to send a message to their party.</param>
-        /// <param name="message">The message to send.</param>
-        /// <param name="color">The color assigned to this message.</param>
-        /// <param name="target">The sender of this message, should we decide to respond from the client.</param>
-        public static void SendPartyMsg(Player player, string message, Color color, string target = "")
+        //Now send the cached game data that we send to all clients
+        client.Send(CachedGameDataPacket);
+    }
+
+    //GameDataPacket
+    public static void CacheGameDataPacket()
+    {
+        var gameObjects = new List<GameObjectPacket>();
+
+        //Send massive amounts of game data
+        foreach (var val in Enum.GetValues(typeof(GameObjectType)))
         {
-            foreach (var p in player.Party)
+            if ((GameObjectType)val == GameObjectType.Map)
             {
-                if (p != null)
+                continue;
+            }
+
+            if ((GameObjectType)val == GameObjectType.Shop ||
+                (GameObjectType)val == GameObjectType.Event ||
+                (GameObjectType)val == GameObjectType.PlayerVariable ||
+                (GameObjectType)val == GameObjectType.ServerVariable ||
+                (GameObjectType)val == GameObjectType.GuildVariable ||
+                (GameObjectType)val == GameObjectType.UserVariable)
+            {
+                continue;
+            }
+
+            SendGameObjects(null, (GameObjectType)val, gameObjects);
+        }
+
+        CachedGameDataPacket = new GameDataPacket(gameObjects.ToArray(), CustomColors.Json());
+    }
+
+    /// <summary>
+    /// Sends a global chat message to every user online.
+    /// </summary>
+    /// <param name="message">The message to send.</param>
+    /// <param name="target">The sender of this message, should we decide to respond from the client.</param>
+    public static void SendGlobalMsg(string message, string target = "")
+    {
+        SendGlobalMsg(message, CustomColors.Chat.AnnouncementChat, target);
+    }
+
+    /// <summary>
+    /// Sends a global chat message to every user online.
+    /// </summary>
+    /// <param name="message">The message to send.</param>
+    /// <param name="color">The color assigned to this message.</param>
+    /// <param name="target">The sender of this message, should we decide to respond from the client.</param>
+    /// <param name="type">The type of message we are sending.</param>
+    public static void SendGlobalMsg(string message, Color color, string target = "", ChatMessageType type = ChatMessageType.Global)
+    {
+        SendDataToAllPlayers(new ChatMsgPacket(message, type, color, target));
+    }
+
+    /// <summary>
+    /// Sends a chat message to the proximity of a specified map.
+    /// </summary>
+    /// <param name="message">The message to send.</param>
+    /// <param name="type">The type of message we are sending.</param>
+    /// <param name="mapId">The Map we are sending this message to (and its surroundings).</param>
+    /// <param name="target">The sender of this message, should we decide to respond from the client.</param>
+    /// <returns>Returns whether or not the message was sent successfully.</returns>
+    public static bool SendProximityMsg(string message, ChatMessageType type, Guid mapId, string target = "")
+    {
+        return SendProximityMsg(message, type, mapId, CustomColors.Chat.ProximityMsg);
+    }
+
+    /// <summary>
+    /// Sends a chat message to the proximity of a specified map.
+    /// </summary>
+    /// <param name="message">The message to send.</param>
+    /// <param name="type">The type of message we are sending.</param>
+    /// <param name="mapId">The Map we are sending this message to (and its surroundings).</param>
+    /// <param name="color">The color assigned to this message.</param>
+    /// <param name="target">The sender of this message, should we decide to respond from the client.</param>
+    /// <returns></returns>
+    public static bool SendProximityMsg(string message, ChatMessageType type, Guid mapId, Color color, string target = "")
+    {
+        return SendDataAcrossMapInstancesInProximity(mapId, new ChatMsgPacket(message, type, color, target));
+    }
+
+    /// <summary>
+    /// Sends a chat message to the proximity of a specified map.
+    /// </summary>
+    /// <param name="message">The message to send.</param>
+    /// <param name="type">The type of message we are sending.</param>
+    /// <param name="mapId">The Map we are sending this message to (and its surroundings).</param>
+    /// <param name="mapInstanceId">The ID of the map instance to send the message to.</param>
+    /// <param name="color">The color assigned to this message.</param>
+    /// <param name="target">The sender of this message, should we decide to respond from the client.</param>
+    /// <returns></returns>
+    public static bool SendProximityMsgToLayer(string message, ChatMessageType type, Guid mapId, Guid mapInstanceId, Color color, string target = "")
+    {
+        return SendDataToProximityOnMapInstance(mapId, mapInstanceId, new ChatMsgPacket(message, type, color, target));
+    }
+
+    /// <summary>
+    /// Sends a message to all online staff members.
+    /// </summary>
+    /// <param name="message">The message to send.</param>
+    /// <param name="color">The color assigned to this message.</param>
+    /// <param name="target">The sender of this message, should we decide to respond from the client.</param>
+    public static void SendAdminMsg(string message, Color color, string target = "")
+    {
+        foreach (var player in Globals.OnlineList)
+        {
+            if (player != null)
+            {
+                if (player.Power != UserRights.None)
                 {
-                    SendChatMsg(p, message, ChatMessageType.Party, color, target);
+                    SendChatMsg(player, message, ChatMessageType.Admin, color, target);
                 }
             }
         }
+    }
 
-        //ProjectileDeadPacket
-        public static void SendRemoveProjectileSpawnsFromAllLayers(Guid mapId, Guid[] projDeaths, KeyValuePair<Guid, int>[] spawnDeaths)
+    /// <summary>
+    /// Sends a message to our player's party.
+    /// </summary>
+    /// <param name="player">The player of which to send a message to their party.</param>
+    /// <param name="message">The message to send.</param>
+    /// <param name="color">The color assigned to this message.</param>
+    /// <param name="target">The sender of this message, should we decide to respond from the client.</param>
+    public static void SendPartyMsg(Player player, string message, Color color, string target = "")
+    {
+        foreach (var p in player.Party)
         {
-            SendDataAcrossMapInstancesInProximity(mapId, new ProjectileDeadPacket(projDeaths, spawnDeaths));
-        }
-
-        public static void SendRemoveProjectileSpawns(Guid mapId, Guid mapInstanceId, Guid[] projDeaths, KeyValuePair<Guid, int>[] spawnDeaths)
-        {
-            SendDataToProximityOnMapInstance(mapId, mapInstanceId, new ProjectileDeadPacket(projDeaths, spawnDeaths));
-        }
-
-        //EntityMovePacket
-        public static void SendEntityMove(Entity en, bool correction = false)
-        {
-            if (en == null)
+            if (p != null)
             {
+                SendChatMsg(p, message, ChatMessageType.Party, color, target);
+            }
+        }
+    }
+
+    //ProjectileDeadPacket
+    public static void SendRemoveProjectileSpawnsFromAllLayers(Guid mapId, Guid[] projDeaths, KeyValuePair<Guid, int>[] spawnDeaths)
+    {
+        SendDataAcrossMapInstancesInProximity(mapId, new ProjectileDeadPacket(projDeaths, spawnDeaths));
+    }
+
+    public static void SendRemoveProjectileSpawns(Guid mapId, Guid mapInstanceId, Guid[] projDeaths, KeyValuePair<Guid, int>[] spawnDeaths)
+    {
+        SendDataToProximityOnMapInstance(mapId, mapInstanceId, new ProjectileDeadPacket(projDeaths, spawnDeaths));
+    }
+
+    //EntityMovePacket
+    public static void SendEntityMove(Entity en, bool correction = false)
+    {
+        if (en == null)
+        {
+            return;
+        }
+        if (MapController.TryGetInstanceFromMap(en.Map.Id, en.MapInstanceId, out var mapInstance))
+        {
+            if (en is Player && !Options.Instance.Packets.BatchPlayerMovementPackets)
+            {
+                SendDataToProximityOnMapInstance(
+                    en.MapId, en.MapInstanceId,
+                    new EntityMovePacket(
+                        en.Id, en.GetEntityType(), en.MapId, (byte)en.X, (byte)en.Y, (byte)en.Dir, correction
+                    ), null, TransmissionMode.Any
+                );
                 return;
             }
-            if (MapController.TryGetInstanceFromMap(en.Map.Id, en.MapInstanceId, out var mapInstance))
-            {
-                if (en is Player && !Options.Instance.Packets.BatchPlayerMovementPackets)
-                {
-                    SendDataToProximityOnMapInstance(
-                        en.MapId, en.MapInstanceId,
-                        new EntityMovePacket(
-                            en.Id, en.GetEntityType(), en.MapId, (byte)en.X, (byte)en.Y, (byte)en.Dir, correction
-                        ), null, TransmissionMode.Any
-                    );
-                    return;
-                }
-                mapInstance.AddBatchedMovement(en, correction, null);
-            }
+            mapInstance.AddBatchedMovement(en, correction, null);
+        }
+    }
+
+    //EntityMovePacket
+    public static void SendEntityMoveTo(Player player, Entity en, bool correction = false)
+    {
+        if (en == null || player == null)
+        {
+            return;
         }
 
-        //EntityMovePacket
-        public static void SendEntityMoveTo(Player player, Entity en, bool correction = false)
+        var map = en?.Map;
+        if (MapController.TryGetInstanceFromMap(en.Map.Id, en.MapInstanceId, out var mapInstance))
         {
-            if (en == null || player == null)
+            if (en is Player && !Options.Instance.Packets.BatchPlayerMovementPackets)
             {
+                player.SendPacket(
+                    new EntityMovePacket(
+                        en.Id, en.GetEntityType(), en.MapId, (byte)en.X, (byte)en.Y, (byte)en.Dir, correction
+                    )
+                );
                 return;
             }
+            mapInstance.AddBatchedMovement(en, correction, player);
+            return;
+        }
+    }
 
-            var map = en?.Map;
-            if (MapController.TryGetInstanceFromMap(en.Map.Id, en.MapInstanceId, out var mapInstance))
+    //EntityVitalsPacket
+    public static EntityVitalsPacket GenerateEntityVitalsPacket(Entity en)
+    {
+        return new EntityVitalsPacket(
+            en.Id, en.GetEntityType(), en.MapId, en.GetVitals(), en.GetMaxVitals(), en.StatusPackets(),
+            en.CombatTimer - Timing.Global.Milliseconds
+        );
+    }
+
+    //EntityVitalsPacket
+    public static void SendMapEntityVitalUpdate(MapController map, Entity[] entities, Guid mapInstanceId)
+    {
+        // Generate a list of vitals to send to our users!
+        var data = new List<EntityVitalData>();
+        foreach (var entity in entities)
+        {
+            data.Add(new EntityVitalData()
             {
-                if (en is Player && !Options.Instance.Packets.BatchPlayerMovementPackets)
+                Id = entity.Id,
+                Type = entity.GetEntityType(),
+                Vitals = entity.GetVitals(),
+                MaxVitals = entity.GetMaxVitals(),
+                CombatTimeRemaining = entity.CombatTimer - Timing.Global.Milliseconds
+            });
+        }
+
+        // Send the data to the surroundings!
+        SendDataToProximityOnMapInstance(map.Id, mapInstanceId, new MapEntityVitalsPacket(map.Id, data.ToArray()));
+    }
+
+    public static void SendMapEntityStatusUpdate(MapController map, Entity[] entities, Guid mapInstanceId)
+    {
+        // Generate a list of statuses to send to our users!
+        var data = new List<EntityStatusData>();
+        foreach (var entity in entities)
+        {
+            data.Add(new EntityStatusData()
+            {
+                Id = entity.Id,
+                Type = entity.GetEntityType(),
+                Statuses = entity.StatusPackets()
+            });
+        }
+
+        // Send the data to the surroundings!
+        SendDataToProximityOnMapInstance(map.Id, mapInstanceId, new MapEntityStatusPacket(map.Id, data.ToArray()));
+    }
+
+    //EntityStatsPacket
+    public static void SendEntityStats(Entity en)
+    {
+        if (en == null || en is EventPageInstance || en is Projectile || en is Resource)
+        {
+            return;
+        }
+
+        SendDataToProximityOnMapInstance(en.MapId, en.MapInstanceId, GenerateEntityStatsPacket(en), null, TransmissionMode.Any);
+    }
+
+    //EntityVitalsPacket
+    public static void SendEntityVitalsTo(Client client, Entity en)
+    {
+        if (en == null || en is EventPageInstance || en is Projectile)
+        {
+            return;
+        }
+
+        client.Send(GenerateEntityVitalsPacket(en), TransmissionMode.Any);
+    }
+
+    //EntityStatsPacket
+    public static EntityStatsPacket GenerateEntityStatsPacket(Entity en)
+    {
+        var stats = new int[Enum.GetValues<Stat>().Length];
+        for (var i = 0; i < Enum.GetValues<Stat>().Length; i++)
+        {
+            stats[i] = en.Stat[i].Value();
+        }
+
+        return new EntityStatsPacket(en.Id, en.GetEntityType(), en.MapId, stats);
+    }
+
+    //EntityStatsPacket
+    public static void SendEntityStatsTo(Client client, Entity en)
+    {
+        client.Send(GenerateEntityStatsPacket(en), TransmissionMode.Any);
+    }
+
+    //EntityDirectionPacket
+    public static void SendEntityDir(Entity en)
+    {
+        SendDataToProximityOnMapInstance(
+            en.MapId, en.MapInstanceId, new EntityDirectionPacket(en.Id, en.GetEntityType(), en.MapId, (byte)en.Dir), null, TransmissionMode.Any
+        );
+    }
+
+    //EntityAttackPacket
+    public static void SendEntityAttack(Entity en, int attackTime, bool isBlocking = false)
+    {
+        SendDataToProximityOnMapInstance(en.MapId, en.MapInstanceId, new EntityAttackPacket(en.Id, en.GetEntityType(), en.MapId, attackTime, isBlocking), null, TransmissionMode.Any);
+    }
+
+    //EntityDiePacket
+    public static void SendEntityDie(Entity en)
+    {
+        SendDataToProximityOnMapInstance(en.MapId, en.MapInstanceId, new EntityDiePacket(en.Id, en.GetEntityType(), en.MapId));
+    }
+
+    //EntityDirectionPacket
+    public static void SendEntityDirTo(Player player, Entity en)
+    {
+        player.SendPacket(new EntityDirectionPacket(en.Id, en.GetEntityType(), en.MapId, (byte)en.Dir), TransmissionMode.Any);
+    }
+
+    //EventDialogPacket
+    public static void SendEventDialog(Player player, string prompt, string face, Guid eventId)
+    {
+        player.SendPacket(new EventDialogPacket(eventId, prompt, face, 0, null));
+    }
+
+    //EventDialogPacket
+    public static void SendEventDialog(
+        Player player,
+        string prompt,
+        string opt1,
+        string opt2,
+        string opt3,
+        string opt4,
+        string face,
+        Guid eventId
+    )
+    {
+        player.SendPacket(new EventDialogPacket(eventId, prompt, face, 1, new string[4] { opt1, opt2, opt3, opt4 }));
+    }
+
+    public static void SendInputVariableDialog(
+        Player player,
+        string title,
+        string prompt,
+        VariableDataType type,
+        Guid eventId
+    )
+    {
+        player.SendPacket(new InputVariablePacket(eventId, title, prompt, type));
+    }
+
+    //MapListPacket
+    public static void SendMapList(Client client)
+    {
+        client.Send(new MapListPacket(MapList.List.JsonData));
+    }
+
+    //MapListPacket
+    public static void SendMapListToAll()
+    {
+        SendDataToAll(new MapListPacket(MapList.List.JsonData));
+    }
+
+    //ErrorPacket
+    public static void SendError(Client client, string error, string header = "")
+    {
+        client.Send(new ErrorMessagePacket(header, error));
+    }
+
+    //MapItemsPacket
+    public static MapItemsPacket GenerateMapItemsPacket(Player player, Guid mapId)
+    {
+        var items = new List<MapItemUpdatePacket>();
+        if (MapController.TryGetInstanceFromMap(mapId, player.MapInstanceId, out var mapInstance))
+        {
+            // Generate our data to be send to the client.
+            foreach (var item in mapInstance.AllMapItems.Values)
+            {
+                if (item.VisibleToAll || item.Owner == player?.Id)
                 {
-                    player.SendPacket(
-                        new EntityMovePacket(
-                            en.Id, en.GetEntityType(), en.MapId, (byte)en.X, (byte)en.Y, (byte)en.Dir, correction
-                        )
-                    );
-                    return;
-                }
-                mapInstance.AddBatchedMovement(en, correction, player);
-                return;
-            }
-        }
-
-        //EntityVitalsPacket
-        public static EntityVitalsPacket GenerateEntityVitalsPacket(Entity en)
-        {
-            return new EntityVitalsPacket(
-                en.Id, en.GetEntityType(), en.MapId, en.GetVitals(), en.GetMaxVitals(), en.StatusPackets(),
-                en.CombatTimer - Timing.Global.Milliseconds
-            );
-        }
-
-        //EntityVitalsPacket
-        public static void SendMapEntityVitalUpdate(MapController map, Entity[] entities, Guid mapInstanceId)
-        {
-            // Generate a list of vitals to send to our users!
-            var data = new List<EntityVitalData>();
-            foreach (var entity in entities)
-            {
-                data.Add(new EntityVitalData()
-                {
-                    Id = entity.Id,
-                    Type = entity.GetEntityType(),
-                    Vitals = entity.GetVitals(),
-                    MaxVitals = entity.GetMaxVitals(),
-                    CombatTimeRemaining = entity.CombatTimer - Timing.Global.Milliseconds
-                });
-            }
-
-            // Send the data to the surroundings!
-            SendDataToProximityOnMapInstance(map.Id, mapInstanceId, new MapEntityVitalsPacket(map.Id, data.ToArray()));
-        }
-
-        public static void SendMapEntityStatusUpdate(MapController map, Entity[] entities, Guid mapInstanceId)
-        {
-            // Generate a list of statuses to send to our users!
-            var data = new List<EntityStatusData>();
-            foreach (var entity in entities)
-            {
-                data.Add(new EntityStatusData()
-                {
-                    Id = entity.Id,
-                    Type = entity.GetEntityType(),
-                    Statuses = entity.StatusPackets()
-                });
-            }
-
-            // Send the data to the surroundings!
-            SendDataToProximityOnMapInstance(map.Id, mapInstanceId, new MapEntityStatusPacket(map.Id, data.ToArray()));
-        }
-
-        //EntityStatsPacket
-        public static void SendEntityStats(Entity en)
-        {
-            if (en == null || en is EventPageInstance || en is Projectile || en is Resource)
-            {
-                return;
-            }
-
-            SendDataToProximityOnMapInstance(en.MapId, en.MapInstanceId, GenerateEntityStatsPacket(en), null, TransmissionMode.Any);
-        }
-
-        //EntityVitalsPacket
-        public static void SendEntityVitalsTo(Client client, Entity en)
-        {
-            if (en == null || en is EventPageInstance || en is Projectile)
-            {
-                return;
-            }
-
-            client.Send(GenerateEntityVitalsPacket(en), TransmissionMode.Any);
-        }
-
-        //EntityStatsPacket
-        public static EntityStatsPacket GenerateEntityStatsPacket(Entity en)
-        {
-            var stats = new int[Enum.GetValues<Stat>().Length];
-            for (var i = 0; i < Enum.GetValues<Stat>().Length; i++)
-            {
-                stats[i] = en.Stat[i].Value();
-            }
-
-            return new EntityStatsPacket(en.Id, en.GetEntityType(), en.MapId, stats);
-        }
-
-        //EntityStatsPacket
-        public static void SendEntityStatsTo(Client client, Entity en)
-        {
-            client.Send(GenerateEntityStatsPacket(en), TransmissionMode.Any);
-        }
-
-        //EntityDirectionPacket
-        public static void SendEntityDir(Entity en)
-        {
-            SendDataToProximityOnMapInstance(
-                en.MapId, en.MapInstanceId, new EntityDirectionPacket(en.Id, en.GetEntityType(), en.MapId, (byte)en.Dir), null, TransmissionMode.Any
-            );
-        }
-
-        //EntityAttackPacket
-        public static void SendEntityAttack(Entity en, int attackTime, bool isBlocking = false)
-        {
-            SendDataToProximityOnMapInstance(en.MapId, en.MapInstanceId, new EntityAttackPacket(en.Id, en.GetEntityType(), en.MapId, attackTime, isBlocking), null, TransmissionMode.Any);
-        }
-
-        //EntityDiePacket
-        public static void SendEntityDie(Entity en)
-        {
-            SendDataToProximityOnMapInstance(en.MapId, en.MapInstanceId, new EntityDiePacket(en.Id, en.GetEntityType(), en.MapId));
-        }
-
-        //EntityDirectionPacket
-        public static void SendEntityDirTo(Player player, Entity en)
-        {
-            player.SendPacket(new EntityDirectionPacket(en.Id, en.GetEntityType(), en.MapId, (byte)en.Dir), TransmissionMode.Any);
-        }
-
-        //EventDialogPacket
-        public static void SendEventDialog(Player player, string prompt, string face, Guid eventId)
-        {
-            player.SendPacket(new EventDialogPacket(eventId, prompt, face, 0, null));
-        }
-
-        //EventDialogPacket
-        public static void SendEventDialog(
-            Player player,
-            string prompt,
-            string opt1,
-            string opt2,
-            string opt3,
-            string opt4,
-            string face,
-            Guid eventId
-        )
-        {
-            player.SendPacket(new EventDialogPacket(eventId, prompt, face, 1, new string[4] { opt1, opt2, opt3, opt4 }));
-        }
-
-        public static void SendInputVariableDialog(
-            Player player,
-            string title,
-            string prompt,
-            VariableDataType type,
-            Guid eventId
-        )
-        {
-            player.SendPacket(new InputVariablePacket(eventId, title, prompt, type));
-        }
-
-        //MapListPacket
-        public static void SendMapList(Client client)
-        {
-            client.Send(new MapListPacket(MapList.List.JsonData));
-        }
-
-        //MapListPacket
-        public static void SendMapListToAll()
-        {
-            SendDataToAll(new MapListPacket(MapList.List.JsonData));
-        }
-
-        //ErrorPacket
-        public static void SendError(Client client, string error, string header = "")
-        {
-            client.Send(new ErrorMessagePacket(header, error));
-        }
-
-        //MapItemsPacket
-        public static MapItemsPacket GenerateMapItemsPacket(Player player, Guid mapId)
-        {
-            var items = new List<MapItemUpdatePacket>();
-            if (MapController.TryGetInstanceFromMap(mapId, player.MapInstanceId, out var mapInstance))
-            {
-                // Generate our data to be send to the client.
-                foreach (var item in mapInstance.AllMapItems.Values)
-                {
-                    if (item.VisibleToAll || item.Owner == player?.Id)
-                    {
-                        items.Add(new MapItemUpdatePacket(mapId, item.TileIndex, item.UniqueId, item.ItemId, item.BagId, item.Quantity, item.Properties));
-                    }
+                    items.Add(new MapItemUpdatePacket(mapId, item.TileIndex, item.UniqueId, item.ItemId, item.BagId, item.Quantity, item.Properties));
                 }
             }
-            return new MapItemsPacket(mapId, items.ToArray());
         }
+        return new MapItemsPacket(mapId, items.ToArray());
+    }
 
-        //MapItemsPacket
-        public static void SendMapItems(Player player, Guid mapId)
+    //MapItemsPacket
+    public static void SendMapItems(Player player, Guid mapId)
+    {
+        player.SendPacket(GenerateMapItemsPacket(player, mapId));
+    }
+
+    //MapItemsPacket
+    public static void SendMapItemsToProximity(Guid mapId, MapInstance mapInstance)
+    {
+        // Send all players on a map instance and its surrounding instances a map item update.
+        foreach (var player in mapInstance.GetPlayers(true))
         {
             player.SendPacket(GenerateMapItemsPacket(player, mapId));
         }
+    }
 
-        //MapItemsPacket
-        public static void SendMapItemsToProximity(Guid mapId, MapInstance mapInstance)
+    /// <summary>
+    /// Send a map item update to the relevant players.
+    /// </summary>
+    /// <param name="mapId">The Id of the <see cref="MapController"/> containing the relevant instance.</param>
+    /// <param name="mapInstanceId">The instance ID of the <see cref="MapInstance"/> we are sending the item update for.</param>
+    /// <param name="uniqueId">The Id for the <see cref="MapItem"/> we are sending the item update for.</param>
+    /// <param name="itemRef">The map item that we are sending (or null if removing), passing this saves us a lookup for it.</param>
+    /// <param name="sendToAll">If we are removing the item from the map, do we send this data to everyone?</param>
+    /// <param name="owner">The previous owner of an item being removed when the data is not send to everyone.</param>
+    public static void SendMapItemUpdate(Guid mapId, Guid mapInstanceId, MapItem itemRef, bool removing, bool sendToAll = true, Guid owner = new Guid())
+    {
+        // Does the item exist? If not, send a delete notification. If it does, send an update.
+        if (removing)
         {
-            // Send all players on a map instance and its surrounding instances a map item update.
-            foreach (var player in mapInstance.GetPlayers(true))
+            // Are we to send the removal to all players?
+            if (sendToAll)
             {
-                player.SendPacket(GenerateMapItemsPacket(player, mapId));
-            }
-        }
-
-        /// <summary>
-        /// Send a map item update to the relevant players.
-        /// </summary>
-        /// <param name="mapId">The Id of the <see cref="MapController"/> containing the relevant instance.</param>
-        /// <param name="mapInstanceId">The instance ID of the <see cref="MapInstance"/> we are sending the item update for.</param>
-        /// <param name="uniqueId">The Id for the <see cref="MapItem"/> we are sending the item update for.</param>
-        /// <param name="itemRef">The map item that we are sending (or null if removing), passing this saves us a lookup for it.</param>
-        /// <param name="sendToAll">If we are removing the item from the map, do we send this data to everyone?</param>
-        /// <param name="owner">The previous owner of an item being removed when the data is not send to everyone.</param>
-        public static void SendMapItemUpdate(Guid mapId, Guid mapInstanceId, MapItem itemRef, bool removing, bool sendToAll = true, Guid owner = new Guid())
-        {
-            // Does the item exist? If not, send a delete notification. If it does, send an update.
-            if (removing)
-            {
-                // Are we to send the removal to all players?
-                if (sendToAll)
-                {
-                    SendDataToProximityOnMapInstance(mapId, mapInstanceId, new MapItemUpdatePacket(mapId, itemRef.TileIndex, itemRef.UniqueId));
-                }
-                else
-                {
-                    // Nope, just to its owner!
-                    var player = Player.FindOnline(owner);
-                    if (player != null)
-                    {
-                        player.SendPacket(new MapItemUpdatePacket(mapId, itemRef.TileIndex, itemRef.UniqueId));
-                    }
-                    else
-                    {
-                        // Uh, our player doesn't exist.. send it to everyone anyway.
-                        SendDataToProximityOnMapInstance(mapId, mapInstanceId, new MapItemUpdatePacket(mapId, itemRef.TileIndex, itemRef.UniqueId));
-                    }
-                }
-
+                SendDataToProximityOnMapInstance(mapId, mapInstanceId, new MapItemUpdatePacket(mapId, itemRef.TileIndex, itemRef.UniqueId));
             }
             else
             {
-                // Is the item owned? If so, only send to that particular player.
-                if (!itemRef.VisibleToAll)
+                // Nope, just to its owner!
+                var player = Player.FindOnline(owner);
+                if (player != null)
                 {
-                    var player = Player.FindOnline(itemRef.Owner);
-                    if (player != null)
-                    {
-                        player.SendPacket(new MapItemUpdatePacket(mapId, itemRef.TileIndex, itemRef.UniqueId, itemRef.ItemId, itemRef.BagId, itemRef.Quantity, itemRef.Properties));
-                    }
+                    player.SendPacket(new MapItemUpdatePacket(mapId, itemRef.TileIndex, itemRef.UniqueId));
                 }
                 else
                 {
-                    SendDataToProximityOnMapInstance(mapId, mapInstanceId, new MapItemUpdatePacket(mapId, itemRef.TileIndex, itemRef.UniqueId, itemRef.ItemId, itemRef.BagId, itemRef.Quantity, itemRef.Properties));
+                    // Uh, our player doesn't exist.. send it to everyone anyway.
+                    SendDataToProximityOnMapInstance(mapId, mapInstanceId, new MapItemUpdatePacket(mapId, itemRef.TileIndex, itemRef.UniqueId));
                 }
             }
+
+        }
+        else
+        {
+            // Is the item owned? If so, only send to that particular player.
+            if (!itemRef.VisibleToAll)
+            {
+                var player = Player.FindOnline(itemRef.Owner);
+                if (player != null)
+                {
+                    player.SendPacket(new MapItemUpdatePacket(mapId, itemRef.TileIndex, itemRef.UniqueId, itemRef.ItemId, itemRef.BagId, itemRef.Quantity, itemRef.Properties));
+                }
+            }
+            else
+            {
+                SendDataToProximityOnMapInstance(mapId, mapInstanceId, new MapItemUpdatePacket(mapId, itemRef.TileIndex, itemRef.UniqueId, itemRef.ItemId, itemRef.BagId, itemRef.Quantity, itemRef.Properties));
+            }
+        }
+    }
+
+
+    //InventoryPacket
+    public static void SendInventory(Player player)
+    {
+        if (player == null)
+        {
+            return;
         }
 
-
-        //InventoryPacket
-        public static void SendInventory(Player player)
+        var invItems = new InventoryUpdatePacket[Options.MaxInvItems];
+        if (player.Items.Count < Options.MaxInvItems)
         {
-            if (player == null)
-            {
-                return;
-            }
-
-            var invItems = new InventoryUpdatePacket[Options.MaxInvItems];
-            if (player.Items.Count < Options.MaxInvItems)
-            {
-                throw new InvalidOperationException($"Tried to send inventory before fully loading player {player.Id}");
-            }
-
-            for (var i = 0; i < Options.MaxInvItems; i++)
-            {
-                var playerItem = player.Items[i];
-                invItems[i] = new InventoryUpdatePacket(
-                    i,
-                    playerItem.ItemId,
-                    playerItem.Quantity,
-                    playerItem.BagId,
-                    playerItem.Properties
-                );
-            }
-
-            player.SendPacket(new InventoryPacket(invItems));
+            throw new InvalidOperationException($"Tried to send inventory before fully loading player {player.Id}");
         }
 
-        //InventoryUpdatePacket
-        public static void SendInventoryItemUpdate(Player player, int slot)
+        for (var i = 0; i < Options.MaxInvItems; i++)
         {
-            if (player == null)
-            {
-                return;
-            }
-
-            player.SendPacket(
-                new InventoryUpdatePacket(
-                    slot, player.Items[slot].ItemId, player.Items[slot].Quantity, player.Items[slot].BagId,
-                    player.Items[slot].Properties
-                )
+            var playerItem = player.Items[i];
+            invItems[i] = new InventoryUpdatePacket(
+                i,
+                playerItem.ItemId,
+                playerItem.Quantity,
+                playerItem.BagId,
+                playerItem.Properties
             );
         }
 
-        //SpellsPacket
-        public static void SendPlayerSpells(Player player)
+        player.SendPacket(new InventoryPacket(invItems));
+    }
+
+    //InventoryUpdatePacket
+    public static void SendInventoryItemUpdate(Player player, int slot)
+    {
+        if (player == null)
         {
-            if (player == null)
-            {
-                return;
-            }
-
-            var spells = new SpellUpdatePacket[Options.MaxPlayerSkills];
-            for (var i = 0; i < Options.MaxPlayerSkills; i++)
-            {
-                spells[i] = new SpellUpdatePacket(i, player.Spells[i].SpellId);
-            }
-
-            player.SendPacket(new SpellsPacket(spells));
+            return;
         }
 
-        //SpellUpdatePacket
-        public static void SendPlayerSpellUpdate(Player player, int slot)
-        {
-            if (player == null)
-            {
-                return;
-            }
+        player.SendPacket(
+            new InventoryUpdatePacket(
+                slot, player.Items[slot].ItemId, player.Items[slot].Quantity, player.Items[slot].BagId,
+                player.Items[slot].Properties
+            )
+        );
+    }
 
-            player.SendPacket(new SpellUpdatePacket(slot, player.Spells[slot].SpellId));
+    //SpellsPacket
+    public static void SendPlayerSpells(Player player)
+    {
+        if (player == null)
+        {
+            return;
         }
 
-        //EquipmentPacket
-        public static EquipmentPacket GenerateEquipmentPacket(Player forPlayer, Player en)
+        var spells = new SpellUpdatePacket[Options.MaxPlayerSkills];
+        for (var i = 0; i < Options.MaxPlayerSkills; i++)
         {
-            if (forPlayer != null && forPlayer == en)
-            {
-                return new EquipmentPacket(en.Id, en.Equipment, null);
-            }
-            else
-            {
-                var equipment = new Guid[Options.EquipmentSlots.Count];
+            spells[i] = new SpellUpdatePacket(i, player.Spells[i].SpellId);
+        }
 
-                for (var i = 0; i < Options.EquipmentSlots.Count; i++)
+        player.SendPacket(new SpellsPacket(spells));
+    }
+
+    //SpellUpdatePacket
+    public static void SendPlayerSpellUpdate(Player player, int slot)
+    {
+        if (player == null)
+        {
+            return;
+        }
+
+        player.SendPacket(new SpellUpdatePacket(slot, player.Spells[slot].SpellId));
+    }
+
+    //EquipmentPacket
+    public static EquipmentPacket GenerateEquipmentPacket(Player forPlayer, Player en)
+    {
+        if (forPlayer != null && forPlayer == en)
+        {
+            return new EquipmentPacket(en.Id, en.Equipment, null);
+        }
+        else
+        {
+            var equipment = new Guid[Options.EquipmentSlots.Count];
+
+            for (var i = 0; i < Options.EquipmentSlots.Count; i++)
+            {
+                if (en.Equipment[i] == -1 || en.Items[en.Equipment[i]].ItemId == Guid.Empty)
                 {
-                    if (en.Equipment[i] == -1 || en.Items[en.Equipment[i]].ItemId == Guid.Empty)
-                    {
-                        equipment[i] = Guid.Empty;
-                    }
-                    else
-                    {
-                        equipment[i] = en.Items[en.Equipment[i]].ItemId;
-                    }
-
+                    equipment[i] = Guid.Empty;
+                }
+                else
+                {
+                    equipment[i] = en.Items[en.Equipment[i]].ItemId;
                 }
 
-                return new EquipmentPacket(en.Id, null, equipment);
+            }
+
+            return new EquipmentPacket(en.Id, null, equipment);
+        }
+    }
+
+    //EquipmentPacket
+    public static void SendPlayerEquipmentTo(Player forPlayer, Player en)
+    {
+        forPlayer.SendPacket(GenerateEquipmentPacket(forPlayer, en), TransmissionMode.Any);
+    }
+
+    //EquipmentPacket
+    public static void SendPlayerEquipmentToProximity(Player en)
+    {
+        SendDataToProximityOnMapInstance(en.MapId, en.MapInstanceId, GenerateEquipmentPacket(null, en), null, TransmissionMode.Any);
+        SendPlayerEquipmentTo(en, en);
+    }
+
+    //StatPointsPacket
+    public static void SendPointsTo(Player player)
+    {
+        player.SendPacket(new StatPointsPacket(player.StatPoints), TransmissionMode.Any);
+    }
+
+    //HotbarPacket
+    public static void SendHotbarSlots(Player player)
+    {
+        var hotbarData = new string[Options.Instance.PlayerOpts.HotbarSlotCount];
+        for (var i = 0; i < Options.Instance.PlayerOpts.HotbarSlotCount; i++)
+        {
+            hotbarData[i] = player.Hotbar[i].Data();
+        }
+
+        player.SendPacket(new HotbarPacket(hotbarData));
+    }
+
+    //CreateCharacterPacket
+    public static void SendCreateCharacter(Client client)
+    {
+        client.Send(new CharacterCreationPacket());
+    }
+
+    //CharactersPacket
+    public static void SendPlayerCharacters(Client client, bool skipLoadingRelationships = false)
+    {
+        if (client == default)
+        {
+            Log.Warn($"Tried to {nameof(SendPlayerCharacters)}() to a null client?");
+            return;
+        }
+
+        var user = client.User;
+        if (user == default)
+        {
+            Log.Warn($"Tried to {nameof(SendPlayerCharacters)}() to client with no user? ({client.Id})");
+            return;
+        }
+
+        var clientCharacters = client.Characters;
+        if (clientCharacters == default)
+        {
+            Log.Warn($"Tried to {nameof(SendPlayerCharacters)}() to client with no characters? (client {client.Id}/user {user.Id})");
+            return;
+        }
+
+        if (!skipLoadingRelationships)
+        {
+            using var playerContext = DbInterface.CreatePlayerContext();
+            foreach (var player in client.Characters.OrderByDescending(p => p.LastOnline))
+            {
+                player.LoadRelationships(playerContext);
             }
         }
 
-        //EquipmentPacket
-        public static void SendPlayerEquipmentTo(Player forPlayer, Player en)
+        var characterPackets = new List<CharacterPacket>();
+
+        var equipmentSlotsOptions = Options.EquipmentSlots;
+        var paperdollOrderOptions = Options.PaperdollOrder;
+
+        if (clientCharacters.Count < 1)
         {
-            forPlayer.SendPacket(GenerateEquipmentPacket(forPlayer, en), TransmissionMode.Any);
-        }
-
-        //EquipmentPacket
-        public static void SendPlayerEquipmentToProximity(Player en)
-        {
-            SendDataToProximityOnMapInstance(en.MapId, en.MapInstanceId, GenerateEquipmentPacket(null, en), null, TransmissionMode.Any);
-            SendPlayerEquipmentTo(en, en);
-        }
-
-        //StatPointsPacket
-        public static void SendPointsTo(Player player)
-        {
-            player.SendPacket(new StatPointsPacket(player.StatPoints), TransmissionMode.Any);
-        }
-
-        //HotbarPacket
-        public static void SendHotbarSlots(Player player)
-        {
-            var hotbarData = new string[Options.Instance.PlayerOpts.HotbarSlotCount];
-            for (var i = 0; i < Options.Instance.PlayerOpts.HotbarSlotCount; i++)
-            {
-                hotbarData[i] = player.Hotbar[i].Data();
-            }
-
-            player.SendPacket(new HotbarPacket(hotbarData));
-        }
-
-        //CreateCharacterPacket
-        public static void SendCreateCharacter(Client client)
-        {
-            client.Send(new CharacterCreationPacket());
-        }
-
-        //CharactersPacket
-        public static void SendPlayerCharacters(Client client, bool skipLoadingRelationships = false)
-        {
-            if (client == default)
-            {
-                Log.Warn($"Tried to {nameof(SendPlayerCharacters)}() to a null client?");
-                return;
-            }
-
-            var user = client.User;
-            if (user == default)
-            {
-                Log.Warn($"Tried to {nameof(SendPlayerCharacters)}() to client with no user? ({client.Id})");
-                return;
-            }
-
-            var clientCharacters = client.Characters;
-            if (clientCharacters == default)
-            {
-                Log.Warn($"Tried to {nameof(SendPlayerCharacters)}() to client with no characters? (client {client.Id}/user {user.Id})");
-                return;
-            }
-
-            if (!skipLoadingRelationships)
-            {
-                using var playerContext = DbInterface.CreatePlayerContext();
-                foreach (var player in client.Characters.OrderByDescending(p => p.LastOnline))
-                {
-                    player.LoadRelationships(playerContext);
-                }
-            }
-
-            var characterPackets = new List<CharacterPacket>();
-
-            var equipmentSlotsOptions = Options.EquipmentSlots;
-            var paperdollOrderOptions = Options.PaperdollOrder;
-
-            if (clientCharacters.Count < 1)
-            {
-                CharactersPacket emptyBulkCharactersPacket = new(
-                    Array.Empty<CharacterPacket>(),
-                    client.Characters.Count < Options.MaxCharacters
-                );
-
-                if (!client.Send(emptyBulkCharactersPacket))
-                {
-                    Log.Error($"Failed to send empty bulk characters packet to {client.Id}");
-                }
-
-                return;
-            }
-
-            foreach (var character in clientCharacters.OrderByDescending(p => p.LastOnline))
-            {
-                var equipmentArray = character.Equipment;
-                var equipment = new EquipmentFragment[equipmentSlotsOptions.Count + 1];
-
-                // Draw the equipment/paperdolls
-                var paperdollOrderOptionLayer1 = paperdollOrderOptions[1];
-                for (var z = 0; z < paperdollOrderOptionLayer1.Count; z++)
-                {
-                    var indexOfPaperdoll = equipmentSlotsOptions.IndexOf(Options.PaperdollOrder[1][z]);
-                    if (indexOfPaperdoll < 0)
-                    {
-                        const string equipmentFragmentNamePlayer = "Player";
-                        if (Options.PaperdollOrder[1][z] == equipmentFragmentNamePlayer)
-                        {
-                            equipment[z] = new EquipmentFragment { Name = equipmentFragmentNamePlayer };
-                        }
-
-                        continue;
-                    }
-
-                    var inventoryIndexOfEquip = equipmentArray[indexOfPaperdoll];
-                    if (inventoryIndexOfEquip <= -1 || inventoryIndexOfEquip >= Options.MaxInvItems)
-                    {
-                        continue;
-                    }
-
-                    var paperdollOrder = paperdollOrderOptionLayer1[z];
-                    var equipmentSlot = equipmentSlotsOptions.IndexOf(paperdollOrder);
-                    var itemIndex = equipmentArray[equipmentSlot];
-
-                    var itemId = character.Items[itemIndex].ItemId;
-
-                    if (!ItemBase.TryGet(itemId, out var itemDescriptor))
-                    {
-                        continue;
-                    }
-
-                    equipment[z] = new EquipmentFragment
-                    {
-                        Name = itemDescriptor.GetPaperdollForGender(character.Gender),
-                        RenderColor = itemDescriptor.Color,
-                    };
-                }
-
-                characterPackets.Add(
-                    new CharacterPacket(
-                        character.Id,
-                        character.Name,
-                        character.Sprite,
-                        character.Face,
-                        character.Level,
-                        ClassBase.GetName(character.ClassId),
-                        equipment
-                    )
-                );
-            }
-
-            CharactersPacket bulkCharactersPacket = new(
-                characterPackets.ToArray(),
+            CharactersPacket emptyBulkCharactersPacket = new(
+                Array.Empty<CharacterPacket>(),
                 client.Characters.Count < Options.MaxCharacters
             );
 
-            if (!client.Send(bulkCharactersPacket))
+            if (!client.Send(emptyBulkCharactersPacket))
             {
-                Log.Error($"Failed to send {bulkCharactersPacket.Characters.Length} characters to {client.Id}");
+                Log.Error($"Failed to send empty bulk characters packet to {client.Id}");
             }
+
+            return;
         }
 
-        //AdminPanelPacket
-        public static void SendOpenAdminWindow(Client client)
+        foreach (var character in clientCharacters.OrderByDescending(p => p.LastOnline))
         {
-            client.Send(new AdminPanelPacket(), TransmissionMode.Any);
-        }
+            var equipmentArray = character.Equipment;
+            var equipment = new EquipmentFragment[equipmentSlotsOptions.Count + 1];
 
-        //MapGridPacket
-        public static void SendMapGridToAll(int gridId)
-        {
-            SendMapGridToAll(DbInterface.GetGrid(gridId));
-        }
-        public static void SendMapGridToAll(MapGrid grid)
-        {
-            if (grid == null) return;
-            var clients = Globals.Clients.ToArray();
-            foreach (var client in clients)
+            // Draw the equipment/paperdolls
+            var paperdollOrderOptionLayer1 = paperdollOrderOptions[1];
+            for (var z = 0; z < paperdollOrderOptionLayer1.Count; z++)
             {
-                if (client == default)
+                var indexOfPaperdoll = equipmentSlotsOptions.IndexOf(Options.PaperdollOrder[1][z]);
+                if (indexOfPaperdoll < 0)
+                {
+                    const string equipmentFragmentNamePlayer = "Player";
+                    if (Options.PaperdollOrder[1][z] == equipmentFragmentNamePlayer)
+                    {
+                        equipment[z] = new EquipmentFragment { Name = equipmentFragmentNamePlayer };
+                    }
+
+                    continue;
+                }
+
+                var inventoryIndexOfEquip = equipmentArray[indexOfPaperdoll];
+                if (inventoryIndexOfEquip <= -1 || inventoryIndexOfEquip >= Options.MaxInvItems)
                 {
                     continue;
                 }
 
-                var isEditor = client.IsEditor;
-                var mapId = isEditor ? client.EditorMap : (client.Entity?.MapId ?? default);
+                var paperdollOrder = paperdollOrderOptionLayer1[z];
+                var equipmentSlot = equipmentSlotsOptions.IndexOf(paperdollOrder);
+                var itemIndex = equipmentArray[equipmentSlot];
 
-                if (grid.Contains(mapId))
+                var itemId = character.Items[itemIndex].ItemId;
+
+                if (!ItemBase.TryGet(itemId, out var itemDescriptor))
                 {
-                    SendMapGrid(client, grid, clearKnownMaps: !isEditor);
+                    continue;
                 }
+
+                equipment[z] = new EquipmentFragment
+                {
+                    Name = itemDescriptor.GetPaperdollForGender(character.Gender),
+                    RenderColor = itemDescriptor.Color,
+                };
             }
+
+            characterPackets.Add(
+                new CharacterPacket(
+                    character.Id,
+                    character.Name,
+                    character.Sprite,
+                    character.Face,
+                    character.Level,
+                    ClassBase.GetName(character.ClassId),
+                    equipment
+                )
+            );
         }
 
-        //MapGridPacket
-        public static void SendMapGrid(Client client, int gridId, bool clearKnownMaps = false)
+        CharactersPacket bulkCharactersPacket = new(
+            characterPackets.ToArray(),
+            client.Characters.Count < Options.MaxCharacters
+        );
+
+        if (!client.Send(bulkCharactersPacket))
         {
-            var grid = DbInterface.GetGrid(gridId);
-            SendMapGrid(client, grid, clearKnownMaps);
+            Log.Error($"Failed to send {bulkCharactersPacket.Characters.Length} characters to {client.Id}");
         }
-        public static void SendMapGrid(Client client, MapGrid grid, bool clearKnownMaps = false)
+    }
+
+    //AdminPanelPacket
+    public static void SendOpenAdminWindow(Client client)
+    {
+        client.Send(new AdminPanelPacket(), TransmissionMode.Any);
+    }
+
+    //MapGridPacket
+    public static void SendMapGridToAll(int gridId)
+    {
+        SendMapGridToAll(DbInterface.GetGrid(gridId));
+    }
+    public static void SendMapGridToAll(MapGrid grid)
+    {
+        if (grid == null) return;
+        var clients = Globals.Clients.ToArray();
+        foreach (var client in clients)
         {
-            if (client == null || grid == null)
+            if (client == default)
             {
-                return;
+                continue;
             }
 
+            var isEditor = client.IsEditor;
+            var mapId = isEditor ? client.EditorMap : (client.Entity?.MapId ?? default);
+
+            if (grid.Contains(mapId))
+            {
+                SendMapGrid(client, grid, clearKnownMaps: !isEditor);
+            }
+        }
+    }
+
+    //MapGridPacket
+    public static void SendMapGrid(Client client, int gridId, bool clearKnownMaps = false)
+    {
+        var grid = DbInterface.GetGrid(gridId);
+        SendMapGrid(client, grid, clearKnownMaps);
+    }
+    public static void SendMapGrid(Client client, MapGrid grid, bool clearKnownMaps = false)
+    {
+        if (client == null || grid == null)
+        {
+            return;
+        }
+
+        if (clearKnownMaps)
+        {
+            client.SentMaps.Clear();
+        }
+
+        if (client.IsEditor)
+        {
+            client.Send(new MapGridPacket(null, grid.GetEditorData(), clearKnownMaps));
+        }
+        else
+        {
+            client.Send(new MapGridPacket(grid.GetClientData(), null, clearKnownMaps));
             if (clearKnownMaps)
             {
-                client.SentMaps.Clear();
-            }
-
-            if (client.IsEditor)
-            {
-                client.Send(new MapGridPacket(null, grid.GetEditorData(), clearKnownMaps));
-            }
-            else
-            {
-                client.Send(new MapGridPacket(grid.GetClientData(), null, clearKnownMaps));
-                if (clearKnownMaps)
-                {
-                    SendAreaPacket(client.Entity);
-                }
+                SendAreaPacket(client.Entity);
             }
         }
+    }
 
-        //SpellCastPacket
-        public static void SendEntityCastTime(Entity en, Guid spellId)
+    //SpellCastPacket
+    public static void SendEntityCastTime(Entity en, Guid spellId)
+    {
+        SendDataToProximityOnMapInstance(en.MapId, en.MapInstanceId, new SpellCastPacket(en.Id, spellId), null, TransmissionMode.Any);
+    }
+
+    //CancelCastPacket
+    public static void SendEntityCancelCast(Entity en)
+    {
+        if (en == null || en is EventPageInstance || en is Projectile)
         {
-            SendDataToProximityOnMapInstance(en.MapId, en.MapInstanceId, new SpellCastPacket(en.Id, spellId), null, TransmissionMode.Any);
+            return;
         }
 
-        //CancelCastPacket
-        public static void SendEntityCancelCast(Entity en)
+        SendDataToProximityOnMapInstance(en.MapId, en.MapInstanceId, new CancelCastPacket(en.Id), null, TransmissionMode.Any);
+    }
+
+    //SpellCooldownPacket
+    public static void SendSpellCooldown(Player player, Guid spellId)
+    {
+        if (player.SpellCooldowns.ContainsKey(spellId))
         {
-            if (en == null || en is EventPageInstance || en is Projectile)
+            var cds = new Dictionary<Guid, long>();
+            cds.Add(spellId, player.SpellCooldowns[spellId] - Timing.Global.MillisecondsUtc);
+            player.SendPacket(new SpellCooldownPacket(cds), TransmissionMode.All);
+        }
+    }
+
+    public static void SendSpellCooldowns(Player player)
+    {
+        if (player.SpellCooldowns.Count > 0)
+        {
+            var cds = new Dictionary<Guid, long>();
+            foreach (var cd in player.SpellCooldowns)
             {
-                return;
+                cds.Add(cd.Key, cd.Value - Timing.Global.MillisecondsUtc);
             }
 
-            SendDataToProximityOnMapInstance(en.MapId, en.MapInstanceId, new CancelCastPacket(en.Id), null, TransmissionMode.Any);
+            player.SendPacket(new SpellCooldownPacket(cds), TransmissionMode.All);
         }
+    }
 
-        //SpellCooldownPacket
-        public static void SendSpellCooldown(Player player, Guid spellId)
+    //ItemCooldownPacket
+    public static void SendItemCooldown(Player player, Guid itemId)
+    {
+        if (player.ItemCooldowns.ContainsKey(itemId))
         {
-            if (player.SpellCooldowns.ContainsKey(spellId))
+            var cds = new Dictionary<Guid, long>();
+            cds.Add(itemId, player.ItemCooldowns[itemId] - Timing.Global.MillisecondsUtc);
+            player.SendPacket(new ItemCooldownPacket(cds), TransmissionMode.All);
+        }
+    }
+
+    public static void SendItemCooldowns(Player player)
+    {
+        if (player.ItemCooldowns.Count > 0)
+        {
+            var cds = new Dictionary<Guid, long>();
+            foreach (var cd in player.ItemCooldowns)
             {
-                var cds = new Dictionary<Guid, long>();
-                cds.Add(spellId, player.SpellCooldowns[spellId] - Timing.Global.MillisecondsUtc);
-                player.SendPacket(new SpellCooldownPacket(cds), TransmissionMode.All);
-            }
-        }
-
-        public static void SendSpellCooldowns(Player player)
-        {
-            if (player.SpellCooldowns.Count > 0)
-            {
-                var cds = new Dictionary<Guid, long>();
-                foreach (var cd in player.SpellCooldowns)
-                {
-                    cds.Add(cd.Key, cd.Value - Timing.Global.MillisecondsUtc);
-                }
-
-                player.SendPacket(new SpellCooldownPacket(cds), TransmissionMode.All);
-            }
-        }
-
-        //ItemCooldownPacket
-        public static void SendItemCooldown(Player player, Guid itemId)
-        {
-            if (player.ItemCooldowns.ContainsKey(itemId))
-            {
-                var cds = new Dictionary<Guid, long>();
-                cds.Add(itemId, player.ItemCooldowns[itemId] - Timing.Global.MillisecondsUtc);
-                player.SendPacket(new ItemCooldownPacket(cds), TransmissionMode.All);
-            }
-        }
-
-        public static void SendItemCooldowns(Player player)
-        {
-            if (player.ItemCooldowns.Count > 0)
-            {
-                var cds = new Dictionary<Guid, long>();
-                foreach (var cd in player.ItemCooldowns)
-                {
-                    cds.Add(cd.Key, cd.Value - Timing.Global.MillisecondsUtc);
-                }
-
-                player.SendPacket(new ItemCooldownPacket(cds), TransmissionMode.All);
-            }
-        }
-
-        //GlobalCooldownPacket
-        public static void SendGlobalCooldown(Player player, long cooldown)
-        {
-            player.SendPacket(new GlobalCooldownPacket(cooldown - Timing.Global.MillisecondsUtc), TransmissionMode.All);
-        }
-
-        //ExperiencePacket
-        public static void SendExperience(Player player)
-        {
-            player.SendPacket(new ExperiencePacket(player.Exp, player.ExperienceToNextLevel), TransmissionMode.Any);
-        }
-
-        //PlayAnimationPacket
-        public static void SendAnimationToProximity(
-            Guid animId,
-            int targetType,
-            Guid entityId,
-            Guid mapId,
-            int x,
-            int y,
-            Direction direction,
-            Guid mapInstanceId
-        )
-        {
-            if (MapController.TryGetInstanceFromMap(mapId, mapInstanceId, out var mapInstance))
-            {
-                if (Options.Instance.Packets.BatchAnimationPackets)
-                {
-                    mapInstance.AddBatchedAnimation(new PlayAnimationPacket(animId, targetType, entityId, mapId, x, y, direction));
-                }
-                else
-                {
-                    SendDataToProximityOnMapInstance(mapId, mapInstanceId, new PlayAnimationPacket(animId, targetType, entityId, mapId, x, y, direction), null, TransmissionMode.Any);
-                }
-            }
-        }
-
-        public static void SendAnimationTo(
-            Guid animId,
-            int targetType,
-            Guid entityId,
-            Guid mapId,
-            byte x,
-            byte y,
-            Direction direction,
-            Player target
-        )
-        {
-            if (animId == Guid.Empty)
-            {
-                return;
+                cds.Add(cd.Key, cd.Value - Timing.Global.MillisecondsUtc);
             }
 
-            target.SendPacket(new PlayAnimationPacket(animId, targetType, entityId, mapId, x, y, direction));
+            player.SendPacket(new ItemCooldownPacket(cds), TransmissionMode.All);
         }
+    }
 
-        //HoldPlayerPacket
-        public static void SendHoldPlayer(Player player, Guid eventId, Guid mapId)
-        {
-            player.SendPacket(new HoldPlayerPacket(eventId, mapId, false));
-        }
+    //GlobalCooldownPacket
+    public static void SendGlobalCooldown(Player player, long cooldown)
+    {
+        player.SendPacket(new GlobalCooldownPacket(cooldown - Timing.Global.MillisecondsUtc), TransmissionMode.All);
+    }
 
-        //HoldPlayerPacket
-        public static void SendReleasePlayer(Player player, Guid eventId)
-        {
-            player.SendPacket(new HoldPlayerPacket(eventId, Guid.Empty, true));
-        }
+    //ExperiencePacket
+    public static void SendExperience(Player player)
+    {
+        player.SendPacket(new ExperiencePacket(player.Exp, player.ExperienceToNextLevel), TransmissionMode.Any);
+    }
 
-        //PlayMusicPacket
-        public static void SendPlayMusic(Player player, string bgm)
+    //PlayAnimationPacket
+    public static void SendAnimationToProximity(
+        Guid animId,
+        int targetType,
+        Guid entityId,
+        Guid mapId,
+        int x,
+        int y,
+        Direction direction,
+        Guid mapInstanceId
+    )
+    {
+        if (MapController.TryGetInstanceFromMap(mapId, mapInstanceId, out var mapInstance))
         {
-            player.SendPacket(new PlayMusicPacket(bgm));
-        }
-
-        //StopMusicPacket
-        public static void SendFadeMusic(Player player)
-        {
-            player.SendPacket(new StopMusicPacket());
-        }
-
-        //PlaySoundPacket
-        public static void SendPlaySound(Player player, string sound)
-        {
-            player.SendPacket(new PlaySoundPacket(sound));
-        }
-
-        //StopSoundPacket
-        public static void SendStopSounds(Player player)
-        {
-            player.SendPacket(new StopSoundsPacket());
-        }
-
-        //ShowPicturePacket
-        public static void SendShowPicture(Player player, string picture, int size, bool clickable, int hideTime, Guid eventId)
-        {
-            player.SendPacket(new ShowPicturePacket(picture, size, clickable, hideTime, eventId));
-        }
-
-        //HidePicturePacket
-        public static void SendHidePicture(Player player)
-        {
-            player.SendPacket(new HidePicturePacket());
-        }
-
-        //ShopPacket
-        public static void SendOpenShop(Player player, ShopBase shop)
-        {
-            if (shop == null)
+            if (Options.Instance.Packets.BatchAnimationPackets)
             {
-                return;
-            }
-
-            player.SendPacket(new ShopPacket(shop.JsonData, false));
-        }
-
-        //ShopPacket
-        public static void SendCloseShop(Player player)
-        {
-            player.SendPacket(new ShopPacket(null, true));
-        }
-
-        //CraftingTablePacket
-        public static void SendOpenCraftingTable(Player player, CraftingTableBase table, bool journalMode)
-        {
-            if (table != null)
-            {
-                //Use Json To Cheaply Clone The Table
-                var playerTable = JsonConvert.DeserializeObject<CraftingTableBase>(table.JsonData);
-
-                //Strip our the items the player can't craft
-                foreach (var craft in table.Crafts)
-                {
-                    var craftBase = CraftBase.Get(craft);
-                    if (!(craftBase != null && Conditions.MeetsConditionLists(craftBase.CraftingRequirements, player, null)))
-                    {
-                        playerTable.Crafts.Remove(craft);
-                    }
-                }
-
-                //Send the modfied table
-                player.SendPacket(new CraftingTablePacket(playerTable.JsonData, false, journalMode));
-            }
-        }
-
-        //CraftingTablePacket
-        public static void SendCloseCraftingTable(Player player)
-        {
-            player.SendPacket(new CraftingTablePacket(null, true, false));
-        }
-
-        //GameObjectPacket
-        public static void SendGameObjects(Client client, GameObjectType type, List<GameObjectPacket> packetList = null)
-        {
-            switch (type)
-            {
-                case GameObjectType.Animation:
-                    foreach (var obj in AnimationBase.Lookup)
-                    {
-                        SendGameObject(client, obj.Value, false, false, packetList);
-                    }
-
-                    break;
-                case GameObjectType.Class:
-                    foreach (var obj in ClassBase.Lookup)
-                    {
-                        SendGameObject(client, obj.Value, false, false, packetList);
-                    }
-
-                    break;
-                case GameObjectType.Item:
-                    foreach (var obj in ItemBase.Lookup)
-                    {
-                        SendGameObject(client, obj.Value, false, false, packetList);
-                    }
-
-                    break;
-                case GameObjectType.Npc:
-                    foreach (var obj in NpcBase.Lookup)
-                    {
-                        SendGameObject(client, obj.Value, false, false, packetList);
-                    }
-
-                    break;
-                case GameObjectType.Projectile:
-                    foreach (var obj in ProjectileBase.Lookup)
-                    {
-                        SendGameObject(client, obj.Value, false, false, packetList);
-                    }
-
-                    break;
-                case GameObjectType.Quest:
-                    foreach (var obj in QuestBase.Lookup)
-                    {
-                        SendGameObject(client, obj.Value, false, false, packetList);
-                    }
-
-                    break;
-                case GameObjectType.Resource:
-                    foreach (var obj in ResourceBase.Lookup)
-                    {
-                        SendGameObject(client, obj.Value, false, false, packetList);
-                    }
-
-                    break;
-                case GameObjectType.Shop:
-                    foreach (var obj in ShopBase.Lookup)
-                    {
-                        SendGameObject(client, obj.Value, false, false, packetList);
-                    }
-
-                    break;
-                case GameObjectType.Spell:
-                    foreach (var obj in SpellBase.Lookup)
-                    {
-                        SendGameObject(client, obj.Value, false, false, packetList);
-                    }
-
-                    break;
-                case GameObjectType.CraftTables:
-                    foreach (var obj in CraftingTableBase.Lookup)
-                    {
-                        SendGameObject(client, obj.Value, false, false, packetList);
-                    }
-
-                    break;
-                case GameObjectType.Crafts:
-                    foreach (var obj in CraftBase.Lookup)
-                    {
-                        SendGameObject(client, obj.Value, false, false, packetList);
-                    }
-
-                    break;
-                case GameObjectType.Map:
-                    throw new Exception("Maps are not sent as batches, use the proper send map functions");
-                case GameObjectType.Event:
-                    foreach (var obj in EventBase.Lookup)
-                    {
-                        if (((EventBase)obj.Value).CommonEvent)
-                        {
-                            SendGameObject(client, obj.Value, false, false, packetList);
-                        }
-                    }
-
-                    break;
-                case GameObjectType.PlayerVariable:
-                    foreach (var obj in PlayerVariableBase.Lookup)
-                    {
-                        SendGameObject(client, obj.Value, false, false, packetList);
-                    }
-
-                    break;
-                case GameObjectType.ServerVariable:
-                    foreach (var obj in ServerVariableBase.Lookup)
-                    {
-                        SendGameObject(client, obj.Value, false, false, packetList);
-                    }
-
-                    break;
-                case GameObjectType.Tileset:
-                    foreach (var obj in TilesetBase.Lookup)
-                    {
-                        SendGameObject(client, obj.Value, false, false, packetList);
-                    }
-
-                    break;
-                case GameObjectType.Time:
-                    break;
-                case GameObjectType.GuildVariable:
-                    foreach (var obj in GuildVariableBase.Lookup)
-                    {
-                        SendGameObject(client, obj.Value, false, false, packetList);
-                    }
-
-                    break;
-                case GameObjectType.UserVariable:
-                    foreach (var obj in UserVariableBase.Lookup)
-                    {
-                        SendGameObject(client, obj.Value, false, false, packetList);
-                    }
-
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(type), type, null);
-            }
-        }
-
-        //GameObjectPacket
-        public static void SendGameObject(
-            Client client,
-            IDatabaseObject obj,
-            bool deleted = false,
-            bool another = false,
-            List<GameObjectPacket> packetList = null
-        )
-        {
-            if (client == null && packetList == null || obj == null)
-            {
-                return;
-            }
-
-            if (client != null && client.IsEditor)
-            {
-                //If editor send quest events and map events
-                if (obj.Type == GameObjectType.Quest)
-                {
-                    SendQuestEventsTo(client, (QuestBase)obj);
-                }
-            }
-
-            if (packetList == null)
-            {
-                client.Send(
-                    new GameObjectPacket(obj.Id, obj.Type, deleted ? null : obj.JsonData, deleted, another)
-                );
+                mapInstance.AddBatchedAnimation(new PlayAnimationPacket(animId, targetType, entityId, mapId, x, y, direction));
             }
             else
             {
-                packetList.Add(new GameObjectPacket(obj.Id, obj.Type, deleted ? null : obj.JsonData, deleted, another));
+                SendDataToProximityOnMapInstance(mapId, mapInstanceId, new PlayAnimationPacket(animId, targetType, entityId, mapId, x, y, direction), null, TransmissionMode.Any);
             }
         }
+    }
 
-        //GameObjectPacket
-        public static void SendQuestEventsTo(Client client, QuestBase qst)
+    public static void SendAnimationTo(
+        Guid animId,
+        int targetType,
+        Guid entityId,
+        Guid mapId,
+        byte x,
+        byte y,
+        Direction direction,
+        Player target
+    )
+    {
+        if (animId == Guid.Empty)
         {
-            SendEventIfExists(client, qst.StartEvent);
-            SendEventIfExists(client, qst.EndEvent);
-            foreach (var tsk in qst.Tasks)
+            return;
+        }
+
+        target.SendPacket(new PlayAnimationPacket(animId, targetType, entityId, mapId, x, y, direction));
+    }
+
+    //HoldPlayerPacket
+    public static void SendHoldPlayer(Player player, Guid eventId, Guid mapId)
+    {
+        player.SendPacket(new HoldPlayerPacket(eventId, mapId, false));
+    }
+
+    //HoldPlayerPacket
+    public static void SendReleasePlayer(Player player, Guid eventId)
+    {
+        player.SendPacket(new HoldPlayerPacket(eventId, Guid.Empty, true));
+    }
+
+    //PlayMusicPacket
+    public static void SendPlayMusic(Player player, string bgm)
+    {
+        player.SendPacket(new PlayMusicPacket(bgm));
+    }
+
+    //StopMusicPacket
+    public static void SendFadeMusic(Player player)
+    {
+        player.SendPacket(new StopMusicPacket());
+    }
+
+    //PlaySoundPacket
+    public static void SendPlaySound(Player player, string sound)
+    {
+        player.SendPacket(new PlaySoundPacket(sound));
+    }
+
+    //StopSoundPacket
+    public static void SendStopSounds(Player player)
+    {
+        player.SendPacket(new StopSoundsPacket());
+    }
+
+    //ShowPicturePacket
+    public static void SendShowPicture(Player player, string picture, int size, bool clickable, int hideTime, Guid eventId)
+    {
+        player.SendPacket(new ShowPicturePacket(picture, size, clickable, hideTime, eventId));
+    }
+
+    //HidePicturePacket
+    public static void SendHidePicture(Player player)
+    {
+        player.SendPacket(new HidePicturePacket());
+    }
+
+    //ShopPacket
+    public static void SendOpenShop(Player player, ShopBase shop)
+    {
+        if (shop == null)
+        {
+            return;
+        }
+
+        player.SendPacket(new ShopPacket(shop.JsonData, false));
+    }
+
+    //ShopPacket
+    public static void SendCloseShop(Player player)
+    {
+        player.SendPacket(new ShopPacket(null, true));
+    }
+
+    //CraftingTablePacket
+    public static void SendOpenCraftingTable(Player player, CraftingTableBase table, bool journalMode)
+    {
+        if (table != null)
+        {
+            //Use Json To Cheaply Clone The Table
+            var playerTable = JsonConvert.DeserializeObject<CraftingTableBase>(table.JsonData);
+
+            //Strip our the items the player can't craft
+            foreach (var craft in table.Crafts)
             {
-                SendEventIfExists(client, tsk.CompletionEvent);
-            }
-        }
-
-        //GameObjectPacket
-        public static void SendEventIfExists(Client client, EventBase evt)
-        {
-            if (evt != null && evt.Id != Guid.Empty)
-            {
-                SendGameObject(client, evt, false, false);
-            }
-        }
-
-        //GameObjectPacket
-        public static void SendGameObjectToAll(IDatabaseObject obj, bool deleted = false, bool another = false)
-        {
-            foreach (var client in Globals.Clients)
-            {
-                SendGameObject(client, obj, deleted, another);
-            }
-        }
-
-        //OpenEditorPacket
-        public static void SendOpenEditor(Client client, GameObjectType type)
-        {
-            client.Send(new OpenEditorPacket(type));
-        }
-
-        //EntityDashPacket
-        public static void SendEntityDash(Entity en, Guid endMapId, byte endX, byte endY, int dashTime, Direction direction)
-        {
-            SendDataToProximityOnMapInstance(en.MapId, en.MapInstanceId, new EntityDashPacket(en.Id, endMapId, endX, endY, dashTime, direction));
-        }
-
-        /// <summary>
-        /// Send a game announcement to all players.
-        /// </summary>
-        /// <param name="message">The message to send as an announcement.</param>
-        /// <param name="duration">The duration (in milliseconds) for the message to display.</param>
-        public static void SendGameAnnouncement(string message, long duration)
-        {
-            SendDataToAllPlayers(new AnnouncementPacket(message, duration));
-        }
-
-        //ActionMsgPacket
-        public static void SendActionMsg(Entity en, string message, Color color)
-        {
-            if (en == null)
-            {
-                return;
-            }
-
-            if (MapController.TryGetInstanceFromMap(en.Map.Id, en.MapInstanceId, out var mapInstance))
-            {
-                if (Options.Instance.Packets.BatchActionMessagePackets)
+                var craftBase = CraftBase.Get(craft);
+                if (!(craftBase != null && Conditions.MeetsConditionLists(craftBase.CraftingRequirements, player, null)))
                 {
-                    mapInstance.AddBatchedActionMessage(new ActionMsgPacket(en.MapId, en.X, en.Y, message, color));
+                    playerTable.Crafts.Remove(craft);
                 }
-                else
+            }
+
+            //Send the modfied table
+            player.SendPacket(new CraftingTablePacket(playerTable.JsonData, false, journalMode));
+        }
+    }
+
+    //CraftingTablePacket
+    public static void SendCloseCraftingTable(Player player)
+    {
+        player.SendPacket(new CraftingTablePacket(null, true, false));
+    }
+
+    //GameObjectPacket
+    public static void SendGameObjects(Client client, GameObjectType type, List<GameObjectPacket> packetList = null)
+    {
+        switch (type)
+        {
+            case GameObjectType.Animation:
+                foreach (var obj in AnimationBase.Lookup)
                 {
-                    SendDataToProximityOnMapInstance(en.MapId, en.MapInstanceId, new ActionMsgPacket(en.MapId, en.X, en.Y, message, color));
+                    SendGameObject(client, obj.Value, false, false, packetList);
                 }
+
+                break;
+            case GameObjectType.Class:
+                foreach (var obj in ClassBase.Lookup)
+                {
+                    SendGameObject(client, obj.Value, false, false, packetList);
+                }
+
+                break;
+            case GameObjectType.Item:
+                foreach (var obj in ItemBase.Lookup)
+                {
+                    SendGameObject(client, obj.Value, false, false, packetList);
+                }
+
+                break;
+            case GameObjectType.Npc:
+                foreach (var obj in NpcBase.Lookup)
+                {
+                    SendGameObject(client, obj.Value, false, false, packetList);
+                }
+
+                break;
+            case GameObjectType.Projectile:
+                foreach (var obj in ProjectileBase.Lookup)
+                {
+                    SendGameObject(client, obj.Value, false, false, packetList);
+                }
+
+                break;
+            case GameObjectType.Quest:
+                foreach (var obj in QuestBase.Lookup)
+                {
+                    SendGameObject(client, obj.Value, false, false, packetList);
+                }
+
+                break;
+            case GameObjectType.Resource:
+                foreach (var obj in ResourceBase.Lookup)
+                {
+                    SendGameObject(client, obj.Value, false, false, packetList);
+                }
+
+                break;
+            case GameObjectType.Shop:
+                foreach (var obj in ShopBase.Lookup)
+                {
+                    SendGameObject(client, obj.Value, false, false, packetList);
+                }
+
+                break;
+            case GameObjectType.Spell:
+                foreach (var obj in SpellBase.Lookup)
+                {
+                    SendGameObject(client, obj.Value, false, false, packetList);
+                }
+
+                break;
+            case GameObjectType.CraftTables:
+                foreach (var obj in CraftingTableBase.Lookup)
+                {
+                    SendGameObject(client, obj.Value, false, false, packetList);
+                }
+
+                break;
+            case GameObjectType.Crafts:
+                foreach (var obj in CraftBase.Lookup)
+                {
+                    SendGameObject(client, obj.Value, false, false, packetList);
+                }
+
+                break;
+            case GameObjectType.Map:
+                throw new Exception("Maps are not sent as batches, use the proper send map functions");
+            case GameObjectType.Event:
+                foreach (var obj in EventBase.Lookup)
+                {
+                    if (((EventBase)obj.Value).CommonEvent)
+                    {
+                        SendGameObject(client, obj.Value, false, false, packetList);
+                    }
+                }
+
+                break;
+            case GameObjectType.PlayerVariable:
+                foreach (var obj in PlayerVariableBase.Lookup)
+                {
+                    SendGameObject(client, obj.Value, false, false, packetList);
+                }
+
+                break;
+            case GameObjectType.ServerVariable:
+                foreach (var obj in ServerVariableBase.Lookup)
+                {
+                    SendGameObject(client, obj.Value, false, false, packetList);
+                }
+
+                break;
+            case GameObjectType.Tileset:
+                foreach (var obj in TilesetBase.Lookup)
+                {
+                    SendGameObject(client, obj.Value, false, false, packetList);
+                }
+
+                break;
+            case GameObjectType.Time:
+                break;
+            case GameObjectType.GuildVariable:
+                foreach (var obj in GuildVariableBase.Lookup)
+                {
+                    SendGameObject(client, obj.Value, false, false, packetList);
+                }
+
+                break;
+            case GameObjectType.UserVariable:
+                foreach (var obj in UserVariableBase.Lookup)
+                {
+                    SendGameObject(client, obj.Value, false, false, packetList);
+                }
+
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(type), type, null);
+        }
+    }
+
+    //GameObjectPacket
+    public static void SendGameObject(
+        Client client,
+        IDatabaseObject obj,
+        bool deleted = false,
+        bool another = false,
+        List<GameObjectPacket> packetList = null
+    )
+    {
+        if (client == null && packetList == null || obj == null)
+        {
+            return;
+        }
+
+        if (client != null && client.IsEditor)
+        {
+            //If editor send quest events and map events
+            if (obj.Type == GameObjectType.Quest)
+            {
+                SendQuestEventsTo(client, (QuestBase)obj);
             }
         }
 
-        //EnterMapPacket
-        public static void SendEnterMap(Client client, Guid mapId)
+        if (packetList == null)
         {
-            client.Send(new EnterMapPacket(mapId));
+            client.Send(
+                new GameObjectPacket(obj.Id, obj.Type, deleted ? null : obj.JsonData, deleted, another)
+            );
+        }
+        else
+        {
+            packetList.Add(new GameObjectPacket(obj.Id, obj.Type, deleted ? null : obj.JsonData, deleted, another));
+        }
+    }
+
+    //GameObjectPacket
+    public static void SendQuestEventsTo(Client client, QuestBase qst)
+    {
+        SendEventIfExists(client, qst.StartEvent);
+        SendEventIfExists(client, qst.EndEvent);
+        foreach (var tsk in qst.Tasks)
+        {
+            SendEventIfExists(client, tsk.CompletionEvent);
+        }
+    }
+
+    //GameObjectPacket
+    public static void SendEventIfExists(Client client, EventBase evt)
+    {
+        if (evt != null && evt.Id != Guid.Empty)
+        {
+            SendGameObject(client, evt, false, false);
+        }
+    }
+
+    //GameObjectPacket
+    public static void SendGameObjectToAll(IDatabaseObject obj, bool deleted = false, bool another = false)
+    {
+        foreach (var client in Globals.Clients)
+        {
+            SendGameObject(client, obj, deleted, another);
+        }
+    }
+
+    //OpenEditorPacket
+    public static void SendOpenEditor(Client client, GameObjectType type)
+    {
+        client.Send(new OpenEditorPacket(type));
+    }
+
+    //EntityDashPacket
+    public static void SendEntityDash(Entity en, Guid endMapId, byte endX, byte endY, int dashTime, Direction direction)
+    {
+        SendDataToProximityOnMapInstance(en.MapId, en.MapInstanceId, new EntityDashPacket(en.Id, endMapId, endX, endY, dashTime, direction));
+    }
+
+    /// <summary>
+    /// Send a game announcement to all players.
+    /// </summary>
+    /// <param name="message">The message to send as an announcement.</param>
+    /// <param name="duration">The duration (in milliseconds) for the message to display.</param>
+    public static void SendGameAnnouncement(string message, long duration)
+    {
+        SendDataToAllPlayers(new AnnouncementPacket(message, duration));
+    }
+
+    //ActionMsgPacket
+    public static void SendActionMsg(Entity en, string message, Color color)
+    {
+        if (en == null)
+        {
+            return;
         }
 
-        //TimeDataPacket
-        public static void SendTimeBaseTo(Client client)
+        if (MapController.TryGetInstanceFromMap(en.Map.Id, en.MapInstanceId, out var mapInstance))
         {
-            client.Send(new TimeDataPacket(TimeBase.GetTimeBase().GetInstanceJson()));
+            if (Options.Instance.Packets.BatchActionMessagePackets)
+            {
+                mapInstance.AddBatchedActionMessage(new ActionMsgPacket(en.MapId, en.X, en.Y, message, color));
+            }
+            else
+            {
+                SendDataToProximityOnMapInstance(en.MapId, en.MapInstanceId, new ActionMsgPacket(en.MapId, en.X, en.Y, message, color));
+            }
         }
+    }
 
-        //TimeDataPacket
-        public static void SendTimeBaseToAllEditors()
-        {
-            SendDataToEditors(new TimeDataPacket(TimeBase.GetTimeBase().GetInstanceJson()));
-        }
+    //EnterMapPacket
+    public static void SendEnterMap(Client client, Guid mapId)
+    {
+        client.Send(new EnterMapPacket(mapId));
+    }
 
-        //TimePacket
-        public static void SendTimeToAll()
+    //TimeDataPacket
+    public static void SendTimeBaseTo(Client client)
+    {
+        client.Send(new TimeDataPacket(TimeBase.GetTimeBase().GetInstanceJson()));
+    }
+
+    //TimeDataPacket
+    public static void SendTimeBaseToAllEditors()
+    {
+        SendDataToEditors(new TimeDataPacket(TimeBase.GetTimeBase().GetInstanceJson()));
+    }
+
+    //TimePacket
+    public static void SendTimeToAll()
+    {
+        SendDataToAllPlayers(
+            new TimePacket(
+                Time.GetTime(), TimeBase.GetTimeBase().SyncTime ? 1 : TimeBase.GetTimeBase().Rate,
+                Time.GetTimeColor()
+            )
+        );
+    }
+
+    //TimePacket
+    public static void SendTimeTo(Client client)
+    {
+        client?.Send(
+            new TimePacket(
+                Time.GetTime(), TimeBase.GetTimeBase().SyncTime ? 1 : TimeBase.GetTimeBase().Rate,
+                Time.GetTimeColor()
+            )
+        );
+    }
+
+    //PartyPacket
+    public static void SendParty(Player player)
+    {
+        var memberPackets = new PartyMemberPacket[player.Party.Count];
+        for (var i = 0; i < player.Party.Count; i++)
         {
-            SendDataToAllPlayers(
-                new TimePacket(
-                    Time.GetTime(), TimeBase.GetTimeBase().SyncTime ? 1 : TimeBase.GetTimeBase().Rate,
-                    Time.GetTimeColor()
-                )
+            var mem = player.Party[i];
+            memberPackets[i] = new PartyMemberPacket(
+                mem.Id, mem.Name, mem.GetVitals(), mem.GetMaxVitals(), mem.Level
             );
         }
 
-        //TimePacket
-        public static void SendTimeTo(Client client)
+        player.SendPacket(new PartyPacket(memberPackets));
+    }
+
+    //PartyUpdatePacket
+    public static void SendPartyUpdateTo(Player player, Player member)
+    {
+        var partyIndex = -1;
+        for (var i = 0; i < player.Party.Count; i++)
         {
-            client?.Send(
-                new TimePacket(
-                    Time.GetTime(), TimeBase.GetTimeBase().SyncTime ? 1 : TimeBase.GetTimeBase().Rate,
-                    Time.GetTimeColor()
-                )
-            );
-        }
-
-        //PartyPacket
-        public static void SendParty(Player player)
-        {
-            var memberPackets = new PartyMemberPacket[player.Party.Count];
-            for (var i = 0; i < player.Party.Count; i++)
+            if (player.Party[i] == member)
             {
-                var mem = player.Party[i];
-                memberPackets[i] = new PartyMemberPacket(
-                    mem.Id, mem.Name, mem.GetVitals(), mem.GetMaxVitals(), mem.Level
-                );
-            }
-
-            player.SendPacket(new PartyPacket(memberPackets));
-        }
-
-        //PartyUpdatePacket
-        public static void SendPartyUpdateTo(Player player, Player member)
-        {
-            var partyIndex = -1;
-            for (var i = 0; i < player.Party.Count; i++)
-            {
-                if (player.Party[i] == member)
-                {
-                    partyIndex = i;
-                }
-            }
-
-            if (partyIndex > -1)
-            {
-                player.SendPacket(
-                    new PartyUpdatePacket(
-                        partyIndex,
-                        new PartyMemberPacket(
-                            member.Id, member.Name, member.GetVitals(), member.GetMaxVitals(), member.Level
-                        )
-                    ), TransmissionMode.Any
-                );
+                partyIndex = i;
             }
         }
 
-        //PartyInvitePacket
-        public static void SendPartyInvite(Player player, Player leader)
+        if (partyIndex > -1)
         {
-            player.SendPacket(new PartyInvitePacket(leader.Name, leader.Id));
-        }
-
-        //ChatBubblePacket
-        public static void SendChatBubble(Guid entityId, Guid mapInstanceId, EntityType type, string text, Guid mapId)
-        {
-            SendDataToProximityOnMapInstance(mapId, mapInstanceId, new ChatBubblePacket(entityId, type, mapId, text), null, TransmissionMode.Any);
-        }
-
-        //ChatBubblePacket
-        public static void SendChatBubbleToPlayer(Player player, Guid entityId, EntityType type, string text, Guid mapId)
-        {
-            player.SendPacket(new ChatBubblePacket(entityId, type, mapId, text));
-        }
-
-        //QuestOfferPacket
-        public static void SendQuestOffer(Player player, Guid questId)
-        {
-            player.SendPacket(new QuestOfferPacket(questId));
-        }
-
-        //QuestProgressPacket
-        public static void SendQuestsProgress(Player player)
-        {
-            var dict = new Dictionary<Guid, string>();
-            foreach (var quest in player.Quests)
-            {
-                dict.Add(quest.QuestId, quest.Data());
-            }
-
-            var hiddenQuests = new List<Guid>();
-            foreach (var pair in QuestBase.Lookup)
-            {
-                var quest = (QuestBase)pair.Value;
-                if (!player.Quests.Any(q => q.QuestId == quest.Id) && quest.DoNotShowUnlessRequirementsMet && !player.CanStartQuest(quest))
-                {
-                    hiddenQuests.Add(quest.Id);
-                }
-            }
-
-            player.SendPacket(new QuestProgressPacket(dict, hiddenQuests.ToArray()));
-        }
-
-        //TradePacket
-        public static void StartTrade(Player player, Player target)
-        {
-            player.SendPacket(new TradePacket(target.Name));
-        }
-
-        //TradeUpdatePacket
-        public static void SendTradeUpdate(Player player, Player trader, int slot)
-        {
-            if (trader.Trading.Offer[slot] != null &&
-                trader.Trading.Offer[slot].ItemId != Guid.Empty &&
-                trader.Trading.Offer[slot].Quantity > 0)
-            {
-                player.SendPacket(
-                    new TradeUpdatePacket(
-                        trader.Id, slot, trader.Trading.Offer[slot].ItemId, trader.Trading.Offer[slot].Quantity,
-                        trader.Trading.Offer[slot].BagId, trader.Trading.Offer[slot].Properties
+            player.SendPacket(
+                new PartyUpdatePacket(
+                    partyIndex,
+                    new PartyMemberPacket(
+                        member.Id, member.Name, member.GetVitals(), member.GetMaxVitals(), member.Level
                     )
-                );
+                ), TransmissionMode.Any
+            );
+        }
+    }
+
+    //PartyInvitePacket
+    public static void SendPartyInvite(Player player, Player leader)
+    {
+        player.SendPacket(new PartyInvitePacket(leader.Name, leader.Id));
+    }
+
+    //ChatBubblePacket
+    public static void SendChatBubble(Guid entityId, Guid mapInstanceId, EntityType type, string text, Guid mapId)
+    {
+        SendDataToProximityOnMapInstance(mapId, mapInstanceId, new ChatBubblePacket(entityId, type, mapId, text), null, TransmissionMode.Any);
+    }
+
+    //ChatBubblePacket
+    public static void SendChatBubbleToPlayer(Player player, Guid entityId, EntityType type, string text, Guid mapId)
+    {
+        player.SendPacket(new ChatBubblePacket(entityId, type, mapId, text));
+    }
+
+    //QuestOfferPacket
+    public static void SendQuestOffer(Player player, Guid questId)
+    {
+        player.SendPacket(new QuestOfferPacket(questId));
+    }
+
+    //QuestProgressPacket
+    public static void SendQuestsProgress(Player player)
+    {
+        var dict = new Dictionary<Guid, string>();
+        foreach (var quest in player.Quests)
+        {
+            dict.Add(quest.QuestId, quest.Data());
+        }
+
+        var hiddenQuests = new List<Guid>();
+        foreach (var pair in QuestBase.Lookup)
+        {
+            var quest = (QuestBase)pair.Value;
+            if (!player.Quests.Any(q => q.QuestId == quest.Id) && quest.DoNotShowUnlessRequirementsMet && !player.CanStartQuest(quest))
+            {
+                hiddenQuests.Add(quest.Id);
+            }
+        }
+
+        player.SendPacket(new QuestProgressPacket(dict, hiddenQuests.ToArray()));
+    }
+
+    //TradePacket
+    public static void StartTrade(Player player, Player target)
+    {
+        player.SendPacket(new TradePacket(target.Name));
+    }
+
+    //TradeUpdatePacket
+    public static void SendTradeUpdate(Player player, Player trader, int slot)
+    {
+        if (trader.Trading.Offer[slot] != null &&
+            trader.Trading.Offer[slot].ItemId != Guid.Empty &&
+            trader.Trading.Offer[slot].Quantity > 0)
+        {
+            player.SendPacket(
+                new TradeUpdatePacket(
+                    trader.Id, slot, trader.Trading.Offer[slot].ItemId, trader.Trading.Offer[slot].Quantity,
+                    trader.Trading.Offer[slot].BagId, trader.Trading.Offer[slot].Properties
+                )
+            );
+        }
+        else
+        {
+            player.SendPacket(new TradeUpdatePacket(trader.Id, slot, Guid.Empty, 0, null, null));
+        }
+    }
+
+    //TradePacket
+    public static void SendTradeClose(Player player)
+    {
+        player.SendPacket(new TradePacket(null));
+    }
+
+    //TradeRequestPacket
+    public static void SendTradeRequest(Player player, Player partner)
+    {
+        player.SendPacket(new TradeRequestPacket(partner.Id, partner.Name));
+    }
+
+    //PlayerDeathPacket
+    public static void SendPlayerDeath(Player en)
+    {
+        SendDataToProximityOnMapInstance(en.MapId, en.MapInstanceId, new PlayerDeathPacket(en.Id));
+    }
+
+    //EntityZDimensionPacket
+    public static void UpdateEntityZDimension(Entity en, byte z)
+    {
+        SendDataToProximityOnMapInstance(en.MapId, en.MapInstanceId, new EntityZDimensionPacket(en.Id, z));
+    }
+
+    //BagPacket
+    public static void SendOpenBag(Player player, int slots, Bag bag)
+    {
+        player.SendPacket(new BagPacket(slots, false));
+        for (var i = 0; i < slots; i++)
+        {
+            SendBagUpdate(player, i, bag.Slots[i]);
+        }
+    }
+
+    //BagUpdatePacket
+    public static void SendBagUpdate(Player player, int slot, Item item)
+    {
+        if (item != null && item.ItemId != Guid.Empty && item.Quantity > 0)
+        {
+            player.SendPacket(new BagUpdatePacket(slot, item.ItemId, item.Quantity, item.BagId, item.Properties));
+        }
+        else
+        {
+            player.SendPacket(new BagUpdatePacket(slot, Guid.Empty, 0, null, null));
+        }
+    }
+
+    //BagPacket
+    public static void SendCloseBag(Player player)
+    {
+        player.SendPacket(new BagPacket(0, true));
+    }
+
+    //MoveRoutePacket
+    public static void SendMoveRouteToggle(Player player, bool routeOn)
+    {
+        player.SendPacket(new MoveRoutePacket(routeOn));
+    }
+
+    //FriendsPacket
+    public static void SendFriends(Player player)
+    {
+        if (player == null)
+        {
+            return;
+        }
+
+        var online = new Dictionary<string, string>();
+        var offline = new List<string>();
+
+        foreach (var friend in player.CachedFriends)
+        {
+            var plyr = Player.FindOnline(friend.Key);
+            if (plyr != null)
+            {
+                online.Add(plyr.Name, MapList.List.FindMap(plyr.MapId)?.Name ?? "");
             }
             else
             {
-                player.SendPacket(new TradeUpdatePacket(trader.Id, slot, Guid.Empty, 0, null, null));
+                offline.Add(friend.Value);
             }
         }
 
-        //TradePacket
-        public static void SendTradeClose(Player player)
-        {
-            player.SendPacket(new TradePacket(null));
-        }
+        player.SendPacket(new FriendsPacket(online, offline.ToArray()));
+    }
 
-        //TradeRequestPacket
-        public static void SendTradeRequest(Player player, Player partner)
-        {
-            player.SendPacket(new TradeRequestPacket(partner.Id, partner.Name));
-        }
+    //FriendRequestPacket
+    public static void SendFriendRequest(Player player, Player partner)
+    {
+        player.SendPacket(new FriendRequestPacket(partner.Id, partner.Name));
+    }
 
-        //PlayerDeathPacket
-        public static void SendPlayerDeath(Player en)
-        {
-            SendDataToProximityOnMapInstance(en.MapId, en.MapInstanceId, new PlayerDeathPacket(en.Id));
-        }
+    //PasswordResetResultPacket
+    public static void SendPasswordResetResult(Client client, bool result)
+    {
+        client.Send(new PasswordResetResultPacket(result));
+    }
 
-        //EntityZDimensionPacket
-        public static void UpdateEntityZDimension(Entity en, byte z)
-        {
-            SendDataToProximityOnMapInstance(en.MapId, en.MapInstanceId, new EntityZDimensionPacket(en.Id, z));
-        }
+    //TargetOverridePacket
+    public static void SetPlayerTarget(Player player, Guid targetId)
+    {
+        player.SendPacket(new TargetOverridePacket(targetId));
+    }
 
-        //BagPacket
-        public static void SendOpenBag(Player player, int slots, Bag bag)
+    //GuildMsgPacket
+    public static void SendGuildMsg(Player player, string message, Color clr, string target = "")
+    {
+        foreach (var p in player.Guild.FindOnlineMembers())
         {
-            player.SendPacket(new BagPacket(slots, false));
-            for (var i = 0; i < slots; i++)
+            if (p != null)
             {
-                SendBagUpdate(player, i, bag.Slots[i]);
+                SendChatMsg(p, message, ChatMessageType.Guild, clr, target);
             }
         }
+    }
 
-        //BagUpdatePacket
-        public static void SendBagUpdate(Player player, int slot, Item item)
+    /// <summary>
+    /// Send a player their guild member list.
+    /// </summary>
+    /// <param name="player"></param>
+    public static void SendGuild(Player player)
+    {
+        if (player == null || player.Guild == null)
         {
-            if (item != null && item.ItemId != Guid.Empty && item.Quantity > 0)
+            return;
+        }
+
+        var members = player.Guild.Members.Values.ToArray();
+        var onlineMembers = player.Guild.FindOnlineMembers();
+
+        foreach (var member in members)
+        {
+            member.Online = onlineMembers.Any(m => m.Id == member.Id);
+        }
+
+        player.SendPacket(new GuildPacket(members));
+    }
+
+    //GuildRequestPacket
+    public static void SendGuildInvite(Player player, Player from)
+    {
+        player.SendPacket(new GuildInvitePacket(from.Name, from.Guild.Name));
+    }
+
+    public static void SendFade(Player player, FadeType fadeType, bool waitForCompletion, int speedMs)
+    {
+        player.SendPacket(new FadePacket(fadeType, waitForCompletion, speedMs));
+    }
+
+    public static void SendDataToAllLayersOfMap(Guid mapId, IPacket packet, Player except = null, TransmissionMode mode = TransmissionMode.All)
+    {
+        if (!MapController.Lookup.Keys.Contains(mapId))
+        {
+            return;
+        }
+
+        foreach (var player in MapController.Get(mapId).GetPlayersOnAllInstances())
+        {
+            if (player != null && player != except)
             {
-                player.SendPacket(new BagUpdatePacket(slot, item.ItemId, item.Quantity, item.BagId, item.Properties));
-            }
-            else
-            {
-                player.SendPacket(new BagUpdatePacket(slot, Guid.Empty, 0, null, null));
+                player.SendPacket(packet, mode);
             }
         }
+    }
 
-        //BagPacket
-        public static void SendCloseBag(Player player)
+    public static void SendDataToMapInstance(Guid mapId, Guid mapInstanceId, IPacket packet, Player except = null, TransmissionMode mode = TransmissionMode.All)
+    {
+        if (MapController.TryGetInstanceFromMap(mapId, mapInstanceId, out var mapInstance))
         {
-            player.SendPacket(new BagPacket(0, true));
-        }
-
-        //MoveRoutePacket
-        public static void SendMoveRouteToggle(Player player, bool routeOn)
-        {
-            player.SendPacket(new MoveRoutePacket(routeOn));
-        }
-
-        //FriendsPacket
-        public static void SendFriends(Player player)
-        {
-            if (player == null)
-            {
-                return;
-            }
-
-            var online = new Dictionary<string, string>();
-            var offline = new List<string>();
-
-            foreach (var friend in player.CachedFriends)
-            {
-                var plyr = Player.FindOnline(friend.Key);
-                if (plyr != null)
-                {
-                    online.Add(plyr.Name, MapList.List.FindMap(plyr.MapId)?.Name ?? "");
-                }
-                else
-                {
-                    offline.Add(friend.Value);
-                }
-            }
-
-            player.SendPacket(new FriendsPacket(online, offline.ToArray()));
-        }
-
-        //FriendRequestPacket
-        public static void SendFriendRequest(Player player, Player partner)
-        {
-            player.SendPacket(new FriendRequestPacket(partner.Id, partner.Name));
-        }
-
-        //PasswordResetResultPacket
-        public static void SendPasswordResetResult(Client client, bool result)
-        {
-            client.Send(new PasswordResetResultPacket(result));
-        }
-
-        //TargetOverridePacket
-        public static void SetPlayerTarget(Player player, Guid targetId)
-        {
-            player.SendPacket(new TargetOverridePacket(targetId));
-        }
-
-        //GuildMsgPacket
-        public static void SendGuildMsg(Player player, string message, Color clr, string target = "")
-        {
-            foreach (var p in player.Guild.FindOnlineMembers())
-            {
-                if (p != null)
-                {
-                    SendChatMsg(p, message, ChatMessageType.Guild, clr, target);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Send a player their guild member list.
-        /// </summary>
-        /// <param name="player"></param>
-        public static void SendGuild(Player player)
-        {
-            if (player == null || player.Guild == null)
-            {
-                return;
-            }
-
-            var members = player.Guild.Members.Values.ToArray();
-            var onlineMembers = player.Guild.FindOnlineMembers();
-
-            foreach (var member in members)
-            {
-                member.Online = onlineMembers.Any(m => m.Id == member.Id);
-            }
-
-            player.SendPacket(new GuildPacket(members));
-        }
-
-        //GuildRequestPacket
-        public static void SendGuildInvite(Player player, Player from)
-        {
-            player.SendPacket(new GuildInvitePacket(from.Name, from.Guild.Name));
-        }
-
-        public static void SendFade(Player player, FadeType fadeType, bool waitForCompletion, int speedMs)
-        {
-            player.SendPacket(new FadePacket(fadeType, waitForCompletion, speedMs));
-        }
-
-        public static void SendDataToAllLayersOfMap(Guid mapId, IPacket packet, Player except = null, TransmissionMode mode = TransmissionMode.All)
-        {
-            if (!MapController.Lookup.Keys.Contains(mapId))
-            {
-                return;
-            }
-
-            foreach (var player in MapController.Get(mapId).GetPlayersOnAllInstances())
+            var players = mapInstance.GetPlayers();
+            foreach (var player in players)
             {
                 if (player != null && player != except)
                 {
@@ -2265,108 +2279,92 @@ namespace Intersect.Server.Networking
                 }
             }
         }
+    }
 
-        public static void SendDataToMapInstance(Guid mapId, Guid mapInstanceId, IPacket packet, Player except = null, TransmissionMode mode = TransmissionMode.All)
+    public static bool SendDataAcrossMapInstancesInProximity(Guid mapId, IPacket packet, Player except = null, TransmissionMode mode = TransmissionMode.All)
+    {
+        var map = MapController.Get(mapId);
+        if (map == null)
         {
-            if (MapController.TryGetInstanceFromMap(mapId, mapInstanceId, out var mapInstance))
-            {
-                var players = mapInstance.GetPlayers();
-                foreach (var player in players)
-                {
-                    if (player != null && player != except)
-                    {
-                        player.SendPacket(packet, mode);
-                    }
-                }
-            }
+            return false;
         }
 
-        public static bool SendDataAcrossMapInstancesInProximity(Guid mapId, IPacket packet, Player except = null, TransmissionMode mode = TransmissionMode.All)
+        SendDataToAllLayersOfMap(mapId, packet, except, mode);
+
+        foreach (var surrMap in map.SurroundingMapIds)
         {
-            var map = MapController.Get(mapId);
-            if (map == null)
-            {
-                return false;
-            }
+            SendDataToAllLayersOfMap(surrMap, packet, except, mode);
+        }
 
-            SendDataToAllLayersOfMap(mapId, packet, except, mode);
+        return true;
+    }
 
-            foreach (var surrMap in map.SurroundingMapIds)
+    public static bool SendDataToProximityOnMapInstance(Guid mapId, Guid mapInstanceId, IPacket packet, Player except = null, TransmissionMode mode = TransmissionMode.All)
+    {
+        if (MapController.TryGetInstanceFromMap(mapId, mapInstanceId, out var mapInstance))
+        {
+            SendDataToMapInstance(mapId, mapInstanceId, packet, except, mode);
+            foreach (var surrMap in MapController.Get(mapId).SurroundingMapIds)
             {
-                SendDataToAllLayersOfMap(surrMap, packet, except, mode);
+                SendDataToMapInstance(surrMap, mapInstanceId, packet, except, mode);
             }
 
             return true;
         }
-
-        public static bool SendDataToProximityOnMapInstance(Guid mapId, Guid mapInstanceId, IPacket packet, Player except = null, TransmissionMode mode = TransmissionMode.All)
+        else
         {
-            if (MapController.TryGetInstanceFromMap(mapId, mapInstanceId, out var mapInstance))
-            {
-                SendDataToMapInstance(mapId, mapInstanceId, packet, except, mode);
-                foreach (var surrMap in MapController.Get(mapId).SurroundingMapIds)
-                {
-                    SendDataToMapInstance(surrMap, mapInstanceId, packet, except, mode);
-                }
-
-                return true;
-            }
-            else
-            {
-                return false;
-            }
+            return false;
         }
+    }
 
-        public static void SendDataToPlayers(IPacket packet, IEnumerable<Player> players, TransmissionMode mode = TransmissionMode.All)
+    public static void SendDataToPlayers(IPacket packet, IEnumerable<Player> players, TransmissionMode mode = TransmissionMode.All)
+    {
+        foreach (var player in players)
         {
-            foreach (var player in players)
-            {
-                player.SendPacket(packet, mode);
-            }
+            player.SendPacket(packet, mode);
         }
+    }
 
-        public static void SendDataToEditors(IPacket packet)
+    public static void SendDataToEditors(IPacket packet)
+    {
+        lock (Globals.ClientLock)
         {
-            lock (Globals.ClientLock)
+            foreach (var client in Globals.Clients)
             {
-                foreach (var client in Globals.Clients)
+                if (client.IsEditor)
                 {
-                    if (client.IsEditor)
-                    {
-                        client.Send(packet);
-                    }
+                    client.Send(packet);
                 }
             }
         }
+    }
 
-        public static void SendDataToAllPlayers(IPacket packet, TransmissionMode mode = TransmissionMode.All)
+    public static void SendDataToAllPlayers(IPacket packet, TransmissionMode mode = TransmissionMode.All)
+    {
+        lock (Globals.ClientLock)
         {
-            lock (Globals.ClientLock)
+            foreach (var client in Globals.Clients)
             {
-                foreach (var client in Globals.Clients)
+                if (client?.Entity != null)
                 {
-                    if (client?.Entity != null)
-                    {
-                        client.Send(packet, mode);
-                    }
+                    client.Send(packet, mode);
                 }
             }
         }
+    }
 
-        public static void SendDataToAll(IPacket packet, TransmissionMode mode = TransmissionMode.All)
+    public static void SendDataToAll(IPacket packet, TransmissionMode mode = TransmissionMode.All)
+    {
+        lock (Globals.ClientLock)
         {
-            lock (Globals.ClientLock)
+            foreach (var client in Globals.Clients)
             {
-                foreach (var client in Globals.Clients)
+                if ((client?.IsEditor ?? false) || client?.Entity != null)
                 {
-                    if ((client?.IsEditor ?? false) || client?.Entity != null)
-                    {
-                        client.Send(packet, mode);
-                    }
+                    client.Send(packet, mode);
                 }
             }
         }
-
     }
 
 }

--- a/Intersect.Server.Core/Plugins/Helpers/ServerLifecycleHelper.cs
+++ b/Intersect.Server.Core/Plugins/Helpers/ServerLifecycleHelper.cs
@@ -1,13 +1,12 @@
 ﻿using Intersect.Plugins.Helpers;
 
-namespace Intersect.Server.Plugins.Helpers
+namespace Intersect.Server.Plugins.Helpers;
+
+/// <inheritdoc cref="IServerLifecycleHelper"/>
+internal sealed partial class ServerLifecycleHelper : ContextHelper<IServerPluginContext>, IServerLifecycleHelper
 {
-    /// <inheritdoc cref="IServerLifecycleHelper"/>
-    internal sealed partial class ServerLifecycleHelper : ContextHelper<IServerPluginContext>, IServerLifecycleHelper
+    /// <inheritdoc />
+    public ServerLifecycleHelper(IServerPluginContext context) : base(context)
     {
-        /// <inheritdoc />
-        public ServerLifecycleHelper(IServerPluginContext context) : base(context)
-        {
-        }
     }
 }

--- a/Intersect.Server.Core/Plugins/ServerPluginContext.cs
+++ b/Intersect.Server.Core/Plugins/ServerPluginContext.cs
@@ -1,48 +1,45 @@
-﻿using System;
-
-using Intersect.Factories;
+﻿using Intersect.Factories;
 using Intersect.Plugins;
 using Intersect.Plugins.Contexts;
 using Intersect.Plugins.Interfaces;
 using Intersect.Server.Plugins.Helpers;
 
-namespace Intersect.Server.Plugins
+namespace Intersect.Server.Plugins;
+
+/// <summary>
+/// Implementation of <see cref="IServerPluginContext"/>.
+/// </summary>
+internal sealed partial class ServerPluginContext : PluginContext<ServerPluginContext, IServerLifecycleHelper>,
+    IServerPluginContext
 {
     /// <summary>
-    /// Implementation of <see cref="IServerPluginContext"/>.
+    /// <see cref="IPluginContext"/> factory that creates instances of <see cref="IServerPluginContext"/>.
     /// </summary>
-    internal sealed partial class ServerPluginContext : PluginContext<ServerPluginContext, IServerLifecycleHelper>,
-        IServerPluginContext
+    internal sealed partial class Factory : IFactory<IPluginContext>
     {
-        /// <summary>
-        /// <see cref="IPluginContext"/> factory that creates instances of <see cref="IServerPluginContext"/>.
-        /// </summary>
-        internal sealed partial class Factory : IFactory<IPluginContext>
+        /// <inheritdoc />
+        public IPluginContext Create(params object[] args)
         {
-            /// <inheritdoc />
-            public IPluginContext Create(params object[] args)
+            if (args.Length < 1)
             {
-                if (args.Length < 1)
-                {
-                    throw new ArgumentException($@"Need to provide an instance of {nameof(IManifestHelper)}.");
-                }
-
-                if (!(args[0] is Plugin plugin))
-                {
-                    throw new ArgumentException($@"First argument needs to be non-null and of type {nameof(Plugin)}.");
-                }
-
-                return new ServerPluginContext(plugin);
+                throw new ArgumentException($@"Need to provide an instance of {nameof(IManifestHelper)}.");
             }
-        }
 
-        /// <inheritdoc />
-        public ServerPluginContext(Plugin plugin) : base(plugin)
-        {
-            Lifecycle = new ServerLifecycleHelper(this);
-        }
+            if (!(args[0] is Plugin plugin))
+            {
+                throw new ArgumentException($@"First argument needs to be non-null and of type {nameof(Plugin)}.");
+            }
 
-        /// <inheritdoc />
-        public override IServerLifecycleHelper Lifecycle { get; }
+            return new ServerPluginContext(plugin);
+        }
     }
+
+    /// <inheritdoc />
+    public ServerPluginContext(Plugin plugin) : base(plugin)
+    {
+        Lifecycle = new ServerLifecycleHelper(this);
+    }
+
+    /// <inheritdoc />
+    public override IServerLifecycleHelper Lifecycle { get; }
 }


### PR DESCRIPTION
**Context:** File-scoped namespaces _were introduced in C# 10.0, which was released as part of .NET 6_. This feature allows developers to declare namespaces at the top of a file without enclosing them in a curly brace block, effectively making the namespace applicable to the entire file. Converting namespaces to file-scoped namespaces in C# promotes cleaner, more organized code that is easier to read, maintain, and scale as the project grows. It aligns with modern coding practices and helps prevent potential namespace conflicts, contributing to overall code quality and developer productivity.