### PR TITLE
fix: editor build after cleanup

### DIFF
--- a/Intersect.Editor/Content/ContentManager.cs
+++ b/Intersect.Editor/Content/ContentManager.cs
@@ -1,3 +1,4 @@
+using Intersect.Editor.Core;
 using Intersect.Editor.Localization;
 using Intersect.Editor.Networking;
 using Intersect.GameObjects;

--- a/Intersect.Editor/Forms/DockingElements/frmMapGrid.cs
+++ b/Intersect.Editor/Forms/DockingElements/frmMapGrid.cs
@@ -1,3 +1,4 @@
+using Intersect.Editor.Core;
 using Intersect.Editor.General;
 using Intersect.Editor.Localization;
 using Intersect.Editor.Maps;

--- a/Intersect.Editor/Forms/DockingElements/frmMapLayers.cs
+++ b/Intersect.Editor/Forms/DockingElements/frmMapLayers.cs
@@ -1,5 +1,6 @@
 using Intersect.Config;
 using Intersect.Editor.Content;
+using Intersect.Editor.Core;
 using Intersect.Editor.General;
 using Intersect.Editor.Localization;
 using Intersect.Enums;

--- a/Intersect.Editor/Forms/DockingElements/frmMapList.cs
+++ b/Intersect.Editor/Forms/DockingElements/frmMapList.cs
@@ -1,5 +1,5 @@
 using DarkUI.Forms;
-
+using Intersect.Editor.Core;
 using Intersect.Editor.General;
 using Intersect.Editor.Localization;
 using Intersect.Editor.Networking;

--- a/Intersect.Editor/Forms/DockingElements/frmMapProperties.cs
+++ b/Intersect.Editor/Forms/DockingElements/frmMapProperties.cs
@@ -1,4 +1,5 @@
-﻿using Intersect.Editor.Localization;
+﻿using Intersect.Editor.Core;
+using Intersect.Editor.Localization;
 using Intersect.Editor.Maps;
 
 using WeifenLuo.WinFormsUI.Docking;

--- a/Intersect.Editor/Forms/Editors/EditorForm.cs
+++ b/Intersect.Editor/Forms/Editors/EditorForm.cs
@@ -1,3 +1,4 @@
+using Intersect.Editor.Core;
 using Intersect.Editor.Networking;
 using Intersect.Enums;
 using Intersect.Logging;

--- a/Intersect.Editor/Forms/Editors/Events/frmEvent.cs
+++ b/Intersect.Editor/Forms/Editors/Events/frmEvent.cs
@@ -2,6 +2,7 @@ using DarkUI.Controls;
 using DarkUI.Forms;
 
 using Intersect.Editor.Content;
+using Intersect.Editor.Core;
 using Intersect.Editor.Forms.Editors.Events.Event_Commands;
 using Intersect.Editor.Localization;
 using Intersect.Editor.Maps;

--- a/Intersect.Editor/Forms/Editors/Quest/frmQuest.cs
+++ b/Intersect.Editor/Forms/Editors/Quest/frmQuest.cs
@@ -1,5 +1,5 @@
 ﻿using DarkUI.Forms;
-
+using Intersect.Editor.Core;
 using Intersect.Editor.Forms.Editors.Events;
 using Intersect.Editor.General;
 using Intersect.Editor.Localization;

--- a/Intersect.Editor/Forms/Editors/frmAnimation.cs
+++ b/Intersect.Editor/Forms/Editors/frmAnimation.cs
@@ -4,6 +4,7 @@ using DarkUI.Controls;
 using DarkUI.Forms;
 
 using Intersect.Editor.Content;
+using Intersect.Editor.Core;
 using Intersect.Editor.General;
 using Intersect.Editor.Localization;
 using Intersect.Editor.Networking;

--- a/Intersect.Editor/Forms/Editors/frmClass.cs
+++ b/Intersect.Editor/Forms/Editors/frmClass.cs
@@ -1,6 +1,7 @@
 using DarkUI.Forms;
 
 using Intersect.Editor.Content;
+using Intersect.Editor.Core;
 using Intersect.Editor.General;
 using Intersect.Editor.Localization;
 using Intersect.Editor.Networking;

