### PR TITLE
fix: undo RenderingEntities inline initialization

### DIFF
--- a/Intersect.Client/Core/Graphics.cs
+++ b/Intersect.Client/Core/Graphics.cs
@@ -78,7 +78,7 @@ public static partial class Graphics
     public static GameRenderer? Renderer;
 
     //Cache the Y based rendering
-    public static HashSet<Entity>[,] RenderingEntities = new HashSet<Entity>[6, Options.MapHeight * 5];
+    public static HashSet<Entity>[,]? RenderingEntities;
 
     private static GameContentManager sContentManager = null!;
 
@@ -135,6 +135,7 @@ public static partial class Graphics
 
     public static void InitInGame()
     {
+        RenderingEntities = new HashSet<Entity>[6, Options.MapHeight * 5];
         for (var z = 0; z < 6; z++)
         {
             for (var i = 0; i < Options.MapHeight * 5; i++)


### PR DESCRIPTION
Fixes RenderingEntities inline initialization crashing the client when using custom map width/height

[(We merged this breaking change here)](https://github.com/AscensionGameDev/Intersect-Engine/commit/a5df1c7fae80de097b09112e2e08ad4f0d478b4f#diff-e8a874c3978934c92de6b7e4813fddbfe5dcae510b18694f21827b25e341c1c4L141)

crash log (when changing MapWidth/MapHeight to 64x64):

```
--------------------------------------------------------------------------------
2024-08-07 14:18:25.906 [Error] IndexOutOfRangeException: Index was outside the bounds of the array.
    Stack:    at Intersect.Client.Core.Graphics.InitInGame() in C:\Users\Admin\Desktop\VSCode\Intersect-Engine\Intersect.Client\Core\Graphics.cs:line 142
   at Intersect.Client.Networking.PacketHandler.HandlePacket(IPacketSender packetSender, ConfigPacket packet) in C:\Users\Admin\Desktop\VSCode\Intersect-Engine\Intersect.Client\Networking\PacketHandler.cs:line 180
   at Intersect.Network.PacketHandlerRegistry.<>c__DisplayClass38_1`2.<CreateWeaklyTypedDelegateForMethodInfo>b__1(IPacketSender packetSender, IPacket packet) in C:\Users\Admin\Desktop\VSCode\Intersect-Engine\Intersect (Core)\Network\PacketHandlerRegistry.cs:line 98
   at Intersect.Client.Networking.PacketHandler.HandlePacket(IPacket packet) in C:\Users\Admin\Desktop\VSCode\Intersect-Engine\Intersect.Client\Networking\PacketHandler.cs:line 134
   at Intersect.Client.Networking.Network.OnDataReceived(IPacket packet) in C:\Users\Admin\Desktop\VSCode\Intersect-Engine\Intersect.Client\Networking\Network.cs:line 122
   at Intersect.Client.MonoGame.Network.MonoSocket.Update() in C:\Users\Admin\Desktop\VSCode\Intersect-Engine\Intersect.Client\MonoGame\Network\MonoSocket.cs:line 262
   at Intersect.Client.Core.Main.Update(TimeSpan deltaTime) in C:\Users\Admin\Desktop\VSCode\Intersect-Engine\Intersect.Client\Core\Main.cs:line 103
   at Intersect.Client.MonoGame.IntersectGame.Update(GameTime gameTime) in C:\Users\Admin\Desktop\VSCode\Intersect-Engine\Intersect.Client\MonoGame\IntersectGame.cs:line 280
   at Microsoft.Xna.Framework.Game.DoUpdate(GameTime gameTime)
   at Microsoft.Xna.Framework.Game.Tick()
   at Microsoft.Xna.Framework.SdlGamePlatform.RunLoop()
   at Microsoft.Xna.Framework.Game.Run(GameRunBehavior runBehavior)
   at Microsoft.Xna.Framework.Game.Run()
   at Intersect.Client.MonoGame.IntersectGame.MonoGameRunner.Start(IClientContext context, Action postStartupAction) in C:\Users\Admin\Desktop\VSCode\Intersect-Engine\Intersect.Client\MonoGame\IntersectGame.cs:line 562
   at Intersect.Client.Core.ClientContext.InternalStart() in C:\Users\Admin\Desktop\VSCode\Intersect-Engine\Intersect.Client\Core\ClientContext.cs:line 41
   at Intersect.Core.ApplicationContext`2.Start(Boolean lockUntilShutdown) in C:\Users\Admin\Desktop\VSCode\Intersect-Engine\Intersect (Core)\Core\ApplicationContext`2.cs:line 231


--------------------------------------------------------------------------------
```