### PR TITLE
cleanup shop window/item

### DIFF
--- a/Intersect.Client.Core/Interface/Game/GameInterface.cs
+++ b/Intersect.Client.Core/Interface/Game/GameInterface.cs
@@ -583,7 +583,7 @@ public partial class GameInterface : MutableInterface
             closedWindows = true;
         }
 
-        if (mShopWindow is { IsVisibleInTree: false })
+        if (mShopWindow is { IsVisibleInTree: true })
         {
             CloseShop();
             closedWindows = true;

--- a/Intersect.Client.Core/Interface/Game/GameInterface.cs
+++ b/Intersect.Client.Core/Interface/Game/GameInterface.cs
@@ -209,9 +209,7 @@ public partial class GameInterface : MutableInterface
 
     public void OpenShop()
     {
-        mShopWindow?.Close();
-
-        mShopWindow = new ShopWindow(GameCanvas);
+        mShopWindow = new ShopWindow(GameCanvas) { DeleteOnClose = true };
         mShouldOpenShop = false;
     }
 
@@ -392,7 +390,7 @@ public partial class GameInterface : MutableInterface
             GameMenu.OpenInventory();
         }
 
-        if (mShopWindow != null && (!mShopWindow.IsVisible() || mShouldCloseShop))
+        if (mShopWindow != null && (mShopWindow.IsHidden || mShouldCloseShop))
         {
             CloseShop();
         }
@@ -521,7 +519,7 @@ public partial class GameInterface : MutableInterface
     private void CloseShop()
     {
         Globals.GameShop = null;
-        mShopWindow?.Close();
+        mShopWindow?.Hide();
         mShopWindow = null;
         PacketSender.SendCloseShop();
     }
@@ -585,7 +583,7 @@ public partial class GameInterface : MutableInterface
             closedWindows = true;
         }
 
-        if (mShopWindow != null && mShopWindow.IsVisible())
+        if (mShopWindow != null && !mShopWindow.IsHidden)
         {
             CloseShop();
             closedWindows = true;

--- a/Intersect.Client.Core/Interface/Game/GameInterface.cs
+++ b/Intersect.Client.Core/Interface/Game/GameInterface.cs
@@ -390,7 +390,7 @@ public partial class GameInterface : MutableInterface
             GameMenu.OpenInventory();
         }
 
-        if (mShopWindow != null && (mShopWindow.IsHidden || mShouldCloseShop))
+        if (mShopWindow != null && (!mShopWindow.IsVisibleInTree || mShouldCloseShop))
         {
             CloseShop();
         }
@@ -583,7 +583,7 @@ public partial class GameInterface : MutableInterface
             closedWindows = true;
         }
 
