### PR TITLE
chore/fix/feat: change GameBorderStyle into an enum, maked Seamed have effect at high resolution

### DIFF
--- a/Framework/Intersect.Framework.Core/Config/MapOptions.cs
+++ b/Framework/Intersect.Framework.Core/Config/MapOptions.cs
@@ -1,6 +1,8 @@
 ﻿using System.Runtime.Serialization;
 using Intersect.Framework.Annotations;
+using Intersect.Framework.Core.GameObjects.Maps;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace Intersect.Config;
 
@@ -45,9 +47,9 @@ public partial class MapOptions
 
     /// <summary>
     /// The style of the game's border.
-    /// 0: Smart borders, 1: Non-seamless, 2: Black borders
     /// </summary>
-    public int GameBorderStyle { get; set; }
+    [JsonConverter(typeof(StringEnumConverter))]
+    public GameBorderStyle GameBorderStyle { get; set; }
 
     /// <summary>
     /// The time, in milliseconds, until item attributes respawn on the map.

--- a/Framework/Intersect.Framework.Core/GameObjects/Maps/GameBorderStyle.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Maps/GameBorderStyle.cs
@@ -1,0 +1,22 @@
+namespace Intersect.Framework.Core.GameObjects.Maps;
+
+public enum GameBorderStyle
+{
+    /// <summary>
+    /// No transitions between adjacent maps but the camera is locked to map boundaries if the map has adjacent maps.
+    /// </summary>
+    Seamless = 0,
+
+    /// <summary>
+    /// Camera is clamped to the boundaries of the current map, which causes a transition when moving to adjacent maps.
+    /// </summary>
+    /// <remarks>
+    /// This only applies if the effective resolution (zoom shrinks this) is below the pixel dimensions of the map.
+    /// </remarks>
+    Seamed = 1,
+
+    /// <summary>
+    /// No transitions between adjacent maps, and the camera is not locked to map boundaries ("black" borders).
+    /// </summary>
+    SeamlessUnbounded = 2,
+}

--- a/Intersect.Client.Core/Core/Graphics.cs
+++ b/Intersect.Client.Core/Core/Graphics.cs
@@ -8,6 +8,7 @@ using Intersect.Client.General;
 using Intersect.Client.Maps;
 using Intersect.Configuration;
 using Intersect.Enums;
+using Intersect.Framework.Core.GameObjects.Maps;
 using Intersect.GameObjects;
 using Intersect.Utilities;
 
@@ -1000,6 +1001,10 @@ public static partial class Graphics
                 newView.X = restrictView.Right - newView.Width;
             }
         }
+        else if (Options.Instance.Map.GameBorderStyle == GameBorderStyle.Seamed)
+        {
+            newView.X = restrictView.X - (newView.Width - restrictView.Width) / 2;
+        }
 
         if (restrictView.Height >= newView.Height)
         {
@@ -1012,6 +1017,10 @@ public static partial class Graphics
             {
                 newView.Y = restrictView.Bottom - newView.Height;
             }
+        }
+        else if (Options.Instance.Map.GameBorderStyle == GameBorderStyle.Seamed)
+        {
+            newView.Y = restrictView.Y - (newView.Height - restrictView.Height) / 2;
         }
 
         CurrentView = new FloatRect(

--- a/Intersect.Server.Core/Maps/MapController.cs
+++ b/Intersect.Server.Core/Maps/MapController.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using Intersect.Compression;
 using Intersect.Core;
 using Intersect.Enums;
+using Intersect.Framework.Core.GameObjects.Maps;
 using Intersect.GameObjects;
 using Intersect.GameObjects.Maps;
 using Intersect.Network.Packets.Server;
@@ -94,10 +95,10 @@ public partial class MapController : MapBase
     {
         switch (Options.Instance.Map.GameBorderStyle)
         {
-            case 1:
+            case GameBorderStyle.Seamed:
                 return [true, true, true, true];
 
-            case 0:
+            case GameBorderStyle.Seamless:
                 var grid = DbInterface.GetGrid(MapGrid);
                 if (grid != null)
                 {
@@ -109,8 +110,13 @@ public partial class MapController : MapBase
                         grid.XMax - 1 == MapGridX,
                     ];
                 }
-
                 break;
+
+            case GameBorderStyle.SeamlessUnbounded:
+                break;
+
+            default:
+                throw new ArgumentOutOfRangeException();
         }
 
         return null;


### PR DESCRIPTION
- Change `GameBorderStyle` to an enum for clarity of what the different values do
- Serialize `GameBorderStyle` as a string (this option in the config is forward-compatible and automatically migrated from int to string)
- lock map to center camera if the display resolution exceeds map size for `GameBorderStyle.Seamed`