### PR TITLE
fix: debug window crashing client

### DIFF
--- a/Intersect.Client/Interface/Debugging/DebugWindow.cs
+++ b/Intersect.Client/Interface/Debugging/DebugWindow.cs
@@ -222,7 +222,7 @@ internal sealed partial class DebugWindow : Window
             try
             {
                 return Interface.CurrentInterface?.Children.ToArray().SelectManyRecursive(
-                    x => [.. x.Children],
+                    x => x != default ? [.. x.Children] : [],
                     cancellationToken
                 ).ToArray().Length ?? 0;
             }


### PR DESCRIPTION
This is (probably) a fix for an unreported bug, which has no exact reproduction step. Occasionally the debug window would crash the client. I had this problem (client crashing) a few times while doing the previous pr (admin window)

After adding this modification, I no longer had problems with the debug window