-        if (mShopWindow != null && !mShopWindow.IsHidden)
+        if (mShopWindow is { IsVisibleInTree: false })
         {
             CloseShop();
             closedWindows = true;

--- a/Intersect.Client.Core/Interface/Game/Shop/ShopItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Shop/ShopItem.cs
@@ -51,7 +51,7 @@ public partial class ShopItem : ImagePanel
         // TODO: Refactor so shop only has 1 context menu shared between all items
         _contextMenu = new ContextMenu(Interface.CurrentInterface.Root, "ShopContextMenu")
         {
-            IsHidden = true,
+            IsVisibleInParent = false,
             IconMarginDisabled = true,
             ItemFont = GameContentManager.Current.GetFont(name: "sourcesansproblack"),
             ItemFontSize = 10,

--- a/Intersect.Client.Core/Interface/Game/Shop/ShopItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Shop/ShopItem.cs
@@ -28,20 +28,37 @@ public partial class ShopItem : ImagePanel
         _shopWindow = shopWindow;
         _mySlot = index;
 
-        _iconImage = new ImagePanel(this, "ShopItemIcon");
+        MinimumSize = new Point(34, 35);
+        Margin = new Margin(4, 4, 4, 4);
+        MouseInputEnabled = true;
+        TextureFilename = "shopitem.png";
+
+        _iconImage = new ImagePanel(this, "ShopItemIcon")
+        {
+            MinimumSize = new Point(32, 32),
+            MouseInputEnabled = true,
+            Alignment = [Alignments.Center],
+            HoverSound = "octave-tap-resonant.wav",
+        };
         _iconImage.HoverEnter += _iconImage_HoverEnter;
         _iconImage.HoverLeave += _iconImage_HoverLeave;
         _iconImage.Clicked += _iconImage_RightClicked;
         _iconImage.DoubleClicked += _iconImage_DoubleClicked;
 
+        LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
+
         // Generate our context menu with basic options.
         _contextMenu = new ContextMenu(Interface.CurrentInterface.Root, "ShopContextMenu")
         {
             IsHidden = true,
-            IconMarginDisabled = true
+            IconMarginDisabled = true,
         };
 
-        LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
+        var font = GameContentManager.Current.GetFont(name: "sourcesansproblack");
+        if (font != default)
+        {
+            _contextMenu.SetItemFont(font, 10);
+        }
 
         //TODO: Is this a memory leak?
         _contextMenu.ClearChildren();

--- a/Intersect.Client.Core/Interface/Game/Shop/ShopItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Shop/ShopItem.cs
@@ -1,5 +1,6 @@
-using Intersect.Client.Framework.GenericClasses;
-using Intersect.Client.Framework.Graphics;
+using Intersect.Client.Core;
+using Intersect.Client.Framework.File_Management;
+using Intersect.Client.Framework.Gwen;
 using Intersect.Client.Framework.Gwen.Control;
 using Intersect.Client.Framework.Gwen.Control.EventArguments;
 using Intersect.Client.Framework.Gwen.Input;
@@ -13,102 +14,45 @@ using Intersect.Network.Packets.Server;
 
 namespace Intersect.Client.Interface.Game.Shop;
 
-
-public partial class ShopItem
+public partial class ShopItem : ImagePanel
 {
+    private readonly int _mySlot;
+    private readonly ShopWindow _shopWindow;
+    public ImagePanel _iconImage;
+    private readonly ContextMenu _contextMenu;
+    private readonly MenuItem _buyMenuItem;
+    private ItemDescriptionWindow? _itemDescWindow;
 
-    public ImagePanel Container;
-
-    private int mCurrentItem = -2;
-
-    private ItemDescriptionWindow mDescWindow;
-
-    private bool mIsEquipped;
-
-    //Mouse Event Variables
-    private bool mMouseOver;
-
-    private int mMouseX = -1;
-
-    private int mMouseY = -1;
-
-    //Slot info
-    private int mMySlot;
-
-    //Textures
-    private IGameRenderTexture mSfTex;
-
-    //Drag/Drop References
-    private ShopWindow mShopWindow;
-
-    public ImagePanel Pnl;
-
-    public ShopItem(ShopWindow shopWindow, int index)
+    public ShopItem(ShopWindow shopWindow, Base parent, int index) : base(parent, nameof(ShopItem))
     {
-        mShopWindow = shopWindow;
-        mMySlot = index;
-    }
+        _shopWindow = shopWindow;
+        _mySlot = index;
 
-    public void Setup()
-    {
-        Pnl = new ImagePanel(Container, "ShopItemIcon");
-        Pnl.HoverEnter += pnl_HoverEnter;
-        Pnl.HoverLeave += pnl_HoverLeave;
-        Pnl.Clicked += Pnl_RightClicked;
-        Pnl.DoubleClicked += Pnl_DoubleClicked;
-    }
+        _iconImage = new ImagePanel(this, "ShopItemIcon");
+        _iconImage.HoverEnter += _iconImage_HoverEnter;
+        _iconImage.HoverLeave += _iconImage_HoverLeave;
+        _iconImage.Clicked += _iconImage_RightClicked;
+        _iconImage.DoubleClicked += _iconImage_DoubleClicked;
 
-    private void Pnl_DoubleClicked(Base sender, MouseButtonState arguments)
-    {
-        Globals.Me?.TryBuyItem(mMySlot);
-    }
-
-    private void Pnl_RightClicked(Base sender, MouseButtonState arguments)
-    {
-        if (arguments.MouseButton != MouseButton.Right)
+        // Generate our context menu with basic options.
+        _contextMenu = new ContextMenu(Interface.CurrentInterface.Root, "ShopContextMenu")
         {
-            return;
-        }
+            IsHidden = true,
+            IconMarginDisabled = true
+        };
 
-        if (ClientConfiguration.Instance.EnableContextMenus)
-        {
-            mShopWindow.OpenContextMenu(mMySlot);
-        }
-        else
-        {
-            Pnl_DoubleClicked(sender, arguments);
-        }
+        LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
+
+        //TODO: Is this a memory leak?
+        _contextMenu.ClearChildren();
+        _buyMenuItem = _contextMenu.AddItem(Strings.ShopContextMenu.Buy);
+        _buyMenuItem.Clicked += _buyMenuItem_Clicked;
+        _contextMenu.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
+
+        LoadItem();
     }
 
-    public void LoadItem()
-    {
-        var item = ItemBase.Get(Globals.GameShop.SellingItems[mMySlot].ItemId);
-        if (item != null)
-        {
-            var itemTex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Item, item.Icon);
-            if (itemTex != null)
-            {
-                Pnl.Texture = itemTex;
-                Pnl.RenderColor = item.Color;
-            }
-        }
-    }
-
-
-
-    void pnl_HoverLeave(Base sender, EventArgs arguments)
-    {
-        mMouseOver = false;
-        mMouseX = -1;
-        mMouseY = -1;
-        if (mDescWindow != null)
-        {
-            mDescWindow.Dispose();
-            mDescWindow = null;
-        }
-    }
-
-    void pnl_HoverEnter(Base sender, EventArgs arguments)
+    private void _iconImage_HoverEnter(Base sender, EventArgs arguments)
     {
         if (InputHandler.MouseFocus != null)
         {
@@ -120,42 +64,118 @@ public partial class ShopItem
             return;
         }
 
-        if (mDescWindow != null)
+        if (_itemDescWindow != default)
         {
-            mDescWindow.Dispose();
-            mDescWindow = null;
+            _itemDescWindow.Dispose();
+            _itemDescWindow = default;
         }
 
-        var item = ItemBase.Get(Globals.GameShop.SellingItems[mMySlot].CostItemId);
-        if (item != null && Globals.GameShop.SellingItems[mMySlot].Item != null)
+        if (Globals.GameShop == default || Globals.GameShop.SellingItems.Count == 0)
+        {
+            return;
+        }
+
+        if (!ItemBase.TryGet(Globals.GameShop.SellingItems[_mySlot].CostItemId, out var item))
+        {
+            return;
+        }
+
+        if (Globals.GameShop.SellingItems[_mySlot].Item != default)
         {
             ItemProperties itemProperty = new ItemProperties()
             {
                 StatModifiers = item.StatsGiven,
             };
 
-            mDescWindow = new ItemDescriptionWindow(
-                Globals.GameShop.SellingItems[mMySlot].Item, 1, mShopWindow.X, mShopWindow.Y, itemProperty, "",
-                Strings.Shop.Costs.ToString(Globals.GameShop.SellingItems[mMySlot].CostItemQuantity, item.Name)
+            _itemDescWindow = new ItemDescriptionWindow(
+                item: Globals.GameShop.SellingItems[_mySlot].Item,
+                amount: 1,
+                x: _shopWindow.X,
+                y: _shopWindow.Y,
+                itemProperties: itemProperty,
+                valueLabel: Strings.Shop.Costs.ToString(Globals.GameShop.SellingItems[_mySlot].CostItemQuantity, item.Name)
             );
         }
     }
 
-    public FloatRect RenderBounds()
+    private void _iconImage_HoverLeave(Base sender, EventArgs arguments)
     {
-        var rect = new FloatRect()
+        if (_itemDescWindow != null)
         {
-            X = Pnl.ToCanvas(new Point(0, 0)).X,
-            Y = Pnl.ToCanvas(new Point(0, 0)).Y,
-            Width = Pnl.Width,
-            Height = Pnl.Height
-        };
-
-        return rect;
+            _itemDescWindow.Dispose();
+            _itemDescWindow = null;
+        }
     }
 
-    public void Update()
+    private void _iconImage_RightClicked(Base sender, MouseButtonState arguments)
     {
+        if (arguments.MouseButton != MouseButton.Right)
+        {
+            return;
+        }
+
+        if (ClientConfiguration.Instance.EnableContextMenus)
+        {
+            OpenContextMenu(_mySlot);
+        }
+        else
+        {
+            _iconImage_DoubleClicked(sender, arguments);
+        }
     }
 
+    private void _iconImage_DoubleClicked(Base sender, MouseButtonState arguments)
+    {
+        Globals.Me?.TryBuyItem(_mySlot);
+    }
+
+    private void _buyMenuItem_Clicked(Base sender, Framework.Gwen.Control.EventArguments.MouseButtonState arguments)
+    {
+        if (sender.Parent?.UserData is not int slot)
+        {
+            return;
+        }
+
+        Globals.Me?.TryBuyItem(slot);
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        _contextMenu?.Close();
+        base.Dispose(disposing);
+    }
+
+    public void OpenContextMenu(int slot)
+    {
+        if (Globals.GameShop?.SellingItems[slot] == default)
+        {
+            return;
+        }
+
+        if (!ItemBase.TryGet(Globals.GameShop.SellingItems[slot].ItemId, out var item))
+        {
+            return;
+        }
+
+        _buyMenuItem.SetText(Strings.ShopContextMenu.Buy.ToString(item.Name));
+
+        _contextMenu.UserData = slot;
+        _contextMenu.SizeToChildren();
+        _contextMenu.Open(Pos.None);
+    }
+
+    public void LoadItem()
+    {
+        if (Globals.GameShop == default || !ItemBase.TryGet(Globals.GameShop.SellingItems[_mySlot].ItemId, out var item))
+        {
+            return;
+        }
+
+        var itemTex = Globals.ContentManager?.GetTexture(Framework.Content.TextureType.Item, item.Icon);
+        if (itemTex != null)
+        {
+            _iconImage.Texture = itemTex;
+            _iconImage.RenderColor = item.Color;
+        }
+    }
 }

