### PR TITLE
enhancement: texture preload on startup

### DIFF
--- a/Intersect.Client.Core/MonoGame/Graphics/MonoRenderer.cs
+++ b/Intersect.Client.Core/MonoGame/Graphics/MonoRenderer.cs
@@ -712,11 +712,6 @@ public class MonoRenderer : GameRenderer
             mFpsTimer = Timing.Global.MillisecondsUtc + 1000;
             mGameWindow.Title = Strings.Main.GameName;
         }
-
-        foreach (var texture in mAllTextures)
-        {
-            texture?.Update();
-        }
     }
 
     public override int GetFps()
@@ -913,12 +908,14 @@ public class MonoRenderer : GameRenderer
         if (packFrame != null)
         {
             var tx = new MonoTexture(mGraphicsDevice, filename, packFrame);
+            tx.LoadTexture();
             mAllTextures.Add(tx);
 
             return tx;
         }
 
         var tex = new MonoTexture(mGraphicsDevice, filename, realFilename);
+        tex.LoadTexture();
         mAllTextures.Add(tex);
 
         return tex;

--- a/Intersect.Client.Core/MonoGame/Graphics/MonoTexture.cs
+++ b/Intersect.Client.Core/MonoGame/Graphics/MonoTexture.cs
@@ -26,15 +26,11 @@ public partial class MonoTexture : GameTexture
 
     private readonly GameTexturePackFrame? _packFrame;
 
-    private readonly bool _doNotFree;
-
     private int _width = -1;
 
     private Texture2D? _texture;
 
     private int _height = -1;
-
-    private long _lastAccessTime;
 
     private bool _loadError;
 
@@ -45,7 +41,6 @@ public partial class MonoTexture : GameTexture
         _realPath = string.Empty;
         _name = assetName;
         _texture = texture2D;
-        _doNotFree = true;
     }
 
     public MonoTexture(GraphicsDevice graphicsDevice, string filename, string realPath) : base(
@@ -160,17 +155,10 @@ public partial class MonoTexture : GameTexture
         }
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void ResetAccessTime()
-    {
-        _lastAccessTime = Timing.Global.MillisecondsUtc + 15000;
-    }
-
     public override int Width
     {
         get
         {
-            ResetAccessTime();
             if (_width != -1)
             {
                 return _width;
@@ -194,7 +182,6 @@ public partial class MonoTexture : GameTexture
     {
         get
         {
-            ResetAccessTime();
             if (_height != -1)
             {
                 return _height;
@@ -221,8 +208,6 @@ public partial class MonoTexture : GameTexture
         {
             return _packFrame.PackTexture.GetTexture();
         }
-
-        ResetAccessTime();
 
         if (_texture == null)
         {
@@ -274,17 +259,7 @@ public partial class MonoTexture : GameTexture
 
     public void Update()
     {
-        if (_doNotFree)
-        {
-            return;
-        }
-
         if (_texture == null)
-        {
-            return;
-        }
-
-        if (_lastAccessTime >= Timing.Global.MillisecondsUtc)
         {
             return;
         }


### PR DESCRIPTION
_(originally tested within our myra repo)_

- Based on code and discussions along with MAO's project @AlexVild (thanks!).
- Massive enhancement on texture render, just load in all textures at startup and never dispose them, this way we don't need to reload them all at run time anymore.

Draft for now:
- More code needs to be written to handle live background loading
- This will obliterate any old machine that doesn't have enough memory for all textures in a game (ie: games that use way too many and heavy resources)

Resolves #450