### PR TITLE
fix: avoid jackpots on changed slot collection sizes

### DIFF
--- a/Intersect (Core)/Collections/Slotting/ISlot.cs
+++ b/Intersect (Core)/Collections/Slotting/ISlot.cs
@@ -1,0 +1,11 @@
+﻿namespace Intersect.Collections.Slotting;
+
+
+public interface ISlot
+{
+
+    int Slot { get; }
+
+    bool IsEmpty { get; }
+
+}

--- a/Intersect (Core)/Collections/Slotting/SlotList.cs
+++ b/Intersect (Core)/Collections/Slotting/SlotList.cs
@@ -1,0 +1,101 @@
+using System.Collections;
+
+namespace Intersect.Collections.Slotting;
+
+public class SlotList<TSlot> : IList<TSlot> where TSlot : ISlot
+{
+    private readonly SortedList<int, TSlot> _slots;
+    private readonly Func<int, TSlot> _factory;
+
+    public SlotList(int capacity, Func<int, TSlot> factory)
+    {
+        _slots = new SortedList<int, TSlot>(capacity);
+        _factory = factory;
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    public IEnumerator<TSlot> GetEnumerator() => _slots.Values.GetEnumerator();
+
+    public void Add(TSlot slot)
+    {
+        if (_slots.TryGetValue(slot.Slot, out var existingSlot))
+        {
+            if (existingSlot.IsEmpty)
+            {
+                _slots[slot.Slot] = slot;
+            }
+            else
+            {
+                throw new ArgumentException($"Slot {slot.Slot} is already filled with a non-empty slot.", nameof(slot));
+            }
+        }
+        else
+        {
+            _slots.Add(slot.Slot, slot);
+        }
+    }
+
+    public void Clear() => _slots.Clear();
+
+    public bool Contains(TSlot slot) => _slots.ContainsValue(slot);
+
+    public void CopyTo(TSlot[] array, int arrayIndex) =>
+        _slots.Select(kvp => kvp.Value).ToArray().CopyTo(array, arrayIndex);
+
+    public bool Remove(TSlot slot) => _slots.Remove(slot.Slot);
+
+    public int Capacity
+    {
+        get => _slots.Capacity;
+        set => _slots.Capacity = value;
+    }
+
+    public int Count => _slots.Count;
+
+    public bool IsReadOnly => ((IDictionary)_slots).IsReadOnly;
+
+    public int IndexOf(TSlot slot) => _slots.IndexOfValue(slot);
+
+    public void Insert(int slotIndex, TSlot slot)
+    {
+        if (slotIndex != slot.Slot)
+        {
+            throw new ArgumentException($"Tried to insert slot {slot.Slot} to slot index {slotIndex}", nameof(slotIndex));
+        }
+
+        _slots.Add(slotIndex, slot);
+    }
+
+    public void RemoveAt(int slotIndex) => _slots.Remove(slotIndex);
+
+    public TSlot this[int slotIndex]
+    {
+        get
+        {
+            if (_slots.TryGetValue(slotIndex, out var slot))
+            {
+                return slot;
+            }
+
+            slot = _factory(slotIndex);
+            _slots[slotIndex] = slot;
+            return slot;
+        }
+        set => _slots[slotIndex] = value;
+    }
+
+    public int FindIndex(Func<TSlot, bool> predicate)
+    {
+        var copy = this.ToArray();
+        for (var index = 0; index < copy.Length; ++index)
+        {
+            if (predicate(copy[index]))
+            {
+                return index;
+            }
+        }
+
+        return -1;
+    }
+}

--- a/Intersect (Core)/Config/Options.cs
+++ b/Intersect (Core)/Config/Options.cs
@@ -119,8 +119,6 @@ public partial class Options
 
     public static int MaxInvItems => Instance.PlayerOpts.MaxInventory;
 
-    public static int MaxPlayerSkills => Instance.PlayerOpts.MaxSpells;
-
     public static int MaxCharacters => Instance.PlayerOpts.MaxCharacters;
 
     public static int ItemDropChance => Instance.PlayerOpts.ItemDropChance;

--- a/Intersect.Client.Core/Entities/Entity.cs
+++ b/Intersect.Client.Core/Entities/Entity.cs
@@ -173,7 +173,7 @@ public partial class Entity : IEntity
         }
     }
 
-    public Spell[] Spells { get; set; } = new Spell[Options.MaxPlayerSkills];
+    public Spell[] Spells { get; set; } = new Spell[Options.Instance.PlayerOpts.MaxSpells];
 
     IReadOnlyList<Guid> IEntity.Spells => Spells.Select(x => x.Id).ToList();
 
