### PR TITLE
fix(743): Reset player after warping to new map to prevent getting hit by a new effect while mid-respawn

### DIFF
--- a/Intersect.Server.Core/Entities/Entity.cs
+++ b/Intersect.Server.Core/Entities/Entity.cs
@@ -198,7 +198,7 @@ public abstract partial class Entity : IEntity
     }
 
     [NotMapped]
-    public bool Dead { get; set; }
+    public bool IsDead { get; set; }
 
     //Combat
     [NotMapped, JsonIgnore]
@@ -1667,7 +1667,7 @@ public abstract partial class Entity : IEntity
             }
         }
 
-        if (targetPlayer == null && !(target is Npc) || target.IsDead())
+        if (targetPlayer == null && !(target is Npc) || target.IsDead)
         {
             return;
         }
@@ -2309,7 +2309,7 @@ public abstract partial class Entity : IEntity
             else
             {
                 //PVP Kill common events
-                if (!enemy.Dead && enemy is Player enemyPlayer && this is Player)
+                if (!enemy.IsDead && enemy is Player enemyPlayer && this is Player)
                 {
                     thisPlayer.StartCommonEventsWithTrigger(CommonEventTrigger.PVPKill, "", enemy.Name);
                     enemyPlayer.StartCommonEventsWithTrigger(CommonEventTrigger.PVPDeath, "", this.Name);
@@ -2352,7 +2352,7 @@ public abstract partial class Entity : IEntity
 
     protected virtual void CheckForOnhitAttack(Entity enemy, bool isAutoAttack)
     {
-        if (isAutoAttack && !enemy.IsDead()) //Ignore spell damage.
+        if (isAutoAttack && !enemy.IsDead) //Ignore spell damage.
         {
             foreach (var status in CachedStatuses)
             {
@@ -3022,7 +3022,7 @@ public abstract partial class Entity : IEntity
     //Spawning/Dying
     public virtual void Die(bool dropItems = true, Entity killer = null)
     {
-        if (IsDead() || Items == null)
+        if (IsDead || Items == null)
         {
             return;
         }
@@ -3095,7 +3095,7 @@ public abstract partial class Entity : IEntity
         CachedStatuses = new Status[0];
         Stat?.ToList().ForEach(stat => stat?.Reset());
 
-        Dead = true;
+        IsDead = true;
     }
 
     protected virtual bool ShouldDropItem(Entity killer, ItemBase itemDescriptor, Item item, float dropRateModifier, out Guid lootOwner)
@@ -3161,11 +3161,6 @@ public abstract partial class Entity : IEntity
 
     protected abstract EntityItemSource? AsItemSource();
 
-    public bool IsDead()
-    {
-        return Dead;
-    }
-
     public virtual void Reset()
     {
         for (var i = 0; i < Enum.GetValues<Vital>().Length; i++)
@@ -3173,7 +3168,15 @@ public abstract partial class Entity : IEntity
             RestoreVital((Vital)i);
         }
 
-        Dead = false;
+        // Remove any damage over time effects
+        DoT.Clear();
+        CachedDots = [];
+        Statuses.Clear();
+        CachedStatuses = [];
+
+        CombatTimer = 0;
+
+        IsDead = false;
     }
 
     //Empty virtual functions for players

--- a/Intersect.Server.Core/Entities/Npc.cs
+++ b/Intersect.Server.Core/Entities/Npc.cs
@@ -832,7 +832,7 @@ public partial class Npc : Entity
                     var targetY = 0;
                     var targetZ = 0;
 
-                    if (tempTarget != null && (tempTarget.IsDead() || !InRangeOf(tempTarget, Options.Instance.Map.MapWidth * 2) || !CanTarget(tempTarget)))
+                    if (tempTarget != null && (tempTarget.IsDead || !InRangeOf(tempTarget, Options.Instance.Map.MapWidth * 2) || !CanTarget(tempTarget)))
                     {
                         _ = TryFindNewTarget(Timing.Global.Milliseconds, tempTarget.Id, !CanTarget(tempTarget));
                         tempTarget = Target;
@@ -886,7 +886,7 @@ public partial class Npc : Entity
                     //Check if there is a target, if so, run their ass down.
                     if (tempTarget != null && CanTarget(tempTarget))
                     {
-                        if (!tempTarget.IsDead() && CanAttack(tempTarget, null))
+                        if (!tempTarget.IsDead && CanAttack(tempTarget, null))
                         {
                             targetMap = tempTarget.MapId;
                             targetX = tempTarget.X;
@@ -1448,7 +1448,7 @@ public partial class Npc : Entity
                 }
 
                 // Is this entry dead?, if so skip it.
-                if (en.Key.IsDead())
+                if (en.Key.IsDead)
                 {
                     continue;
                 }
@@ -1480,7 +1480,7 @@ public partial class Npc : Entity
         {
             foreach (var entity in instance.GetCachedEntities())
             {
-                if (entity != null && !entity.IsDead() && entity != this && entity.Id != avoidId)
+                if (entity != null && !entity.IsDead && entity != this && entity.Id != avoidId)
                 {
                     //TODO Check if NPC is allowed to attack player with new conditions
                     if (entity is Player player)

--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -1091,23 +1091,16 @@ public partial class Player : Entity
     //Spawning/Dying
     private void Respawn()
     {
-        //Remove any damage over time effects
-        DoT.Clear();
-        CachedDots = new DoT[0];
-        Statuses.Clear();
-        CachedStatuses = new Status[0];
-
-        CombatTimer = 0;
-
-        var cls = ClassBase.Get(ClassId);
-        if (cls != null)
+        if (ClassBase.TryGet(ClassId, out _))
         {
             WarpToSpawn();
         }
         else
         {
-            Warp(Guid.Empty, 0, 0, 0);
+            Warp(default, 0, 0, 0);
         }
+
+        Reset();
 
         PacketSender.SendEntityDataToProximity(this);
 
@@ -1159,7 +1152,6 @@ public partial class Player : Entity
             }
         }
         PacketSender.SendEntityDie(this);
-        Reset();
         Respawn();
         PacketSender.SendInventory(this);
     }
@@ -1572,7 +1564,7 @@ public partial class Player : Entity
         //If Entity is resource, check for the correct tool and make sure its not a spell cast.
         if (target is Resource resource)
         {
-            if (resource.IsDead())
+            if (resource.IsDead)
             {
                 return;
             }
@@ -1625,7 +1617,7 @@ public partial class Player : Entity
 
     protected override void ReactToDamage(Vital vital)
     {
-        if (IsDead() || IsDisposed)
+        if (IsDead || IsDisposed)
         {
             base.ReactToDamage(vital);
             return;
@@ -1725,7 +1717,7 @@ public partial class Player : Entity
         //If Entity is resource, check for the correct tool and make sure its not a spell cast.
         if (target is Resource resource)
         {
-            if (resource.IsDead())
+            if (resource.IsDead)
             {
                 return;
             }

--- a/Intersect.Server.Core/Entities/ProjectileSpawn.cs
+++ b/Intersect.Server.Core/Entities/ProjectileSpawn.cs
@@ -121,7 +121,7 @@ public partial class ProjectileSpawn
             }
             else if (targetEntity is Resource targetResource)
             {
-                if (targetResource.IsDead())
+                if (targetResource.IsDead)
                 {
                     if (!ProjectileBase.IgnoreExhaustedResources)
                     {

--- a/Intersect.Server.Core/Entities/Resource.cs
+++ b/Intersect.Server.Core/Entities/Resource.cs
@@ -44,7 +44,7 @@ public partial class Resource : Entity
         {
             Die(dropItems, killer);
         }
-        
+
         PacketSender.SendEntityDie(this);
         PacketSender.SendEntityLeave(this);
     }
@@ -55,10 +55,10 @@ public partial class Resource : Entity
         {
             base.Die(false, killer);
         }
-        
+
         Sprite = Base.Exhausted.Graphic;
         Passable = Base.WalkableAfter;
-        Dead = true;
+        IsDead = true;
 
         if (dropItems)
         {
@@ -101,7 +101,7 @@ public partial class Resource : Entity
             }
         }
 
-        Dead = false;
+        IsDead = false;
         PacketSender.SendEntityDataToProximity(this);
         PacketSender.SendEntityPositionToAll(this);
     }
@@ -158,7 +158,7 @@ public partial class Resource : Entity
             {
                 selectedTile = tiles[Randomization.Next(0, tiles.Count)];
             }
-            
+
             var itemSource = AsItemSource();
 
             // Drop items
@@ -177,7 +177,7 @@ public partial class Resource : Entity
 
         Items.Clear();
     }
-    
+
     protected override EntityItemSource? AsItemSource()
     {
         return new EntityItemSource
@@ -191,13 +191,13 @@ public partial class Resource : Entity
     public override void ProcessRegen()
     {
         //For now give npcs/resources 10% health back every regen tick... in the future we should put per-npc and per-resource regen settings into their respective editors.
-        if (!IsDead())
+        if (!IsDead)
         {
             if (Base == null)
             {
                 return;
             }
-            
+
             var vital = Vital.Health;
 
             var vitalId = (int) vital;
@@ -216,7 +216,7 @@ public partial class Resource : Entity
 
     public override bool IsPassable()
     {
-        return IsDead() & Base.WalkableAfter || !IsDead() && Base.WalkableBefore;
+        return IsDead & Base.WalkableAfter || !IsDead && Base.WalkableBefore;
     }
 
     public override EntityPacket EntityPacket(EntityPacket packet = null, Player forPlayer = null)
@@ -230,7 +230,7 @@ public partial class Resource : Entity
 
         var pkt = (ResourceEntityPacket) packet;
         pkt.ResourceId = Base.Id;
-        pkt.IsDead = IsDead();
+        pkt.IsDead = IsDead;
 
         return pkt;
     }


### PR DESCRIPTION
Resolves #743

I wasn't able to reproduce the bug myself, but from Weylon's reproduction scenario comment I only see one way to reproduce this, and this change _should_ fix it:

Weylon's comment:
> to reproduce the npc must cast a spell the moment you die