### PR TITLE
chore: Refactor tool cursor updates in MapEditor

### DIFF
--- a/Intersect.Editor/Forms/DockingElements/frmMapEditor.cs
+++ b/Intersect.Editor/Forms/DockingElements/frmMapEditor.cs
@@ -16,7 +16,6 @@ using Intersect.GameObjects.Maps;
 using Intersect.Logging;
 using Microsoft.Xna.Framework.Graphics;
 using WeifenLuo.WinFormsUI.Docking;
-using Timer = System.Windows.Forms.Timer;
 
 namespace Intersect.Editor.Forms.DockingElements;
 
@@ -65,11 +64,13 @@ public partial class FrmMapEditor : DockContent
         InitializeComponent();
         Icon = Program.Icon;
         picMap.MouseLeave += (_sender, _args) => tooltipMapAttribute?.Hide();
-        // Initialize cursor timer
-        cursorUpdateTimer = new Timer();
-        cursorUpdateTimer.Interval = 200;
-        cursorUpdateTimer.Tick += CursorUpdateTimer_Tick;
-        cursorUpdateTimer.Start();
+
+        Globals.ToolChanged += Globals_ToolChanged;
+    }
+
+    private void Globals_ToolChanged(object? sender, EventArgs e)
+    {
+        SetCursorSpriteInGrid();
     }
 
     private void InitLocalization()
@@ -2345,12 +2346,12 @@ public partial class FrmMapEditor : DockContent
 
     private void picMap_MouseEnter(object sender, EventArgs e)
     {
-        if (!Globals.MapEditorWindow.DockPanel.Focused && Globals.CurrentEditor == -1)
+        if (Globals.EditingLight != null || Globals.CurrentEditor != -1 || !Globals.MapEditorWindow.DockPanel.Focused)
         {
-            Globals.MapEditorWindow.DockPanel.Focus();
+            return;
         }
 
-        RemoveSpriteCursorInGrid();
+        SetCursorSpriteInGrid();
     }
 
     private void picMap_MouseLeave(object sender, EventArgs e)

--- a/Intersect.Editor/Forms/DockingElements/frmMapEditor.cs
+++ b/Intersect.Editor/Forms/DockingElements/frmMapEditor.cs
@@ -36,9 +36,6 @@ public partial class FrmMapEditor : DockContent
 
     private bool mMapChanged;
 
-    // MapGrid Cursor
-    private Timer cursorUpdateTimer;
-
     public struct IconInfo
     {
         public bool FIcon;
@@ -2359,17 +2356,6 @@ public partial class FrmMapEditor : DockContent
     private void picMap_MouseLeave(object sender, EventArgs e)
     {
         RemoveSpriteCursorInGrid();
-    }
-
-    private void CursorUpdateTimer_Tick(object sender, EventArgs e)
-    {
-        if (Globals.EditingLight != null || Globals.CurrentEditor != -1 ||
-            !Globals.MapEditorWindow.DockPanel.Focused)
-        {
-            return;
-        }
-
-        SetCursorSpriteInGrid();
     }
 
     private void SetCursorSpriteInGrid()

--- a/Intersect.Editor/Forms/DockingElements/frmMapEditor.cs
+++ b/Intersect.Editor/Forms/DockingElements/frmMapEditor.cs
@@ -2346,14 +2346,19 @@ public partial class FrmMapEditor : DockContent
 
     private void picMap_MouseEnter(object sender, EventArgs e)
     {
-        if (Globals.EditingLight != null || Globals.CurrentEditor != -1 || !Globals.MapEditorWindow.DockPanel.Focused)
+        if (Globals.EditingLight != null || Globals.CurrentEditor != -1)
         {
+            RemoveSpriteCursorInGrid();
             return;
+        }
+
+        if (!Globals.MapEditorWindow.DockPanel.Focused)
+        {
+            Globals.MapEditorWindow.DockPanel.Focus();
         }
 
         SetCursorSpriteInGrid();
     }
-
     private void picMap_MouseLeave(object sender, EventArgs e)
     {
         RemoveSpriteCursorInGrid();

--- a/Intersect.Editor/General/Globals.cs
+++ b/Intersect.Editor/General/Globals.cs
@@ -49,7 +49,22 @@ public static partial class Globals
 
     public static TilesetBase CurrentTileset = null;
 
-    public static EditingTool CurrentTool = EditingTool.Brush;
+    public static EditingTool _currentTool = EditingTool.Brush;
+
+    public static event EventHandler<EventArgs> ToolChanged;
+    public static EditingTool CurrentTool
+    {
+        get { return _currentTool; }
+        set
+        {
+            _currentTool = value;
+            OnToolChanged(new EventArgs());
+        }
+    }
+    static void OnToolChanged(EventArgs e)
+    {
+        ToolChanged?.Invoke(null, e);
+    }
 
     public static int CurSelH;
 


### PR DESCRIPTION
- Removed `CursorUpdateTimer_Tick` method.
- Added global `CurrentTool` property with `ToolChanged` event to manage tool state.
- Reduced unnecessary calls to `SetCursorSpriteInGrid()`.