### PR TITLE
feature: simplified escape menu

### DIFF
--- a/Intersect.Client.Framework/Database/GameDatabase.cs
+++ b/Intersect.Client.Framework/Database/GameDatabase.cs
@@ -58,6 +58,8 @@ public abstract partial class GameDatabase
     public bool ShowHealthAsPercentage { get; set; }
 
     public bool ShowManaAsPercentage { get; set; }
+    
+    public bool SimplifiedEscapeMenu { get; set; }
 
     public TypewriterBehavior TypewriterBehavior { get; set; }
 
@@ -130,6 +132,7 @@ public abstract partial class GameDatabase
         ShowExperienceAsPercentage = LoadPreference(nameof(ShowExperienceAsPercentage), true);
         ShowHealthAsPercentage = LoadPreference(nameof(ShowHealthAsPercentage), false);
         ShowManaAsPercentage = LoadPreference(nameof(ShowManaAsPercentage), false);
+        SimplifiedEscapeMenu = LoadPreference(nameof(SimplifiedEscapeMenu), false);
         TypewriterBehavior = LoadPreference(nameof(TypewriterBehavior), TypewriterBehavior.Word);
         UIScale = LoadPreference(nameof(UIScale), 1.0f);
         WorldZoom = LoadPreference(nameof(WorldZoom), 1.0f);
@@ -166,6 +169,7 @@ public abstract partial class GameDatabase
         SavePreference(nameof(ShowExperienceAsPercentage), ShowExperienceAsPercentage);
         SavePreference(nameof(ShowHealthAsPercentage), ShowHealthAsPercentage);
         SavePreference(nameof(ShowManaAsPercentage), ShowManaAsPercentage);
+        SavePreference(nameof(SimplifiedEscapeMenu), SimplifiedEscapeMenu);
         SavePreference(nameof(TypewriterBehavior), TypewriterBehavior);
         SavePreference(nameof(UIScale), UIScale);
         SavePreference(nameof(WorldZoom), WorldZoom);

--- a/Intersect.Client.Framework/Gwen/Control/Base.cs
+++ b/Intersect.Client.Framework/Gwen/Control/Base.cs
@@ -766,9 +766,13 @@ public partial class Base : IDisposable
         Animation.Cancel(this);
 
         // [Fix]: "InvalidOperationException: Collection was modified (during iteration); enumeration operation may not execute".
-        // (Creates a copy of the children list to avoid modifying the collection during iteration).
-        var childrenCopy = new List<Base>(mChildren);
-        childrenCopy.ForEach(child => child.Dispose());
+        // (Creates an array copy of the children to avoid modifying the collection during iteration).
+        var children = mChildren.ToArray();
+        foreach (var child in children)
+        {
+            child.Dispose();
+        }
+
         mChildren?.Clear();
 
         mInnerPanel?.Dispose();

--- a/Intersect.Client.Framework/Gwen/Control/Base.cs
+++ b/Intersect.Client.Framework/Gwen/Control/Base.cs
@@ -765,7 +765,10 @@ public partial class Base : IDisposable
         Gwen.ToolTip.ControlDeleted(this);
         Animation.Cancel(this);
 
-        mChildren?.ForEach(child => child?.Dispose());
+        // [Fix]: "InvalidOperationException: Collection was modified (during iteration); enumeration operation may not execute".
+        // (Creates a copy of the children list to avoid modifying the collection during iteration).
+        var childrenCopy = new List<Base>(mChildren);
+        childrenCopy.ForEach(child => child.Dispose());
         mChildren?.Clear();
 
         mInnerPanel?.Dispose();

--- a/Intersect.Client/Core/Input.cs
+++ b/Intersect.Client/Core/Input.cs
@@ -133,7 +133,16 @@ public static partial class Input
             }
             else
             {
-                Interface.Interface.GameUi?.EscapeMenu?.ToggleHidden();
+                var simplifiedEscapeMenuSetting = Globals.Database.SimplifiedEscapeMenu;
+
+                if (!simplifiedEscapeMenuSetting)
+                {
+                    Interface.Interface.GameUi?.EscapeMenu?.ToggleHidden();
+                }
+                else
+                {
+                    Interface.Interface.GameUi?.SimplifiedEscapeMenu?.ToggleHidden();
+                }
             }
         }
 

