### PR TITLE
enhancement: bind description window to hovered control

### DIFF
--- a/Intersect (Core)/Intersect.Core.csproj
+++ b/Intersect (Core)/Intersect.Core.csproj
@@ -125,7 +125,7 @@
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
     <PackageReference Include="System.Runtime.Extensions" Version="4.3.1" />
     <PackageReference Include="System.Text.Encoding.Extensions" Version="4.3.0" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="7.0.0" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="8.0.0" />
     <PackageReference Include="System.Threading" Version="4.3.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />

--- a/Intersect.Client/Interface/Game/DescriptionWindows/DescriptionWindowBase.cs
+++ b/Intersect.Client/Interface/Game/DescriptionWindows/DescriptionWindowBase.cs
@@ -1,4 +1,5 @@
 using Intersect.Client.Framework.Gwen.Control;
+using Intersect.Client.Framework.Gwen.Input;
 using Intersect.Client.Interface.Game.DescriptionWindows.Components;
 
 namespace Intersect.Client.Interface.Game.DescriptionWindows;
@@ -11,15 +12,10 @@ public partial class DescriptionWindowBase : ComponentBase
     // Our internal list of components.
     private List<ComponentBase> mComponents;
 
-    private bool mCenterOnPosition;
-
-    public DescriptionWindowBase(Base parent, string name, bool centerOnPosition = false) : base(parent, name)
+    public DescriptionWindowBase(Base parent, string name) : base(parent, name)
     {
         // Set up our internal component list we use for re-ordering.
         mComponents = new List<ComponentBase>();
-
-        // Set up whether we should center on our desired position.
-        mCenterOnPosition = centerOnPosition;
 
         GenerateComponents();
     }
@@ -135,32 +131,29 @@ public partial class DescriptionWindowBase : ComponentBase
     /// <inheritdoc/>
     public override void SetPosition(int x, int y)
     {
-        var newX = x - mContainer.Width - mContainer.Padding.Right;
-        var newY = y + mContainer.Padding.Top;
-
-        // Center on the desired position if requested.
-        if (mCenterOnPosition)
+        if (mContainer == null || mContainer.Canvas == null)
         {
-            newX += (mContainer.Width - mContainer.Padding.Right) / 2;
+            return;
         }
-        
+
+        int newX, newY;
+        int HoveredControlX, HoveredControlY;
+
+        // Bind description window to the HoveredControl position.
+        HoveredControlX = InputHandler.HoveredControl.LocalPosToCanvas(new Point(0, 0)).X;
+        HoveredControlY = InputHandler.HoveredControl.LocalPosToCanvas(new Point(0, 0)).Y;
+        newX = HoveredControlX + InputHandler.HoveredControl.Width;
+        newY = HoveredControlY + InputHandler.HoveredControl.Height;
+
         // Do not allow it to render outside of the screen canvas.
-        if (newX < 0)
+        if (newX > mContainer.Canvas.Width - mContainer.Width)
         {
-            newX = 0;
-        }
-        else if (newX > mContainer.Canvas.Width - mContainer.Width)
-        {
-            newX = mContainer.Canvas.Width - mContainer.Width;
+            newX = HoveredControlX - mContainer.Width;
         }
 
-        if (newY < 0)
+        if (newY > mContainer.Canvas.Height - mContainer.Height)
         {
-            newY = 0;
-        }
-        else if (newY > mContainer.Canvas.Height - mContainer.Height)
-        {
-            newY = mContainer.Canvas.Height - mContainer.Height;
+            newY = HoveredControlY - mContainer.Height;
         }
 
         mContainer.MoveTo(newX, newY);

--- a/Intersect.Client/Interface/Game/DescriptionWindows/ItemDescriptionWindow.cs
+++ b/Intersect.Client/Interface/Game/DescriptionWindows/ItemDescriptionWindow.cs
@@ -29,9 +29,8 @@ public partial class ItemDescriptionWindow : DescriptionWindowBase
         int y,
         ItemProperties itemProperties,
         string titleOverride = "",
-        string valueLabel = "",
-        bool centerOnPosition = false
-    ) : base(Interface.GameUi.GameCanvas, "DescriptionWindow", centerOnPosition)
+        string valueLabel = ""
+    ) : base(Interface.GameUi.GameCanvas, "DescriptionWindow")
     {
         mItem = item;
         mAmount = amount;

--- a/Intersect.Client/Interface/Game/DescriptionWindows/SpellDescriptionWindow.cs
+++ b/Intersect.Client/Interface/Game/DescriptionWindows/SpellDescriptionWindow.cs
@@ -11,7 +11,7 @@ public partial class SpellDescriptionWindow : DescriptionWindowBase
 {
     protected SpellBase mSpell;
 
-    public SpellDescriptionWindow(Guid spellId, int x, int y, bool centerOnPosition = false) : base(Interface.GameUi.GameCanvas, "DescriptionWindow", centerOnPosition)
+    public SpellDescriptionWindow(Guid spellId, int x, int y) : base(Interface.GameUi.GameCanvas, "DescriptionWindow")
     {
         mSpell = SpellBase.Get(spellId);
 

--- a/Intersect.Client/Interface/Game/Hotbar/HotbarItem.cs
+++ b/Intersect.Client/Interface/Game/Hotbar/HotbarItem.cs
@@ -171,7 +171,7 @@ public partial class HotbarItem
             return;
         }
 
-        if (mCurrentItem != null)
+        if (mCurrentItem != null && mInventoryItem != null)
         {
             if (mItemDescWindow != null)
             {
@@ -181,7 +181,7 @@ public partial class HotbarItem
 
             mItemDescWindow = new ItemDescriptionWindow(
                 mCurrentItem, 1, mHotbarWindow.X + (mHotbarWindow.Width / 2), mHotbarWindow.Y + mHotbarWindow.Height + 2,
-                mInventoryItem?.ItemProperties, mCurrentItem.Name, "", true
+                mInventoryItem.ItemProperties, mCurrentItem.Name, ""
             );
         }
         else if (mCurrentSpell != null)
@@ -193,7 +193,7 @@ public partial class HotbarItem
             }
 
             mSpellDescWindow = new SpellDescriptionWindow(
-                mCurrentSpell.Id, mHotbarWindow.X + (mHotbarWindow.Width / 2), mHotbarWindow.Y + mHotbarWindow.Height + 2, true
+                mCurrentSpell.Id, mHotbarWindow.X + (mHotbarWindow.Width / 2), mHotbarWindow.Y + mHotbarWindow.Height + 2
             );
         }
     }


### PR DESCRIPTION
- Previous work related to this -> #1650
- Updates the description windows positioning logic to a modern and better approach, similar to what it's seen in most of the MMOs out there where description windows are positioned based on the hovered element.
- Description windows re-positions itself when created near screen borders (inverts positioning side), preventing flicker
   -  Fixes #1784
- Works for everything that uses description windows: inventory slots, spell slots, hotbars, trading slots, craft items, bank slots, status, etc.

### Preview:

https://github.com/AscensionGameDev/Intersect-Engine/assets/17498701/5660f969-7559-42b0-98a6-449b3a20220d

