### PR TITLE
enhancement: ability to drop multiple stacks of stackable items

### DIFF
--- a/Intersect.Client/Entities/Player.cs
+++ b/Intersect.Client/Entities/Player.cs
@@ -430,7 +430,7 @@ public partial class Player : Entity, IPlayer
                 // Send the drop item packet for the initial slot.
                 PacketSender.SendDropItem(invSlot, quantity);
                 value -= quantity;
-                itemSlots.Remove(inventorySlot); // Remove the initial slot from the list of item slots
+                _ = itemSlots.Remove(inventorySlot); // Remove the initial slot from the list of item slots
 
                 // Iterate through the remaining slots containing the item
                 foreach (var slot in itemSlots)

--- a/Intersect.Client/Interface/Game/Inventory/InventoryItem.cs
+++ b/Intersect.Client/Interface/Game/Inventory/InventoryItem.cs
@@ -7,6 +7,7 @@ using Intersect.Client.Framework.Input;
 using Intersect.Client.General;
 using Intersect.Client.Interface.Game.DescriptionWindows;
 using Intersect.Client.Localization;
+using Intersect.Client.Networking;
 using Intersect.Configuration;
 using Intersect.GameObjects;
 using Intersect.Utilities;
@@ -530,6 +531,10 @@ public partial class InventoryItem
                             );
                         }
                     }
+                }
+                else if (!Globals.Me.IsBusy)
+                {
+                    PacketSender.SendDropItem(mMySlot, Globals.Me.Inventory[mMySlot].Quantity);
                 }
 
                 mDragIcon.Dispose();

--- a/Intersect.Client/Interface/Shared/InputBox.cs
+++ b/Intersect.Client/Interface/Shared/InputBox.cs
@@ -87,9 +87,10 @@ public partial class InputBox : WindowControl
         {
             NotchCount = maxQuantity,
             SnapToNotches = true,
+            Min = 1,
+            Max = maxQuantity,
             Value = quantity
         };
-        _numericSlider.SetRange(1, maxQuantity);
         _numericSlider.ValueChanged += _numericSlider_ValueChanged;
         _txtNumericSlider = new TextBoxNumeric(_numericSliderBg, "SliderboxText")
         {


### PR DESCRIPTION
Updates `TryDropItem` so we can drop more than a single stack of stackable items, the slider will now also count every inventory item based on the selected stack.

### Preview:

https://github.com/user-attachments/assets/1302c783-be79-43a0-b194-2fc60e39cc72

### [27/07/2024]
Also fixes slider's current stack value when the prompt is opened (Thanks @WeylonSantana for finding this out !):
![image](https://github.com/user-attachments/assets/4d8465e2-4e10-440d-9b2b-6c875dd43e4c)

https://github.com/user-attachments/assets/ff53ef94-9583-47ac-ac9a-ec1009bf7dce


### Ability to drag and drop single stack of items:

https://github.com/user-attachments/assets/77163364-c2af-45d1-bd30-eb0961d7f82d