@@ -233,7 +233,7 @@ public partial class Entity : IEntity
                 Inventory[i] = new Item();
             }
 
-            for (var i = 0; i < Options.MaxPlayerSkills; i++)
+            for (var i = 0; i < Options.Instance.PlayerOpts.MaxSpells; i++)
             {
                 Spells[i] = new Spell();
             }

--- a/Intersect.Client.Core/Interface/Game/Spells/SpellItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Spells/SpellItem.cs
@@ -86,7 +86,7 @@ public partial class SpellItem
         else
         {
             Globals.Me.TryForgetSpell(mYindex);
-        }   
+        }
     }
 
     void pnl_HoverLeave(Base sender, EventArgs arguments)
@@ -263,7 +263,7 @@ public partial class SpellItem
                 //Check spell first.
                 if (mSpellWindow.RenderBounds().IntersectsWith(dragRect))
                 {
-                    for (var i = 0; i < Options.MaxInvItems; i++)
+                    for (var i = 0; i < Options.Instance.PlayerOpts.MaxSpells; i++)
                     {
                         if (i < mSpellWindow.Items.Count &&
                             mSpellWindow.Items[i].RenderBounds().IntersectsWith(dragRect))

--- a/Intersect.Client.Core/Interface/Game/Spells/SpellsWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Spells/SpellsWindow.cs
@@ -120,7 +120,7 @@ public partial class SpellsWindow
 
         X = mSpellWindow.X;
         Y = mSpellWindow.Y;
-        for (var i = 0; i < Options.MaxPlayerSkills; i++)
+        for (var i = 0; i < Options.Instance.PlayerOpts.MaxSpells; i++)
         {
             var spell = SpellBase.Get(Globals.Me.Spells[i].Id);
             Items[i].Pnl.IsHidden = spell == null || Items[i].IsDragging;
@@ -133,7 +133,7 @@ public partial class SpellsWindow
 
     private void InitItemContainer()
     {
-        for (var i = 0; i < Options.MaxPlayerSkills; i++)
+        for (var i = 0; i < Options.Instance.PlayerOpts.MaxSpells; i++)
         {
             Items.Add(new SpellItem(this, i));
             Items[i].Container = new ImagePanel(mItemContainer, "Spell");

--- a/Intersect.Server.Core/Database/DbInterface.cs
+++ b/Intersect.Server.Core/Database/DbInterface.cs
@@ -522,8 +522,7 @@ public static partial class DbInterface
             try
             {
                 using var playerContext = CreatePlayerContext(readOnly: true, explicitLoad: false);
-                player.LoadRelationships(playerContext);
-                _ = Player.Validate(player);
+                _ = player.LoadRelationships(playerContext);
             }
             catch (Exception exception)
             {

--- a/Intersect.Server.Core/Database/Item.cs
+++ b/Intersect.Server.Core/Database/Item.cs
@@ -10,7 +10,7 @@ using Newtonsoft.Json;
 
 namespace Intersect.Server.Database;
 
-public class Item: IItem
+public class Item : IItem
 {
     [JsonIgnore][NotMapped] public double DropChance { get; set; } = 100;
 

--- a/Intersect.Server.Core/Database/PlayerData/Players/BagSlot.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Players/BagSlot.cs
@@ -1,5 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations.Schema;
-
+using Intersect.Collections.Slotting;
 using Newtonsoft.Json;
 
 // ReSharper disable UnusedAutoPropertyAccessor.Local
@@ -23,6 +23,8 @@ public partial class BagSlot : Item, ISlot
     [DatabaseGenerated(DatabaseGeneratedOption.Identity), JsonIgnore]
     public Guid Id { get; private set; }
 
+    public bool IsEmpty => ItemId == default;
+
     [JsonIgnore]
     public Guid ParentBagId { get; private set; }
 
@@ -30,5 +32,4 @@ public partial class BagSlot : Item, ISlot
     public virtual Bag ParentBag { get; private set; }
 
     public int Slot { get; private set; }
-
 }

--- a/Intersect.Server.Core/Database/PlayerData/Players/BankSlot.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Players/BankSlot.cs
@@ -1,5 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations.Schema;
-
+using Intersect.Collections.Slotting;
 using Intersect.Server.Entities;
 
 using Newtonsoft.Json;
@@ -12,6 +12,7 @@ namespace Intersect.Server.Database.PlayerData.Players;
 
 public partial class BankSlot : Item, ISlot, IPlayerOwned
 {
+    public static BankSlot Create(int slotIndex) => new(slotIndex);
 
     public BankSlot()
     {
@@ -24,6 +25,8 @@ public partial class BankSlot : Item, ISlot, IPlayerOwned
 
     [DatabaseGenerated(DatabaseGeneratedOption.Identity), JsonIgnore]
     public Guid Id { get; private set; }
+
+    public bool IsEmpty => ItemId == default;
 
     [JsonIgnore]
     public Guid PlayerId { get; private set; }

--- a/Intersect.Server.Core/Database/PlayerData/Players/GuildBankSlot.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Players/GuildBankSlot.cs
@@ -1,5 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations.Schema;
-
+using Intersect.Collections.Slotting;
 using Newtonsoft.Json;
 
 // ReSharper disable UnusedAutoPropertyAccessor.Local
@@ -10,6 +10,7 @@ namespace Intersect.Server.Database.PlayerData.Players;
 
 public partial class GuildBankSlot : Item, ISlot
 {
+    public static GuildBankSlot Create(int slotIndex) => new(slotIndex);
 
     public GuildBankSlot()
     {
@@ -23,6 +24,8 @@ public partial class GuildBankSlot : Item, ISlot
     [DatabaseGenerated(DatabaseGeneratedOption.Identity), JsonIgnore]
     public Guid Id { get; private set; }
 
+    public bool IsEmpty => ItemId == default;
+
     [JsonIgnore]
     public Guid GuildId { get; private set; }
 
@@ -30,5 +33,4 @@ public partial class GuildBankSlot : Item, ISlot
     public virtual Guild Guild { get; private set; }
 
     public int Slot { get; private set; }
-
 }

--- a/Intersect.Server.Core/Database/PlayerData/Players/HotbarSlot.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Players/HotbarSlot.cs
@@ -1,5 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations.Schema;
-
+using Intersect.Collections.Slotting;
 using Intersect.Enums;
 using Intersect.Server.Entities;
 using Intersect.Utilities;
@@ -14,6 +14,7 @@ namespace Intersect.Server.Database.PlayerData.Players;
 
 public partial class HotbarSlot : ISlot, IPlayerOwned
 {
+    public static HotbarSlot Create(int slotIndex) => new(slotIndex);
 
     public HotbarSlot()
     {
@@ -26,6 +27,8 @@ public partial class HotbarSlot : ISlot, IPlayerOwned
 
     [DatabaseGenerated(DatabaseGeneratedOption.Identity), JsonIgnore]
     public Guid Id { get; private set; }
+
+    public bool IsEmpty => ItemOrSpellId == default;
 
     public Guid ItemOrSpellId { get; set; } = Guid.Empty;
 

--- a/Intersect.Server.Core/Database/PlayerData/Players/ISlot.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Players/ISlot.cs
@@ -1,9 +1,0 @@
-﻿namespace Intersect.Server.Database.PlayerData.Players;
-
-
-public interface ISlot
-{
-
-    int Slot { get; }
-
-}

--- a/Intersect.Server.Core/Database/PlayerData/Players/InventorySlot.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Players/InventorySlot.cs
@@ -1,5 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations.Schema;
-
+using Intersect.Collections.Slotting;
 using Intersect.Server.Entities;
 
 using Newtonsoft.Json;
@@ -12,6 +12,7 @@ namespace Intersect.Server.Database.PlayerData.Players;
 
 public partial class InventorySlot : Item, ISlot, IPlayerOwned
 {
+    public static InventorySlot Create(int slotIndex) => new(slotIndex);
 
     public InventorySlot()
     {
@@ -24,6 +25,8 @@ public partial class InventorySlot : Item, ISlot, IPlayerOwned
 
     [DatabaseGenerated(DatabaseGeneratedOption.Identity), JsonIgnore]
     public Guid Id { get; private set; }
+
+    public bool IsEmpty => ItemId == default;
 
     [JsonIgnore]
     public Guid PlayerId { get; private set; }

--- a/Intersect.Server.Core/Database/PlayerData/Players/SpellSlot.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Players/SpellSlot.cs
@@ -1,5 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations.Schema;
-
+using Intersect.Collections.Slotting;
 using Intersect.Server.Entities;
 
 using Newtonsoft.Json;
@@ -12,6 +12,7 @@ namespace Intersect.Server.Database.PlayerData.Players;
 
 public partial class SpellSlot : Spell, ISlot, IPlayerOwned
 {
+    public static SpellSlot Create(int slotIndex) => new(slotIndex);
 
     public SpellSlot()
     {
@@ -24,6 +25,8 @@ public partial class SpellSlot : Spell, ISlot, IPlayerOwned
 
     [DatabaseGenerated(DatabaseGeneratedOption.Identity), JsonIgnore]
     public Guid Id { get; private set; }
+
+    public bool IsEmpty => SpellId == default;
 
     [JsonIgnore]
     public Guid PlayerId { get; private set; }

--- a/Intersect.Server.Core/Database/PlayerData/User.cs
+++ b/Intersect.Server.Core/Database/PlayerData/User.cs
@@ -199,7 +199,7 @@ public partial class User
 
                 Players.Add(newCharacter);
 
-                Player.Validate(newCharacter);
+                _ = Player.Validate(newCharacter);
 
                 context.ChangeTracker.DetectChanges();
 

--- a/Intersect.Server.Core/Entities/Entity.cs
+++ b/Intersect.Server.Core/Entities/Entity.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.ComponentModel.DataAnnotations.Schema;
+using Intersect.Collections.Slotting;
 using Intersect.Enums;
 using Intersect.GameObjects;
 using Intersect.GameObjects.Events;
@@ -27,8 +28,8 @@ public abstract partial class Entity : IEntity
 {
     //Instance Values
     private Guid _id = Guid.NewGuid();
-    
-    [NotMapped] 
+
+    [NotMapped]
     public Guid MapInstanceId { get; set; } = Guid.Empty;
 
     [JsonProperty("MaxVitals"), NotMapped] private long[] _maxVital = new long[Enum.GetValues<Vital>().Length];
@@ -138,11 +139,17 @@ public abstract partial class Entity : IEntity
 
     //Inventory
     [JsonIgnore]
-    public virtual List<InventorySlot> Items { get; set; } = new List<InventorySlot>();
+    public virtual SlotList<InventorySlot> Items { get; set; } = new(
+        Options.Instance.PlayerOpts.MaxInventory,
+        InventorySlot.Create
+    );
 
     //Spells
     [JsonIgnore]
-    public virtual List<SpellSlot> Spells { get; set; } = new List<SpellSlot>();
+    public virtual SlotList<SpellSlot> Spells { get; set; } = new(
+        Options.Instance.PlayerOpts.MaxSpells,
+        SpellSlot.Create
+    );
 
     [JsonIgnore, Column(nameof(NameColor))]
     public string NameColorJson
@@ -386,7 +393,7 @@ public abstract partial class Entity : IEntity
     /// </summary>
     public virtual void UpdateSpellCooldown(SpellBase spellBase, int spellSlot)
     {
-        if (spellSlot < 0 || spellSlot >= Options.MaxPlayerSkills)
+        if (spellSlot < 0 || spellSlot >= Options.Instance.PlayerOpts.MaxSpells)
         {
             return;
         }

--- a/Intersect.Server.Core/Entities/IBankInterface.cs
+++ b/Intersect.Server.Core/Entities/IBankInterface.cs
@@ -1,0 +1,14 @@
+using Intersect.Server.Database;
+
+namespace Intersect.Server.Entities;
+
+public interface IBankInterface : IDisposable
+{
+    void SendOpenBank();
+    void SendBankUpdate(int slot, bool sendToAll = true);
+    void SendCloseBank();
+    bool TryDepositItem(Item slot, int inventorySlotIndex, int quantityHint, int bankSlotIndex = -1, bool sendUpdate = true);
+    bool TryDepositItem(Item item, bool sendUpdate = true);
+    bool TryWithdrawItem(Item slot, int bankSlotIndex, int quantityHint, int inventorySlotIndex = -1);
+    void SwapBankItems(int slotFrom, int slotTo);
+}

--- a/Intersect.Server.Core/Networking/PacketSender.cs
+++ b/Intersect.Server.Core/Networking/PacketSender.cs
@@ -1175,7 +1175,7 @@ public static partial class PacketSender
         }
 
         var invItems = new InventoryUpdatePacket[Options.MaxInvItems];
-        if (player.Items.Count < Options.MaxInvItems)
+        if (player.Items.Capacity < Options.Instance.PlayerOpts.MaxInventory)
         {
             throw new InvalidOperationException($"Tried to send inventory before fully loading player {player.Id}");
         }
@@ -1219,8 +1219,8 @@ public static partial class PacketSender
             return;
         }
 
-        var spells = new SpellUpdatePacket[Options.MaxPlayerSkills];
-        for (var i = 0; i < Options.MaxPlayerSkills; i++)
+        var spells = new SpellUpdatePacket[Options.Instance.PlayerOpts.MaxSpells];
+        for (var i = 0; i < Options.Instance.PlayerOpts.MaxSpells; i++)
         {
             spells[i] = new SpellUpdatePacket(i, player.Spells[i].SpellId);
         }


### PR DESCRIPTION
Resolves #2122 

This should resolve collection-size related jackpot crashes in the various "slot" lists, including [the one mentioned in Discord](https://discord.com/channels/363106200243535872/965617981159788614/1320063351400828949) (I don't think it has a bug open?)