--- a/Intersect.Client/Core/Input.cs
+++ b/Intersect.Client/Core/Input.cs
@@ -135,13 +135,13 @@ public static partial class Input
             {
                 var simplifiedEscapeMenuSetting = Globals.Database.SimplifiedEscapeMenu;
 
-                if (!simplifiedEscapeMenuSetting)
+                if (simplifiedEscapeMenuSetting)
                 {
-                    Interface.Interface.GameUi?.EscapeMenu?.ToggleHidden();
+                    Interface.Interface.GameUi?.SimplifiedEscapeMenu?.ToggleHidden();
                 }
                 else
                 {
-                    Interface.Interface.GameUi?.SimplifiedEscapeMenu?.ToggleHidden();
+                    Interface.Interface.GameUi?.EscapeMenu?.ToggleHidden();
                 }
             }
         }

--- a/Intersect.Client/Interface/Game/GameInterface.cs
+++ b/Intersect.Client/Interface/Game/GameInterface.cs
@@ -93,6 +93,7 @@ public partial class GameInterface : MutableInterface
     {
         GameCanvas = canvas;
         EscapeMenu = new EscapeMenu(GameCanvas) {IsHidden = true};
+        SimplifiedEscapeMenu = new SimplifiedEscapeMenu(GameCanvas) {IsHidden = true};
         AnnouncementWindow = new AnnouncementWindow(GameCanvas) { IsHidden = true };
 
         InitGameGui();
@@ -101,6 +102,8 @@ public partial class GameInterface : MutableInterface
     public Canvas GameCanvas { get; }
 
     public EscapeMenu EscapeMenu { get; }
+    
+    public SimplifiedEscapeMenu SimplifiedEscapeMenu { get; }
 
     public AnnouncementWindow AnnouncementWindow { get; }
 

--- a/Intersect.Client/Interface/Game/Menu.cs
+++ b/Intersect.Client/Interface/Game/Menu.cs
@@ -359,13 +359,13 @@ public partial class Menu
     {
         var simplifiedEscapeMenuSetting = Globals.Database.SimplifiedEscapeMenu;
 
-        if (!simplifiedEscapeMenuSetting)
+        if (simplifiedEscapeMenuSetting)
         {
-            Interface.GameUi?.EscapeMenu?.ToggleHidden();
+            Interface.GameUi?.SimplifiedEscapeMenu?.ToggleHidden();
         }
         else
         {
-            Interface.GameUi?.SimplifiedEscapeMenu?.ToggleHidden();
+            Interface.GameUi?.EscapeMenu?.ToggleHidden();
         }
     }
 

--- a/Intersect.Client/Interface/Game/Menu.cs
+++ b/Intersect.Client/Interface/Game/Menu.cs
@@ -37,7 +37,7 @@ public partial class Menu
 
     private readonly ImagePanel mMenuBackground;
 
-    private readonly Button mMenuButton;
+    public readonly Button mMenuButton;
 
     //Menu Container
     private readonly ImagePanel mMenuContainer;
@@ -357,7 +357,16 @@ public partial class Menu
     //Input Handlers
     private static void MenuButtonClicked(Base sender, ClickedEventArgs arguments)
     {
-        Interface.GameUi?.EscapeMenu?.ToggleHidden();
+        var simplifiedEscapeMenuSetting = Globals.Database.SimplifiedEscapeMenu;
+
+        if (!simplifiedEscapeMenuSetting)
+        {
+            Interface.GameUi?.EscapeMenu?.ToggleHidden();
+        }
+        else
+        {
+            Interface.GameUi?.SimplifiedEscapeMenu?.ToggleHidden();
+        }
     }
 
     private void PartyBtn_Clicked(Base sender, ClickedEventArgs arguments)

--- a/Intersect.Client/Interface/Game/Menu.cs
+++ b/Intersect.Client/Interface/Game/Menu.cs
@@ -37,7 +37,7 @@ public partial class Menu
 
     private readonly ImagePanel mMenuBackground;
 
-    public readonly Button mMenuButton;
+    private readonly Button mMenuButton;
 
     //Menu Container
     private readonly ImagePanel mMenuContainer;
@@ -355,13 +355,13 @@ public partial class Menu
     }
 
     //Input Handlers
