### PR TITLE
Have the client independently spawn the resource exhaustion animation to avoid having frames between when the animation begins playing and when the resource's graphic changes

### DIFF
--- a/Intersect.Client.Core/Entities/Resource.cs
+++ b/Intersect.Client.Core/Entities/Resource.cs
@@ -4,10 +4,12 @@ using Intersect.Client.Framework.File_Management;
 using Intersect.Client.Framework.GenericClasses;
 using Intersect.Client.Framework.Maps;
 using Intersect.Client.General;
+using Intersect.Core;
 using Intersect.Enums;
 using Intersect.Framework.Core.GameObjects.Resources;
 using Intersect.GameObjects;
 using Intersect.Network.Packets.Server;
+using Microsoft.Extensions.Logging;
 
 namespace Intersect.Client.Entities;
 
@@ -20,7 +22,9 @@ public partial class Resource : Entity, IResource
     private bool _waitingForTilesets;
 
     private bool _isDead;
+    private Guid _descriptorId;
     private ResourceDescriptor? _descriptor;
+    private IAnimation? _activeAnimation;
 
     public Resource(Guid id, ResourceEntityPacket packet) : base(id, packet, EntityType.Resource)
     {
@@ -108,14 +112,67 @@ public partial class Resource : Entity, IResource
             return;
         }
 
+        var wasDead = IsDead;
         IsDead = resourceEntityPacket.IsDead;
 
-        if (!ResourceDescriptor.TryGet(resourceEntityPacket.ResourceId, out _descriptor))
+        var descriptorId = resourceEntityPacket.ResourceId;
+        _descriptorId = descriptorId;
+
+        var justDied = !wasDead && resourceEntityPacket.IsDead;
+        if (!ResourceDescriptor.TryGet(descriptorId, out var descriptor))
+        {
+            if (justDied)
+            {
+                ApplicationContext.CurrentContext.Logger.LogError(
+                    "Unable to play resource exhaustion animation because resource {EntityId} ({EntityName}) is missing the descriptor ({DescriptorId})",
+                    Id,
+                    Name,
+                    descriptorId
+                );
+            }
+
+            return;
+        }
+
+        _descriptor = descriptor;
+        UpdateFromDescriptor(_descriptor);
+
+        if (!justDied)
         {
             return;
         }
 
-        UpdateFromDescriptor(_descriptor);
+        if (MapInstance is { } mapInstance)
+        {
+            var animation = mapInstance.AddTileAnimation(descriptor.AnimationId, X, Y, Direction.Up);
+            if (animation is { IsDisposed: false })
+            {
+                animation.Finished += OnAnimationDisposedOrFinished;
+                animation.Disposed += OnAnimationDisposedOrFinished;
+            }
+            _activeAnimation = animation;
+        }
+        else
+        {
+            ApplicationContext.CurrentContext.Logger.LogError(
+                "Unable to play resource exhaustion animation because resource {EntityId} ({EntityName}) has no reference to the map instance for map {MapId}",
+                Id,
+                Name,
+                MapId
+            );
+        }
+    }
+
+    private void OnAnimationDisposedOrFinished(IAnimation animation)
+    {
+        if (_activeAnimation != animation)
+        {
+            return;
+        }
+
+        _activeAnimation = null;
+        animation.Disposed -= OnAnimationDisposedOrFinished;
+        animation.Finished -= OnAnimationDisposedOrFinished;
     }
 
     private void UpdateFromDescriptor(ResourceDescriptor? descriptor)
@@ -353,9 +410,17 @@ public partial class Resource : Entity, IResource
             return;
         }
 
-        if (Texture != null)
+        if (Texture == null)
         {
-            Graphics.DrawGameTexture(Texture, _renderBoundsSrc, _renderBoundsDest, Intersect.Color.White);
+            return;
         }
+
+        // TODO: Add an option to hide the exhausted sprite until the exhaustion animation is finished, but this is not necessary if the graphics line up like Blinkuz' sample provided to fix #2572
+        // if (_activeAnimation != null)
+        // {
+        //     return;
+        // }
+
+        Graphics.DrawGameTexture(Texture, _renderBoundsSrc, _renderBoundsDest, Intersect.Color.White);
     }
 }

--- a/Intersect.Client.Core/Entities/Resource.cs
+++ b/Intersect.Client.Core/Entities/Resource.cs
@@ -415,11 +415,11 @@ public partial class Resource : Entity, IResource
             return;
         }
 
-        // TODO: Add an option to hide the exhausted sprite until the exhaustion animation is finished, but this is not necessary if the graphics line up like Blinkuz' sample provided to fix #2572
-        // if (_activeAnimation != null)
-        // {
-        //     return;
-        // }
+        // TODO: Add an option to show the exhausted sprite until the exhaustion animation is finished, but this is not necessary if the graphics line up like Blinkuz' sample provided to fix #2572
+        if (_activeAnimation != null)
+        {
+            return;
+        }
 
         Graphics.DrawGameTexture(Texture, _renderBoundsSrc, _renderBoundsDest, Intersect.Color.White);
     }

--- a/Intersect.Client.Core/Maps/MapInstance.cs
+++ b/Intersect.Client.Core/Maps/MapInstance.cs
@@ -725,8 +725,8 @@ public partial class MapInstance : MapDescriptor, IGameObject<Guid, MapInstance>
     }
 
     //Animations
