### PR TITLE
fix(2468): treat TargetContextMenu as one of the windows that should be closed

### DIFF
--- a/Intersect.Client.Core/Interface/Game/GameInterface.cs
+++ b/Intersect.Client.Core/Interface/Game/GameInterface.cs
@@ -569,6 +569,12 @@ public partial class GameInterface : MutableInterface
             closedWindows = true;
         }
 
+        if (TargetContextMenu.IsVisible)
+        {
+            TargetContextMenu.ToggleHidden();
+            closedWindows = true;
+        }
+
         return closedWindows;
     }
 


### PR DESCRIPTION
Resolves #2468