--- a/Intersect.Editor/Forms/Editors/frmCraftingTables.cs
+++ b/Intersect.Editor/Forms/Editors/frmCraftingTables.cs
@@ -1,5 +1,5 @@
 ﻿using DarkUI.Forms;
-
+using Intersect.Editor.Core;
 using Intersect.Editor.General;
 using Intersect.Editor.Localization;
 using Intersect.Editor.Networking;

--- a/Intersect.Editor/Forms/Editors/frmCrafts.cs
+++ b/Intersect.Editor/Forms/Editors/frmCrafts.cs
@@ -1,5 +1,5 @@
 using DarkUI.Forms;
-
+using Intersect.Editor.Core;
 using Intersect.Editor.General;
 using Intersect.Editor.Localization;
 using Intersect.Editor.Networking;

--- a/Intersect.Editor/Forms/Editors/frmDynamicRequirements.cs
+++ b/Intersect.Editor/Forms/Editors/frmDynamicRequirements.cs
@@ -1,4 +1,5 @@
-﻿using Intersect.Editor.Forms.Editors.Events.Event_Commands;
+﻿using Intersect.Editor.Core;
+using Intersect.Editor.Forms.Editors.Events.Event_Commands;
 using Intersect.Editor.Localization;
 using Intersect.GameObjects.Conditions;
 using Intersect.GameObjects.Events;

--- a/Intersect.Editor/Forms/Editors/frmItem.cs
+++ b/Intersect.Editor/Forms/Editors/frmItem.cs
@@ -2,6 +2,7 @@ using System.Drawing.Imaging;
 using DarkUI.Forms;
 
 using Intersect.Editor.Content;
+using Intersect.Editor.Core;
 using Intersect.Editor.General;
 using Intersect.Editor.Localization;
 using Intersect.Editor.Networking;

--- a/Intersect.Editor/Forms/Editors/frmNpc.cs
+++ b/Intersect.Editor/Forms/Editors/frmNpc.cs
@@ -3,6 +3,7 @@ using System.Drawing.Imaging;
 using DarkUI.Forms;
 
 using Intersect.Editor.Content;
+using Intersect.Editor.Core;
 using Intersect.Editor.General;
 using Intersect.Editor.Localization;
 using Intersect.Editor.Networking;

--- a/Intersect.Editor/Forms/Editors/frmProjectile.cs
+++ b/Intersect.Editor/Forms/Editors/frmProjectile.cs
@@ -1,5 +1,6 @@
 using DarkUI.Controls;
 using DarkUI.Forms;
+using Intersect.Editor.Core;
 using Intersect.Editor.General;
 using Intersect.Editor.Localization;
 using Intersect.Editor.Networking;

--- a/Intersect.Editor/Forms/Editors/frmResource.cs
+++ b/Intersect.Editor/Forms/Editors/frmResource.cs
@@ -1,6 +1,7 @@
 using DarkUI.Forms;
 
 using Intersect.Editor.Content;
+using Intersect.Editor.Core;
 using Intersect.Editor.General;
 using Intersect.Editor.Localization;
 using Intersect.Editor.Networking;

--- a/Intersect.Editor/Forms/Editors/frmShop.cs
+++ b/Intersect.Editor/Forms/Editors/frmShop.cs
@@ -1,5 +1,6 @@
 ﻿using DarkUI.Forms;
 using Intersect.Editor.Content;
+using Intersect.Editor.Core;
 using Intersect.Editor.General;
 using Intersect.Editor.Localization;
 using Intersect.Editor.Networking;

--- a/Intersect.Editor/Forms/Editors/frmSpell.cs
+++ b/Intersect.Editor/Forms/Editors/frmSpell.cs
@@ -2,6 +2,7 @@ using DarkUI.Controls;
 using DarkUI.Forms;
 
 using Intersect.Editor.Content;
+using Intersect.Editor.Core;
 using Intersect.Editor.General;
 using Intersect.Editor.Localization;
 using Intersect.Editor.Networking;

--- a/Intersect.Editor/Forms/Editors/frmVariable.cs
+++ b/Intersect.Editor/Forms/Editors/frmVariable.cs
@@ -1,5 +1,5 @@
 using DarkUI.Forms;
