### PR TITLE
Fix party disbanding logic when last player leaves

### DIFF
--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -5265,19 +5265,30 @@ public partial class Player : Entity
 
         string partyMessage = currentParty.Count > 1
             ? Strings.Parties.MemberLeft.ToString(Name)
-            : Strings.Parties.Disbanded;
+            : Strings.Parties.Disbanded.ToString();
 
         // Update all members of the party with the new list
         foreach (var partyMember in currentParty)
         {
             partyMember.Party = currentParty.ToList();
             PacketSender.SendParty(partyMember);
-            PacketSender.SendChatMsg(
-                partyMember,
-                partyMessage,
-                ChatMessageType.Party,
-                CustomColors.Alerts.Error
-            );
+            if (partyMessage != Strings.Parties.Disbanded.ToString())
+            {
+                PacketSender.SendChatMsg(
+                    partyMember,
+                    partyMessage,
+                    ChatMessageType.Party,
+                    CustomColors.Alerts.Error
+                );
+            }
+        }
+        // If theres only one player left, lets disband the party
+        if (currentParty.Count == 1)
+        {
+            var remainingMember = currentParty[0];
+            remainingMember.Party.Clear();
+            PacketSender.SendParty(remainingMember);
+            PacketSender.SendChatMsg(remainingMember, Strings.Parties.Disbanded, ChatMessageType.Party, CustomColors.Alerts.Error);
         }
 
         Party = new List<Player>();


### PR DESCRIPTION
Updated the LeaveParty method to ensure that:
- The party list is correctly cleared when only one member remains.
- The "party disbanded" mesage is sent only once when the last member leaves.
- The party list of the remaining player is properly cleared and updated to reflect the disbanded state.