### PR TITLE
fix: spell item description

### DIFF
--- a/Intersect.Client/Interface/Game/DescriptionWindows/Components/ComponentBase.cs
+++ b/Intersect.Client/Interface/Game/DescriptionWindows/Components/ComponentBase.cs
@@ -72,7 +72,8 @@ public partial class ComponentBase : IDisposable
     /// </summary>
     /// <param name="x">The X position to move the control to.</param>
     /// <param name="y">The Y position to move the control to.</param>
-    public virtual void SetPosition(int x, int y) => mContainer.SetPosition(x, y);
+    /// <param name="itemDecriptionContainer">The container for the item description.</param>
+    public virtual void SetPosition(int x, int y, ImagePanel? itemDecriptionContainer = null) => mContainer.SetPosition(x, y);
 
     /// <summary>
     /// Sets the control position based on ImagePanel.

--- a/Intersect.Client/Interface/Game/DescriptionWindows/DescriptionWindowBase.cs
+++ b/Intersect.Client/Interface/Game/DescriptionWindows/DescriptionWindowBase.cs
@@ -129,7 +129,7 @@ public partial class DescriptionWindowBase : ComponentBase
     }
 
     /// <inheritdoc/>
-    public override void SetPosition(int x, int y)
+    public override void SetPosition(int x, int y, ImagePanel? itemDecriptionContainer = null)
     {
         if (mContainer == null || mContainer.Canvas == null)
         {
@@ -143,7 +143,7 @@ public partial class DescriptionWindowBase : ComponentBase
         HoveredControlX = InputHandler.HoveredControl.LocalPosToCanvas(new Point(0, 0)).X;
         HoveredControlY = InputHandler.HoveredControl.LocalPosToCanvas(new Point(0, 0)).Y;
         newX = HoveredControlX + InputHandler.HoveredControl.Width;
-        newY = HoveredControlY + InputHandler.HoveredControl.Height;
+        newY = itemDecriptionContainer != null ? itemDecriptionContainer.Bottom : HoveredControlY + InputHandler.HoveredControl.Height;
 
         // Do not allow it to render outside of the screen canvas.
         if (newX > mContainer.Canvas.Width - mContainer.Width)
@@ -153,7 +153,7 @@ public partial class DescriptionWindowBase : ComponentBase
 
         if (newY > mContainer.Canvas.Height - mContainer.Height)
         {
-            newY = HoveredControlY - mContainer.Height;
+            newY = itemDecriptionContainer != null ? itemDecriptionContainer.Y - mContainer.Height : HoveredControlY - mContainer.Height;
         }
 
         mContainer.MoveTo(newX, newY);

--- a/Intersect.Client/Interface/Game/DescriptionWindows/ItemDescriptionWindow.cs
+++ b/Intersect.Client/Interface/Game/DescriptionWindows/ItemDescriptionWindow.cs
@@ -20,7 +20,7 @@ public partial class ItemDescriptionWindow : DescriptionWindowBase
 
     protected string mValueLabel;
 
-    protected SpellDescriptionWindow mSpellDescWindow;
+    protected SpellDescriptionWindow? mSpellDescWindow;
 
     public ItemDescriptionWindow(
         ItemBase item,
@@ -45,7 +45,7 @@ public partial class ItemDescriptionWindow : DescriptionWindowBase
         // If a spell, also display the spell description!
         if (mItem.ItemType == ItemType.Spell)
         {
-            mSpellDescWindow = new SpellDescriptionWindow(mItem.SpellId, x, mContainer.Bottom);
+            mSpellDescWindow = new SpellDescriptionWindow(mItem.SpellId, x, y, mContainer);
         }
     }
 

--- a/Intersect.Client/Interface/Game/DescriptionWindows/SpellDescriptionWindow.cs
+++ b/Intersect.Client/Interface/Game/DescriptionWindows/SpellDescriptionWindow.cs
@@ -11,13 +11,13 @@ public partial class SpellDescriptionWindow : DescriptionWindowBase
 {
     protected SpellBase mSpell;
 
-    public SpellDescriptionWindow(Guid spellId, int x, int y) : base(Interface.GameUi.GameCanvas, "DescriptionWindow")
+    public SpellDescriptionWindow(Guid spellId, int x, int y, ImagePanel? itemDecriptionContainer = null) : base(Interface.GameUi.GameCanvas, "DescriptionWindow")
     {
         mSpell = SpellBase.Get(spellId);
 
         GenerateComponents();
         SetupDescriptionWindow();
-        SetPosition(x, y);
+        SetPosition(x, y, itemDecriptionContainer);
     }
 
     public SpellDescriptionWindow(Guid spellId, ImagePanel _statusIcon) : base(Interface.GameUi.GameCanvas, "DescriptionWindow")


### PR DESCRIPTION
Fixes #2336

I forgot to consider item-spell descriptions while coding #2322
This never really worked as intended anyways, before #2322 it was hard-coded to item description's bottom only and without considering screen edges. This PR fixes that logic and makes it so it dynamically adapts to the hovered control as seen in #2322

![2024-07-20 21_45_25-Intersect Client](https://github.com/user-attachments/assets/dd53201a-7a4e-4a72-bdc8-fc60470b7426) ![2024-07-20 21_45_42-Intersect Client](https://github.com/user-attachments/assets/1fbf898d-6086-4d42-865e-39c88b959bd5) ![2024-07-20 21_47_30-Intersect Client](https://github.com/user-attachments/assets/c30db0fb-012a-43ef-aebe-93c52d9822d1) ![2024-07-20 21_47_56-Intersect Client](https://github.com/user-attachments/assets/4a251b7b-9b2e-4201-a7ab-608336c38899)
