### PR TITLE
feat: engine version indicator

### DIFF
--- a/Framework/Intersect.Framework.Core/Core/IApplicationContext.cs
+++ b/Framework/Intersect.Framework.Core/Core/IApplicationContext.cs
@@ -1,4 +1,5 @@
 ﻿
+using Intersect.Framework.Reflection;
 using Intersect.Plugins.Interfaces;
 using Intersect.Threading;
 using Microsoft.Extensions.Logging;
@@ -14,6 +15,26 @@ public interface IApplicationContext : IDisposable
     /// If the application has encountered unhandled/unobserved exceptions during its lifespan.
     /// </summary>
     bool HasErrors { get; }
+
+    /// <summary>
+    /// If the application is a debug build.
+    /// </summary>
+    bool IsDebug
+    {
+        get
+        {
+#if !DEBUG
+            return true;
+#else
+            return false;
+#endif
+        }
+    }
+
+    /// <summary>
+    /// If the application is being run in developer mode.
+    /// </summary>
+    bool IsDeveloper => false;
 
     /// <summary>
     /// If the application has been disposed.
@@ -49,6 +70,11 @@ public interface IApplicationContext : IDisposable
     /// The <see cref="IApplicationService"/>s currently registered.
     /// </summary>
     List<IApplicationService> Services { get; }
+
+    /// <summary>
+    /// The human-friendly version string.
+    /// </summary>
+    string VersionName => GetType().Assembly.GetMetadataVersionName();
 
     /// <summary>
     /// Gets a service of type <typeparamref name="TApplicationService"/> if one has been registered.

--- a/Framework/Intersect.Framework/Reflection/AssemblyExtensions.cs
+++ b/Framework/Intersect.Framework/Reflection/AssemblyExtensions.cs
@@ -56,6 +56,9 @@ public static partial class AssemblyExtensions
         return GetMetadataVersionFrom(assembly, assemblyName, excludeCommitSha);
     }
 
