### PR TITLE
fix(2358): pass empty array into Ping.Send() to avoid cap_net_raw breaking change

### DIFF
--- a/Intersect.Network/ClientNetwork.cs
+++ b/Intersect.Network/ClientNetwork.cs
@@ -61,7 +61,7 @@ public partial class ClientNetwork : AbstractNetwork, IClient
         get
         {
             // Send a ping to the server. Timeout: 5000ms (5 seconds). Packet size: 32 bytes. TTL: 64. Don't fragment.
-            var reply = new Ping().Send(Configuration.Host, 5000, new byte[32], new PingOptions(64, true));
+            var reply = new Ping().Send(Configuration.Host, 5000, [], new PingOptions(64, true));
 
             // Return the roundtrip time in milliseconds (ms) as an integer value (no decimals).
             return reply?.Status == IPStatus.Success ? (int)reply.RoundtripTime : 999999;


### PR DESCRIPTION
See more: https://learn.microsoft.com/en-us/dotnet/core/compatibility/networking/7.0/ping-custom-payload-linux

Resolves #2358 