### PR TITLE
feature: display quantity of items within hotbar slots

### DIFF
--- a/Intersect.Client/Interface/Game/Hotbar/HotBar.cs
+++ b/Intersect.Client/Interface/Game/Hotbar/HotBar.cs
@@ -19,29 +19,28 @@ public partial class HotBarWindow
     //Init
     public HotBarWindow(Canvas gameCanvas)
     {
-        HotbarWindow = new ImagePanel(gameCanvas, "HotbarWindow");
-        HotbarWindow.ShouldCacheToTexture = true;
+        HotbarWindow = new ImagePanel(gameCanvas, "HotbarWindow")
+        {
+            ShouldCacheToTexture = true
+        };
+
+        if (Graphics.Renderer == null)
+        {
+            return;
+        }
+
         InitHotbarItems();
         HotbarWindow.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
-
-        for (var i = 0; i < Items.Count; i++)
-        {
-            if (Items[i].EquipPanel.Texture == null)
-            {
-                Items[i].EquipPanel.Texture = Graphics.Renderer.GetWhiteTexture();
-            }
-        }
     }
 
     private void InitHotbarItems()
     {
-        var x = 12;
         for (var i = 0; i < Options.Instance.PlayerOpts.HotbarSlotCount; i++)
         {
             Items.Add(new HotbarItem((byte) i, HotbarWindow));
-            Items[i].Pnl = new ImagePanel(HotbarWindow, "HotbarContainer" + i);
+            Items[i].HotbarIcon = new ImagePanel(HotbarWindow, "HotbarContainer" + i);
             Items[i].Setup();
-            Items[i].KeyLabel = new Label(Items[i].Pnl, "HotbarLabel" + i);
+            Items[i].KeyLabel = new Label(Items[i].HotbarIcon, "HotbarLabel" + i);
         }
     }
 


### PR DESCRIPTION
This PR adds a new feature [(requested here)](https://github.com/AscensionGameDev/Intersect-Engine/discussions/2300) which allows the hotbar to display quantity of items.

_Currently part of_ [_(v0.8.0-beta.120+) Roadmap_](https://github.com/AscensionGameDev/Intersect-Engine/discussions/2303)

This also features the the ability for the hotbar to count every item, and not only display the value with the right abbreviation as a label, but it will also display the exact value when hovering the cursor over the item/spell in order to view it's description window.

_Reminder: [Merge Assets before Engine PR](https://github.com/AscensionGameDev/Intersect-Assets/pull/52)_

### Preview:

https://github.com/user-attachments/assets/fc685c4f-a1cf-44de-a1d0-1e136531bf24