-    private static void MenuButtonClicked(Base sender, ClickedEventArgs arguments)
+    private void MenuButtonClicked(Base sender, ClickedEventArgs arguments)
     {
         var simplifiedEscapeMenuSetting = Globals.Database.SimplifiedEscapeMenu;
 
         if (simplifiedEscapeMenuSetting)
         {
-            Interface.GameUi?.SimplifiedEscapeMenu?.ToggleHidden();
+            Interface.GameUi?.SimplifiedEscapeMenu?.ToggleHidden(mMenuButton);
         }
         else
         {

--- a/Intersect.Client/Interface/Game/SimplifiedEscapeMenu.cs
+++ b/Intersect.Client/Interface/Game/SimplifiedEscapeMenu.cs
@@ -1,0 +1,167 @@
+using Intersect.Client.Core;
+using Intersect.Client.Framework.File_Management;
+using Intersect.Client.Framework.Gwen;
+using Intersect.Client.Framework.Gwen.Control;
+using Intersect.Client.Framework.Gwen.Control.EventArguments;
+using Intersect.Client.General;
+using Intersect.Client.Interface.Shared;
+using Intersect.Client.Localization;
+using Intersect.Utilities;
+
+namespace Intersect.Client.Interface.Game;
+
+public sealed partial class SimplifiedEscapeMenu : Framework.Gwen.Control.Menu
+{
+    private readonly SettingsWindow _settingsWindow;
+    private readonly MenuItem _settings;
+    private readonly MenuItem _character;
+    private readonly MenuItem _logout;
+    private readonly MenuItem _exit;
+
+    public SimplifiedEscapeMenu(Canvas gameCanvas) : base(gameCanvas, nameof(SimplifiedEscapeMenu))
+    {
+        IsHidden = true;
+        IconMarginDisabled = true;
+        _settingsWindow = new SettingsWindow(gameCanvas, null, null);
+
+        Children.Clear();
+
+        _settings = AddItem(Strings.EscapeMenu.Settings);
+        _character = AddItem(Strings.EscapeMenu.CharacterSelect);
+        _logout = AddItem(Strings.EscapeMenu.Logout);
+        _exit = AddItem(Strings.EscapeMenu.ExitToDesktop);
+
+        _settings.Clicked += OpenSettingsWindow;
+        _character.Clicked += LogoutToCharacterSelectSelectClicked;
+        _logout.Clicked += LogoutToMainToMainMenuClicked;
+        _exit.Clicked += ExitToDesktopToDesktopClicked;
+
+        LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer?.GetResolutionString());
+    }
+
+    public override void ToggleHidden()
+    {
+        if (!_settingsWindow.IsHidden)
+        {
+            return;
+        }
+
+        if (this.IsHidden)
+        {
+            // Position the context menu within the game canvas if near borders.
+            var menuPosX = Interface.GameUi.GameMenu.mMenuButton.LocalPosToCanvas(new Point(0, 0)).X;
+            var menuPosY = Interface.GameUi.GameMenu.mMenuButton.LocalPosToCanvas(new Point(0, 0)).Y;
+            var newX = menuPosX;
+            var newY = menuPosY + Interface.GameUi.GameMenu.mMenuButton.Height + 6;
+
+            if (newX + Width >= Canvas?.Width)
+            {
+                newX = menuPosX - Width + Interface.GameUi.GameMenu.mMenuButton.Width;
+            }
+
+            if (newY + Height >= Canvas?.Height)
+            {
+                newY = menuPosY - Height - 6;
+            }
+
+            SizeToChildren();
+            Open(Pos.None);
+            SetPosition(newX, newY);
+        }
+        else
+        {
+            Close();
+        }
+    }
+
+    private void LogoutToCharacterSelectSelectClicked(Base sender, ClickedEventArgs arguments)
+    {
+        if (Globals.Me?.CombatTimer > Timing.Global.Milliseconds)
+        {
+            _ = new InputBox(
+                title: Strings.Combat.WarningTitle,
+                prompt: Strings.Combat.WarningCharacterSelect,
+                inputType: InputBox.InputType.YesNo,
+                onSuccess: LogoutToCharacterSelect
+            );
+        }
+        else
+        {
+            LogoutToCharacterSelect(null, null);
+        }
+    }
+
+    private void LogoutToMainToMainMenuClicked(Base sender, ClickedEventArgs arguments)
+    {
+        if (Globals.Me?.CombatTimer > Timing.Global.Milliseconds)
+        {
+            _ = new InputBox(
+                title: Strings.Combat.WarningTitle,
+                prompt: Strings.Combat.WarningLogout,
+                inputType: InputBox.InputType.YesNo,
+                onSuccess: LogoutToMainMenu
+            );
+        }
+        else
+        {
+            LogoutToMainMenu(null, null);
+        }
+    }
+
+    private void ExitToDesktopToDesktopClicked(Base sender, ClickedEventArgs arguments)
+    {
+        if (Globals.Me?.CombatTimer > Timing.Global.Milliseconds)
+        {
+            _ = new InputBox(
+                title: Strings.Combat.WarningTitle,
+                prompt: Strings.Combat.WarningExitDesktop,
+                inputType: InputBox.InputType.YesNo,
+                onSuccess: ExitToDesktop
+            );
+        }
+        else
+        {
+            ExitToDesktop(null, null);
+        }
+    }
+
+    private void OpenSettingsWindow(object? sender, EventArgs? e)
+    {
+        if (!_settingsWindow.IsHidden)
+        {
+            return;
+        }
+
+        _settingsWindow.Show();
+    }
+
+    private static void LogoutToCharacterSelect(object? sender, EventArgs? e)
+    {
+        if (Globals.Me != null)
+        {
+            Globals.Me.CombatTimer = 0;
+        }
+
+        Main.Logout(true);
+    }
+
+    private static void LogoutToMainMenu(object? sender, EventArgs? e)
+    {
+        if (Globals.Me != null)
+        {
+            Globals.Me.CombatTimer = 0;
+        }
+
+        Main.Logout(false);
+    }
+
+    private static void ExitToDesktop(object? sender, EventArgs? e)
+    {
+        if (Globals.Me != null)
+        {
+            Globals.Me.CombatTimer = 0;
+        }
+
+        Globals.IsRunning = false;
+    }
+}

--- a/Intersect.Client/Interface/Game/SimplifiedEscapeMenu.cs
+++ b/Intersect.Client/Interface/Game/SimplifiedEscapeMenu.cs
@@ -39,9 +39,9 @@ public sealed partial class SimplifiedEscapeMenu : Framework.Gwen.Control.Menu
         LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer?.GetResolutionString());
     }
 
