### PR TITLE
fix: some npc behaviors

### DIFF
--- a/Intersect.Server.Core/Entities/Entity.cs
+++ b/Intersect.Server.Core/Entities/Entity.cs
@@ -1261,7 +1261,7 @@ public abstract partial class Entity : IEntity
 
     protected virtual bool CanLookInDirection(Direction direction) => true;
 
-    public void ChangeDir(Direction dir)
+    public virtual void ChangeDir(Direction dir)
     {
         if (!CanLookInDirection(dir))
         {
@@ -2918,6 +2918,11 @@ public abstract partial class Entity : IEntity
     protected Direction DirectionToTarget(Entity en)
     {
         if (en == null || IsTurnAroundWhileCastingDisabled)
+        {
+            return Dir;
+        }
+
+        if (en.CachedStatuses.Any(status => status.Type == SpellEffect.Stealth))
         {
             return Dir;
         }

--- a/Intersect.Server.Core/Entities/Npc.cs
+++ b/Intersect.Server.Core/Entities/Npc.cs
@@ -691,6 +691,12 @@ public partial class Npc : Entity
             Log.Warn($"Combat data missing for {spellBase.Id}.");
         }
 
+        //TODO: try cast spell to find out hidden targets?
+        if (TargetHasStealth(target) /* && spellBase.Combat.TargetType != SpellTargetType.AoE*/)
+        {
+            return;
+        }
+
         // Check if we are even allowed to cast this spell.
         if (!CanCastSpell(spellBase, target, true, out _))
         {


### PR DESCRIPTION
resolves #2460 

1. Hit entity when entity is invisble in 3 cases
  a. when using projectiles spells
  b. when using aoe spells
  c. when using single target spell on a visible player, but there is player in stealth inside hit radius
2. Dont keep looking at the entity if the entity is invisible
3. If there is another valid target on range when the current target becomes invisible, change target.