--- a/Intersect.Client.Core/Interface/Game/Shop/ShopItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Shop/ShopItem.cs
@@ -145,12 +145,7 @@ public partial class ShopItem : ImagePanel
 
     private void _buyMenuItem_Clicked(Base sender, Framework.Gwen.Control.EventArguments.MouseButtonState arguments)
     {
-        if (sender.Parent?.UserData is not int slot)
-        {
-            return;
-        }
-
-        Globals.Me?.TryBuyItem(slot);
+        Globals.Me?.TryBuyItem(_mySlot);
     }
 
     protected override void Dispose(bool disposing)
@@ -161,20 +156,17 @@ public partial class ShopItem : ImagePanel
 
     public void OpenContextMenu(int slot)
     {
-        if (Globals.GameShop?.SellingItems[slot] == default)
+        if (Globals.GameShop is not { SellingItems.Count: > 0 } gameShop)
         {
             return;
         }
 
-        if (!ItemBase.TryGet(Globals.GameShop.SellingItems[slot].ItemId, out var item))
+        if (!ItemBase.TryGet(gameShop.SellingItems[slot].ItemId, out var item))
         {
             return;
         }
 
         _buyMenuItem.SetText(Strings.ShopContextMenu.Buy.ToString(item.Name));
-
-        _contextMenu.UserData = slot;
-        _contextMenu.SizeToChildren();
         _contextMenu.Open(Pos.None);
     }
 

--- a/Intersect.Client.Core/Interface/Game/Shop/ShopWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Shop/ShopWindow.cs
@@ -18,7 +18,7 @@ public partial class ShopWindow : Window
         Interface.InputBlockingComponents.Add(this);
 
         Alignment = [Alignments.Center];
-        MinimumSize = new Point(x: 442, y: 469);
+        MinimumSize = new Point(x: 435, y: 469);
         IsResizable = false;
         IsClosable = true;
 
