### PR TITLE
fix: select character arrow visibility

### DIFF
--- a/Intersect.Client.Core/Interface/Menu/SelectCharacterWindow.cs
+++ b/Intersect.Client.Core/Interface/Menu/SelectCharacterWindow.cs
@@ -173,7 +173,7 @@ public partial class SelectCharacterWindow : Window
         SizeToChildren(recursive: true);
 
         LoadJsonUi(GameContentManager.UI.Menu, Graphics.Renderer?.GetResolutionString());
-        _ensureArrowsVisibility();
+        EnsureArrowsVisibility();
     }
 
     //Methods
@@ -341,10 +341,10 @@ public partial class SelectCharacterWindow : Window
         _selectedCharacterIndex = 0;
         UpdateDisplay();
         base.Show();
-        _ensureArrowsVisibility();
+        EnsureArrowsVisibility();
     }
 
-    private void _ensureArrowsVisibility()
+    private void EnsureArrowsVisibility()
     {
         // in case the json load is changing the visibility of the arrows when it shouldn't
         // lets ensure the right value

--- a/Intersect.Client.Core/Interface/Menu/SelectCharacterWindow.cs
+++ b/Intersect.Client.Core/Interface/Menu/SelectCharacterWindow.cs
@@ -173,6 +173,14 @@ public partial class SelectCharacterWindow : Window
         SizeToChildren(recursive: true);
 
         LoadJsonUi(GameContentManager.UI.Menu, Graphics.Renderer?.GetResolutionString());
+
+        // in case the json load is changing the visibility of the arrows when it shouldn't
+        // lets ensure the right value
+        if (CharacterSelectionPreviews != default)
+        {
+            _selectCharacterRightButton.IsHidden = CharacterSelectionPreviews.Length <= 1;
+            _selectCharacterLeftButton.IsHidden = CharacterSelectionPreviews.Length <= 1;
+        }
     }
 
     //Methods

--- a/Intersect.Client.Core/Interface/Menu/SelectCharacterWindow.cs
+++ b/Intersect.Client.Core/Interface/Menu/SelectCharacterWindow.cs
@@ -173,14 +173,7 @@ public partial class SelectCharacterWindow : Window
         SizeToChildren(recursive: true);
 
         LoadJsonUi(GameContentManager.UI.Menu, Graphics.Renderer?.GetResolutionString());
-
-        // in case the json load is changing the visibility of the arrows when it shouldn't
-        // lets ensure the right value
-        if (CharacterSelectionPreviews != default)
-        {
-            _selectCharacterRightButton.IsHidden = CharacterSelectionPreviews.Length <= 1;
-            _selectCharacterLeftButton.IsHidden = CharacterSelectionPreviews.Length <= 1;
-        }
+        _ensureArrowsVisibility();
     }
 
     //Methods
@@ -348,6 +341,18 @@ public partial class SelectCharacterWindow : Window
         _selectedCharacterIndex = 0;
         UpdateDisplay();
         base.Show();
+        _ensureArrowsVisibility();
+    }
+
+    private void _ensureArrowsVisibility()
+    {
+        // in case the json load is changing the visibility of the arrows when it shouldn't
+        // lets ensure the right value
+        if (CharacterSelectionPreviews != default)
+        {
+            _selectCharacterRightButton.IsHidden = CharacterSelectionPreviews.Length <= 1;
+            _selectCharacterLeftButton.IsHidden = CharacterSelectionPreviews.Length <= 1;
+        }
     }
 
     private void _buttonLogout_Clicked(Base sender, MouseButtonState arguments)


### PR DESCRIPTION
resolves #2604 

UpdateDisplay() is called before EnsureEnsureInitialized()

Update display hides the arrows, when the condition is true, EnsureEnsureInitialized loads the json value which is false, so the arrows appear when they shouldn't