### PR TITLE
feat: window background transparency

### DIFF
--- a/Intersect.Client.Framework/Gwen/Control/WindowControl.cs
+++ b/Intersect.Client.Framework/Gwen/Control/WindowControl.cs
@@ -163,9 +163,15 @@ public partial class WindowControl : ResizableControl
         get { return Parent.Children.Where(x => x is WindowControl).Last() == this; }
     }
 
+    /// <summary>
+    /// If the shadow under the window should be drawn.
+    /// </summary>
+    public bool DrawShadow { get; set; } = true;
+
     public override JObject GetJson(bool isRoot = default)
     {
         var obj = base.GetJson(isRoot);
+        obj.Add(nameof(DrawShadow), DrawShadow);
         obj.Add("ActiveImage", GetImageFilename(ControlState.Active));
         obj.Add("InactiveImage", GetImageFilename(ControlState.Inactive));
         obj.Add("ActiveColor", Color.ToString(mActiveColor));
@@ -182,6 +188,13 @@ public partial class WindowControl : ResizableControl
     public override void LoadJson(JToken obj, bool isRoot = default)
     {
         base.LoadJson(obj);
+
+        var tokenDrawShadow = obj[nameof(DrawShadow)];
+        if (tokenDrawShadow != null)
+        {
+            DrawShadow = (bool)tokenDrawShadow;
+        }
+
         if (obj["ActiveImage"] != null)
         {
             SetImage(
@@ -333,7 +346,11 @@ public partial class WindowControl : ResizableControl
     protected override void RenderUnder(Skin.Base skin)
     {
         base.RenderUnder(skin);
-        skin.DrawShadow(this);
+
+        if (DrawShadow)
+        {
+            skin.DrawShadow(this);
+        }
     }
 
     public override void Touch()

--- a/Intersect.Client.Framework/Gwen/Skin/Intersect2021.cs
+++ b/Intersect.Client.Framework/Gwen/Skin/Intersect2021.cs
@@ -158,7 +158,6 @@ public class Intersect2021 : TexturedBase
             return;
         }
 
-
         GameTexture? renderTexture = null;
         if (windowControl.TryGetTexture(WindowControl.ControlState.Active, out var activeTexture))
         {
@@ -193,7 +192,8 @@ public class Intersect2021 : TexturedBase
 
         Rectangle frameBounds = windowControl.RenderBounds;
 
-        if (titleBar != default)
+        var shouldDrawTitlebarBackground = titleBar != default && windowControl.TitleBar.ShouldDrawBackground;
+        if (shouldDrawTitlebarBackground)
         {
             frameBounds = new Rectangle(
                 0,
@@ -201,11 +201,17 @@ public class Intersect2021 : TexturedBase
                 control.RenderBounds.Width,
                 control.RenderBounds.Height
             );
-
-            titleBar.Draw(Renderer, windowControl.TitleBar.Bounds, windowControl.RenderColor);
         }
 
-        frame.Draw(Renderer, frameBounds, windowControl.RenderColor);
+        if (frame != default && windowControl.ShouldDrawBackground)
+        {
+            frame.Draw(Renderer, frameBounds, windowControl.RenderColor);
+        }
+
+        if (shouldDrawTitlebarBackground)
+        {
+            titleBar.Draw(Renderer, windowControl.TitleBar.Bounds, windowControl.RenderColor);
+        }
     }
 
     #endregion


### PR DESCRIPTION
- Add DrawShadow property (default true) to control drawing the backdrop shadow
- DrawBackground of the window now controls if the "frame" (the background, minus the titlebar) is visible
- DrawBackground of the Titlebar node now controls if the "titlebar" image is drawn

Resolves https://www.ascensiongamedev.com/topic/7075-how-do-i-get-this-off-my-screen-v2/