@@ -41,30 +41,27 @@ public partial class ShopWindow : Window
 
     private void InitItemContainer()
     {
-        if (Globals.GameShop == default || Globals.GameShop.SellingItems.Count == 0)
+        if (Globals.GameShop is not { SellingItems.Count: > 0 } gameShop)
         {
             return;
         }
 
-        for (var i = 0; i < Globals.GameShop.SellingItems.Count; i++)
+        float containerInnerWidth = _slotContainer.InnerPanel.InnerWidth;
+        for (var slotIndex = 0; slotIndex < gameShop.SellingItems.Count; slotIndex++)
         {
-            _items.Add(new ShopItem(this, _slotContainer, i));
+            var slotContainer = new ShopItem(this, _slotContainer, slotIndex);
+            _items.Add(slotContainer);
 
-            var xPadding = _items[i].Margin.Left + _items[i].Margin.Right;
-            var yPadding = _items[i].Margin.Top + _items[i].Margin.Bottom;
+            var outerSize = slotContainer.OuterBounds.Size;
+            var itemsPerRow = (int)(containerInnerWidth / outerSize.X);
 
-            var itemWidthWithPadding = _items[i].Width + xPadding;
-            var itemHeightWithPadding = _items[i].Height + yPadding;
+            var column = slotIndex % itemsPerRow;
+            var row = slotIndex / itemsPerRow;
 
-            var itemsPerRow = _slotContainer.Width / itemWidthWithPadding;
+            var xPosition = column * outerSize.X + slotContainer.Margin.Left;
+            var yPosition = row * outerSize.Y + slotContainer.Margin.Top;
 
-            var column = i % itemsPerRow;
-            var row = i / itemsPerRow;
-
-            var xPosition = column * itemWidthWithPadding + xPadding;
-            var yPosition = row * itemHeightWithPadding + yPadding;
-
-            _items[i].SetPosition(xPosition, yPosition);
+            slotContainer.SetPosition(xPosition, yPosition);
         }
     }
 }

--- a/Intersect.Client.Core/Interface/Game/Shop/ShopWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Shop/ShopWindow.cs
@@ -1,129 +1,57 @@
-﻿using Intersect.Client.Core;
+using Intersect.Client.Core;
 using Intersect.Client.Framework.File_Management;
 using Intersect.Client.Framework.Gwen.Control;
 using Intersect.Client.General;
 using Intersect.Client.Localization;
-using Intersect.GameObjects;
 
 namespace Intersect.Client.Interface.Game.Shop;
 
-
-public partial class ShopWindow
+public partial class ShopWindow : Window
 {
+    private readonly List<ShopItem> _items = [];
+    private readonly ScrollControl _slotContainer;
 
-    private static int sItemXPadding = 4;
-
-    private static int sItemYPadding = 4;
-
-    public List<ShopItem> Items = new List<ShopItem>();
-
-    private ScrollControl mItemContainer;
-
-    //Controls
-    private WindowControl mShopWindow;
-
-    // Context menu
-    private Framework.Gwen.Control.Menu mContextMenu;
-
-    private MenuItem mBuyContextItem;
-
-    //Init
-    public ShopWindow(Canvas gameCanvas)
+    public ShopWindow(Canvas gameCanvas) : base(gameCanvas, Globals.GameShop?.Name ?? Strings.Shop.Title, false, nameof(ShopWindow))
     {
-        mShopWindow = new WindowControl(gameCanvas, Globals.GameShop.Name, false, "ShopWindow");
-        mShopWindow.DisableResizing();
-        Interface.InputBlockingComponents.Add(mShopWindow);
+        DisableResizing();
+        Interface.InputBlockingComponents.Add(this);
 
-        mItemContainer = new ScrollControl(mShopWindow, "ItemContainer");
-        mItemContainer.EnableScroll(false, true);
+        _slotContainer = new ScrollControl(this, "ItemContainer");
+        _slotContainer.EnableScroll(false, true);
+    }
 
-        mShopWindow.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
-
+    protected override void EnsureInitialized()
+    {
+        LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
         InitItemContainer();
-
-        // Generate our context menu with basic options.
-        mContextMenu = new Framework.Gwen.Control.Menu(gameCanvas, "ShopContextMenu");
-        mContextMenu.IsHidden = true;
-        mContextMenu.IconMarginDisabled = true;
-        //TODO: Is this a memory leak?
-        mContextMenu.ClearChildren();
-        mBuyContextItem = mContextMenu.AddItem(Strings.ShopContextMenu.Buy);
-        mBuyContextItem.Clicked += MBuyContextItem_Clicked;
-        mContextMenu.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
-    }
-
-    public void OpenContextMenu(int slot)
-    {
-        var item = ItemBase.Get(Globals.GameShop.SellingItems[slot].ItemId);
-
-        // No point showing a menu for blank space.
-        if (item == null)
-        {
-            return;
-        }
-
-        mBuyContextItem.SetText(Strings.ShopContextMenu.Buy.ToString(item.Name));
-
-        // Set our spell slot as userdata for future reference.
-        mContextMenu.UserData = slot;
-
-        mContextMenu.SizeToChildren();
-        mContextMenu.Open(Framework.Gwen.Pos.None);
-    }
-
-    private void MBuyContextItem_Clicked(Base sender, Framework.Gwen.Control.EventArguments.MouseButtonState arguments)
-    {
-        var slot = (int) sender.Parent.UserData;
-        Globals.Me.TryBuyItem(slot);
-    }
-
-    //Location
-    public int X => mShopWindow.X;
-
-    public int Y => mShopWindow.Y;
-
-    public void Close()
-    {
-        mContextMenu?.Close();
-        mShopWindow.Close();
-    }
-
-    public bool IsVisible()
-    {
-        return !mShopWindow.IsHidden;
-    }
-
-    public void Hide()
-    {
-        mShopWindow.IsHidden = true;
     }
 
     private void InitItemContainer()
     {
+        if (Globals.GameShop == default || Globals.GameShop.SellingItems.Count == 0)
+        {
+            return;
+        }
+
         for (var i = 0; i < Globals.GameShop.SellingItems.Count; i++)
         {
-            Items.Add(new ShopItem(this, i));
-            Items[i].Container = new ImagePanel(mItemContainer, "ShopItem");
-            Items[i].Setup();
+            _items.Add(new ShopItem(this, _slotContainer, i));
 
-            Items[i].Container.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
+            var xPadding = _items[i].Margin.Left + _items[i].Margin.Right;
+            var yPadding = _items[i].Margin.Top + _items[i].Margin.Bottom;
 
-            Items[i].LoadItem();
+            var itemWidthWithPadding = _items[i].Width + xPadding;
+            var itemHeightWithPadding = _items[i].Height + yPadding;
 
-            var xPadding = Items[i].Container.Margin.Left + Items[i].Container.Margin.Right;
-            var yPadding = Items[i].Container.Margin.Top + Items[i].Container.Margin.Bottom;
-            Items[i]
-                .Container.SetPosition(
-                    i %
-                    (mItemContainer.Width / (Items[i].Container.Width + xPadding)) *
-                    (Items[i].Container.Width + xPadding) +
-                    xPadding,
-                    i /
-                    (mItemContainer.Width / (Items[i].Container.Width + xPadding)) *
-                    (Items[i].Container.Height + yPadding) +
-                    yPadding
-                );
+            var itemsPerRow = _slotContainer.Width / itemWidthWithPadding;
+
+            var column = i % itemsPerRow;
+            var row = i / itemsPerRow;
+
+            var xPosition = column * itemWidthWithPadding + xPadding;
+            var yPosition = row * itemHeightWithPadding + yPadding;
+
+            _items[i].SetPosition(xPosition, yPosition);
         }
     }
-
 }