-    public override void ToggleHidden()
+    public void ToggleHidden(Button? target)
     {
-        if (!_settingsWindow.IsHidden)
+        if (!_settingsWindow.IsHidden || target == null)
         {
             return;
         }
@@ -49,14 +49,14 @@ public sealed partial class SimplifiedEscapeMenu : Framework.Gwen.Control.Menu
         if (this.IsHidden)
         {
             // Position the context menu within the game canvas if near borders.
-            var menuPosX = Interface.GameUi.GameMenu.mMenuButton.LocalPosToCanvas(new Point(0, 0)).X;
-            var menuPosY = Interface.GameUi.GameMenu.mMenuButton.LocalPosToCanvas(new Point(0, 0)).Y;
+            var menuPosX = target.LocalPosToCanvas(new Point(0, 0)).X;
+            var menuPosY = target.LocalPosToCanvas(new Point(0, 0)).Y;
             var newX = menuPosX;
-            var newY = menuPosY + Interface.GameUi.GameMenu.mMenuButton.Height + 6;
+            var newY = menuPosY + target.Height + 6;
 
             if (newX + Width >= Canvas?.Width)
             {
-                newX = menuPosX - Width + Interface.GameUi.GameMenu.mMenuButton.Width;
+                newX = menuPosX - Width + target.Width;
             }
 
             if (newY + Height >= Canvas?.Height)

--- a/Intersect.Client/Interface/Shared/SettingsWindow.cs
+++ b/Intersect.Client/Interface/Shared/SettingsWindow.cs
@@ -45,6 +45,7 @@ public partial class SettingsWindow : ImagePanel
     private readonly LabeledCheckBox _showExperienceAsPercentageCheckbox;
     private readonly LabeledCheckBox _showHealthAsPercentageCheckbox;
     private readonly LabeledCheckBox _showManaAsPercentageCheckbox;
+    private readonly LabeledCheckBox _simplifiedEscapeMenu;
 
     // Game Settings - Information.
     private readonly ScrollControl _informationSettings;
@@ -179,6 +180,12 @@ public partial class SettingsWindow : ImagePanel
         _showManaAsPercentageCheckbox = new LabeledCheckBox(_interfaceSettings, "ShowManaAsPercentageCheckbox")
         {
             Text = Strings.Settings.ShowManaAsPercentage
+        };
+        
+        // Game Settings - Interface: simplified escape menu.
+        _simplifiedEscapeMenu = new LabeledCheckBox(_interfaceSettings, "SimplifiedEscapeMenu")
+        {
+            Text = Strings.Settings.SimplifiedEscapeMenu
         };
 
         // Game Settings - Information.
@@ -730,6 +737,7 @@ public partial class SettingsWindow : ImagePanel
         _showHealthAsPercentageCheckbox.IsChecked = Globals.Database.ShowHealthAsPercentage;
         _showManaAsPercentageCheckbox.IsChecked = Globals.Database.ShowManaAsPercentage;
         _showExperienceAsPercentageCheckbox.IsChecked = Globals.Database.ShowExperienceAsPercentage;
+        _simplifiedEscapeMenu.IsChecked = Globals.Database.SimplifiedEscapeMenu;
         _friendOverheadInfoCheckbox.IsChecked = Globals.Database.FriendOverheadInfo;
         _guildMemberOverheadInfoCheckbox.IsChecked = Globals.Database.GuildMemberOverheadInfo;
         _myOverheadInfoCheckbox.IsChecked = Globals.Database.MyOverheadInfo;
@@ -910,6 +918,7 @@ public partial class SettingsWindow : ImagePanel
         Globals.Database.ShowExperienceAsPercentage = _showExperienceAsPercentageCheckbox.IsChecked;
         Globals.Database.ShowHealthAsPercentage = _showHealthAsPercentageCheckbox.IsChecked;
         Globals.Database.ShowManaAsPercentage = _showManaAsPercentageCheckbox.IsChecked;
+        Globals.Database.SimplifiedEscapeMenu = _simplifiedEscapeMenu.IsChecked;
         Globals.Database.FriendOverheadInfo = _friendOverheadInfoCheckbox.IsChecked;
         Globals.Database.GuildMemberOverheadInfo = _guildMemberOverheadInfoCheckbox.IsChecked;
         Globals.Database.MyOverheadInfo = _myOverheadInfoCheckbox.IsChecked;

--- a/Intersect.Client/Localization/Strings.cs
+++ b/Intersect.Client/Localization/Strings.cs
@@ -1932,6 +1932,9 @@ public static partial class Strings
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public static LocalizedString ShowPlayerOverheadInformation = @"Show players overhead information";
+        
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString SimplifiedEscapeMenu = @"Simplified escape menu";
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public static LocalizedString StickyTarget = @"Sticky Target";


### PR DESCRIPTION
This pull request introduces a simplified escape menu feature with an in-game interface setting to toggle it on/off. It also fixes a long-standing bug that caused an InvalidOperationException client crash when selecting 'yes' on the Combat Warning prompt during logout/exit. 

[Assets (make sure to merge before this PR)](https://github.com/AscensionGameDev/Intersect-Assets/pull/55)

### Preview:

https://github.com/user-attachments/assets/89178793-c94f-49df-bb3c-5c209563ef97

### Updated Preview (18-11-24)

https://github.com/user-attachments/assets/099ce515-5886-4c86-8bba-eb802512fa54

### Updated Preview (23-11-24)
https://github.com/user-attachments/assets/8a3e3694-b77f-4183-9c51-be877429b8ba