### PR TITLE
fix: Fixed cursor warping when sending chat messages

### DIFF
--- a/Intersect.Client.Core/MonoGame/Input/MonoInput.cs
+++ b/Intersect.Client.Core/MonoGame/Input/MonoInput.cs
@@ -147,9 +147,10 @@ public partial class MonoInput : GameInput
             return;
         }
 
-        if (GameInput.Current.CursorMovementDevice != InputDeviceType.Controller)
+        switch (CursorMovementDevice)
         {
-            return;
+            case InputDeviceType.Mouse:
+                return;
         }
 
         Vector2 center = new(
@@ -319,7 +320,7 @@ public partial class MonoInput : GameInput
 
                 if (deltaX != 0 || deltaY != 0)
                 {
-                    GameInput.Current.CursorMovementDevice = InputDeviceType.Controller;
+                    CursorMovementDevice = InputDeviceType.Controller;
                 }
 
                 var temporaryMouseState = Mouse.GetState();
@@ -334,7 +335,7 @@ public partial class MonoInput : GameInput
                 mMouseX = (int)(mouseState.X * ((MonoRenderer)Core.Graphics.Renderer).GetMouseOffset().X);
                 mMouseY = (int)(mouseState.Y * ((MonoRenderer)Core.Graphics.Renderer).GetMouseOffset().Y);
 
-                GameInput.Current.CursorMovementDevice = InputDeviceType.Mouse;
+                CursorMovementDevice = InputDeviceType.Mouse;
 
                 Interface.Interface.GwenInput.ProcessMessage(
                     new GwenInputMessage(

--- a/Intersect.Client.Core/MonoGame/Input/MonoInput.cs
+++ b/Intersect.Client.Core/MonoGame/Input/MonoInput.cs
@@ -21,7 +21,8 @@ using MonoGameKeys = Microsoft.Xna.Framework.Input.Keys;
 public partial class MonoInput : GameInput
 {
     private readonly Dictionary<Keys, MonoGameKeys> _intersectToMonoGameKeyMap;
-
+    public override InputDeviceType CursorMovementDevice { get; set; } = InputDeviceType.Mouse;
+    
     private GamePadState _currentGamePadState;
     private GamePadState _previousGamePadState;
 
@@ -142,6 +143,11 @@ public partial class MonoInput : GameInput
         }
 
         if (focusSource == FocusSource.Mouse)
+        {
+            return;
+        }
+
+        if (GameInput.Current.CursorMovementDevice != InputDeviceType.Controller)
         {
             return;
         }
@@ -311,6 +317,11 @@ public partial class MonoInput : GameInput
                 var deltaX = (int)(gamePadState.ThumbSticks.Right.X * elapsed.TotalSeconds * 1000);
                 var deltaY = (int)(-gamePadState.ThumbSticks.Right.Y * elapsed.TotalSeconds * 1000);
 
+                if (deltaX != 0 || deltaY != 0)
+                {
+                    GameInput.Current.CursorMovementDevice = InputDeviceType.Controller;
+                }
+
                 var temporaryMouseState = Mouse.GetState();
                 Mouse.SetPosition(temporaryMouseState.X + deltaX, temporaryMouseState.Y + deltaY);
             }
@@ -322,6 +333,9 @@ public partial class MonoInput : GameInput
             {
                 mMouseX = (int)(mouseState.X * ((MonoRenderer)Core.Graphics.Renderer).GetMouseOffset().X);
                 mMouseY = (int)(mouseState.Y * ((MonoRenderer)Core.Graphics.Renderer).GetMouseOffset().Y);
+
+                GameInput.Current.CursorMovementDevice = InputDeviceType.Mouse;
+
                 Interface.Interface.GwenInput.ProcessMessage(
                     new GwenInputMessage(
                         IntersectInput.InputEvent.MouseMove, GetMousePosition(), MouseButton.None, Keys.Alt

--- a/Intersect.Client.Framework/Input/GameInput.cs
+++ b/Intersect.Client.Framework/Input/GameInput.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Immutable;
+using System.Collections.Immutable;
 using System.Numerics;
 using Intersect.Client.Framework.GenericClasses;
 using Intersect.Core;
@@ -116,6 +116,8 @@ public abstract partial class GameInput : IGameInput
     public abstract bool IsKeyDown(Keys key);
 
     public abstract bool WasKeyDown(Keys key);
+
+    public abstract InputDeviceType CursorMovementDevice { get; set; }
 
     public Vector2 MousePosition => GetMousePosition();
 

--- a/Intersect.Client.Framework/Input/InputDeviceType.cs
+++ b/Intersect.Client.Framework/Input/InputDeviceType.cs
@@ -1,0 +1,7 @@
+namespace Intersect.Client.Framework.Input;
+
+public enum InputDeviceType
+{
+    Mouse,
+    Controller
+}


### PR DESCRIPTION
Resolves https://github.com/AscensionGameDev/Intersect-Engine/issues/2605

- Implemented tracking of the last input device (mouse or controller).
- Ensured that the cursor only moves if the last input was from a controller.