--- a/Intersect.Client.Core/Interface/Game/Shop/ShopWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Shop/ShopWindow.cs
@@ -1,5 +1,6 @@
 using Intersect.Client.Core;
 using Intersect.Client.Framework.File_Management;
+using Intersect.Client.Framework.Gwen;
 using Intersect.Client.Framework.Gwen.Control;
 using Intersect.Client.General;
 using Intersect.Client.Localization;
@@ -16,8 +17,20 @@ public partial class ShopWindow : Window
         DisableResizing();
         Interface.InputBlockingComponents.Add(this);
 
-        _slotContainer = new ScrollControl(this, "ItemContainer");
-        _slotContainer.EnableScroll(false, true);
+        Alignment = [Alignments.Center];
+        MinimumSize = new Point(x: 442, y: 469);
+        IsResizable = false;
+        IsClosable = true;
+
+        TitleLabel.FontSize = 14;
+        TitleLabel.TextColorOverride = Color.White;
+
+        _slotContainer = new ScrollControl(this, "ItemContainer")
+        {
+            Dock = Pos.Fill,
+            OverflowX = OverflowBehavior.Auto,
+            OverflowY = OverflowBehavior.Scroll,
+        };
     }
 
     protected override void EnsureInitialized()

--- a/Intersect.Client.Core/Localization/Strings.cs
+++ b/Intersect.Client.Core/Localization/Strings.cs
@@ -2457,6 +2457,9 @@ If you are sure you want to hand over your guild enter '\c{{#ff8080}}{02}\c{{}}'
     public partial struct Shop
     {
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Title = @"Shop";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public static LocalizedString BuyItem = @"Buy Item";
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]

--- a/Intersect.Client.Framework/Gwen/Control/Base.cs
+++ b/Intersect.Client.Framework/Gwen/Control/Base.cs
@@ -1586,6 +1586,16 @@ public partial class Base : IDisposable
             }
         }
 
+        if (obj[nameof(MinimumSize)] != null)
+        {
+            MinimumSize = Point.FromString((string)obj[nameof(MinimumSize)]);
+        }
+
+        if (obj[nameof(MaximumSize)] != null)
+        {
+            MaximumSize = Point.FromString((string)obj[nameof(MaximumSize)]);
+        }
+
         if (obj[nameof(Bounds)] != null)
         {
             _boundsOnDisk = Rectangle.FromString((string)obj[nameof(Bounds)]);
@@ -1633,16 +1643,6 @@ public partial class Base : IDisposable
         if (obj["DrawBackground"] != null)
         {
             ShouldDrawBackground = (bool) obj["DrawBackground"];
-        }
-
-        if (obj[nameof(MinimumSize)] != null)
-        {
-            MinimumSize = Point.FromString((string) obj[nameof(MinimumSize)]);
-        }
-
-        if (obj[nameof(MaximumSize)] != null)
-        {
-            MaximumSize = Point.FromString((string) obj[nameof(MaximumSize)]);
         }
 
         if (obj["Disabled"] != null)

--- a/Intersect.Client.Framework/Gwen/Control/ImagePanel.cs
+++ b/Intersect.Client.Framework/Gwen/Control/ImagePanel.cs
@@ -2,7 +2,6 @@ using Intersect.Client.Framework.Content;
 using Intersect.Client.Framework.File_Management;
 using Intersect.Client.Framework.GenericClasses;
 using Intersect.Client.Framework.Graphics;
-using Intersect.Client.Framework.Gwen.ControlInternal;
 using Intersect.Client.Framework.Gwen.Skin.Texturing;
 using Intersect.Client.Framework.Input;
 using Newtonsoft.Json.Linq;
@@ -19,11 +18,11 @@ public partial class ImagePanel : Base
     private readonly float[] _uv;
 
     //Sound Effects
-    public string HoverSound;
+    public string? HoverSound { get; set; }
 
-    protected string mLeftMouseClickSound;
+    protected string? LeftMouseClickSound { get; set; }
 
-    protected string mRightMouseClickSound;
+    protected string? RightMouseClickSound { get; set; }
 
     private IGameTexture? _texture { get; set; }
     private string? _textureName;
@@ -154,8 +153,8 @@ public partial class ImagePanel : Base
         PlaySound(
             mouseButton switch
             {
-                MouseButton.Left => mLeftMouseClickSound,
-                MouseButton.Right => mRightMouseClickSound,
+                MouseButton.Left => LeftMouseClickSound,
+                MouseButton.Right => RightMouseClickSound,
                 _ => null,
             }
         );
@@ -181,9 +180,9 @@ public partial class ImagePanel : Base
 
         serializedProperties.Add(nameof(Texture), TextureFilename);
         serializedProperties.Add(nameof(TextureNinePatchMargin), TextureNinePatchMargin?.ToString());
-        serializedProperties.Add("HoverSound", HoverSound);
-        serializedProperties.Add("LeftMouseClickSound", mLeftMouseClickSound);
-        serializedProperties.Add("RightMouseClickSound", mRightMouseClickSound);
+        serializedProperties.Add(nameof(HoverSound), HoverSound);
+        serializedProperties.Add(nameof(LeftMouseClickSound), LeftMouseClickSound);
+        serializedProperties.Add(nameof(RightMouseClickSound), RightMouseClickSound);
 
         return base.FixJson(serializedProperties);
     }
