### PR TITLE
enhancement: Add target context menu item

### DIFF
--- a/Intersect.Client.Core/Interface/Game/TargetContextMenu.cs
+++ b/Intersect.Client.Core/Interface/Game/TargetContextMenu.cs
@@ -37,9 +37,6 @@ public sealed partial class TargetContextMenu : Framework.Gwen.Control.Menu
         _me = Globals.Me;
 
         _targetNameMenuItem = AddItem(string.Empty);
-        _targetNameMenuItem.SetText("");
-        _targetNameMenuItem.MouseInputEnabled = false;
-
         AddDivider();
 
         _tradeMenuItem = AddItem(Strings.EntityContextMenu.Trade);
@@ -67,6 +64,8 @@ public sealed partial class TargetContextMenu : Framework.Gwen.Control.Menu
             return;
         }
 
+        bool shouldShowTargetNameMenuItem = false;
+
         float posX, posY, newX, newY;
 
         switch (target)
@@ -91,6 +90,8 @@ public sealed partial class TargetContextMenu : Framework.Gwen.Control.Menu
                 posY = InputHandler.MousePosition.Y;
                 newX = posX;
                 newY = posY;
+
+                shouldShowTargetNameMenuItem = true;
                 break;
 
             default:
@@ -115,11 +116,10 @@ public sealed partial class TargetContextMenu : Framework.Gwen.Control.Menu
             }
         }
 
+
         if (IsHidden)
         {
-
-            _targetNameMenuItem.SetText(_entity.Name);
-            _targetNameMenuItem.Alignment = Pos.Left;
+            TryShowTargetButton(shouldShowTargetNameMenuItem);
             TryShowGuildButton();
             SizeToChildren();
             Open(Pos.None);
@@ -128,6 +128,22 @@ public sealed partial class TargetContextMenu : Framework.Gwen.Control.Menu
         else if (!Globals.InputManager.MouseButtonDown(MouseButtons.Right))
         {
             Close();
+        }
+    }
+
+
+    private void TryShowTargetButton(bool shouldShow)
+    {
+        _targetNameMenuItem.SetText(shouldShow ? _entity.Name : string.Empty);
+        _targetNameMenuItem.MouseInputEnabled = false;
+
+        if (shouldShow && !Children.Contains(_targetNameMenuItem))
+        {
+            Children.Insert(0, _targetNameMenuItem);
+        }
+        else if (!shouldShow && Children.Contains(_targetNameMenuItem))
+        {
+            Children.Remove(_targetNameMenuItem);
         }
     }
 

--- a/Intersect.Client.Core/Interface/Game/TargetContextMenu.cs
+++ b/Intersect.Client.Core/Interface/Game/TargetContextMenu.cs
@@ -19,6 +19,7 @@ namespace Intersect.Client.Interface.Game;
 /// </summary>
 public sealed partial class TargetContextMenu : Framework.Gwen.Control.Menu
 {
+    private readonly MenuItem _targetNameMenuItem;
     private readonly MenuItem _tradeMenuItem;
     private readonly MenuItem _partyMenuItem;
     private readonly MenuItem _friendMenuItem;
@@ -34,6 +35,12 @@ public sealed partial class TargetContextMenu : Framework.Gwen.Control.Menu
         Children.Clear();
 
         _me = Globals.Me;
+
+        _targetNameMenuItem = AddItem(string.Empty);
+        _targetNameMenuItem.SetText("");
+        _targetNameMenuItem.MouseInputEnabled = false;
+
+        AddDivider();
 
         _tradeMenuItem = AddItem(Strings.EntityContextMenu.Trade);
         _tradeMenuItem.Clicked += tradeRequest_Clicked;
@@ -90,6 +97,11 @@ public sealed partial class TargetContextMenu : Framework.Gwen.Control.Menu
                 return;
         }
 
