### PR TITLE
feat: Add TextColorParser for colorized text support in event window

### DIFF
--- a/Framework/Intersect.Framework.Core/Color.cs
+++ b/Framework/Intersect.Framework.Core/Color.cs
@@ -331,15 +331,14 @@ public partial class Color : IEquatable<Color>
             return colorFunc();
         }
 
-        Color? parsedColor = Color.FromHex(val, defaultColor);
-
-        parsedColor ??= Color.FromCsv(val, defaultColor);
+        Color? parsedColor = Color.FromHex(val);
+        parsedColor ??= Color.FromCsv(val);
 
         return parsedColor ?? defaultColor;
     }
 
 
-    public static implicit operator Color(string colorString) => FromCsv(colorString);
+    public static implicit operator Color(string colorString) => FromString(colorString);
 
     public static Color operator *(Color left, Color right) => new Color(
         a: (int)(left.A * right.A / 255f),

--- a/Framework/Intersect.Framework.Core/Color.cs
+++ b/Framework/Intersect.Framework.Core/Color.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Reflection;
 using Intersect.Framework;
 using Intersect.Localization;
 using MessagePack;
@@ -9,7 +10,17 @@ namespace Intersect;
 [MessagePackObject]
 public partial class Color : IEquatable<Color>
 {
-
+    private static readonly Dictionary<string, Func<Color>> KnownColors;
+    static Color()
+    {
+        KnownColors = typeof(Color)
+            .GetProperties(BindingFlags.Public | BindingFlags.Static)
+            .Where(p => p.PropertyType == typeof(Color) && p.GetMethod != null)
+            .ToDictionary(
+                p => p.Name.ToLowerInvariant(),
+                p => (Func<Color>)(() => p.GetMethod?.Invoke(null, null) as Color ?? Color.White)
+            );
+    }
     public enum ChatColor
     {
 
@@ -289,7 +300,7 @@ public partial class Color : IEquatable<Color>
         return new Color(a: a, r: r, g: g, b: b);
     }
 
-    public static Color? FromString(string val, Color? defaultColor = default)
+    public static Color? FromCsv(string val, Color? defaultColor = default)
     {
         if (string.IsNullOrEmpty(val))
         {
@@ -306,7 +317,29 @@ public partial class Color : IEquatable<Color>
         return new Color(parts[0], parts[1], parts[2], parts[3]);
     }
 
-    public static implicit operator Color(string colorString) => FromString(colorString);
+    public static Color? FromString(string val, Color? defaultColor = default)
+    {
+        if (string.IsNullOrWhiteSpace(val))
+        {
+            return defaultColor;
+        }
+
+        val = val.Trim().ToLowerInvariant();
+
+        if (KnownColors.TryGetValue(val, out Func<Color>? colorFunc))
+        {
+            return colorFunc();
+        }
+
+        Color? parsedColor = Color.FromHex(val, defaultColor);
+
+        parsedColor ??= Color.FromCsv(val, defaultColor);
+
+        return parsedColor ?? defaultColor;
+    }
+
+
+    public static implicit operator Color(string colorString) => FromCsv(colorString);
 
     public static Color operator *(Color left, Color right) => new Color(
         a: (int)(left.A * right.A / 255f),

--- a/Intersect.Client.Core/Interface/Game/EventWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/EventWindow.cs
@@ -175,9 +175,11 @@ public partial class EventWindow : Panel
         if (_typewriting)
         {
             _promptLabel.ClearText();
-            _writer = new Typewriter(_dialog.Prompt ?? string.Empty, text => _promptLabel.AppendText(text, _promptTemplateLabel));
+            _writer = new Typewriter(parsedText.ToArray(), (text, color) =>
+            {
+                _promptLabel.AddText(text, color, Alignments.Left, _promptTemplateLabel.Font);
+            });
         }
-
         Defer(
             () =>
             {

--- a/Intersect.Client.Core/Interface/Game/EventWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/EventWindow.cs
@@ -177,7 +177,7 @@ public partial class EventWindow : Panel
             _promptLabel.ClearText();
             _writer = new Typewriter(parsedText.ToArray(), (text, color) =>
             {
-                _promptLabel.AddText(text, color, Alignments.Left, _promptTemplateLabel.Font);
+                _promptLabel.AppendText(text, color, Alignments.Left, _promptTemplateLabel.Font);
             });
         }
         Defer(

--- a/Intersect.Client.Core/Interface/Game/EventWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/EventWindow.cs
@@ -10,6 +10,7 @@ using Intersect.Client.General;
 using Intersect.Client.Interface.Game.Typewriting;
 using Intersect.Client.Localization;
 using Intersect.Client.Networking;
+using Intersect.Client.Utilities;
 using Intersect.Configuration;
 using Intersect.Enums;
 using Intersect.Utilities;
@@ -160,8 +161,13 @@ public partial class EventWindow : Panel
         SkipRender();
 
         _promptLabel.ClearText();
-        _promptLabel.AddText(_dialog.Prompt ?? string.Empty, _promptTemplateLabel);
-        _promptLabel.ForceImmediateRebuild();
+        var parsedText = TextColorParser.Parse(_dialog.Prompt ?? string.Empty, Color.White);
+
+        foreach (var segment in parsedText)
+        {
+            _promptLabel.AddText(segment.Text, segment.Color, Alignments.Left, _promptTemplateLabel.Font);
+        }
+
         _ = _promptLabel.SizeToChildren();
 
         _typewriting = ClientConfiguration.Instance.TypewriterEnabled &&

--- a/Intersect.Client.Core/Interface/Game/Typewriting/Typewriter.cs
+++ b/Intersect.Client.Core/Interface/Game/Typewriting/Typewriter.cs
@@ -15,7 +15,7 @@ internal sealed class Typewriter
     private static long TypingSpeed => ClientConfiguration.Instance.TypewriterPartDelay;
 
     private int _offset;
-    private int _segmentIndex = 0;
+    private int _segmentIndex;
     private string? _lastText;
     private long _nextUpdateTime;
 
@@ -63,6 +63,8 @@ internal sealed class Typewriter
                 return;
             }
 
+            emitSound |= _offset % ClientConfiguration.Instance.TypewriterSoundFrequency == 0;
+
             var segment = _segments[_segmentIndex];
 
             if (_offset >= segment.Text.Length)
@@ -73,13 +75,11 @@ internal sealed class Typewriter
                 if (_segmentIndex >= _segments.Length)
                 {
                     End();
-                    return;
+                    continue;
                 }
 
                 segment = _segments[_segmentIndex];
             }
-
-            emitSound |= _offset % ClientConfiguration.Instance.TypewriterSoundFrequency == 0;
 
             string nextText;
             if (char.IsSurrogatePair(segment.Text, _offset))
@@ -144,7 +144,7 @@ internal sealed class Typewriter
             var segment = _segments[_segmentIndex];
             if (_offset < segment.Text.Length)
             {
-                _textWrittenHandler(segment.Text.Substring(_offset), segment.Color);
+                _textWrittenHandler(segment.Text[_offset..], segment.Color);
             }
             _segmentIndex++;
             _offset = 0;

--- a/Intersect.Client.Core/Interface/Game/Typewriting/Typewriter.cs
+++ b/Intersect.Client.Core/Interface/Game/Typewriting/Typewriter.cs
@@ -1,4 +1,5 @@
 using Intersect.Client.Core;
+using Intersect.Client.Utilities;
 using Intersect.Configuration;
 using Intersect.Utilities;
 
@@ -6,8 +7,7 @@ namespace Intersect.Client.Interface.Game.Typewriting;
 
 internal sealed class Typewriter
 {
-    public delegate void TextWrittenHandler(string text);
-
+    public delegate void TextWrittenHandler(string text, Color color);
     private static HashSet<string> FullStops => ClientConfiguration.Instance.TypewriterFullStops;
     private static long FullStopSpeed => ClientConfiguration.Instance.TypewriterFullStopDelay;
     private static HashSet<string> PartialStops => ClientConfiguration.Instance.TypewriterPauses;
@@ -15,24 +15,24 @@ internal sealed class Typewriter
     private static long TypingSpeed => ClientConfiguration.Instance.TypewriterPartDelay;
 
     private int _offset;
+    private int _segmentIndex = 0;
     private string? _lastText;
     private long _nextUpdateTime;
 
     private readonly TextWrittenHandler _textWrittenHandler;
-    private readonly string _text;
+    private readonly ColorizedText[] _segments;
 
     public bool IsDone { get; private set; }
     public long DoneAtMilliseconds { get; private set; }
 
-    public Typewriter(string text, TextWrittenHandler textWrittenHandler)
+    public Typewriter(ColorizedText[] segments, TextWrittenHandler textWrittenHandler)
     {
-        _text = text.ReplaceLineEndings("\n");
+        _segments = segments;
         _textWrittenHandler = textWrittenHandler;
         _nextUpdateTime = Timing.Global.MillisecondsUtc;
-
+        _segmentIndex = 0;
         _offset = 0;
         _lastText = null;
-
         IsDone = false;
     }
 
@@ -43,7 +43,7 @@ internal sealed class Typewriter
             return;
         }
 
-        if (_offset >= _text.Length)
+        if (_segmentIndex >= _segments.Length)
         {
             End();
             return;
@@ -57,28 +57,44 @@ internal sealed class Typewriter
         var emitSound = false;
         while (_nextUpdateTime <= Timing.Global.MillisecondsUtc)
         {
-            if (_offset >= _text.Length)
+            if (_segmentIndex >= _segments.Length)
             {
                 End();
-                break;
+                return;
+            }
+
+            var segment = _segments[_segmentIndex];
+
+            if (_offset >= segment.Text.Length)
+            {
+                _offset = 0;
+                _segmentIndex++;
+
+                if (_segmentIndex >= _segments.Length)
+                {
+                    End();
+                    return;
+                }
+
+                segment = _segments[_segmentIndex];
             }
 
             emitSound |= _offset % ClientConfiguration.Instance.TypewriterSoundFrequency == 0;
 
             string nextText;
-            if (char.IsSurrogatePair(_text, _offset))
+            if (char.IsSurrogatePair(segment.Text, _offset))
             {
-                nextText = _text[_offset..(_offset + 2)];
+                nextText = segment.Text[_offset..(_offset + 2)];
                 _offset += 2;
             }
             else
             {
-                nextText = _text[_offset..(_offset + 1)];
+                nextText = segment.Text[_offset..(_offset + 1)];
                 ++_offset;
             }
 
             _nextUpdateTime += GetTypingDelayFor(nextText, _lastText);
-            _textWrittenHandler(nextText);
+            _textWrittenHandler(nextText, segment.Color);
             _lastText = nextText;
         }
 
@@ -118,14 +134,20 @@ internal sealed class Typewriter
 
     public void End()
     {
-        if (IsDone || _text.Length < 1)
+        if (IsDone)
         {
             return;
         }
 
-        if (_offset < _text.Length)
+        while (_segmentIndex < _segments.Length)
         {
-            _textWrittenHandler(_text[_offset..]);
+            var segment = _segments[_segmentIndex];
+            if (_offset < segment.Text.Length)
+            {
+                _textWrittenHandler(segment.Text.Substring(_offset), segment.Color);
+            }
+            _segmentIndex++;
+            _offset = 0;
         }
 
         IsDone = true;

--- a/Intersect.Client.Core/Utilities/TextColorParser.cs
+++ b/Intersect.Client.Core/Utilities/TextColorParser.cs
@@ -5,45 +5,24 @@ namespace Intersect.Client.Utilities
 {
     public static class TextColorParser
     {
-        private static readonly Dictionary<string, Func<Color>> KnownColors = InitializeColorDictionary();
-        private static readonly Regex ColorTagRegex = new(@"\\c{([^}]*)}", RegexOptions.Compiled);
+        private static readonly Regex ColorTagRegex = new(@"(\\c{[^}]*})", RegexOptions.Compiled);
         private static readonly string SplitPattern = @"(\\c{[^}]*})";
-
-        private static Dictionary<string, Func<Color>> InitializeColorDictionary()
-        {
-            return typeof(Color)
-                .GetProperties(BindingFlags.Public | BindingFlags.Static)
-                .Where(p => p.PropertyType == typeof(Color))
-                .ToDictionary(
-                    p => p.Name.ToLowerInvariant(),
-                    p => (Func<Color>)(() => p.GetMethod?.Invoke(null, null) as Color ?? Color.White)
-                );
-        }
 
         public static List<ColorizedText> Parse(string text, Color defaultColor)
         {
-            var output = new List<ColorizedText>();
-            var segments = Regex.Split(text, SplitPattern)
-                .Where(s => !string.IsNullOrWhiteSpace(s));
+            var segments = ColorTagRegex.Split(text)
+                .Where(s => !string.IsNullOrWhiteSpace(s))
+                .ToArray();
 
+            var output = new List<ColorizedText>(segments.Length);
             var currentColor = defaultColor;
 
             foreach (var segment in segments)
             {
-                var match = ColorTagRegex.Match(segment);
-
-                if (match.Success)
+                if (segment.StartsWith("\\c{") && segment.EndsWith("}"))
                 {
-                    string colorCode = match.Groups[1].Value.ToLowerInvariant();
-
-                    if (KnownColors.TryGetValue(colorCode, out Func<Color>? colorFunc))
-                    {
-                        currentColor = colorFunc();
-                    }
-                    else
-                    {
-                        currentColor = Color.FromHex(colorCode, defaultColor) ?? defaultColor;
-                    }
+                    string colorCode = segment[3..^1].ToLowerInvariant();
+                    currentColor = Color.FromString(colorCode, defaultColor) ?? defaultColor;
                 }
                 else
                 {

--- a/Intersect.Client.Core/Utilities/TextColorParser.cs
+++ b/Intersect.Client.Core/Utilities/TextColorParser.cs
@@ -21,7 +21,7 @@ namespace Intersect.Client.Utilities
                 if (segment.StartsWith("\\c{") && segment.EndsWith("}"))
                 {
                     string colorCode = segment[3..^1].ToLowerInvariant();
-                    currentColor = Color.FromString(colorCode, defaultColor) ?? defaultColor;
+                    currentColor = Color.FromString(colorCode, defaultColor);
                 }
                 else
                 {

--- a/Intersect.Client.Core/Utilities/TextColorParser.cs
+++ b/Intersect.Client.Core/Utilities/TextColorParser.cs
@@ -1,0 +1,69 @@
+using System.Reflection;
+using System.Text.RegularExpressions;
+
+namespace Intersect.Client.Utilities
+{
+    public static class TextColorParser
+    {
+        private static readonly Dictionary<string, Func<Color>> KnownColors = InitializeColorDictionary();
+        private static readonly Regex ColorTagRegex = new(@"\\c{([^}]*)}", RegexOptions.Compiled);
+        private static readonly string SplitPattern = @"(\\c{[^}]*})";
+
+        private static Dictionary<string, Func<Color>> InitializeColorDictionary()
+        {
+            return typeof(Color)
+                .GetProperties(BindingFlags.Public | BindingFlags.Static)
+                .Where(p => p.PropertyType == typeof(Color))
+                .ToDictionary(
+                    p => p.Name.ToLowerInvariant(),
+                    p => (Func<Color>)(() => p.GetMethod?.Invoke(null, null) as Color ?? Color.White)
+                );
+        }
+
+        public static List<ColorizedText> Parse(string text, Color defaultColor)
+        {
+            var output = new List<ColorizedText>();
+            var segments = Regex.Split(text, SplitPattern)
+                .Where(s => !string.IsNullOrWhiteSpace(s));
+
+            var currentColor = defaultColor;
+
+            foreach (var segment in segments)
+            {
+                var match = ColorTagRegex.Match(segment);
+
+                if (match.Success)
+                {
+                    string colorCode = match.Groups[1].Value.ToLowerInvariant();
+
+                    if (KnownColors.TryGetValue(colorCode, out Func<Color>? colorFunc))
+                    {
+                        currentColor = colorFunc();
+                    }
+                    else
+                    {
+                        currentColor = Color.FromHex(colorCode, defaultColor) ?? defaultColor;
+                    }
+                }
+                else
+                {
+                    output.Add(new ColorizedText(segment, currentColor));
+                }
+            }
+
+            return output;
+        }
+    }
+
+    public class ColorizedText
+    {
+        public string Text { get; }
+        public Color Color { get; }
+
+        public ColorizedText(string text, Color color)
+        {
+            Text = text;
+            Color = color;
+        }
+    }
+}

--- a/Intersect.Client.Core/Utilities/TextColorParser.cs
+++ b/Intersect.Client.Core/Utilities/TextColorParser.cs
@@ -6,7 +6,6 @@ namespace Intersect.Client.Utilities
     public static class TextColorParser
     {
         private static readonly Regex ColorTagRegex = new(@"(\\c{[^}]*})", RegexOptions.Compiled);
-        private static readonly string SplitPattern = @"(\\c{[^}]*})";
 
         public static List<ColorizedText> Parse(string text, Color defaultColor)
         {

--- a/Intersect.Client.Framework/Gwen/Control/RichLabel.cs
+++ b/Intersect.Client.Framework/Gwen/Control/RichLabel.cs
@@ -183,8 +183,8 @@ public partial class RichLabel : Base
             var appendAlignment = alignment;
             var appendFont = font ?? lastTextBlock.Font;
 
-            if (appendAlignment != lastTextBlock.Alignment &&
-                appendColor != lastTextBlock.Color &&
+            if (appendAlignment != lastTextBlock.Alignment ||
+                appendColor != lastTextBlock.Color ||
                 appendFont != lastTextBlock.Font)
             {
                 AddText(text, color, alignment, font);


### PR DESCRIPTION
This PR introduces `TextColorParser`, enabling **colorized text support** in the event window. It allows uers to specify text colors using:
- **Known colors** (e.g., `\c{red}Red text\c{}`)
- **Hex color codes** (e.g., `\c{#87CEEB}Hexcooode text\c{}`)

### Example Usage in Event Editor
```plaintext
None of the above. \c{red}Red text\c{} next text \c{#87CEEB}Hexcooode text\c{} \c{red}Red text\c{}
```
![image](https://github.com/user-attachments/assets/9291a0de-cf04-44bf-9eaa-459cd6ef3407)

