### PR TITLE
Update texture name to avoid EnsureTextureLoaded() reloading the nulled-out texture #2561

### DIFF
--- a/Intersect.Client.Framework/Gwen/Control/ImagePanel.cs
+++ b/Intersect.Client.Framework/Gwen/Control/ImagePanel.cs
@@ -81,6 +81,7 @@ public partial class ImagePanel : Base
             }
 
             _texture = value;
+            _textureName = _texture?.Name;
             RecomputeTextureSourceBounds();
             if (_texture != null)
             {


### PR DESCRIPTION
Resolves #2561 