### PR TITLE
fix black text on combobox when losing keyboard focus

### DIFF
--- a/Intersect.Client.Framework/Gwen/Control/ComboBox.cs
+++ b/Intersect.Client.Framework/Gwen/Control/ComboBox.cs
@@ -358,7 +358,7 @@ public partial class ComboBox : Button
             return;
         }
 
-        TextColor = Color.Black;
+        UpdateColors();
     }
 
     /// <summary>
@@ -374,7 +374,7 @@ public partial class ComboBox : Button
             return;
         }
 
-        TextColor = Color.White;
+        UpdateColors();
     }
 
     /// <summary>


### PR DESCRIPTION
(most easily reproducible by clicking another combobox like Resolution -> FPS in settings)