### PR TITLE
enhancement: press enter key to select character to play

### DIFF
--- a/Intersect.Client/Core/Input.cs
+++ b/Intersect.Client/Core/Input.cs
@@ -210,6 +210,20 @@ public static partial class Input
                             break;
 
                         case GameStates.Menu:
+                            var selectCharacterWindow = Interface.Interface.MenuUi.MainMenu.mSelectCharacterWindow;
+
+                            switch (control)
+                            {
+                                case Control.Enter:
+                                    if (!selectCharacterWindow.IsHidden && selectCharacterWindow.Characters[selectCharacterWindow.mSelectedChar] != null)
+                                    {
+                                        selectCharacterWindow.PlayButton_Clicked(null, null);
+                                        consumeKey = true;
+                                    }
+
+                                    break;
+                            }
+
                             break;
 
                         case GameStates.InGame:

--- a/Intersect.Client/Interface/Menu/MainMenu.cs
+++ b/Intersect.Client/Interface/Menu/MainMenu.cs
@@ -43,7 +43,7 @@ public partial class MainMenu : MutableInterface
 
     private readonly ResetPasswordWindow mResetPasswordWindow;
 
-    private readonly SelectCharacterWindow mSelectCharacterWindow;
+    public readonly SelectCharacterWindow mSelectCharacterWindow;
 
     //Character creation feild check
     private bool mHasMadeCharacterCreation;

--- a/Intersect.Client/Interface/Menu/SelectCharacterWindow.cs
+++ b/Intersect.Client/Interface/Menu/SelectCharacterWindow.cs
@@ -51,7 +51,7 @@ public partial class SelectCharacterWindow
     private Button mPrevCharButton;
 
     //Selected Char
-    private int mSelectedChar = 0;
+    public int mSelectedChar = 0;
 
     //Init
     public SelectCharacterWindow(Canvas parent, MainMenu mainMenu)
@@ -88,7 +88,7 @@ public partial class SelectCharacterWindow
         //Play Button
         mPlayButton = new Button(mCharacterSelectionPanel, "PlayButton");
         mPlayButton.SetText(Strings.CharacterSelection.Play);
-        mPlayButton.Clicked += _playButton_Clicked;
+        mPlayButton.Clicked += PlayButton_Clicked;
         mPlayButton.Hide();
 
         //Delete Button
@@ -366,7 +366,7 @@ public partial class SelectCharacterWindow
         UpdateDisplay();
     }
 
-    private void _playButton_Clicked(Base sender, ClickedEventArgs arguments)
+    public void PlayButton_Clicked(Base? sender, ClickedEventArgs? arguments)
     {
         if (Globals.WaitingOnServer)
         {


### PR DESCRIPTION
Enhancement that allows the game user to press the enter key while in the character select window, in order to select a character to play with. By enabling the player to simply press the enter key to confirm their choice of character, we streamline the user interface and reduce the need for additional mouse clicks or button presses, creating a smoother and more efficient experience for the player.

Preview:

https://github.com/user-attachments/assets/15aa8882-51bc-4d38-ba64-b5feeda0c104