-
+using Intersect.Editor.Core;
 using Intersect.Editor.General;
 using Intersect.Editor.Localization;
 using Intersect.Editor.Networking;

--- a/Intersect.Editor/Forms/frmAbout.cs
+++ b/Intersect.Editor/Forms/frmAbout.cs
@@ -1,3 +1,4 @@
+using Intersect.Editor.Core;
 using Intersect.Editor.Localization;
 using Intersect.Utilities;
 

--- a/Intersect.Editor/Forms/frmMain.cs
+++ b/Intersect.Editor/Forms/frmMain.cs
@@ -8,6 +8,7 @@ using Intersect.Compression;
 using Intersect.Config;
 using Intersect.Editor.Classes.ContentManagement;
 using Intersect.Editor.Content;
+using Intersect.Editor.Core;
 using Intersect.Editor.Forms.DockingElements;
 using Intersect.Editor.Forms.Editors;
 using Intersect.Editor.Forms.Editors.Quest;

--- a/Intersect.Editor/Forms/frmOptions.cs
+++ b/Intersect.Editor/Forms/frmOptions.cs
@@ -1,5 +1,5 @@
 ﻿using System.Globalization;
-
+using Intersect.Editor.Core;
 using Intersect.Editor.Localization;
 
 namespace Intersect.Editor.Forms;

--- a/Intersect.Editor/Forms/frmProgress.cs
+++ b/Intersect.Editor/Forms/frmProgress.cs
@@ -1,3 +1,4 @@
+using Intersect.Editor.Core;
 using Intersect.Editor.Localization;
 
 namespace Intersect.Editor.Forms;

--- a/Intersect.Editor/Forms/frmUpdate.cs
+++ b/Intersect.Editor/Forms/frmUpdate.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 
 using Intersect.Configuration;
 using Intersect.Editor.Content;
+using Intersect.Editor.Core;
 using Intersect.Editor.General;
 using Intersect.Editor.Localization;
 using Intersect.Logging;

--- a/Intersect.Editor/Forms/frmVariableSelector.cs
+++ b/Intersect.Editor/Forms/frmVariableSelector.cs
@@ -1,3 +1,4 @@
+using Intersect.Editor.Core;
 using Intersect.Editor.Localization;
 using Intersect.Enums;
 using Intersect.Extensions;

--- a/Intersect.Editor/Forms/frmWarpSelection.cs
+++ b/Intersect.Editor/Forms/frmWarpSelection.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using Intersect.Editor.Core;
 using Intersect.Editor.General;
 using Intersect.Editor.Localization;
 using Intersect.Editor.Maps;

--- a/Intersect.Editor/Maps/MapGrid.cs
+++ b/Intersect.Editor/Maps/MapGrid.cs
@@ -1,7 +1,7 @@
 using DarkUI.Forms;
 
 using Hjg.Pngcs;
-
+using Intersect.Editor.Core;
 using Intersect.Editor.Forms;
 using Intersect.Editor.General;
 using Intersect.Editor.Localization;

--- a/Intersect.Editor/Maps/MapInstance.cs
+++ b/Intersect.Editor/Maps/MapInstance.cs
@@ -1,6 +1,7 @@
 ﻿using System.Drawing.Imaging;
 using Intersect.Compression;
 using Intersect.Editor.Classes.Maps;
+using Intersect.Editor.Core;
 using Intersect.Editor.Entities;
 using Intersect.Editor.General;
 using Intersect.GameObjects;

--- a/Intersect.Editor/Networking/PacketHandler.cs
+++ b/Intersect.Editor/Networking/PacketHandler.cs
@@ -1,5 +1,6 @@
 using Intersect.Core;
 using Intersect.Editor.Content;
+using Intersect.Editor.Core;
 using Intersect.Editor.General;
 using Intersect.Editor.Localization;
 using Intersect.Editor.Maps;


### PR DESCRIPTION
fixes an issue with some missing `using Intersect.Editor.Core` that were updated to their corresponding namespace and folders.
tested and built locally, GHA should properly build the engine now.