+    public static string GetMetadataVersionName(this Assembly assembly, bool excludeCommitSha = false) =>
+        $"v{GetMetadataVersion(assembly: assembly, excludeCommitSha: excludeCommitSha)}";
+
     private static string GetMetadataVersionFrom(Assembly assembly, AssemblyName assemblyName, bool excludeCommitSha)
     {
         var assemblyVersion = assemblyName.Version ?? new Version(0, 0, 0, 0);

--- a/Framework/Intersect.Framework/StringExtensions.cs
+++ b/Framework/Intersect.Framework/StringExtensions.cs
@@ -1,0 +1,27 @@
+using System.Text;
+
+namespace Intersect.Framework;
+
+public static class StringExtensions
+{
+    public static string Reverse(this string @string)
+    {
+        var codepoints = new int[@string.Length];
+        var numCodepoints = 0;
+        for (var index = 0; index < @string.Length; ++index)
+        {
+            ++numCodepoints;
+
+            codepoints[index] = char.ConvertToUtf32(@string, index);
+            if (char.IsSurrogatePair(@string, index))
+            {
+                ++index;
+            }
+        }
+
+        codepoints = codepoints[..numCodepoints];
+        Array.Reverse(codepoints);
+
+        return codepoints.Aggregate(string.Empty, (current, codepoint) => current + char.ConvertFromUtf32(codepoint));
+    }
+}

--- a/Intersect.Client.Core/Core/ClientCommandLineOptions.cs
+++ b/Intersect.Client.Core/Core/ClientCommandLineOptions.cs
@@ -6,6 +6,7 @@ namespace Intersect.Client.Core;
 
 internal readonly partial struct ClientCommandLineOptions : ICommandLineOptions
 {
+    // ReSharper disable once ConvertToPrimaryConstructor
     public ClientCommandLineOptions(
         bool borderlessWindow,
         int screenWidth,
@@ -33,7 +34,7 @@ internal readonly partial struct ClientCommandLineOptions : ICommandLineOptions
     public int ScreenHeight { get; }
 
     [Option('S', "server", Default = null, Required = false)]
-    public string Server { get; }
+    public string Server { get; init; }
 
     [Option("working-directory", Default = null, Required = false)]
     public string WorkingDirectory { get; }

--- a/Intersect.Client.Core/Interface/Game/EscapeMenu.cs
+++ b/Intersect.Client.Core/Interface/Game/EscapeMenu.cs
@@ -1,10 +1,12 @@
 using Intersect.Client.Core;
 using Intersect.Client.Framework.File_Management;
+using Intersect.Client.Framework.Gwen;
 using Intersect.Client.Framework.Gwen.Control;
 using Intersect.Client.Framework.Gwen.Control.EventArguments;
 using Intersect.Client.General;
 using Intersect.Client.Interface.Shared;
 using Intersect.Client.Localization;
+using Intersect.Core;
 using Intersect.Utilities;
 
 namespace Intersect.Client.Interface.Game;
@@ -13,6 +15,8 @@ public partial class EscapeMenu : ImagePanel
 {
     private readonly SettingsWindow _settingsWindow;
     private readonly Button _buttonCharacterSelect;
+    private readonly Panel _versionPanel;
+    private readonly Label _versionLabel;
 
     public EscapeMenu(Canvas gameCanvas) : base(gameCanvas, nameof(EscapeMenu))
     {
@@ -76,6 +80,29 @@ public partial class EscapeMenu : ImagePanel
         {
             _buttonCharacterSelect.IsDisabled = true;
         }
+
+        _versionPanel = new Panel(this, name: nameof(_versionPanel))
+        {
+            Alignment = [Alignments.Bottom, Alignments.Right],
+            BackgroundColor = new Color(0x7f, 0, 0, 0),
+            Padding = new Padding(8, 4),
+            RestrictToParent = true,
+            IsVisible = ApplicationContext.CurrentContext.IsDeveloper, // TODO: Remove this when showing a game version is added
+        };
+
+        _versionLabel = new Label(_versionPanel, name: nameof(_versionLabel))
+        {
+            Alignment = [Alignments.Center],
+            AutoSizeToContents = true,
+            Font = GameContentManager.Current.GetFont("sourcesansproblack", 10),
+            Text = ApplicationContext.CurrentContext.VersionName,
+            TextPadding = new Padding(2, 0),
+            IsVisible = ApplicationContext.CurrentContext.IsDeveloper,
+        };
+
+        _versionLabel.SizeToContents();
+
+        _versionPanel.SizeToChildren();
     }
 
     public override void Invalidate()

--- a/Intersect.Client.Core/Interface/Game/EscapeMenu.cs
+++ b/Intersect.Client.Core/Interface/Game/EscapeMenu.cs
@@ -1,12 +1,10 @@
 using Intersect.Client.Core;
 using Intersect.Client.Framework.File_Management;
-using Intersect.Client.Framework.Gwen;
 using Intersect.Client.Framework.Gwen.Control;
 using Intersect.Client.Framework.Gwen.Control.EventArguments;
 using Intersect.Client.General;
 using Intersect.Client.Interface.Shared;
 using Intersect.Client.Localization;
-using Intersect.Core;
 using Intersect.Utilities;
 
 namespace Intersect.Client.Interface.Game;
@@ -16,7 +14,6 @@ public partial class EscapeMenu : ImagePanel
     private readonly SettingsWindow _settingsWindow;
     private readonly Button _buttonCharacterSelect;
     private readonly Panel _versionPanel;
-    private readonly Label _versionLabel;
 
     public EscapeMenu(Canvas gameCanvas) : base(gameCanvas, nameof(EscapeMenu))
     {
@@ -81,28 +78,7 @@ public partial class EscapeMenu : ImagePanel
             _buttonCharacterSelect.IsDisabled = true;
         }
 
-        _versionPanel = new Panel(this, name: nameof(_versionPanel))
-        {
-            Alignment = [Alignments.Bottom, Alignments.Right],
-            BackgroundColor = new Color(0x7f, 0, 0, 0),
-            Padding = new Padding(8, 4),
-            RestrictToParent = true,
-            IsVisible = ApplicationContext.CurrentContext.IsDeveloper, // TODO: Remove this when showing a game version is added
-        };
-
-        _versionLabel = new Label(_versionPanel, name: nameof(_versionLabel))
-        {
-            Alignment = [Alignments.Center],
-            AutoSizeToContents = true,
-            Font = GameContentManager.Current.GetFont("sourcesansproblack", 10),
-            Text = ApplicationContext.CurrentContext.VersionName,
-            TextPadding = new Padding(2, 0),
-            IsVisible = ApplicationContext.CurrentContext.IsDeveloper,
-        };
-
-        _versionLabel.SizeToContents();
-
-        _versionPanel.SizeToChildren();
+        _versionPanel = new VersionPanel(this, name: nameof(_versionPanel));
     }
 
     public override void Invalidate()

--- a/Intersect.Client.Core/Interface/Menu/MenuGuiBase.cs
+++ b/Intersect.Client.Core/Interface/Menu/MenuGuiBase.cs
@@ -1,8 +1,10 @@
 using Intersect.Client.Core;
 using Intersect.Client.Framework.File_Management;
+using Intersect.Client.Framework.Gwen;
 using Intersect.Client.Framework.Gwen.Control;
 using Intersect.Client.Localization;
 using Intersect.Client.Networking;
+using Intersect.Core;
 
 namespace Intersect.Client.Interface.Menu;
 
@@ -11,6 +13,8 @@ public partial class MenuGuiBase : IMutableInterface
     private readonly Canvas _menuCanvas;
     private readonly ImagePanel _serverStatusArea;
     private readonly Label _serverStatusLabel;
+    private readonly Panel _versionPanel;
+    private readonly Label _versionLabel;
 
     public MainMenu MainMenu { get; }
 
@@ -21,6 +25,30 @@ public partial class MenuGuiBase : IMutableInterface
         _menuCanvas = myCanvas;
 
         MainMenu = new MainMenu(_menuCanvas);
+
+        _versionPanel = new Panel(_menuCanvas, name: nameof(_versionPanel))
+        {
+            Alignment = [Alignments.Bottom, Alignments.Right],
+            BackgroundColor = new Color(0x7f, 0, 0, 0),
+            Padding = new Padding(8, 4),
+            RestrictToParent = true,
+            IsVisible = ApplicationContext.CurrentContext.IsDeveloper, // TODO: Remove this when showing a game version is added
+        };
+
+        _versionLabel = new Label(_versionPanel, name: nameof(_versionLabel))
+        {
+            Alignment = [Alignments.Center],
+            AutoSizeToContents = true,
+            Font = GameContentManager.Current.GetFont("sourcesansproblack", 10),
+            Text = ApplicationContext.CurrentContext.VersionName,
+            TextPadding = new Padding(2, 0),
+            IsVisible = ApplicationContext.CurrentContext.IsDeveloper,
+        };
+
+        _versionLabel.SizeToContents();
+
+        _versionPanel.SizeToChildren();
+
         _serverStatusArea = new ImagePanel(_menuCanvas, "ServerStatusArea")
         {
             IsHidden = ClientContext.IsSinglePlayer,

--- a/Intersect.Client.Core/Interface/Menu/MenuGuiBase.cs
+++ b/Intersect.Client.Core/Interface/Menu/MenuGuiBase.cs
@@ -2,6 +2,7 @@ using Intersect.Client.Core;
 using Intersect.Client.Framework.File_Management;
 using Intersect.Client.Framework.Gwen;
 using Intersect.Client.Framework.Gwen.Control;
+using Intersect.Client.Interface.Shared;
 using Intersect.Client.Localization;
 using Intersect.Client.Networking;
 using Intersect.Core;
@@ -13,8 +14,7 @@ public partial class MenuGuiBase : IMutableInterface
     private readonly Canvas _menuCanvas;
     private readonly ImagePanel _serverStatusArea;
     private readonly Label _serverStatusLabel;
-    private readonly Panel _versionPanel;
-    private readonly Label _versionLabel;
+    private readonly VersionPanel _versionPanel;
 
     public MainMenu MainMenu { get; }
 
@@ -26,28 +26,7 @@ public partial class MenuGuiBase : IMutableInterface
 
         MainMenu = new MainMenu(_menuCanvas);
 
-        _versionPanel = new Panel(_menuCanvas, name: nameof(_versionPanel))
-        {
-            Alignment = [Alignments.Bottom, Alignments.Right],
-            BackgroundColor = new Color(0x7f, 0, 0, 0),
-            Padding = new Padding(8, 4),
-            RestrictToParent = true,
-            IsVisible = ApplicationContext.CurrentContext.IsDeveloper, // TODO: Remove this when showing a game version is added
-        };
-
-        _versionLabel = new Label(_versionPanel, name: nameof(_versionLabel))
-        {
-            Alignment = [Alignments.Center],
-            AutoSizeToContents = true,
-            Font = GameContentManager.Current.GetFont("sourcesansproblack", 10),
-            Text = ApplicationContext.CurrentContext.VersionName,
-            TextPadding = new Padding(2, 0),
-            IsVisible = ApplicationContext.CurrentContext.IsDeveloper,
-        };
-
-        _versionLabel.SizeToContents();
-
-        _versionPanel.SizeToChildren();
+        _versionPanel = new VersionPanel(_menuCanvas, name: nameof(_versionPanel));
 
         _serverStatusArea = new ImagePanel(_menuCanvas, "ServerStatusArea")
         {

--- a/Intersect.Client.Core/Interface/Shared/VersionLabel.cs
+++ b/Intersect.Client.Core/Interface/Shared/VersionLabel.cs
@@ -1,0 +1,34 @@
+using Intersect.Client.Framework.Gwen;
+using Intersect.Client.Framework.Gwen.Control;
+using Intersect.Client.Framework.Gwen.Platform;
+using Intersect.Client.Framework.Input;
+
+namespace Intersect.Client.Interface.Shared;
+
+public partial class VersionLabel : Label
+{
+    public VersionLabel(Base parent, string name = nameof(VersionLabel)) : base(parent: parent, name: name)
+    {
+        AutoSizeToContents = true;
+        Dock = Pos.Top;
+        MouseInputEnabled = true;
+        TextPadding = new Padding(2, 0);
+    }
+
+    protected override void Layout(Framework.Gwen.Skin.Base skin)
+    {
+        base.Layout(skin);
+
+        SizeToContents();
+    }
+
+    protected override void OnMouseClicked(MouseButton mouseButton, Point mousePosition, bool userAction = true)
+    {
+        base.OnMouseClicked(mouseButton, mousePosition, userAction);
+
+        if (Text is { } text && !string.IsNullOrWhiteSpace(text))
+        {
+            Neutral.SetClipboardText(text);
+        }
+    }
+}

--- a/Intersect.Client.Core/Interface/Shared/VersionPanel.cs
+++ b/Intersect.Client.Core/Interface/Shared/VersionPanel.cs
@@ -1,0 +1,37 @@
+using Intersect.Client.Framework.File_Management;
+using Intersect.Client.Framework.Gwen;
+using Intersect.Client.Framework.Gwen.Control;
+using Intersect.Core;
+
+namespace Intersect.Client.Interface.Shared;
+
+public partial class VersionPanel : Panel
+{
+    private readonly VersionLabel _engineVersionLabel;
+
+    public VersionPanel(Base parent, string name = nameof(VersionPanel)) : base(parent: parent, name: name)
+    {
+        Alignment = [Alignments.Bottom, Alignments.Right];
+        BackgroundColor = new Color(0x7f, 0, 0, 0);
+        Padding = new Padding(8, 4);
+        RestrictToParent = true;
+        // TODO: Remove this when showing a game version is added
+        IsVisible = ApplicationContext.CurrentContext.IsDeveloper;
+
+        var font = GameContentManager.Current.GetFont("sourcesansproblack", 10);
+
+        _engineVersionLabel = new VersionLabel(this, name: nameof(_engineVersionLabel))
+        {
+            Font = font,
+            Text = ApplicationContext.CurrentContext.VersionName,
+            IsVisible = ApplicationContext.CurrentContext.IsDeveloper,
+        };
+    }
+
+    protected override void Layout(Framework.Gwen.Skin.Base skin)
+    {
+        base.Layout(skin);
+
+        SizeToChildren();
+    }
+}

--- a/Intersect.Client.Core/MonoGame/Network/MonoSocket.cs
+++ b/Intersect.Client.Core/MonoGame/Network/MonoSocket.cs
@@ -96,8 +96,6 @@ internal partial class MonoSocket : GameSocket
     private IPEndPoint? _lastEndpoint;
     private volatile bool _resolvingHost;
 
-    private static readonly HashSet<string> UnresolvableHostNames = [];
-
     public static MonoSocket Instance { get; private set; } = default!;
 
     internal MonoSocket(IClientContext context)
@@ -113,7 +111,7 @@ internal partial class MonoSocket : GameSocket
     private bool TryResolveEndPoint([NotNullWhen(true)] out IPEndPoint? endPoint)
     {
         var currentHost = ClientConfiguration.Instance.Host;
-        if (UnresolvableHostNames.Contains(currentHost))
+        if (ClientNetwork.UnresolvableHostNames.Contains(currentHost))
         {
             endPoint = default;
             return false;
@@ -165,7 +163,7 @@ internal partial class MonoSocket : GameSocket
                 throw;
             }
 
-            UnresolvableHostNames.Add(_lastHost);
+            ClientNetwork.UnresolvableHostNames.Add(_lastHost);
             Interface.Interface.ShowError(Strings.Errors.HostNotFound);
             ApplicationContext.Context.Value?.Logger.LogError(socketException, $"Failed to resolve host: '{_lastHost}'");
             endPoint = default;
@@ -237,7 +235,7 @@ internal partial class MonoSocket : GameSocket
                                         network.SendUnconnected(serverEndpoint, new ServerStatusRequestPacket());
                                     }
                                 }
-                                else if (!UnresolvableHostNames.Contains(_lastHost))
+                                else if (!ClientNetwork.UnresolvableHostNames.Contains(_lastHost))
                                 {
                                     ApplicationContext.Context.Value?.Logger.LogInformation($"Unable to resolve '{_lastHost}:{_lastPort}'");
                                 }

--- a/Intersect.Client.Framework/Gwen/Control/Base.cs
+++ b/Intersect.Client.Framework/Gwen/Control/Base.cs
@@ -89,7 +89,7 @@ public partial class Base : IDisposable
 
     private Package mDragAndDrop_package;
 
-    private bool mDrawBackground;
+    private bool mDrawBackground = true;
 
     private bool mDrawDebugOutlines;
 

--- a/Intersect.Client.Framework/Gwen/Control/ILabel.cs
+++ b/Intersect.Client.Framework/Gwen/Control/ILabel.cs
@@ -2,7 +2,7 @@ using Intersect.Client.Framework.Graphics;
 
 namespace Intersect.Client.Framework.Gwen.Control;
 
-public interface ILabel : IAutoSizeToContents, IColorableText
+public interface ILabel : IAutoSizeToContents, IColorableText, ITextContainer
 {
     Pos TextAlign { get; set; }
 

--- a/Intersect.Client.Framework/Gwen/Control/ITextContainer.cs
+++ b/Intersect.Client.Framework/Gwen/Control/ITextContainer.cs
@@ -1,0 +1,10 @@
+namespace Intersect.Client.Framework.Gwen.Control;
+
+public interface ITextContainer
+{
+    string? Text { get; set; }
+
+    Padding TextPadding { get; set; }
+
+    Color? TextPaddingDebugColor { get; set; }
+}

--- a/Intersect.Client.Framework/Gwen/Control/Label.cs
+++ b/Intersect.Client.Framework/Gwen/Control/Label.cs
@@ -384,6 +384,8 @@ public partial class Label : Base, ILabel
         }
     }
 
+    public Color? TextPaddingDebugColor { get; set; }
+
     public override JObject? GetJson(bool isRoot = false, bool onlySerializeIfNotEmpty = false)
     {
         var serializedProperties = base.GetJson(isRoot, onlySerializeIfNotEmpty);

--- a/Intersect.Client.Framework/Gwen/Control/Panel.cs
+++ b/Intersect.Client.Framework/Gwen/Control/Panel.cs
@@ -1,3 +1,5 @@
+using Intersect.Client.Framework.GenericClasses;
+
 namespace Intersect.Client.Framework.Gwen.Control;
 
 /// <summary>
@@ -7,10 +9,29 @@ namespace Intersect.Client.Framework.Gwen.Control;
 /// <param name="name"></param>
 public class Panel(Base parent, string? name = default) : Base(parent: parent, name: name)
 {
+    private Color? _backgroundColor;
+
+    public Color? BackgroundColor
+    {
+        get => _backgroundColor;
+        set => SetAndDoIfChanged(ref _backgroundColor, value, Invalidate);
+    }
+
     protected override void Render(Skin.Base skin)
     {
         base.Render(skin);
 
-        skin.DrawPanel(this);
+        if (!ShouldDrawBackground)
+        {
+            return;
+        }
+
+        if (BackgroundColor is not { } backgroundColor)
+        {
+            skin.DrawPanel(this);
+            return;
+        }
+
+        skin.DrawRectFill(Bounds with { X = 0, Y = 0 }, backgroundColor);
     }
 }

--- a/Intersect.Client.Framework/Gwen/ControlInternal/Text.cs
+++ b/Intersect.Client.Framework/Gwen/ControlInternal/Text.cs
@@ -10,6 +10,8 @@ namespace Intersect.Client.Framework.Gwen.ControlInternal;
 /// </summary>
 public partial class Text : Base
 {
+    public static readonly Color DefaultBoundsOutlineColor = Color.FromHex("bf4060", Color.Pink);
+    public static readonly Color DefaultMarginOutlineColor = Color.FromHex("1fad1f", Color.ForestGreen);
 
     private GameFont? _font;
 
@@ -30,6 +32,9 @@ public partial class Text : Base
         Color = Skin.Colors.Label.Normal;
         MouseInputEnabled = false;
         ColorOverride = Color.FromArgb(0, 255, 255, 255); // A==0, override disabled
+
+        BoundsOutlineColor = DefaultBoundsOutlineColor;
+        MarginOutlineColor = DefaultMarginOutlineColor;
     }
 
     /// <summary>

--- a/Intersect.Client.Framework/Gwen/Renderer/IntersectRenderer.cs
+++ b/Intersect.Client.Framework/Gwen/Renderer/IntersectRenderer.cs
@@ -19,7 +19,7 @@ public partial class IntersectRenderer : Base, ICacheToTexture
 
     private GameRenderer mRenderer;
 
-    private GameRenderTexture mRenderTarget;
+    private GameRenderTexture? mRenderTarget;
 
     /// <summary>
     ///     Initializes a new instance of the <see cref="UnityGwenRenderer" /> class.
@@ -99,7 +99,9 @@ public partial class IntersectRenderer : Base, ICacheToTexture
     public override void DrawFilledRect(Rectangle targetRect)
     {
         var rect = new FloatRect(
-            Translate(targetRect).X, Translate(targetRect).Y, Translate(targetRect).Width,
+            Translate(targetRect).X,
+            Translate(targetRect).Y,
+            Translate(targetRect).Width,
             Translate(targetRect).Height
         );
 
@@ -154,15 +156,41 @@ public partial class IntersectRenderer : Base, ICacheToTexture
         if (mRenderTarget == null)
         {
             mRenderer.DrawTexture(
-                mRenderer.GetWhiteTexture(), 0, 0, 1, 1, rect.X, rect.Y, rect.Width, rect.Height, mColor,
-                mRenderTarget, GameBlendModes.None, null, 0f, true
+                mRenderer.GetWhiteTexture(),
+                0,
+                0,
+                1,
+                1,
+                rect.X,
+                rect.Y,
+                rect.Width,
+                rect.Height,
+                mColor,
+                mRenderTarget,
+                GameBlendModes.None,
+                null,
+                0f,
+                true
             );
         }
         else
         {
             mRenderer.DrawTexture(
-                mRenderer.GetWhiteTexture(), 0, 0, 1, 1, rect.X, rect.Y, rect.Width, rect.Height, mColor,
-                mRenderTarget, GameBlendModes.None, null, 0f, true
+                mRenderer.GetWhiteTexture(),
+                0,
+                0,
+                1,
+                1,
+                rect.X,
+                rect.Y,
+                rect.Width,
+                rect.Height,
+                mColor,
+                mRenderTarget,
+                GameBlendModes.None,
+                null,
+                0f,
+                true
             );
         }
     }

--- a/Intersect.Client.Framework/Gwen/Skin/Base.cs
+++ b/Intersect.Client.Framework/Gwen/Skin/Base.cs
@@ -234,25 +234,53 @@ public partial class Base : IDisposable
             return;
         }
 
-        mRenderer.DrawColor = control.PaddingOutlineColor;
-        var paddingRect = new Rectangle(
-            control.Bounds.Left + control.Padding.Left, control.Bounds.Top + control.Padding.Top,
-            control.Bounds.Width - control.Padding.Right - control.Padding.Left,
-            control.Bounds.Height - control.Padding.Bottom - control.Padding.Top
-        );
+        var padding = control.Padding;
+        if (padding != default)
+        {
+            var paddingRect = new Rectangle(
+                control.Bounds.Left + padding.Left,
+                control.Bounds.Top + padding.Top,
+                control.Bounds.Width - padding.Right - padding.Left,
+                control.Bounds.Height - padding.Bottom - padding.Top
+            );
 
-        DrawRectStroke(paddingRect, control.PaddingOutlineColor);
+            DrawRectStroke(paddingRect, control.PaddingOutlineColor);
+        }
 
-        var marginRect = new Rectangle(
-            control.Bounds.Left - control.Margin.Left, control.Bounds.Top - control.Margin.Top,
-            control.Bounds.Width + control.Margin.Right + control.Margin.Left,
-            control.Bounds.Height + control.Margin.Bottom + control.Margin.Top
-        );
+        var margin = control.Margin;
+        if (margin != default)
+        {
+            var marginRect = new Rectangle(
+                control.Bounds.Left - margin.Left,
+                control.Bounds.Top - margin.Top,
+                control.Bounds.Width + margin.Right + margin.Left,
+                control.Bounds.Height + margin.Bottom + margin.Top
+            );
 
-        DrawRectStroke(marginRect, control.MarginOutlineColor);
+            DrawRectStroke(marginRect, control.MarginOutlineColor);
+        }
+
+        if (control is ITextContainer textContainer)
+        {
+            var textPadding = textContainer.TextPadding;
+            if (textPadding != default)
+            {
+                var color = textContainer.TextPaddingDebugColor ?? DefaultTextPaddingDebugColor;
+                var textPaddingRect = new Rectangle(
+                    control.Bounds.Left + textPadding.Left,
+                    control.Bounds.Top + textPadding.Top,
+                    control.Bounds.Width - textPadding.Right - textPadding.Left,
+                    control.Bounds.Height - textPadding.Bottom - textPadding.Top
+                );
+
+                DrawRectStroke(textPaddingRect, color);
+            }
+        }
 
         DrawRectStroke(control.Bounds, control.BoundsOutlineColor);
     }
+
+    public static Color DefaultTextPaddingDebugColor = Color.FromHex("79b5d2", Color.White);
 
     public virtual void DrawRectStroke(Rectangle rect, Color color) => DrawRect(rect, color, filled: false);
 

--- a/Intersect.Network/ClientNetwork.cs
+++ b/Intersect.Network/ClientNetwork.cs
@@ -12,7 +12,8 @@ namespace Intersect.Network;
 
 public partial class ClientNetwork : AbstractNetwork, IClient
 {
-    private static readonly HashSet<string> UnresolvableHostNames = [];
+    public static readonly HashSet<string> UnresolvableHostNames = [];
+
     private static readonly NetworkLayerInterfaceFactory DefaultNetworkLayerInterfaceFactory =
         (network, parameters) => new LiteNetLibInterface(network, parameters);
 


### PR DESCRIPTION
- add `IsDeveloper` to the application context, this is true when the client host is non-public or failed to be resolved and false in all other cases
- Version indicator is shown in bottom left corner of main menu
- Version indicator is shown in bottom left corner of in-game escape menu (not including the simplified menu)
- make version label copy version string to clipboard on click