@@ -226,19 +225,22 @@ public partial class ImagePanel : Base
             }
         }
 
-        if (obj["HoverSound"] != null)
+        if (obj[nameof(HoverSound)] is JValue { Type: JTokenType.String } hoverSound &&
+            hoverSound.Value<string>()?.Trim() is { Length: > 0 })
         {
-            HoverSound = (string) obj["HoverSound"];
+            HoverSound = hoverSound?.Value<string>();
         }
 
-        if (obj["LeftMouseClickSound"] != null)
+        if (obj[nameof(LeftMouseClickSound)] is JValue { Type: JTokenType.String } leftMouseClickSound &&
+            leftMouseClickSound.Value<string>()?.Trim() is { Length: > 0 })
         {
-            mLeftMouseClickSound = (string) obj["LeftMouseClickSound"];
+            LeftMouseClickSound = leftMouseClickSound?.Value<string>();
         }
 
-        if (obj["RightMouseClickSound"] != null)
+        if (obj[nameof(RightMouseClickSound)] is JValue { Type: JTokenType.String } rightMouseClickSound &&
+            rightMouseClickSound.Value<string>()?.Trim() is { Length: > 0 })
         {
-            mRightMouseClickSound = (string) obj["RightMouseClickSound"];
+            RightMouseClickSound = rightMouseClickSound?.Value<string>();
         }
     }
 

--- a/Intersect.Client.Framework/Gwen/Control/ImagePanel.cs
+++ b/Intersect.Client.Framework/Gwen/Control/ImagePanel.cs
@@ -19,7 +19,7 @@ public partial class ImagePanel : Base
     private readonly float[] _uv;
 
     //Sound Effects
-    protected string mHoverSound;
+    public string HoverSound;
 
     protected string mLeftMouseClickSound;
 
@@ -145,7 +145,7 @@ public partial class ImagePanel : Base
     protected override void OnMouseEntered()
     {
         base.OnMouseEntered();
-        PlaySound(mHoverSound);
+        PlaySound(HoverSound);
     }
 
     protected override void OnMouseClicked(MouseButton mouseButton, Point mousePosition, bool userAction = true)
@@ -181,7 +181,7 @@ public partial class ImagePanel : Base
 
         serializedProperties.Add(nameof(Texture), TextureFilename);
         serializedProperties.Add(nameof(TextureNinePatchMargin), TextureNinePatchMargin?.ToString());
-        serializedProperties.Add("HoverSound", mHoverSound);
+        serializedProperties.Add("HoverSound", HoverSound);
         serializedProperties.Add("LeftMouseClickSound", mLeftMouseClickSound);
         serializedProperties.Add("RightMouseClickSound", mRightMouseClickSound);
 
@@ -228,7 +228,7 @@ public partial class ImagePanel : Base
 
         if (obj["HoverSound"] != null)
         {
-            mHoverSound = (string) obj["HoverSound"];
+            HoverSound = (string) obj["HoverSound"];
         }
 
         if (obj["LeftMouseClickSound"] != null)

--- a/Intersect.Client.Framework/Gwen/Control/ImagePanel.cs
+++ b/Intersect.Client.Framework/Gwen/Control/ImagePanel.cs
@@ -225,22 +225,22 @@ public partial class ImagePanel : Base
             }
         }
 
-        if (obj[nameof(HoverSound)] is JValue { Type: JTokenType.String } hoverSound &&
-            hoverSound.Value<string>()?.Trim() is { Length: > 0 })
+        if (obj[nameof(HoverSound)] is JValue { Type: JTokenType.String } tokenHoverSound &&
+            tokenHoverSound.Value<string>()?.Trim() is { Length: > 0 } hoverSound)
         {
-            HoverSound = hoverSound?.Value<string>();
+            HoverSound = hoverSound;
         }
 
-        if (obj[nameof(LeftMouseClickSound)] is JValue { Type: JTokenType.String } leftMouseClickSound &&
-            leftMouseClickSound.Value<string>()?.Trim() is { Length: > 0 })
+        if (obj[nameof(LeftMouseClickSound)] is JValue { Type: JTokenType.String } tokenLeftMouseClickSound &&
+            tokenLeftMouseClickSound.Value<string>()?.Trim() is { Length: > 0 } leftMouseClickSound)
         {
-            LeftMouseClickSound = leftMouseClickSound?.Value<string>();
+            LeftMouseClickSound = leftMouseClickSound;
         }
 