+        if (_entity == null)
+        {
+            return;
+        }
+
         if (Canvas is { } canvas)
         {
             if (newX + Width >= canvas.Width)
@@ -105,6 +117,9 @@ public sealed partial class TargetContextMenu : Framework.Gwen.Control.Menu
 
         if (IsHidden)
         {
+
+            _targetNameMenuItem.SetText(_entity.Name);
+            _targetNameMenuItem.Alignment = Pos.Left;
             TryShowGuildButton();
             SizeToChildren();
             Open(Pos.None);

--- a/Intersect.Client.Core/Interface/Game/TargetContextMenu.cs
+++ b/Intersect.Client.Core/Interface/Game/TargetContextMenu.cs
@@ -53,7 +53,7 @@ public sealed partial class TargetContextMenu : Framework.Gwen.Control.Menu
         _guildMenuItem.Clicked += guildRequest_Clicked;
 
         _privateMessageMenuItem = AddItem(Strings.EntityContextMenu.PrivateMessage);
-        _privateMessageMenuItem.Clicked += privateMessageRequest_Clicked;
+        _privateMessageMenuItem.Clicked += privateMessageRequest_Clicked;   
 
         LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer?.GetResolutionString());
     }
@@ -132,16 +132,25 @@ public sealed partial class TargetContextMenu : Framework.Gwen.Control.Menu
         }
     }
 
-
     private void TryShowTargetButton(bool shouldShow)
     {
         _targetNameMenuItem.SetText(shouldShow ? _entity.Name : string.Empty);
 
-        if (shouldShow && !Children.Contains(_targetNameMenuItem))
+        if (shouldShow)
         {
-            Children.Insert(0, _targetNameMenuItem);
+            var indexOf = Children.IndexOf(_targetNameMenuItem);
+
+            if (indexOf > 0)
+            {
+                Children.RemoveAt(indexOf);
+            }
+
+            if (indexOf != 0)
+            {
+                Children.Insert(0, _targetNameMenuItem);
+            }
         }
-        else if (!shouldShow && Children.Contains(_targetNameMenuItem))
+        else
         {
             Children.Remove(_targetNameMenuItem);
         }

--- a/Intersect.Client.Core/Interface/Game/TargetContextMenu.cs
+++ b/Intersect.Client.Core/Interface/Game/TargetContextMenu.cs
@@ -37,6 +37,7 @@ public sealed partial class TargetContextMenu : Framework.Gwen.Control.Menu
         _me = Globals.Me;
 
         _targetNameMenuItem = AddItem(string.Empty);
+        _targetNameMenuItem.MouseInputEnabled = false;
         AddDivider();
 
         _tradeMenuItem = AddItem(Strings.EntityContextMenu.Trade);
@@ -135,7 +136,6 @@ public sealed partial class TargetContextMenu : Framework.Gwen.Control.Menu
     private void TryShowTargetButton(bool shouldShow)
     {
         _targetNameMenuItem.SetText(shouldShow ? _entity.Name : string.Empty);
-        _targetNameMenuItem.MouseInputEnabled = false;
 
         if (shouldShow && !Children.Contains(_targetNameMenuItem))
         {

--- a/Intersect.Client.Core/Interface/Game/TargetContextMenu.cs
+++ b/Intersect.Client.Core/Interface/Game/TargetContextMenu.cs
@@ -53,7 +53,7 @@ public sealed partial class TargetContextMenu : Framework.Gwen.Control.Menu
         _guildMenuItem.Clicked += guildRequest_Clicked;
 
         _privateMessageMenuItem = AddItem(Strings.EntityContextMenu.PrivateMessage);
-        _privateMessageMenuItem.Clicked += privateMessageRequest_Clicked;   
+        _privateMessageMenuItem.Clicked += privateMessageRequest_Clicked;
 
         LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer?.GetResolutionString());
     }


### PR DESCRIPTION
_targetNameMenuItem to display the target player's name in the context menu. Instead of using label, ensured  the menu item is non-interactive.

Co-authored-by @Arufonsu 


https://github.com/user-attachments/assets/0d5d4e2f-de36-405c-83c6-92135c4e2abf

