### PR TITLE
add ForceImmediateRebuild() back to properly compute prompt label height for long text

### DIFF
--- a/Intersect.Client.Core/Interface/Game/EventWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/EventWindow.cs
@@ -171,6 +171,8 @@ public partial class EventWindow : Panel
             _promptLabel.AddText(segment.Text, segment.Color, Alignments.Left, _promptTemplateLabel.Font);
         }
 
+        _promptLabel.ForceImmediateRebuild();
+
         _ = _promptLabel.SizeToChildren();
 
         _typewriting = ClientConfiguration.Instance.TypewriterEnabled &&


### PR DESCRIPTION
Resolves #2583 