-        if (obj[nameof(RightMouseClickSound)] is JValue { Type: JTokenType.String } rightMouseClickSound &&
-            rightMouseClickSound.Value<string>()?.Trim() is { Length: > 0 })
+        if (obj[nameof(RightMouseClickSound)] is JValue { Type: JTokenType.String } tokenRightMouseClickSound &&
+            tokenRightMouseClickSound.Value<string>()?.Trim() is { Length: > 0 } rightMouseClickSound)
         {
-            RightMouseClickSound = rightMouseClickSound?.Value<string>();
+            RightMouseClickSound = rightMouseClickSound;
         }
     }
 

--- a/Intersect.Client.Framework/Gwen/Control/ImagePanel.cs
+++ b/Intersect.Client.Framework/Gwen/Control/ImagePanel.cs
@@ -20,9 +20,9 @@ public partial class ImagePanel : Base
     //Sound Effects
     public string? HoverSound { get; set; }
 
-    protected string? LeftMouseClickSound { get; set; }
+    public string? LeftMouseClickSound { get; set; }
 
-    protected string? RightMouseClickSound { get; set; }
+    public string? RightMouseClickSound { get; set; }
 
     private IGameTexture? _texture { get; set; }
     private string? _textureName;

--- a/Intersect.Client.Framework/Gwen/Control/Menu.cs
+++ b/Intersect.Client.Framework/Gwen/Control/Menu.cs
@@ -413,4 +413,12 @@ public partial class Menu : ScrollControl
         mBackgroundTemplateTex = texture;
     }
 
+    public void SetItemFont(IFont font, int fontSize)
+    {
+        mItemFont = font;
+        _itemFontSize = fontSize;
+        mItemFontInfo = $"{font.Name},{fontSize}";
+        UpdateItemStyles();
+    }
+
 }

--- a/Intersect.Client.Framework/Gwen/Control/Menu.cs
+++ b/Intersect.Client.Framework/Gwen/Control/Menu.cs
@@ -55,7 +55,7 @@ public partial class Menu : ScrollControl
     public string? ItemFontName
     {
         get => _itemFontName;
-        set => SetItemFont(GameContentManager.Current.GetFont(_itemFontName), _itemFontName);
+        set => SetItemFont(GameContentManager.Current.GetFont(value), value);
     }
 
     private int _itemFontSize;

--- a/Intersect.Client.Framework/Gwen/Control/Menu.cs
+++ b/Intersect.Client.Framework/Gwen/Control/Menu.cs
@@ -507,12 +507,4 @@ public partial class Menu : ScrollControl
         mBackgroundTemplateFilename = fileName;
         mBackgroundTemplateTex = texture;
     }
-
-    public void SetItemFont(IFont font, int fontSize)
-    {
-        _itemFont = font;
-        _itemFontSize = fontSize;
-        UpdateItemStyles();
-    }
-
 }

--- a/Intersect.Client.Framework/Gwen/ControlInternal/Dragger.cs
+++ b/Intersect.Client.Framework/Gwen/ControlInternal/Dragger.cs
@@ -17,8 +17,8 @@ public partial class Dragger : Base
     protected Point mHoldPos;
 
     //Sound Effects
-    protected readonly Dictionary<ButtonSoundState, string> _stateSoundNames = [];
-    protected DateTime _ignoreMouseUpSoundsUntil;
+    private readonly Dictionary<ButtonSoundState, string> _stateSoundNames = [];
+    private DateTime _ignoreMouseUpSoundsUntil;
 
     private IGameTexture? mClickedImage;
     private string? mClickedImageFilename;

--- a/Intersect.Client.Framework/Gwen/ControlInternal/Dragger.cs
+++ b/Intersect.Client.Framework/Gwen/ControlInternal/Dragger.cs
@@ -57,9 +57,9 @@ public partial class Dragger : Base
     {
         base.OnMouseEntered();
 
-        if (ShouldDrawHover)
+        if (ShouldDrawHover && _stateSoundNames.TryGetValue(ButtonSoundState.Hover, out var value))
         {
-            PlaySound(_stateSoundNames[ButtonSoundState.Hover]);
+            PlaySound(value);
         }
     }
 
@@ -74,9 +74,9 @@ public partial class Dragger : Base
             return;
         }
 
-        if (userAction)
+        if (userAction && _stateSoundNames.TryGetValue(ButtonSoundState.MouseDown, out var value))
         {
-            PlaySound(_stateSoundNames[ButtonSoundState.MouseDown]);
+            PlaySound(value);
         }
 
         mHoldPos = _target.CanvasPosToLocal(mousePosition);
@@ -87,9 +87,9 @@ public partial class Dragger : Base
     {
         base.OnMouseUp(mouseButton, mousePosition, userAction);
 
-        if (userAction)
+        if (userAction && _stateSoundNames.TryGetValue(ButtonSoundState.MouseUp, out var value))
         {
-            PlaySound(_stateSoundNames[ButtonSoundState.MouseUp]);
+            PlaySound(value);
         }
 
         InputHandler.MouseFocus = null;
@@ -269,9 +269,10 @@ public partial class Dragger : Base
         }
     }
 
-    public string GetMouseUpSound()
+    public string? GetMouseUpSound()
     {
-        return _stateSoundNames[ButtonSoundState.MouseUp];
+        _ = _stateSoundNames.TryGetValue(ButtonSoundState.MouseUp, out var value);
+        return value;
     }
 
     /// <summary>

--- a/Intersect.Client.Framework/Gwen/ControlInternal/ScrollBarBar.cs
+++ b/Intersect.Client.Framework/Gwen/ControlInternal/ScrollBarBar.cs
@@ -1,7 +1,6 @@
 using Intersect.Client.Framework.GenericClasses;
 using Intersect.Client.Framework.Gwen.Control;
 using Intersect.Client.Framework.Input;
