### PR TITLE
fix: dereference of possibly null references in core graphics

### DIFF
--- a/Intersect.Client/Core/Graphics.cs
+++ b/Intersect.Client/Core/Graphics.cs
@@ -241,7 +241,7 @@ public static partial class Graphics
             return;
         }
 
-        if (Globals.NeedsMaps || Globals.MapGrid == default)
+        if (Globals.NeedsMaps || Globals.MapGrid == null || RenderingEntities == null)
         {
             return;
         }


### PR DESCRIPTION
- Adds Null Check: RenderingEntities == null checks if RenderingEntities is not initialized.
- Adds Null Check: Globals.MapGrid == null checks if the 2D array is not initialized.
- Removes default Check: Globals.MapGrid is an array, checking against default is unnecessary.

![image](https://github.com/user-attachments/assets/4fab871d-c46c-434d-9d38-bede3bf709a6)