-    public void AddTileAnimation(
-        Guid animId,
+    public IAnimation? AddTileAnimation(
+        Guid animationDescriptorId,
         int tileX,
         int tileY,
         Direction dir = Direction.None,
@@ -734,22 +734,42 @@ public partial class MapInstance : MapDescriptor, IGameObject<Guid, MapInstance>
         AnimationSource source = default
     )
     {
-        var animBase = AnimationDescriptor.Get(animId);
-        if (animBase == null)
+        if (!AnimationDescriptor.TryGet(animationDescriptorId, out var animationDescriptor))
         {
-            return;
+            return null;
         }
 
-        var anim = new MapAnimation(
-            animBase,
+        return AddTileAnimation(
+            animationDescriptor,
+            tileX,
+            tileY,
+            dir,
+            owner,
+            source
+        );
+    }
+
+    public IAnimation? AddTileAnimation(
+        AnimationDescriptor animationDescriptor,
+        int tileX,
+        int tileY,
+        Direction dir = Direction.None,
+        IEntity? owner = null,
+        AnimationSource source = default
+    )
+    {
+        var animationInstance = new MapAnimation(
+            animationDescriptor,
             tileX,
             tileY,
             dir,
             owner as Entity,
             source: source
         );
-        LocalAnimations.TryAdd(anim.Id, anim);
-        anim.SetPosition(
+
+        LocalAnimations.TryAdd(animationInstance.Id, animationInstance);
+
+        animationInstance.SetPosition(
             X + tileX * _tileWidth + _tileHalfWidth,
             Y + tileY * _tileHeight + _tileHalfHeight,
             tileX,
@@ -757,6 +777,8 @@ public partial class MapInstance : MapDescriptor, IGameObject<Guid, MapInstance>
             Id,
             dir
         );
+
+        return animationInstance;
     }
 
     private void HideActiveAnimations()

--- a/Intersect.Client.Core/Networking/PacketHandler.cs
+++ b/Intersect.Client.Core/Networking/PacketHandler.cs
@@ -389,15 +389,22 @@ internal sealed partial class PacketHandler
     //ResourceEntityPacket
     public void HandlePacket(IPacketSender packetSender, ResourceEntityPacket packet)
     {
-        var en = Globals.GetEntity(packet.EntityId, EntityType.Resource);
-        if (en != null)
+        if (Globals.TryGetEntity(EntityType.Resource, packet.EntityId, out var entity))
         {
-            en.Load(packet);
+            entity.Load(packet);
         }
         else
         {
-            var entity = new Resource(packet.EntityId, packet);
-            Globals.Entities.Add(entity.Id, entity);
+            entity = new Resource(packet.EntityId, packet);
+            if (!Globals.Entities.TryAdd(entity.Id, entity))
+            {
+                ApplicationContext.CurrentContext.Logger.LogError(
+                    "Failed to register new {EntityType} {EntityId} ({EntityName})",
+                    EntityType.Resource,
+                    packet.EntityId,
+                    packet.Name
+                );
+            }
         }
     }
 

--- a/Intersect.Client.Framework/Entities/IAnimation.cs
+++ b/Intersect.Client.Framework/Entities/IAnimation.cs
@@ -1,4 +1,3 @@
-using Intersect.GameObjects;
 using Intersect.Enums;
 using Intersect.Framework.Core.GameObjects.Animations;
 
@@ -6,6 +5,10 @@ namespace Intersect.Client.Framework.Entities;
 
 public interface IAnimation : IDisposable
 {
+    event Action<IAnimation>? Disposed;
+    event Action<IAnimation>? Finished;
+
+    bool IsDisposed { get; }
     bool AutoRotate { get; set; }
     bool Hidden { get; set; }
     bool InfiniteLoop { get; set; }

--- a/Intersect.Client.Framework/Maps/IMapInstance.cs
+++ b/Intersect.Client.Framework/Maps/IMapInstance.cs
@@ -28,8 +28,17 @@ public interface IMapInstance
     bool IsDisposed { get; }
     bool IsLoaded { get; }
 
-    void AddTileAnimation(
+    IAnimation? AddTileAnimation(
         Guid animId,
+        int tileX,
+        int tileY,
+        Direction dir = Direction.None,
+        IEntity? owner = null,
+        AnimationSource source = default
+    );
+
+    IAnimation? AddTileAnimation(
+        AnimationDescriptor animationDescriptor,
         int tileX,
         int tileY,
         Direction dir = Direction.None,

--- a/Intersect.Server.Core/Entities/Resource.cs
+++ b/Intersect.Server.Core/Entities/Resource.cs
@@ -60,19 +60,6 @@ public partial class Resource : Entity
         if (dropItems)
         {
             SpawnResourceItems(killer);
-            if (Descriptor.AnimationId != Guid.Empty)
-            {
-                PacketSender.SendAnimationToProximity(
-                    Descriptor.AnimationId,
-                    -1,
-                    Guid.Empty,
-                    MapId,
-                    X,
-                    Y,
-                    Direction.Up,
-                    MapInstanceId
-                );
-            }
         }
 
         PacketSender.SendEntityDataToProximity(this);


### PR DESCRIPTION
Resolves #2572 