-using Newtonsoft.Json.Linq;
 
 namespace Intersect.Client.Framework.Gwen.ControlInternal;
 
@@ -11,10 +10,6 @@ namespace Intersect.Client.Framework.Gwen.ControlInternal;
 public partial class ScrollBarBar : Dragger
 {
     private bool mHorizontal;
-
-    private readonly Dictionary<ButtonSoundState, string> _stateSoundNames = [];
-
-    private DateTime _ignoreMouseUpSoundsUntil;
 
     /// <summary>
     ///     Initializes a new instance of the <see cref="ScrollBarBar" /> class.
@@ -76,62 +71,6 @@ public partial class ScrollBarBar : Dragger
         InvalidateParent();
     }
 
-    protected override void OnMouseEntered()
-    {
-        base.OnMouseEntered();
-        PlaySound(ButtonSoundState.Hover);
-    }
-
-    protected override void OnMouseDown(MouseButton mouseButton, Point mousePosition, bool userAction = true)
-    {
-        base.OnMouseDown(mouseButton, mousePosition, userAction);
-        PlaySound(ButtonSoundState.MouseDown);
-    }
-
-    protected override void OnMouseUp(MouseButton mouseButton, Point mousePosition, bool userAction = true)
-    {
-        base.OnMouseUp(mouseButton, mousePosition, userAction);
-        PlaySound(ButtonSoundState.MouseUp);
-    }
-
-    protected override void OnMouseClicked(MouseButton mouseButton, Point mousePosition, bool userAction = true)
-    {
-        base.OnMouseClicked(mouseButton, mousePosition, userAction);
-
-        if (mouseButton == MouseButton.Left)
-        {
-            InvalidateParent();
-        }
-
-        PlaySound(ButtonSoundState.MouseClicked);
-    }
-
-    public void PlaySound(ButtonSoundState soundState)
-    {
-        if (soundState == ButtonSoundState.MouseUp)
-        {
-            if (_ignoreMouseUpSoundsUntil > DateTime.UtcNow)
-            {
-                return;
-            }
-        }
-
-        if (!_stateSoundNames.TryGetValue(soundState, out var soundName))
-        {
-            return;
-        }
-
-        if (!base.PlaySound(soundName))
-        {
-            return;
-        }
-
-        if (soundState == ButtonSoundState.MouseDown)
-        {
-            _ignoreMouseUpSoundsUntil = DateTime.UtcNow.AddMilliseconds(200);
-        }
-    }
-
     /// <summary>
     ///     Lays out the control's interior according to alignment, padding, dock etc.
     /// </summary>
@@ -152,75 +91,5 @@ public partial class ScrollBarBar : Dragger
         base.OnBoundsChanged(oldBounds, newBounds);
 
         InvalidateParent();
-    }
-
-    public void SetSound(ButtonSoundState state, string? soundName)
-    {
-        soundName = soundName?.Trim();
-        if (string.IsNullOrEmpty(soundName))
-        {
-            _stateSoundNames.Remove(state);
-        }
-        else
-        {
-            _stateSoundNames[state] = soundName;
-        }
-    }
-
-    public override JObject? GetJson(bool isRoot = false, bool onlySerializeIfNotEmpty = false)
-    {
-        var serializedProperties = base.GetJson(isRoot, onlySerializeIfNotEmpty);
-        if (serializedProperties is null)
-        {
-            return null;
-        }
-
-        serializedProperties.Add(nameof(_stateSoundNames), JObject.FromObject(_stateSoundNames));
-        return FixJson(serializedProperties);
-    }
-
-    public override JObject FixJson(JObject json)
-    {
-        json.Remove("HoverSound");
-        json.Remove("MouseUpSound");
-        json.Remove("MouseDownSound");
-        return base.FixJson(json);
-    }
-
-    public override void LoadJson(JToken token, bool isRoot = default)
-    {
-        base.LoadJson(token, isRoot);
-
-        if (token is not JObject obj)
-        {
-            return;
-        }
-
-        if (obj.TryGetValue(nameof(_stateSoundNames), out var tokenStateSoundNames) && tokenStateSoundNames is JObject valueStateSoundNames)
-        {
-            foreach (var (propertyName, propertyValueToken) in valueStateSoundNames)
-            {
-                if (!Enum.TryParse(propertyName, out ButtonSoundState buttonSoundState) ||
-                    buttonSoundState == ButtonSoundState.None)
-                {
-                    continue;
-                }
-
-                if (propertyValueToken is not JValue { Type: JTokenType.String } valuePropertyValue)
-                {
-                    continue;
-                }
-
-                var stringPropertyValue = valuePropertyValue.Value<string>()?.Trim();
-                if (stringPropertyValue is { Length: > 0 })
-                {
-                    _stateSoundNames[buttonSoundState] = stringPropertyValue;
-                }
-                else
-                {
-                    _stateSoundNames.Remove(buttonSoundState);
-                }
-            }
-        }
     }
 }


### PR DESCRIPTION
resolves #2558 

assets in https://github.com/AscensionGameDev/Intersect-Assets/pull/62

Shop Window inherits from Window
ShopItem inheriting from image
code reduction and cleaning in general

Functions delegated correctly now:
 - The Window only serves as a container, with no context logic when right-clicking on the shop item
 - Shop item dealing with the context menu, since it is the one that is clicked and not the window as before
 
 I recommend looking at the files directly in the ide, github is showing everything strange
 
 working as it should so far
 

https://github.com/user-attachments/assets/0002f4ca-7fc0-4021-9d52-b4af433cbcf8

