### PR TITLE
feat: added reasources states based on resource health

### DIFF
--- a/Framework/Intersect.Framework.Core/GameObjects/Resources/ResourceDescriptor.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Resources/ResourceDescriptor.cs
@@ -22,26 +22,26 @@ public partial class ResourceDescriptor : DatabaseObject<ResourceDescriptor>, IF
     public ResourceDescriptor(Guid id) : base(id)
     {
         Name = "New Resource";
-        HealthGraphics = [];
+        StatesGraphics = [];
     }
 
     //EF wants NO PARAMETERS!!!!!
     public ResourceDescriptor()
     {
         Name = "New Resource";
-        HealthGraphics = [];
+        StatesGraphics = [];
     }
 
     public bool UseExplicitMaxHealthForResourceStates { get; set; }
 
     [NotMapped, JsonIgnore]
-    public Dictionary<string, ResourceStateDescriptor> HealthGraphics { get; set; }
+    public Dictionary<string, ResourceStateDescriptor> StatesGraphics { get; set; }
 
-    [Column("HealthGraphics")]
+    [Column("StatesGraphics")]
     public string JsonHealthGraphics
     {
-        get => JsonConvert.SerializeObject(HealthGraphics);
-        set => HealthGraphics = JsonConvert.DeserializeObject<Dictionary<string, ResourceStateDescriptor>>(value);
+        get => JsonConvert.SerializeObject(StatesGraphics);
+        set => StatesGraphics = JsonConvert.DeserializeObject<Dictionary<string, ResourceStateDescriptor>>(value);
     }
 
     [Column("Animation")]

--- a/Framework/Intersect.Framework.Core/GameObjects/Resources/ResourceDescriptor.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Resources/ResourceDescriptor.cs
@@ -35,13 +35,13 @@ public partial class ResourceDescriptor : DatabaseObject<ResourceDescriptor>, IF
     public bool UseExplicitMaxHealthForResourceStates { get; set; }
 
     [NotMapped, JsonIgnore]
-    public Dictionary<string, ResourceStateDescriptor> StatesGraphics { get; set; }
+    public Dictionary<Guid, ResourceStateDescriptor> StatesGraphics { get; set; }
 
     [Column("StatesGraphics")]
-    public string JsonHealthGraphics
+    public string JsonStates
     {
         get => JsonConvert.SerializeObject(StatesGraphics);
-        set => StatesGraphics = JsonConvert.DeserializeObject<Dictionary<string, ResourceStateDescriptor>>(value);
+        set => StatesGraphics = JsonConvert.DeserializeObject<Dictionary<Guid, ResourceStateDescriptor>>(value);
     }
 
     [Column("Animation")]

--- a/Framework/Intersect.Framework.Core/GameObjects/Resources/ResourceDescriptor.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Resources/ResourceDescriptor.cs
@@ -42,15 +42,15 @@ public partial class ResourceDescriptor : DatabaseObject<ResourceDescriptor>, IF
         set => States = JsonConvert.DeserializeObject<Dictionary<Guid, ResourceStateDescriptor>>(value);
     }
 
-    [Column("Animation")]
-    public Guid AnimationId { get; set; }
+    [Column(nameof(DeathAnimation))]
+    public Guid DeathAnimationId { get; set; }
 
     [NotMapped]
     [JsonIgnore]
-    public AnimationDescriptor Animation
+    public AnimationDescriptor DeathAnimation
     {
-        get => AnimationDescriptor.Get(AnimationId);
-        set => AnimationId = value?.Id ?? Guid.Empty;
+        get => AnimationDescriptor.Get(DeathAnimationId);
+        set => DeathAnimationId = value?.Id ?? Guid.Empty;
     }
 
     // Drops

--- a/Framework/Intersect.Framework.Core/GameObjects/Resources/ResourceDescriptor.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Resources/ResourceDescriptor.cs
@@ -3,7 +3,6 @@ using Intersect.Framework.Core.GameObjects.Animations;
 using Intersect.Framework.Core.GameObjects.Conditions;
 using Intersect.Framework.Core.GameObjects.Events;
 using Intersect.Framework.Core.GameObjects.Items;
-using Intersect.GameObjects;
 using Intersect.Models;
 using Newtonsoft.Json;
 
@@ -23,22 +22,27 @@ public partial class ResourceDescriptor : DatabaseObject<ResourceDescriptor>, IF
     public ResourceDescriptor(Guid id) : base(id)
     {
         Name = "New Resource";
-        Initial = new ResourceStateDescriptor();
-        Exhausted = new ResourceStateDescriptor();
+        HealthGraphics = [];
     }
 
     //EF wants NO PARAMETERS!!!!!
     public ResourceDescriptor()
     {
         Name = "New Resource";
-        Initial = new ResourceStateDescriptor();
-        Exhausted = new ResourceStateDescriptor();
+        HealthGraphics = [];
     }
 
-    // Graphics
-    public ResourceStateDescriptor Initial { get; set; }
+    public bool UseExplicitMaxHealthForResourceStates { get; set; }
 
-    public ResourceStateDescriptor Exhausted { get; set; }
+    [NotMapped, JsonIgnore]
+    public Dictionary<string, ResourceStateDescriptor> HealthGraphics { get; set; }
+
+    [Column("HealthGraphics")]
+    public string JsonHealthGraphics
+    {
+        get => JsonConvert.SerializeObject(HealthGraphics);
+        set => HealthGraphics = JsonConvert.DeserializeObject<Dictionary<string, ResourceStateDescriptor>>(value);
+    }
 
     [Column("Animation")]
     public Guid AnimationId { get; set; }

--- a/Framework/Intersect.Framework.Core/GameObjects/Resources/ResourceDescriptor.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Resources/ResourceDescriptor.cs
@@ -22,26 +22,24 @@ public partial class ResourceDescriptor : DatabaseObject<ResourceDescriptor>, IF
     public ResourceDescriptor(Guid id) : base(id)
     {
         Name = "New Resource";
-        StatesGraphics = [];
     }
 
     //EF wants NO PARAMETERS!!!!!
     public ResourceDescriptor()
     {
         Name = "New Resource";
-        StatesGraphics = [];
     }
 
     public bool UseExplicitMaxHealthForResourceStates { get; set; }
 
     [NotMapped, JsonIgnore]
-    public Dictionary<Guid, ResourceStateDescriptor> StatesGraphics { get; set; }
+    public Dictionary<Guid, ResourceStateDescriptor> States { get; set; } = [];
 
-    [Column("StatesGraphics")]
+    [Column(nameof(States))]
     public string JsonStates
     {
-        get => JsonConvert.SerializeObject(StatesGraphics);
-        set => StatesGraphics = JsonConvert.DeserializeObject<Dictionary<Guid, ResourceStateDescriptor>>(value);
+        get => JsonConvert.SerializeObject(States);
+        set => States = JsonConvert.DeserializeObject<Dictionary<Guid, ResourceStateDescriptor>>(value);
     }
 
     [Column("Animation")]

--- a/Framework/Intersect.Framework.Core/GameObjects/Resources/ResourceGraphicType.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Resources/ResourceGraphicType.cs
@@ -1,0 +1,8 @@
+namespace Intersect.Framework.Core.GameObjects.Resources;
+
+public enum ResourceGraphicType
+{
+    Graphic,
+    Tileset,
+    Animation,
+}

--- a/Framework/Intersect.Framework.Core/GameObjects/Resources/ResourceStateDescriptor.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Resources/ResourceStateDescriptor.cs
@@ -5,7 +5,7 @@ namespace Intersect.Framework.Core.GameObjects.Resources;
 [Owned]
 public partial class ResourceStateDescriptor
 {
-    public string Graphic { get; set; } = default;
+    public string Texture { get; set; } = default;
 
     public ResourceGraphicType GraphicType { get; set; } = ResourceGraphicType.Graphic;
 

--- a/Framework/Intersect.Framework.Core/GameObjects/Resources/ResourceStateDescriptor.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Resources/ResourceStateDescriptor.cs
@@ -1,15 +1,21 @@
-﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
 
 namespace Intersect.Framework.Core.GameObjects.Resources;
 
 [Owned]
 public partial class ResourceStateDescriptor
 {
-    public string Graphic { get; set; } = null;
+    public string Graphic { get; set; } = default;
+
+    public ResourceGraphicType GraphicType { get; set; } = ResourceGraphicType.Graphic;
 
     public bool RenderBelowEntities { get; set; }
 
-    public bool GraphicFromTileset { get; set; }
+    public Guid AnimationId { get; set; } = Guid.Empty;
+
+    public int MinHp { get; set; }
+
+    public int MaxHp { get; set; }
 
     public int X { get; set; }
 

--- a/Framework/Intersect.Framework.Core/GameObjects/Resources/ResourceStateDescriptor.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Resources/ResourceStateDescriptor.cs
@@ -7,7 +7,7 @@ public partial class ResourceStateDescriptor
 {
     public string Texture { get; set; } = default;
 
-    public ResourceGraphicType GraphicType { get; set; } = ResourceGraphicType.Graphic;
+    public ResourceTextureSource TextureType { get; set; } = ResourceTextureSource.Resource;
 
     public bool RenderBelowEntities { get; set; }
 

--- a/Framework/Intersect.Framework.Core/GameObjects/Resources/ResourceStateDescriptor.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Resources/ResourceStateDescriptor.cs
@@ -11,11 +11,11 @@ public partial class ResourceStateDescriptor
 
     public bool RenderBelowEntities { get; set; }
 
-    public Guid AnimationId { get; set; } = Guid.Empty;
+    public Guid AnimationId { get; set; }
 
-    public int MinHp { get; set; }
+    public int MinimumHealth { get; set; }
 
-    public int MaxHp { get; set; }
+    public int MaximumHealth { get; set; }
 
     public int X { get; set; }
 

--- a/Framework/Intersect.Framework.Core/GameObjects/Resources/ResourceStateDescriptor.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Resources/ResourceStateDescriptor.cs
@@ -6,7 +6,7 @@ public partial class ResourceStateDescriptor
 
     public string Name { get; set; }
 
-    public string TextureName { get; set; } = default;
+    public string? TextureName { get; set; } = default;
 
     public ResourceTextureSource TextureType { get; set; } = ResourceTextureSource.Resource;
 

--- a/Framework/Intersect.Framework.Core/GameObjects/Resources/ResourceStateDescriptor.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Resources/ResourceStateDescriptor.cs
@@ -1,10 +1,11 @@
-using Microsoft.EntityFrameworkCore;
-
 namespace Intersect.Framework.Core.GameObjects.Resources;
 
-[Owned]
 public partial class ResourceStateDescriptor
 {
+    public Guid Id { get; set; }
+
+    public string Name { get; set; }
+
     public string Texture { get; set; } = default;
 
     public ResourceTextureSource TextureType { get; set; } = ResourceTextureSource.Resource;

--- a/Framework/Intersect.Framework.Core/GameObjects/Resources/ResourceStateDescriptor.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Resources/ResourceStateDescriptor.cs
@@ -6,7 +6,7 @@ public partial class ResourceStateDescriptor
 
     public string Name { get; set; }
 
-    public string Texture { get; set; } = default;
+    public string TextureName { get; set; } = default;
 
     public ResourceTextureSource TextureType { get; set; } = ResourceTextureSource.Resource;
 

--- a/Framework/Intersect.Framework.Core/GameObjects/Resources/ResourceTextureSource.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Resources/ResourceTextureSource.cs
@@ -1,8 +1,8 @@
 namespace Intersect.Framework.Core.GameObjects.Resources;
 
-public enum ResourceGraphicType
+public enum ResourceTextureSource
 {
-    Graphic,
+    Resource,
     Tileset,
     Animation,
 }

--- a/Intersect.Client.Core/Entities/Resource.cs
+++ b/Intersect.Client.Core/Entities/Resource.cs
@@ -430,7 +430,7 @@ public partial class Resource : Entity, IResource
             }
         }
 
-        if (Texture == null)
+        if (Texture is not { } texture)
         {
             return;
         }
@@ -446,8 +446,8 @@ public partial class Resource : Entity, IResource
         switch(graphicState.TextureType)
         {
             case ResourceTextureSource.Resource:
-                _renderBoundsSrc.Width = Texture.Width;
-                _renderBoundsSrc.Height = Texture.Height;
+                _renderBoundsSrc.Width = texture.Width;
+                _renderBoundsSrc.Height = texture.Height;
                 break;
 
             case ResourceTextureSource.Tileset:

--- a/Intersect.Client.Core/Entities/Resource.cs
+++ b/Intersect.Client.Core/Entities/Resource.cs
@@ -465,7 +465,7 @@ public partial class Resource : Entity, IResource
                 {
                     selectedGraphic = deadGraphic;
                 }
-                else if (!IsDead && graphicState is { MinimumHealth: > 0 } aliveGraphic)
+                else if (graphicState is { MinimumHealth: > 0 } aliveGraphic)
                 {
                     selectedGraphic = aliveGraphic;
                 }

--- a/Intersect.Client.Core/Entities/Resource.cs
+++ b/Intersect.Client.Core/Entities/Resource.cs
@@ -491,6 +491,7 @@ public partial class Resource : Entity, IResource
                 break;
 
             case ResourceTextureSource.Animation:
+                _renderBoundsSrc = new();
                 break;
 
             default:

--- a/Intersect.Client.Core/Entities/Resource.cs
+++ b/Intersect.Client.Core/Entities/Resource.cs
@@ -238,11 +238,19 @@ public partial class Resource : Entity, IResource
         var graphicStates = Descriptor.States;
         var currentHealthPercentage = Math.Floor((float)Vital[(int)Enums.Vital.Health] / _maximumHealthForStates * 100);
 
-        var currentState = graphicStates.FirstOrDefault(
-            s => currentHealthPercentage >= s.Value.MinimumHealth && currentHealthPercentage <= s.Value.MaximumHealth
+        if (_currentState is { } currentState &&
+            currentHealthPercentage >= _currentState?.MinimumHealth &&
+            currentHealthPercentage <= _currentState?.MaximumHealth
+        )
+        {
+            return;
+        }
+
+        currentState = graphicStates.Values.FirstOrDefault(
+            s => currentHealthPercentage >= s.MinimumHealth && currentHealthPercentage <= s.MaximumHealth
         );
 
-        _currentState = currentState.Value;
+        _currentState = currentState;
         _sprite = _currentState?.Texture ?? string.Empty;
         ReloadSpriteTexture();
     }

--- a/Intersect.Client.Core/Entities/Resource.cs
+++ b/Intersect.Client.Core/Entities/Resource.cs
@@ -67,7 +67,7 @@ public partial class Resource : Entity, IResource
                 return default;
             }
 
-            if (currentState.Value.GraphicType == ResourceGraphicType.Animation)
+            if (currentState.Value.TextureType == ResourceTextureSource.Animation)
             {
                 return currentState.Value;
             }
@@ -76,7 +76,7 @@ public partial class Resource : Entity, IResource
             {
                 _currentStateKey = currentState.Key;
                 _sprite = currentState.Value.Texture;
-                var textureType = currentState.Value.GraphicType == ResourceGraphicType.Tileset
+                var textureType = currentState.Value.TextureType == ResourceTextureSource.Tileset
                     ? TextureType.Tileset
                     : TextureType.Resource;
                 Texture = GameContentManager.Current.GetTexture(textureType, _sprite);
@@ -350,14 +350,14 @@ public partial class Resource : Entity, IResource
         _renderBoundsSrc.X = 0;
         _renderBoundsSrc.Y = 0;
 
-        switch(graphicState.GraphicType)
+        switch(graphicState.TextureType)
         {
-            case ResourceGraphicType.Graphic:
+            case ResourceTextureSource.Resource:
                 _renderBoundsSrc.Width = Texture.Width;
                 _renderBoundsSrc.Height = Texture.Height;
                 break;
 
-            case ResourceGraphicType.Tileset:
+            case ResourceTextureSource.Tileset:
                 if (IsDead && graphicState is { MaxHp: 0 } deadGraphic)
                 {
                     _renderBoundsSrc = new(
@@ -367,7 +367,7 @@ public partial class Resource : Entity, IResource
                         (deadGraphic.Height + 1) * TileHeight
                     );
                 }
-                else if (!IsDead && graphicState is { GraphicType: ResourceGraphicType.Tileset, MinHp: > 0 } aliveGraphic)
+                else if (!IsDead && graphicState is { TextureType: ResourceTextureSource.Tileset, MinHp: > 0 } aliveGraphic)
                 {
                     _renderBoundsSrc = new(
                         aliveGraphic.X * TileWidth,
@@ -383,7 +383,7 @@ public partial class Resource : Entity, IResource
                 }
                 break;
 
-            case ResourceGraphicType.Animation:
+            case ResourceTextureSource.Animation:
                 break;
 
             default:

--- a/Intersect.Client.Core/Entities/Resource.cs
+++ b/Intersect.Client.Core/Entities/Resource.cs
@@ -183,7 +183,7 @@ public partial class Resource : Entity, IResource
 
         if (MapInstance is { } mapInstance)
         {
-            var animation = mapInstance.AddTileAnimation(descriptor.AnimationId, X, Y, Direction.Up);
+            var animation = mapInstance.AddTileAnimation(descriptor.DeathAnimationId, X, Y, Direction.Up);
             if (animation is { IsDisposed: false })
             {
                 animation.Finished += OnAnimationDisposedOrFinished;

--- a/Intersect.Client.Core/Entities/Resource.cs
+++ b/Intersect.Client.Core/Entities/Resource.cs
@@ -26,6 +26,7 @@ public partial class Resource : Entity, IResource
     private int _maximumHealthForStates;
     private ResourceStateDescriptor? _currentState;
     private ResourceDescriptor? _descriptor;
+    private AnimationDescriptor? _animationDescriptor;
     private IAnimation? _activeAnimation;
     private IAnimation? _stateAnimation;
 
@@ -134,7 +135,7 @@ public partial class Resource : Entity, IResource
                     return;
                 }
 
-                if (!AnimationDescriptor.TryGet(_currentState.AnimationId, out var animationDescriptor))
+                if (_animationDescriptor is not { } animationDescriptor)
                 {
                     return;
                 }
@@ -252,6 +253,12 @@ public partial class Resource : Entity, IResource
 
         _currentState = currentState;
         _sprite = _currentState?.Texture ?? string.Empty;
+
+        if (currentState is { TextureType: ResourceTextureSource.Animation } && currentState.AnimationId != Guid.Empty)
+        {
+            _ = AnimationDescriptor.TryGet(currentState.AnimationId, out _animationDescriptor);
+        }
+
         ReloadSpriteTexture();
     }
 

--- a/Intersect.Client.Core/Entities/Resource.cs
+++ b/Intersect.Client.Core/Entities/Resource.cs
@@ -57,7 +57,7 @@ public partial class Resource : Entity, IResource
                 : MaxVital[(int)Enums.Vital.Health];
             var currentHealthPercentage = Math.Floor((float)Vital[(int)Enums.Vital.Health] / maxHealth * 100);
             var currentState = graphicStates.FirstOrDefault(
-                s => currentHealthPercentage >= s.Value.MinHp && currentHealthPercentage <= s.Value.MaxHp
+                s => currentHealthPercentage >= s.Value.MinimumHealth && currentHealthPercentage <= s.Value.MaximumHealth
             );
 
             if (currentState.Value == default)
@@ -358,7 +358,7 @@ public partial class Resource : Entity, IResource
                 break;
 
             case ResourceTextureSource.Tileset:
-                if (IsDead && graphicState is { MaxHp: 0 } deadGraphic)
+                if (IsDead && graphicState is { MaximumHealth: 0 } deadGraphic)
                 {
                     _renderBoundsSrc = new(
                         deadGraphic.X * TileWidth,
@@ -367,7 +367,7 @@ public partial class Resource : Entity, IResource
                         (deadGraphic.Height + 1) * TileHeight
                     );
                 }
-                else if (!IsDead && graphicState is { TextureType: ResourceTextureSource.Tileset, MinHp: > 0 } aliveGraphic)
+                else if (!IsDead && graphicState is { TextureType: ResourceTextureSource.Tileset, MinimumHealth: > 0 } aliveGraphic)
                 {
                     _renderBoundsSrc = new(
                         aliveGraphic.X * TileWidth,
@@ -376,7 +376,7 @@ public partial class Resource : Entity, IResource
                         (aliveGraphic.Height + 1) * TileHeight
                     );
                 }
-                else if (IsDead && graphicState is not { MaxHp: 0} reloadingGraphic)
+                else if (IsDead && graphicState is not { MaximumHealth: 0} reloadingGraphic)
                 {
                     // some game dev pressed save on resource editor, tilesets are reloading, show nothing
                     _renderBoundsSrc = new();

--- a/Intersect.Client.Core/Entities/Resource.cs
+++ b/Intersect.Client.Core/Entities/Resource.cs
@@ -49,7 +49,7 @@ public partial class Resource : Entity, IResource
                 return default;
             }
 
-            var graphicStates = Descriptor.HealthGraphics.ToList();
+            var graphicStates = Descriptor.StatesGraphics.ToList();
             var maxHealth = Descriptor.UseExplicitMaxHealthForResourceStates
                 ? Descriptor.MaxHp
                 : MaxVital[(int)Enums.Vital.Health];

--- a/Intersect.Client.Core/Entities/Resource.cs
+++ b/Intersect.Client.Core/Entities/Resource.cs
@@ -25,11 +25,9 @@ public partial class Resource : Entity, IResource
     private ResourceDescriptor? _descriptor;
     private IAnimation? _activeAnimation;
 
-    private int TileWidth => Options.Instance.Map.TileWidth;
-
-    private int TileHeight => Options.Instance.Map.TileHeight;
-
-    private int MapHeight => Options.Instance.Map.MapHeight;
+    private readonly int _tileWidth = Options.Instance.Map.TileWidth;
+    private readonly int _tileHeight = Options.Instance.Map.TileHeight;
+    private readonly int _tapHeight = Options.Instance.Map.MapHeight;
 
     public Resource(Guid id, ResourceEntityPacket packet) : base(id, packet, EntityType.Resource)
     {
@@ -293,11 +291,11 @@ public partial class Resource : Entity, IResource
                         }
                         else if (y == gridY)
                         {
-                            renderSet = Graphics.RenderingEntities[priority, MapHeight + Y];
+                            renderSet = Graphics.RenderingEntities[priority, _tapHeight + Y];
                         }
                         else
                         {
-                            renderSet = Graphics.RenderingEntities[priority, MapHeight * 2 + Y];
+                            renderSet = Graphics.RenderingEntities[priority, _tapHeight * 2 + Y];
                         }
 
                         _ = renderSet.Add(this);
@@ -361,19 +359,19 @@ public partial class Resource : Entity, IResource
                 if (IsDead && graphicState is { MaximumHealth: 0 } deadGraphic)
                 {
                     _renderBoundsSrc = new(
-                        deadGraphic.X * TileWidth,
-                        deadGraphic.Y * TileHeight,
-                        (deadGraphic.Width + 1) * TileWidth,
-                        (deadGraphic.Height + 1) * TileHeight
+                        deadGraphic.X * _tileWidth,
+                        deadGraphic.Y * _tileHeight,
+                        (deadGraphic.Width + 1) * _tileWidth,
+                        (deadGraphic.Height + 1) * _tileHeight
                     );
                 }
                 else if (!IsDead && graphicState is { TextureType: ResourceTextureSource.Tileset, MinimumHealth: > 0 } aliveGraphic)
                 {
                     _renderBoundsSrc = new(
-                        aliveGraphic.X * TileWidth,
-                        aliveGraphic.Y * TileHeight,
-                        (aliveGraphic.Width + 1) * TileWidth,
-                        (aliveGraphic.Height + 1) * TileHeight
+                        aliveGraphic.X * _tileWidth,
+                        aliveGraphic.Y * _tileHeight,
+                        (aliveGraphic.Width + 1) * _tileWidth,
+                        (aliveGraphic.Height + 1) * _tileHeight
                     );
                 }
                 else if (IsDead && graphicState is not { MaximumHealth: 0} reloadingGraphic)
@@ -392,17 +390,17 @@ public partial class Resource : Entity, IResource
 
         _renderBoundsDest.Width = _renderBoundsSrc.Width;
         _renderBoundsDest.Height = _renderBoundsSrc.Height;
-        _renderBoundsDest.Y = (int) (map.Y + Y * TileHeight + OffsetY);
-        _renderBoundsDest.X = (int) (map.X + X * TileWidth + OffsetX);
+        _renderBoundsDest.Y = (int) (map.Y + Y * _tileHeight + OffsetY);
+        _renderBoundsDest.X = (int) (map.X + X * _tileWidth + OffsetX);
 
-        if (_renderBoundsSrc.Height > TileHeight)
+        if (_renderBoundsSrc.Height > _tileHeight)
         {
-            _renderBoundsDest.Y -= _renderBoundsSrc.Height - TileHeight;
+            _renderBoundsDest.Y -= _renderBoundsSrc.Height - _tileHeight;
         }
 
-        if (_renderBoundsSrc.Width > TileWidth)
+        if (_renderBoundsSrc.Width > _tileWidth)
         {
-            _renderBoundsDest.X -= (_renderBoundsSrc.Width - TileWidth) / 2;
+            _renderBoundsDest.X -= (_renderBoundsSrc.Width - _tileWidth) / 2;
         }
     }
 

--- a/Intersect.Client.Core/Entities/Resource.cs
+++ b/Intersect.Client.Core/Entities/Resource.cs
@@ -221,7 +221,7 @@ public partial class Resource : Entity, IResource
             return;
         }
 
-        var graphicStates = Descriptor.StatesGraphics;
+        var graphicStates = Descriptor.States;
         var maxHealth = Descriptor.UseExplicitMaxHealthForResourceStates
             ? Descriptor.MaxHp
             : MaxVital[(int)Enums.Vital.Health];

--- a/Intersect.Client.Core/Entities/Resource.cs
+++ b/Intersect.Client.Core/Entities/Resource.cs
@@ -75,7 +75,7 @@ public partial class Resource : Entity, IResource
             if (currentState.Key != _currentStateKey)
             {
                 _currentStateKey = currentState.Key;
-                _sprite = currentState.Value.Graphic;
+                _sprite = currentState.Value.Texture;
                 var textureType = currentState.Value.GraphicType == ResourceGraphicType.Tileset
                     ? TextureType.Tileset
                     : TextureType.Resource;

--- a/Intersect.Client.Core/Entities/Resource.cs
+++ b/Intersect.Client.Core/Entities/Resource.cs
@@ -252,7 +252,7 @@ public partial class Resource : Entity, IResource
         );
 
         _currentState = currentState;
-        _sprite = _currentState?.Texture ?? string.Empty;
+        _sprite = _currentState?.TextureName ?? string.Empty;
 
         if (currentState is { TextureType: ResourceTextureSource.Animation } && currentState.AnimationId != Guid.Empty)
         {

--- a/Intersect.Client.Core/Entities/Resource.cs
+++ b/Intersect.Client.Core/Entities/Resource.cs
@@ -21,7 +21,7 @@ public partial class Resource : Entity, IResource
     private bool _waitingForTilesets;
 
     private bool _isDead;
-    private string _currentStateKey = string.Empty;
+    private Guid _currentStateKey = Guid.Empty;
     private ResourceDescriptor? _descriptor;
     private IAnimation? _activeAnimation;
 

--- a/Intersect.Client.Core/Entities/Resource.cs
+++ b/Intersect.Client.Core/Entities/Resource.cs
@@ -42,7 +42,7 @@ public partial class Resource : Entity, IResource
         set => _descriptor = value;
     }
 
-    private ResourceStateDescriptor? CurrentGraphicState
+    public ResourceStateDescriptor? CurrentGraphicState
     {
         get
         {
@@ -65,6 +65,11 @@ public partial class Resource : Entity, IResource
                 _sprite = string.Empty;
                 Texture = default;
                 return default;
+            }
+
+            if (currentState.Value.GraphicType == ResourceGraphicType.Animation)
+            {
+                return currentState.Value;
             }
 
             if (currentState.Key != _currentStateKey)

--- a/Intersect.Client.Core/Entities/Resource.cs
+++ b/Intersect.Client.Core/Entities/Resource.cs
@@ -49,17 +49,6 @@ public partial class Resource : Entity, IResource
         get => _descriptor;
         set
         {
-            if (value is { } descriptor)
-            {
-                _maximumHealthForStates = (int)(descriptor.UseExplicitMaxHealthForResourceStates
-                    ? descriptor.MaxHp
-                    : MaxVital[(int)Enums.Vital.Health]);
-            }
-            else
-            {
-                _maximumHealthForStates = 0;
-            }
-
             if (value == _descriptor)
             {
                 return;
@@ -194,6 +183,10 @@ public partial class Resource : Entity, IResource
 
             return;
         }
+
+        _maximumHealthForStates = (int)(descriptor.UseExplicitMaxHealthForResourceStates
+            ? descriptor.MaxHp
+            : MaxVital[(int)Enums.Vital.Health]);
 
         Descriptor = descriptor;
 

--- a/Intersect.Client.Core/Entities/Resource.cs
+++ b/Intersect.Client.Core/Entities/Resource.cs
@@ -31,12 +31,12 @@ public partial class Resource : Entity, IResource
 
     private readonly int _tileWidth = Options.Instance.Map.TileWidth;
     private readonly int _tileHeight = Options.Instance.Map.TileHeight;
-    private readonly int _tapHeight = Options.Instance.Map.MapHeight;
+    private readonly int _mapHeight = Options.Instance.Map.MapHeight;
 
     /// <inheritdoc />
     public override bool CanBeAttacked => !IsDead;
 
-    public ResourceStateDescriptor? CurrentGraphicState => _currentState;
+    public ResourceStateDescriptor? CurrentState => _currentState;
 
     public Resource(Guid id, ResourceEntityPacket packet) : base(id, packet, EntityType.Resource)
     {
@@ -319,7 +319,7 @@ public partial class Resource : Entity, IResource
 
     public override HashSet<Entity>? DetermineRenderOrder(HashSet<Entity>? renderList, IMapInstance? map)
     {
-        if (Descriptor == default || CurrentGraphicState is not { } graphicState || !graphicState.RenderBelowEntities)
+        if (Descriptor == default || CurrentState is not { } graphicState || !graphicState.RenderBelowEntities)
         {
             return base.DetermineRenderOrder(renderList, map);
         }
@@ -378,11 +378,11 @@ public partial class Resource : Entity, IResource
                         }
                         else if (y == gridY)
                         {
-                            renderSet = Graphics.RenderingEntities[priority, _tapHeight + Y];
+                            renderSet = Graphics.RenderingEntities[priority, _mapHeight + Y];
                         }
                         else
                         {
-                            renderSet = Graphics.RenderingEntities[priority, _tapHeight * 2 + Y];
+                            renderSet = Graphics.RenderingEntities[priority, _mapHeight * 2 + Y];
                         }
 
                         _ = renderSet.Add(this);
@@ -428,7 +428,7 @@ public partial class Resource : Entity, IResource
             return;
         }
 
-        if (CurrentGraphicState is not { } graphicState)
+        if (CurrentState is not { } graphicState)
         {
             return;
         }

--- a/Intersect.Client.Core/Entities/Resource.cs
+++ b/Intersect.Client.Core/Entities/Resource.cs
@@ -103,6 +103,11 @@ public partial class Resource : Entity, IResource
             Texture = GameContentManager.Current.GetTexture(TextureType.Resource, _sprite);
         }
 
+        if (Texture == default)
+        {
+            Texture = Graphics.Renderer.WhitePixel;
+        }
+
         _recalculateRenderBounds = true;
     }
 
@@ -196,8 +201,7 @@ public partial class Resource : Entity, IResource
         );
 
         _currentState = currentState.Value;
-        var updatedSprite = _currentState?.Texture;
-        _sprite = updatedSprite ?? string.Empty;
+        _sprite = _currentState?.Texture ?? string.Empty;
         ReloadSpriteTexture();
     }
 

--- a/Intersect.Client.Core/Entities/Resource.cs
+++ b/Intersect.Client.Core/Entities/Resource.cs
@@ -49,12 +49,6 @@ public partial class Resource : Entity, IResource
         get => _descriptor;
         set
         {
-            if (value == _descriptor)
-            {
-                return;
-            }
-
-            _descriptor = value;
             if (value is { } descriptor)
             {
                 _maximumHealthForStates = (int)(descriptor.UseExplicitMaxHealthForResourceStates
@@ -66,6 +60,12 @@ public partial class Resource : Entity, IResource
                 _maximumHealthForStates = 0;
             }
 
+            if (value == _descriptor)
+            {
+                return;
+            }
+
+            _descriptor = value;
             UpdateCurrentState();
         }
     }
@@ -116,7 +116,7 @@ public partial class Resource : Entity, IResource
             case ResourceTextureSource.Tileset:
                 if (GameContentManager.Current.TilesetsLoaded)
                 {
-                    Texture = GameContentManager.Current.GetTexture(TextureType.Tileset, _sprite);
+                    Texture = GameContentManager.Current.GetTexture(TextureType.Tileset, _currentState?.TextureName);
                 }
                 else
                 {
@@ -125,7 +125,7 @@ public partial class Resource : Entity, IResource
                 break;
 
             case ResourceTextureSource.Resource:
-                Texture = GameContentManager.Current.GetTexture(TextureType.Resource, _sprite);
+                Texture = GameContentManager.Current.GetTexture(TextureType.Resource, _currentState?.TextureName);
                 break;
 
             case ResourceTextureSource.Animation:
@@ -269,7 +269,6 @@ public partial class Resource : Entity, IResource
         }
 
         _currentState = currentState;
-        _sprite = _currentState?.TextureName ?? string.Empty;
 
         if (currentState is { TextureType: ResourceTextureSource.Animation } && currentState.AnimationId != Guid.Empty)
         {

--- a/Intersect.Client.Core/Entities/Resource.cs
+++ b/Intersect.Client.Core/Entities/Resource.cs
@@ -251,6 +251,18 @@ public partial class Resource : Entity, IResource
             s => currentHealthPercentage >= s.MinimumHealth && currentHealthPercentage <= s.MaximumHealth
         );
 
+        // dispose animation if animation is not used in this current state,
+        // but the previous state was an animation
+        if (
+            _currentState?.TextureType == ResourceTextureSource.Animation &&
+            _stateAnimation != default &&
+            currentState?.TextureType != ResourceTextureSource.Animation
+            )
+        {
+            _stateAnimation.Dispose();
+            _stateAnimation = default;
+        }
+
         _currentState = currentState;
         _sprite = _currentState?.TextureName ?? string.Empty;
 

--- a/Intersect.Client.Core/Maps/MapInstance.cs
+++ b/Intersect.Client.Core/Maps/MapInstance.cs
@@ -27,7 +27,6 @@ using Intersect.Network.Packets.Server;
 using Intersect.Utilities;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
-using Intersect.Framework.Core.GameObjects.Resources;
 
 namespace Intersect.Client.Maps;
 
@@ -669,59 +668,6 @@ public partial class MapInstance : MapDescriptor, IGameObject<Guid, MapInstance>
                         mAttributeCritterInstances[mapAttribute].Update();
                         break;
                     }
-                    case MapAttributeType.Resource:
-                        {
-                            var resource = Globals.Entities.Values
-                                .Where(e =>
-                                    e.Type == EntityType.Resource &&
-                                    e.X == x && e.Y == y &&
-                                    e.MapInstance?.Id == Id
-                                ).FirstOrDefault() as Resource;
-
-                            if (resource?.CurrentGraphicState is not { } graphicState)
-                            {
-                                continue;
-                            }
-
-                            if (graphicState.TextureType != ResourceTextureSource.Animation)
-                            {
-                                continue;
-                            }
-
-                            if (!AnimationDescriptor.TryGet(graphicState.AnimationId, out var animation))
-                            {
-                                continue;
-                            }
-
-                            if (!mAttributeAnimInstances.ContainsKey(mapAttribute))
-                            {
-                                var animInstance = new Animation(animation, true);
-                                animInstance.SetPosition(
-                                X + x * _tileWidth + _tileHalfWidth,
-                                Y + y * _tileHeight + _tileHalfHeight, x, y, Id, 0
-                            );
-
-                                mAttributeAnimInstances.Add(mapAttribute, animInstance);
-                            }
-                            else
-                            {
-                                var currentResourceAnimation = mAttributeAnimInstances[mapAttribute];
-                                if (currentResourceAnimation.Descriptor?.Id != animation.Id)
-                                {
-                                    currentResourceAnimation.Dispose();
-                                    mAttributeAnimInstances.Remove(mapAttribute);
-                                    var animInstance = new Animation(animation, true);
-                                    animInstance.SetPosition(
-                                        X + x * _tileWidth + _tileHalfWidth,
-                                        Y + y * _tileHeight + _tileHalfHeight, x, y, Id, 0
-                                    );
-                                    mAttributeAnimInstances.Add(mapAttribute, animInstance);
-                                }
-                            }
-
-                            mAttributeAnimInstances[mapAttribute].Update();
-                        }
-                        break;
                 }
             }
         }

--- a/Intersect.Client.Core/Maps/MapInstance.cs
+++ b/Intersect.Client.Core/Maps/MapInstance.cs
@@ -27,6 +27,7 @@ using Intersect.Network.Packets.Server;
 using Intersect.Utilities;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
+using Intersect.Framework.Core.GameObjects.Resources;
 
 namespace Intersect.Client.Maps;
 
@@ -668,6 +669,59 @@ public partial class MapInstance : MapDescriptor, IGameObject<Guid, MapInstance>
                         mAttributeCritterInstances[mapAttribute].Update();
                         break;
                     }
+                    case MapAttributeType.Resource:
+                        {
+                            var resource = Globals.Entities.Values
+                                .Where(e =>
+                                    e.Type == EntityType.Resource &&
+                                    e.X == x && e.Y == y &&
+                                    e.MapInstance?.Id == Id
+                                ).FirstOrDefault() as Resource;
+
+                            if (resource?.CurrentGraphicState is not { } graphicState)
+                            {
+                                continue;
+                            }
+
+                            if (graphicState.GraphicType != ResourceGraphicType.Animation)
+                            {
+                                continue;
+                            }
+
+                            if (!AnimationDescriptor.TryGet(graphicState.AnimationId, out var animation))
+                            {
+                                continue;
+                            }
+
+                            if (!mAttributeAnimInstances.ContainsKey(mapAttribute))
+                            {
+                                var animInstance = new Animation(animation, true);
+                                animInstance.SetPosition(
+                                X + x * _tileWidth + _tileHalfWidth,
+                                Y + y * _tileHeight + _tileHalfHeight, x, y, Id, 0
+                            );
+
+                                mAttributeAnimInstances.Add(mapAttribute, animInstance);
+                            }
+                            else
+                            {
+                                var currentResourceAnimation = mAttributeAnimInstances[mapAttribute];
+                                if (currentResourceAnimation.Descriptor?.Id != animation.Id)
+                                {
+                                    currentResourceAnimation.Dispose();
+                                    mAttributeAnimInstances.Remove(mapAttribute);
+                                    var animInstance = new Animation(animation, true);
+                                    animInstance.SetPosition(
+                                        X + x * _tileWidth + _tileHalfWidth,
+                                        Y + y * _tileHeight + _tileHalfHeight, x, y, Id, 0
+                                    );
+                                    mAttributeAnimInstances.Add(mapAttribute, animInstance);
+                                }
+                            }
+
+                            mAttributeAnimInstances[mapAttribute].Update();
+                        }
+                        break;
                 }
             }
         }

--- a/Intersect.Client.Core/Maps/MapInstance.cs
+++ b/Intersect.Client.Core/Maps/MapInstance.cs
@@ -683,7 +683,7 @@ public partial class MapInstance : MapDescriptor, IGameObject<Guid, MapInstance>
                                 continue;
                             }
 
-                            if (graphicState.GraphicType != ResourceGraphicType.Animation)
+                            if (graphicState.TextureType != ResourceTextureSource.Animation)
                             {
                                 continue;
                             }

--- a/Intersect.Client.Core/Networking/PacketHandler.cs
+++ b/Intersect.Client.Core/Networking/PacketHandler.cs
@@ -866,6 +866,11 @@ internal sealed partial class PacketHandler
                     Globals.Me.CombatTimer = Timing.Global.Milliseconds + en.CombatTimeRemaining;
                 }
             }
+
+            if (entity.Type == EntityType.Resource)
+            {
+                ((Resource)entity).UpdateCurrentState();
+            }
         }
     }
 

--- a/Intersect.Client.Core/Networking/PacketHandler.cs
+++ b/Intersect.Client.Core/Networking/PacketHandler.cs
@@ -867,9 +867,9 @@ internal sealed partial class PacketHandler
                 }
             }
 
-            if (entity.Type == EntityType.Resource)
+            if (entity is Resource resourceEntity)
             {
-                ((Resource)entity).UpdateCurrentState();
+                resourceEntity.UpdateCurrentState();
             }
         }
     }

--- a/Intersect.Client.Framework/Entities/IResource.cs
+++ b/Intersect.Client.Framework/Entities/IResource.cs
@@ -1,11 +1,8 @@
 using Intersect.Framework.Core.GameObjects.Resources;
-using Intersect.GameObjects;
 
 namespace Intersect.Client.Framework.Entities;
 
 public interface IResource : IEntity
 {
     ResourceDescriptor? Descriptor { get; }
-    
-    bool IsDepleted { get; }
 }

--- a/Intersect.Editor/Core/Graphics.cs
+++ b/Intersect.Editor/Core/Graphics.cs
@@ -1388,65 +1388,96 @@ public static partial class Graphics
                         continue;
                     }
 
-                    if (TextUtils.IsNone(resource.Initial.Graphic))
+                    if (resource.HealthGraphics.Count == 0)
                     {
                         continue;
                     }
 
-                    if (resource.Initial.GraphicFromTileset)
+                    var fullVitalResourceGraphic = resource.HealthGraphics.FirstOrDefault(
+                        g => g.Value.MaxHp == 100
+                    );
+
+                    if (fullVitalResourceGraphic.Value is not { MaxHp: 100 } resourceGraphic)
                     {
-                        var res = GameContentManager.GetTexture(
-                            GameContentManager.TextureType.Tileset, resource.Initial.Graphic
-                        );
-
-                        if (res == null)
-                        {
-                            continue;
-                        }
-
-                        float xpos = x * Options.Instance.Map.TileWidth + xoffset;
-                        float ypos = y * Options.Instance.Map.TileHeight + yoffset;
-                        if ((resource.Initial.Height + 1) * Options.Instance.Map.TileHeight > Options.Instance.Map.TileHeight)
-                        {
-                            ypos -= (resource.Initial.Height + 1) * Options.Instance.Map.TileHeight - Options.Instance.Map.TileHeight;
-                        }
-
-                        if ((resource.Initial.Width + 1) * Options.Instance.Map.TileWidth > Options.Instance.Map.TileWidth)
-                        {
-                            xpos -= ((resource.Initial.Width + 1) * Options.Instance.Map.TileWidth - Options.Instance.Map.TileWidth) / 2;
-                        }
-
-                        DrawTexture(
-                            res, xpos, ypos, resource.Initial.X * Options.Instance.Map.TileWidth,
-                            resource.Initial.Y * Options.Instance.Map.TileHeight,
-                            (resource.Initial.Width + 1) * Options.Instance.Map.TileWidth,
-                            (resource.Initial.Height + 1) * Options.Instance.Map.TileHeight, renderTarget
-                        );
+                        continue;
                     }
-                    else
+
+                    // we have the graphic, now lets build based on type
+                    switch(resourceGraphic.GraphicType)
                     {
-                        var res = GameContentManager.GetTexture(
-                            GameContentManager.TextureType.Resource, resource.Initial.Graphic
-                        );
+                        case ResourceGraphicType.Graphic:
+                            {
+                                var texture = GameContentManager.GetTexture(
+                                    GameContentManager.TextureType.Resource, resourceGraphic.Graphic
+                                );
 
-                        if (res == null)
-                        {
-                            continue;
-                        }
+                                if (texture == null)
+                                {
+                                    continue;
+                                }
 
-                        float xpos = x * Options.Instance.Map.TileWidth + xoffset;
-                        float ypos = y * Options.Instance.Map.TileHeight + yoffset;
-                        if (res.Height > Options.Instance.Map.TileHeight)
-                        {
-                            ypos -= res.Height - Options.Instance.Map.TileHeight;
-                        }
+                                float xpos = x * Options.Instance.Map.TileWidth + xoffset;
+                                float ypos = y * Options.Instance.Map.TileHeight + yoffset;
 
-                        if (res.Width > Options.Instance.Map.TileWidth)
-                        {
-                            xpos -= (res.Width - Options.Instance.Map.TileWidth) / 2;
-                        }
+                                if (texture.Height > Options.Instance.Map.TileHeight)
+                                {
+                                    ypos -= texture.Height - Options.Instance.Map.TileHeight;
+                                }
 
-                        DrawTexture(res, xpos, ypos, 0, 0, res.Width, res.Height, renderTarget);
+                                if (texture.Width > Options.Instance.Map.TileWidth)
+                                {
+                                    xpos -= (texture.Width - Options.Instance.Map.TileWidth) / 2;
+                                }
+
+                                DrawTexture(
+                                    texture, xpos, ypos, 0, 0, texture.Width, texture.Height, renderTarget
+                                );
+                            }
+                            break;
+
+                        case ResourceGraphicType.Tileset:
+                            {
+                                var texture = GameContentManager.GetTexture(
+                                    GameContentManager.TextureType.Tileset, resourceGraphic.Graphic
+                                );
+
+                                if (texture == null)
+                                {
+                                    continue;
+                                }
+
+                                float xpos = x * Options.Instance.Map.TileWidth + xoffset;
+                                float ypos = y * Options.Instance.Map.TileHeight + yoffset;
+
+                                if ((resourceGraphic.Height + 1) * Options.Instance.Map.TileHeight > Options.Instance.Map.TileHeight)
+                                {
+                                    ypos -= (resourceGraphic.Height + 1) * Options.Instance.Map.TileHeight - Options.Instance.Map.TileHeight;
+                                }
+
+                                if ((resourceGraphic.Width + 1) * Options.Instance.Map.TileWidth > Options.Instance.Map.TileWidth)
+                                {
+                                    xpos -= ((resourceGraphic.Width + 1) * Options.Instance.Map.TileWidth - Options.Instance.Map.TileWidth) / 2;
+                                }
+
+                                DrawTexture(
+                                    texture, xpos, ypos, resourceGraphic.X * Options.Instance.Map.TileWidth,
+                                    resourceGraphic.Y * Options.Instance.Map.TileHeight,
+                                    (resourceGraphic.Width + 1) * Options.Instance.Map.TileWidth,
+                                    (resourceGraphic.Height + 1) * Options.Instance.Map.TileHeight, renderTarget
+                                );
+                            }
+                            break;
+
+                        case ResourceGraphicType.Animation:
+                            //TODO: FIX THIS
+                            break;
+
+                        default:
+                            throw new ArgumentOutOfRangeException(
+                                nameof(resourceGraphic.GraphicType),
+                                resourceGraphic.GraphicType,
+                                "Unknown ResourceGraphicType"
+                            );
                     }
                 }
                 else if (tmpMap.Attributes[x, y].Type == MapAttributeType.Animation)

--- a/Intersect.Editor/Core/Graphics.cs
+++ b/Intersect.Editor/Core/Graphics.cs
@@ -1469,7 +1469,33 @@ public static partial class Graphics
                             break;
 
                         case ResourceGraphicType.Animation:
-                            //TODO: FIX THIS
+                            {
+                                if (!AnimationDescriptor.TryGet(resourceGraphic.AnimationId, out var animation))
+                                {
+                                    continue;
+                                }
+
+                                float xpos = x * Options.Instance.Map.TileWidth + xoffset + Options.Instance.Map.TileWidth / 2;
+                                float ypos = y * Options.Instance.Map.TileHeight + yoffset + Options.Instance.Map.TileHeight / 2;
+
+                                var animationInstance = tmpMap.GetAttributeAnimation(tmpMap.Attributes[x, y], animation.Id);
+
+                                //Update if the animation isn't right!
+                                if (animationInstance == null || animationInstance.Descriptor != animation)
+                                {
+                                    tmpMap.SetAttributeAnimation(
+                                        tmpMap.Attributes[x, y], new Animation(animation, true)
+                                    );
+                                }
+
+                                if (animationInstance != null)
+                                {
+                                    animationInstance.Update();
+                                    animationInstance.SetPosition((int)xpos, (int)ypos, 0);
+                                    animationInstance.Draw(renderTarget, false, alternate);
+                                    animationInstance.Draw(renderTarget, true, alternate);
+                                }
+                            }
                             break;
 
                         default:

--- a/Intersect.Editor/Core/Graphics.cs
+++ b/Intersect.Editor/Core/Graphics.cs
@@ -1408,7 +1408,7 @@ public static partial class Graphics
                         case ResourceTextureSource.Resource:
                             {
                                 var texture = GameContentManager.GetTexture(
-                                    GameContentManager.TextureType.Resource, resourceGraphic.Texture
+                                    GameContentManager.TextureType.Resource, resourceGraphic.TextureName
                                 );
 
                                 if (texture == null)
@@ -1438,7 +1438,7 @@ public static partial class Graphics
                         case ResourceTextureSource.Tileset:
                             {
                                 var texture = GameContentManager.GetTexture(
-                                    GameContentManager.TextureType.Tileset, resourceGraphic.Texture
+                                    GameContentManager.TextureType.Tileset, resourceGraphic.TextureName
                                 );
 
                                 if (texture == null)

--- a/Intersect.Editor/Core/Graphics.cs
+++ b/Intersect.Editor/Core/Graphics.cs
@@ -1388,12 +1388,12 @@ public static partial class Graphics
                         continue;
                     }
 
-                    if (resource.HealthGraphics.Count == 0)
+                    if (resource.StatesGraphics.Count == 0)
                     {
                         continue;
                     }
 
-                    var fullVitalResourceGraphic = resource.HealthGraphics.FirstOrDefault(
+                    var fullVitalResourceGraphic = resource.StatesGraphics.FirstOrDefault(
                         g => g.Value.MaximumHealth == 100
                     );
 

--- a/Intersect.Editor/Core/Graphics.cs
+++ b/Intersect.Editor/Core/Graphics.cs
@@ -1388,16 +1388,16 @@ public static partial class Graphics
                         continue;
                     }
 
-                    if (resource.StatesGraphics.Count == 0)
+                    if (resource.StatesGraphics.Count < 1)
                     {
                         continue;
                     }
 
-                    var fullVitalResourceGraphic = resource.StatesGraphics.FirstOrDefault(
-                        g => g.Value.MaximumHealth == 100
-                    );
+                    var fullVitalResourceGraphic = resource.StatesGraphics.Values
+                        .OrderByDescending(g => g.MaximumHealth)
+                        .FirstOrDefault();
 
-                    if (fullVitalResourceGraphic.Value is not { MaximumHealth: 100 } resourceGraphic)
+                    if (fullVitalResourceGraphic is not { } resourceGraphic)
                     {
                         continue;
                     }

--- a/Intersect.Editor/Core/Graphics.cs
+++ b/Intersect.Editor/Core/Graphics.cs
@@ -1403,9 +1403,9 @@ public static partial class Graphics
                     }
 
                     // we have the graphic, now lets build based on type
-                    switch(resourceGraphic.GraphicType)
+                    switch(resourceGraphic.TextureType)
                     {
-                        case ResourceGraphicType.Graphic:
+                        case ResourceTextureSource.Resource:
                             {
                                 var texture = GameContentManager.GetTexture(
                                     GameContentManager.TextureType.Resource, resourceGraphic.Texture
@@ -1435,7 +1435,7 @@ public static partial class Graphics
                             }
                             break;
 
-                        case ResourceGraphicType.Tileset:
+                        case ResourceTextureSource.Tileset:
                             {
                                 var texture = GameContentManager.GetTexture(
                                     GameContentManager.TextureType.Tileset, resourceGraphic.Texture
@@ -1468,7 +1468,7 @@ public static partial class Graphics
                             }
                             break;
 
-                        case ResourceGraphicType.Animation:
+                        case ResourceTextureSource.Animation:
                             {
                                 if (!AnimationDescriptor.TryGet(resourceGraphic.AnimationId, out var animation))
                                 {
@@ -1500,8 +1500,8 @@ public static partial class Graphics
 
                         default:
                             throw new ArgumentOutOfRangeException(
-                                nameof(resourceGraphic.GraphicType),
-                                resourceGraphic.GraphicType,
+                                nameof(resourceGraphic.TextureType),
+                                resourceGraphic.TextureType,
                                 "Unknown ResourceGraphicType"
                             );
                     }

--- a/Intersect.Editor/Core/Graphics.cs
+++ b/Intersect.Editor/Core/Graphics.cs
@@ -1348,7 +1348,9 @@ public static partial class Graphics
         var x2 = Options.Instance.Map.MapWidth;
         var y1 = 0;
         var y2 = Options.Instance.Map.MapHeight;
-        var xoffset = CurrentView.Left + gridX * Options.Instance.Map.TileWidth * Options.Instance.Map.MapWidth;
+        var tileWidth = Options.Instance.Map.TileWidth;
+        var tileHeight = Options.Instance.Map.TileHeight;
+        var xoffset = CurrentView.Left + gridX * tileWidth * Options.Instance.Map.MapWidth;
         var yoffset = CurrentView.Top + gridY * Options.Instance.Map.TileHeight * Options.Instance.Map.MapHeight;
 
         if (screenShotting)
@@ -1402,8 +1404,11 @@ public static partial class Graphics
                         continue;
                     }
 
+                    float xpos = x * tileWidth + xoffset;
+                    float ypos = y * Options.Instance.Map.TileHeight + yoffset;
+
                     // we have the graphic, now lets build based on type
-                    switch(resourceGraphic.TextureType)
+                    switch (resourceGraphic.TextureType)
                     {
                         case ResourceTextureSource.Resource:
                             {
@@ -1416,21 +1421,25 @@ public static partial class Graphics
                                     continue;
                                 }
 
-                                float xpos = x * Options.Instance.Map.TileWidth + xoffset;
-                                float ypos = y * Options.Instance.Map.TileHeight + yoffset;
-
                                 if (texture.Height > Options.Instance.Map.TileHeight)
                                 {
                                     ypos -= texture.Height - Options.Instance.Map.TileHeight;
                                 }
 
-                                if (texture.Width > Options.Instance.Map.TileWidth)
+                                if (texture.Width > tileWidth)
                                 {
-                                    xpos -= (texture.Width - Options.Instance.Map.TileWidth) / 2;
+                                    xpos -= (texture.Width - tileWidth) / 2;
                                 }
 
                                 DrawTexture(
-                                    texture, xpos, ypos, 0, 0, texture.Width, texture.Height, renderTarget
+                                    texture,
+                                    xpos,
+                                    ypos,
+                                    0,
+                                    0,
+                                    texture.Width,
+                                    texture.Height,
+                                    renderTarget
                                 );
                             }
                             break;
@@ -1446,24 +1455,25 @@ public static partial class Graphics
                                     continue;
                                 }
 
-                                float xpos = x * Options.Instance.Map.TileWidth + xoffset;
-                                float ypos = y * Options.Instance.Map.TileHeight + yoffset;
-
                                 if ((resourceGraphic.Height + 1) * Options.Instance.Map.TileHeight > Options.Instance.Map.TileHeight)
                                 {
                                     ypos -= (resourceGraphic.Height + 1) * Options.Instance.Map.TileHeight - Options.Instance.Map.TileHeight;
                                 }
 
-                                if ((resourceGraphic.Width + 1) * Options.Instance.Map.TileWidth > Options.Instance.Map.TileWidth)
+                                if ((resourceGraphic.Width + 1) * tileWidth > tileWidth)
                                 {
-                                    xpos -= ((resourceGraphic.Width + 1) * Options.Instance.Map.TileWidth - Options.Instance.Map.TileWidth) / 2;
+                                    xpos -= ((resourceGraphic.Width + 1) * tileWidth - tileWidth) / 2;
                                 }
 
                                 DrawTexture(
-                                    texture, xpos, ypos, resourceGraphic.X * Options.Instance.Map.TileWidth,
+                                    texture,
+                                    xpos,
+                                    ypos,
+                                    resourceGraphic.X * tileWidth,
                                     resourceGraphic.Y * Options.Instance.Map.TileHeight,
-                                    (resourceGraphic.Width + 1) * Options.Instance.Map.TileWidth,
-                                    (resourceGraphic.Height + 1) * Options.Instance.Map.TileHeight, renderTarget
+                                    (resourceGraphic.Width + 1) * tileWidth,
+                                    (resourceGraphic.Height + 1) * Options.Instance.Map.TileHeight,
+                                    renderTarget
                                 );
                             }
                             break;
@@ -1475,8 +1485,8 @@ public static partial class Graphics
                                     continue;
                                 }
 
-                                float xpos = x * Options.Instance.Map.TileWidth + xoffset + Options.Instance.Map.TileWidth / 2f;
-                                float ypos = y * Options.Instance.Map.TileHeight + yoffset + Options.Instance.Map.TileHeight / 2f;
+                                xpos += tileWidth / 2f;
+                                ypos += Options.Instance.Map.TileHeight / 2f;
 
                                 var animationInstance = tmpMap.GetAttributeAnimation(tmpMap.Attributes[x, y], animation.Id);
 
@@ -1514,7 +1524,7 @@ public static partial class Graphics
 
                     if (animation != null)
                     {
-                        float xpos = x * Options.Instance.Map.TileWidth + xoffset + Options.Instance.Map.TileWidth / 2;
+                        float xpos = x * tileWidth + xoffset + tileWidth / 2;
                         float ypos = y * Options.Instance.Map.TileHeight + yoffset + Options.Instance.Map.TileHeight / 2;
                         if (tmpMap.Attributes[x, y] != null)
                         {

--- a/Intersect.Editor/Core/Graphics.cs
+++ b/Intersect.Editor/Core/Graphics.cs
@@ -1344,14 +1344,16 @@ public static partial class Graphics
             return;
         }
 
+        var mapWidth = Options.Instance.Map.MapWidth;
+        var mapHeight = Options.Instance.Map.MapHeight;
         var x1 = 0;
-        var x2 = Options.Instance.Map.MapWidth;
+        var x2 = mapWidth;
         var y1 = 0;
-        var y2 = Options.Instance.Map.MapHeight;
+        var y2 = mapHeight;
         var tileWidth = Options.Instance.Map.TileWidth;
         var tileHeight = Options.Instance.Map.TileHeight;
-        var xoffset = CurrentView.Left + gridX * tileWidth * Options.Instance.Map.MapWidth;
-        var yoffset = CurrentView.Top + gridY * Options.Instance.Map.TileHeight * Options.Instance.Map.MapHeight;
+        var xoffset = CurrentView.Left + gridX * tileWidth * mapWidth;
+        var yoffset = CurrentView.Top + gridY * tileHeight * mapHeight;
 
         if (screenShotting)
         {
@@ -1405,7 +1407,7 @@ public static partial class Graphics
                     }
 
                     float xpos = x * tileWidth + xoffset;
-                    float ypos = y * Options.Instance.Map.TileHeight + yoffset;
+                    float ypos = y * tileHeight + yoffset;
 
                     // we have the graphic, now lets build based on type
                     switch (resourceGraphic.TextureType)
@@ -1421,9 +1423,9 @@ public static partial class Graphics
                                     continue;
                                 }
 
-                                if (texture.Height > Options.Instance.Map.TileHeight)
+                                if (texture.Height > tileHeight)
                                 {
-                                    ypos -= texture.Height - Options.Instance.Map.TileHeight;
+                                    ypos -= texture.Height - tileHeight;
                                 }
 
                                 if (texture.Width > tileWidth)
@@ -1455,9 +1457,9 @@ public static partial class Graphics
                                     continue;
                                 }
 
-                                if ((resourceGraphic.Height + 1) * Options.Instance.Map.TileHeight > Options.Instance.Map.TileHeight)
+                                if ((resourceGraphic.Height + 1) * tileHeight > tileHeight)
                                 {
-                                    ypos -= (resourceGraphic.Height + 1) * Options.Instance.Map.TileHeight - Options.Instance.Map.TileHeight;
+                                    ypos -= (resourceGraphic.Height + 1) * tileHeight - tileHeight;
                                 }
 
                                 if ((resourceGraphic.Width + 1) * tileWidth > tileWidth)
@@ -1470,9 +1472,9 @@ public static partial class Graphics
                                     xpos,
                                     ypos,
                                     resourceGraphic.X * tileWidth,
-                                    resourceGraphic.Y * Options.Instance.Map.TileHeight,
+                                    resourceGraphic.Y * tileHeight,
                                     (resourceGraphic.Width + 1) * tileWidth,
-                                    (resourceGraphic.Height + 1) * Options.Instance.Map.TileHeight,
+                                    (resourceGraphic.Height + 1) * tileHeight,
                                     renderTarget
                                 );
                             }
@@ -1486,7 +1488,7 @@ public static partial class Graphics
                                 }
 
                                 xpos += tileWidth / 2f;
-                                ypos += Options.Instance.Map.TileHeight / 2f;
+                                ypos += tileHeight / 2f;
 
                                 var animationInstance = tmpMap.GetAttributeAnimation(tmpMap.Attributes[x, y], animation.Id);
 
@@ -1525,7 +1527,7 @@ public static partial class Graphics
                     if (animation != null)
                     {
                         float xpos = x * tileWidth + xoffset + tileWidth / 2;
-                        float ypos = y * Options.Instance.Map.TileHeight + yoffset + Options.Instance.Map.TileHeight / 2;
+                        float ypos = y * tileHeight + yoffset + tileHeight / 2;
                         if (tmpMap.Attributes[x, y] != null)
                         {
                             var animInstance = tmpMap.GetAttributeAnimation(tmpMap.Attributes[x, y], animation.Id);

--- a/Intersect.Editor/Core/Graphics.cs
+++ b/Intersect.Editor/Core/Graphics.cs
@@ -1394,10 +1394,10 @@ public static partial class Graphics
                     }
 
                     var fullVitalResourceGraphic = resource.HealthGraphics.FirstOrDefault(
-                        g => g.Value.MaxHp == 100
+                        g => g.Value.MaximumHealth == 100
                     );
 
-                    if (fullVitalResourceGraphic.Value is not { MaxHp: 100 } resourceGraphic)
+                    if (fullVitalResourceGraphic.Value is not { MaximumHealth: 100 } resourceGraphic)
                     {
                         continue;
                     }

--- a/Intersect.Editor/Core/Graphics.cs
+++ b/Intersect.Editor/Core/Graphics.cs
@@ -1384,6 +1384,9 @@ public static partial class Graphics
                     continue;
                 }
 
+                float xpos = x * tileWidth + xoffset;
+                float ypos = y * tileHeight + yoffset;
+
                 if (tmpMap.Attributes[x, y].Type == MapAttributeType.Resource && !upper && !alternate)
                 {
                     var resource = ResourceDescriptor.Get(((MapResourceAttribute) tmpMap.Attributes[x, y]).ResourceId);
@@ -1405,9 +1408,6 @@ public static partial class Graphics
                     {
                         continue;
                     }
-
-                    float xpos = x * tileWidth + xoffset;
-                    float ypos = y * tileHeight + yoffset;
 
                     // we have the graphic, now lets build based on type
                     switch (resourceGraphic.TextureType)
@@ -1526,8 +1526,9 @@ public static partial class Graphics
 
                     if (animation != null)
                     {
-                        float xpos = x * tileWidth + xoffset + tileWidth / 2;
-                        float ypos = y * tileHeight + yoffset + tileHeight / 2;
+                        xpos += tileWidth / 2f;
+                        ypos += tileHeight / 2f;
+
                         if (tmpMap.Attributes[x, y] != null)
                         {
                             var animInstance = tmpMap.GetAttributeAnimation(tmpMap.Attributes[x, y], animation.Id);

--- a/Intersect.Editor/Core/Graphics.cs
+++ b/Intersect.Editor/Core/Graphics.cs
@@ -1475,16 +1475,17 @@ public static partial class Graphics
                                     continue;
                                 }
 
-                                float xpos = x * Options.Instance.Map.TileWidth + xoffset + Options.Instance.Map.TileWidth / 2;
-                                float ypos = y * Options.Instance.Map.TileHeight + yoffset + Options.Instance.Map.TileHeight / 2;
+                                float xpos = x * Options.Instance.Map.TileWidth + xoffset + Options.Instance.Map.TileWidth / 2f;
+                                float ypos = y * Options.Instance.Map.TileHeight + yoffset + Options.Instance.Map.TileHeight / 2f;
 
                                 var animationInstance = tmpMap.GetAttributeAnimation(tmpMap.Attributes[x, y], animation.Id);
 
                                 //Update if the animation isn't right!
-                                if (animationInstance == null || animationInstance.Descriptor != animation)
+                                if (animationInstance?.Descriptor != animation)
                                 {
                                     tmpMap.SetAttributeAnimation(
-                                        tmpMap.Attributes[x, y], new Animation(animation, true)
+                                        tmpMap.Attributes[x, y],
+                                        new Animation(animation, true)
                                     );
                                 }
 

--- a/Intersect.Editor/Core/Graphics.cs
+++ b/Intersect.Editor/Core/Graphics.cs
@@ -1408,7 +1408,7 @@ public static partial class Graphics
                         case ResourceGraphicType.Graphic:
                             {
                                 var texture = GameContentManager.GetTexture(
-                                    GameContentManager.TextureType.Resource, resourceGraphic.Graphic
+                                    GameContentManager.TextureType.Resource, resourceGraphic.Texture
                                 );
 
                                 if (texture == null)
@@ -1438,7 +1438,7 @@ public static partial class Graphics
                         case ResourceGraphicType.Tileset:
                             {
                                 var texture = GameContentManager.GetTexture(
-                                    GameContentManager.TextureType.Tileset, resourceGraphic.Graphic
+                                    GameContentManager.TextureType.Tileset, resourceGraphic.Texture
                                 );
 
                                 if (texture == null)

--- a/Intersect.Editor/Core/Graphics.cs
+++ b/Intersect.Editor/Core/Graphics.cs
@@ -1388,12 +1388,12 @@ public static partial class Graphics
                         continue;
                     }
 
-                    if (resource.StatesGraphics.Count < 1)
+                    if (resource.States.Count < 1)
                     {
                         continue;
                     }
 
-                    var fullVitalResourceGraphic = resource.StatesGraphics.Values
+                    var fullVitalResourceGraphic = resource.States.Values
                         .OrderByDescending(g => g.MaximumHealth)
                         .FirstOrDefault();
 

--- a/Intersect.Editor/Core/Main.cs
+++ b/Intersect.Editor/Core/Main.cs
@@ -1,4 +1,4 @@
-﻿using Intersect.Editor.Content;
+using Intersect.Editor.Content;
 using Intersect.Editor.Forms;
 using Intersect.Editor.General;
 using Intersect.Editor.Localization;
@@ -52,12 +52,6 @@ public static partial class Main
 
     public static void DrawFrame()
     {
-        //Check Editors
-        if (Globals.ResourceEditor != null && Globals.ResourceEditor.IsDisposed == false)
-        {
-            Globals.ResourceEditor.Render();
-        }
-
         if (Globals.MapGrid == null)
         {
             return;

--- a/Intersect.Editor/Forms/Editors/frmResource.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/frmResource.Designer.cs
@@ -37,7 +37,9 @@ namespace Intersect.Editor.Forms.Editors
             txtSearch = new DarkTextBox();
             lstGameObjects = new Controls.GameObjectList();
             grpGeneral = new DarkGroupBox();
+            nudHpRegen = new DarkNumericUpDown();
             chkUseExplicitMaxHealthForResourceStates = new DarkCheckBox();
+            lblHpRegen = new Label();
             btnAddFolder = new DarkButton();
             lblFolder = new Label();
             cmbFolder = new DarkComboBox();
@@ -84,10 +86,6 @@ namespace Intersect.Editor.Forms.Editors
             grpCommonEvent = new DarkGroupBox();
             cmbEvent = new DarkComboBox();
             lblEvent = new Label();
-            grpRegen = new DarkGroupBox();
-            nudHpRegen = new DarkNumericUpDown();
-            lblHpRegen = new Label();
-            lblRegenHint = new Label();
             grpDrops = new DarkGroupBox();
             nudDropMinAmount = new DarkNumericUpDown();
             lblDropMinAmount = new Label();
@@ -115,6 +113,7 @@ namespace Intersect.Editor.Forms.Editors
             toolStripItemUndo = new ToolStripButton();
             grpResources.SuspendLayout();
             grpGeneral.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)nudHpRegen).BeginInit();
             ((System.ComponentModel.ISupportInitialize)nudMaxHp).BeginInit();
             ((System.ComponentModel.ISupportInitialize)nudMinHp).BeginInit();
             ((System.ComponentModel.ISupportInitialize)nudSpawnDuration).BeginInit();
@@ -127,8 +126,6 @@ namespace Intersect.Editor.Forms.Editors
             pnlContainer.SuspendLayout();
             grpRequirements.SuspendLayout();
             grpCommonEvent.SuspendLayout();
-            grpRegen.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)nudHpRegen).BeginInit();
             grpDrops.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)nudDropMinAmount).BeginInit();
             ((System.ComponentModel.ISupportInitialize)nudDropMaxAmount).BeginInit();
@@ -200,7 +197,9 @@ namespace Intersect.Editor.Forms.Editors
             // 
             grpGeneral.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
             grpGeneral.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            grpGeneral.Controls.Add(nudHpRegen);
             grpGeneral.Controls.Add(chkUseExplicitMaxHealthForResourceStates);
+            grpGeneral.Controls.Add(lblHpRegen);
             grpGeneral.Controls.Add(btnAddFolder);
             grpGeneral.Controls.Add(lblFolder);
             grpGeneral.Controls.Add(cmbFolder);
@@ -223,20 +222,42 @@ namespace Intersect.Editor.Forms.Editors
             grpGeneral.Margin = new Padding(4, 3, 4, 3);
             grpGeneral.Name = "grpGeneral";
             grpGeneral.Padding = new Padding(4, 3, 4, 3);
-            grpGeneral.Size = new Size(260, 353);
+            grpGeneral.Size = new Size(260, 380);
             grpGeneral.TabIndex = 15;
             grpGeneral.TabStop = false;
             grpGeneral.Text = "General";
             // 
+            // nudHpRegen
+            // 
+            nudHpRegen.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudHpRegen.ForeColor = System.Drawing.Color.Gainsboro;
+            nudHpRegen.Location = new System.Drawing.Point(108, 173);
+            nudHpRegen.Margin = new Padding(4, 3, 4, 3);
+            nudHpRegen.Name = "nudHpRegen";
+            nudHpRegen.Size = new Size(138, 23);
+            nudHpRegen.TabIndex = 30;
+            nudHpRegen.Value = new decimal(new int[] { 0, 0, 0, 0 });
+            nudHpRegen.ValueChanged += nudHpRegen_ValueChanged;
+            // 
             // chkUseExplicitMaxHealthForResourceStates
             // 
-            chkUseExplicitMaxHealthForResourceStates.Location = new System.Drawing.Point(7, 319);
+            chkUseExplicitMaxHealthForResourceStates.Location = new System.Drawing.Point(7, 339);
             chkUseExplicitMaxHealthForResourceStates.Margin = new Padding(4, 3, 4, 3);
             chkUseExplicitMaxHealthForResourceStates.Name = "chkUseExplicitMaxHealthForResourceStates";
             chkUseExplicitMaxHealthForResourceStates.Size = new Size(246, 34);
             chkUseExplicitMaxHealthForResourceStates.TabIndex = 53;
             chkUseExplicitMaxHealthForResourceStates.Text = "Use explicit Max Health for Resources States?";
             chkUseExplicitMaxHealthForResourceStates.CheckedChanged += chkUseExplicitMaxHealthForResourceStates_CheckedChanged;
+            // 
+            // lblHpRegen
+            // 
+            lblHpRegen.AutoSize = true;
+            lblHpRegen.Location = new System.Drawing.Point(7, 175);
+            lblHpRegen.Margin = new Padding(2, 0, 2, 0);
+            lblHpRegen.Name = "lblHpRegen";
+            lblHpRegen.Size = new Size(83, 15);
+            lblHpRegen.TabIndex = 26;
+            lblHpRegen.Text = "HP Regen (%):";
             // 
             // btnAddFolder
             // 
@@ -311,11 +332,11 @@ namespace Intersect.Editor.Forms.Editors
             // 
             nudSpawnDuration.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
             nudSpawnDuration.ForeColor = System.Drawing.Color.Gainsboro;
-            nudSpawnDuration.Location = new System.Drawing.Point(144, 174);
+            nudSpawnDuration.Location = new System.Drawing.Point(108, 202);
             nudSpawnDuration.Margin = new Padding(4, 3, 4, 3);
             nudSpawnDuration.Maximum = new decimal(new int[] { int.MaxValue, 0, 0, 0 });
             nudSpawnDuration.Name = "nudSpawnDuration";
-            nudSpawnDuration.Size = new Size(102, 23);
+            nudSpawnDuration.Size = new Size(137, 23);
             nudSpawnDuration.TabIndex = 40;
             nudSpawnDuration.Value = new decimal(new int[] { 0, 0, 0, 0 });
             nudSpawnDuration.ValueChanged += nudSpawnDuration_ValueChanged;
@@ -333,7 +354,7 @@ namespace Intersect.Editor.Forms.Editors
             cmbDeathAnimation.FlatStyle = FlatStyle.Flat;
             cmbDeathAnimation.ForeColor = System.Drawing.Color.Gainsboro;
             cmbDeathAnimation.FormattingEnabled = true;
-            cmbDeathAnimation.Location = new System.Drawing.Point(7, 237);
+            cmbDeathAnimation.Location = new System.Drawing.Point(7, 255);
             cmbDeathAnimation.Margin = new Padding(4, 3, 4, 3);
             cmbDeathAnimation.Name = "cmbDeathAnimation";
             cmbDeathAnimation.Size = new Size(239, 24);
@@ -345,7 +366,7 @@ namespace Intersect.Editor.Forms.Editors
             // lblDeathAnimation
             // 
             lblDeathAnimation.AutoSize = true;
-            lblDeathAnimation.Location = new System.Drawing.Point(7, 210);
+            lblDeathAnimation.Location = new System.Drawing.Point(8, 232);
             lblDeathAnimation.Margin = new Padding(4, 0, 4, 0);
             lblDeathAnimation.Name = "lblDeathAnimation";
             lblDeathAnimation.Size = new Size(100, 15);
@@ -365,7 +386,7 @@ namespace Intersect.Editor.Forms.Editors
             // lblSpawnDuration
             // 
             lblSpawnDuration.AutoSize = true;
-            lblSpawnDuration.Location = new System.Drawing.Point(7, 179);
+            lblSpawnDuration.Location = new System.Drawing.Point(6, 204);
             lblSpawnDuration.Margin = new Padding(4, 0, 4, 0);
             lblSpawnDuration.Name = "lblSpawnDuration";
             lblSpawnDuration.Size = new Size(94, 15);
@@ -374,7 +395,7 @@ namespace Intersect.Editor.Forms.Editors
             // 
             // chkWalkableAfter
             // 
-            chkWalkableAfter.Location = new System.Drawing.Point(7, 293);
+            chkWalkableAfter.Location = new System.Drawing.Point(7, 314);
             chkWalkableAfter.Margin = new Padding(4, 3, 4, 3);
             chkWalkableAfter.Name = "chkWalkableAfter";
             chkWalkableAfter.Size = new Size(246, 20);
@@ -384,7 +405,7 @@ namespace Intersect.Editor.Forms.Editors
             // 
             // chkWalkableBefore
             // 
-            chkWalkableBefore.Location = new System.Drawing.Point(7, 267);
+            chkWalkableBefore.Location = new System.Drawing.Point(7, 287);
             chkWalkableBefore.Margin = new Padding(4, 3, 4, 3);
             chkWalkableBefore.Name = "chkWalkableBefore";
             chkWalkableBefore.Size = new Size(246, 20);
@@ -480,7 +501,7 @@ namespace Intersect.Editor.Forms.Editors
             grpGraphics.Controls.Add(lblStates);
             grpGraphics.Controls.Add(graphicContainer);
             grpGraphics.ForeColor = System.Drawing.Color.Gainsboro;
-            grpGraphics.Location = new System.Drawing.Point(0, 359);
+            grpGraphics.Location = new System.Drawing.Point(1, 386);
             grpGraphics.Margin = new Padding(4, 3, 4, 3);
             grpGraphics.Name = "grpGraphics";
             grpGraphics.Padding = new Padding(4, 3, 4, 3);
@@ -753,7 +774,6 @@ namespace Intersect.Editor.Forms.Editors
             pnlContainer.AutoScroll = true;
             pnlContainer.Controls.Add(grpRequirements);
             pnlContainer.Controls.Add(grpCommonEvent);
-            pnlContainer.Controls.Add(grpRegen);
             pnlContainer.Controls.Add(grpDrops);
             pnlContainer.Controls.Add(grpGeneral);
             pnlContainer.Controls.Add(grpGraphics);
@@ -772,11 +792,11 @@ namespace Intersect.Editor.Forms.Editors
             grpRequirements.Controls.Add(btnRequirements);
             grpRequirements.Controls.Add(txtCannotHarvest);
             grpRequirements.ForeColor = System.Drawing.Color.Gainsboro;
-            grpRequirements.Location = new System.Drawing.Point(539, 218);
+            grpRequirements.Location = new System.Drawing.Point(539, 0);
             grpRequirements.Margin = new Padding(2);
             grpRequirements.Name = "grpRequirements";
             grpRequirements.Padding = new Padding(2);
-            grpRequirements.Size = new Size(285, 135);
+            grpRequirements.Size = new Size(285, 107);
             grpRequirements.TabIndex = 33;
             grpRequirements.TabStop = false;
             grpRequirements.Text = "Requirements";
@@ -810,7 +830,7 @@ namespace Intersect.Editor.Forms.Editors
             grpCommonEvent.Controls.Add(cmbEvent);
             grpCommonEvent.Controls.Add(lblEvent);
             grpCommonEvent.ForeColor = System.Drawing.Color.Gainsboro;
-            grpCommonEvent.Location = new System.Drawing.Point(539, 134);
+            grpCommonEvent.Location = new System.Drawing.Point(539, 114);
             grpCommonEvent.Margin = new Padding(2);
             grpCommonEvent.Name = "grpCommonEvent";
             grpCommonEvent.Padding = new Padding(2);
@@ -832,10 +852,10 @@ namespace Intersect.Editor.Forms.Editors
             cmbEvent.FlatStyle = FlatStyle.Flat;
             cmbEvent.ForeColor = System.Drawing.Color.Gainsboro;
             cmbEvent.FormattingEnabled = true;
-            cmbEvent.Location = new System.Drawing.Point(9, 40);
+            cmbEvent.Location = new System.Drawing.Point(9, 39);
             cmbEvent.Margin = new Padding(4, 3, 4, 3);
             cmbEvent.Name = "cmbEvent";
-            cmbEvent.Size = new Size(227, 24);
+            cmbEvent.Size = new Size(262, 24);
             cmbEvent.TabIndex = 19;
             cmbEvent.Text = null;
             cmbEvent.TextPadding = new Padding(2);
@@ -850,54 +870,6 @@ namespace Intersect.Editor.Forms.Editors
             lblEvent.Size = new Size(39, 15);
             lblEvent.TabIndex = 18;
             lblEvent.Text = "Event:";
-            // 
-            // grpRegen
-            // 
-            grpRegen.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
-            grpRegen.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
-            grpRegen.Controls.Add(nudHpRegen);
-            grpRegen.Controls.Add(lblHpRegen);
-            grpRegen.Controls.Add(lblRegenHint);
-            grpRegen.ForeColor = System.Drawing.Color.Gainsboro;
-            grpRegen.Location = new System.Drawing.Point(539, 2);
-            grpRegen.Margin = new Padding(2);
-            grpRegen.Name = "grpRegen";
-            grpRegen.Padding = new Padding(2);
-            grpRegen.Size = new Size(285, 127);
-            grpRegen.TabIndex = 32;
-            grpRegen.TabStop = false;
-            grpRegen.Text = "Regen";
-            // 
-            // nudHpRegen
-            // 
-            nudHpRegen.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
-            nudHpRegen.ForeColor = System.Drawing.Color.Gainsboro;
-            nudHpRegen.Location = new System.Drawing.Point(9, 36);
-            nudHpRegen.Margin = new Padding(4, 3, 4, 3);
-            nudHpRegen.Name = "nudHpRegen";
-            nudHpRegen.Size = new Size(100, 23);
-            nudHpRegen.TabIndex = 30;
-            nudHpRegen.Value = new decimal(new int[] { 0, 0, 0, 0 });
-            nudHpRegen.ValueChanged += nudHpRegen_ValueChanged;
-            // 
-            // lblHpRegen
-            // 
-            lblHpRegen.AutoSize = true;
-            lblHpRegen.Location = new System.Drawing.Point(6, 20);
-            lblHpRegen.Margin = new Padding(2, 0, 2, 0);
-            lblHpRegen.Name = "lblHpRegen";
-            lblHpRegen.Size = new Size(47, 15);
-            lblHpRegen.TabIndex = 26;
-            lblHpRegen.Text = "HP: (%)";
-            // 
-            // lblRegenHint
-            // 
-            lblRegenHint.Location = new System.Drawing.Point(119, 32);
-            lblRegenHint.Margin = new Padding(4, 0, 4, 0);
-            lblRegenHint.Name = "lblRegenHint";
-            lblRegenHint.Size = new Size(160, 83);
-            lblRegenHint.TabIndex = 0;
-            lblRegenHint.Text = "% of HP to restore per tick.\r\n\r\nTick timer saved in server config.json.";
             // 
             // grpDrops
             // 
@@ -919,7 +891,7 @@ namespace Intersect.Editor.Forms.Editors
             grpDrops.Margin = new Padding(4, 3, 4, 3);
             grpDrops.Name = "grpDrops";
             grpDrops.Padding = new Padding(4, 3, 4, 3);
-            grpDrops.Size = new Size(264, 353);
+            grpDrops.Size = new Size(264, 380);
             grpDrops.TabIndex = 31;
             grpDrops.TabStop = false;
             grpDrops.Text = "Drops";
@@ -928,7 +900,7 @@ namespace Intersect.Editor.Forms.Editors
             // 
             nudDropMinAmount.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
             nudDropMinAmount.ForeColor = System.Drawing.Color.Gainsboro;
-            nudDropMinAmount.Location = new System.Drawing.Point(10, 200);
+            nudDropMinAmount.Location = new System.Drawing.Point(10, 254);
             nudDropMinAmount.Margin = new Padding(4, 3, 4, 3);
             nudDropMinAmount.Maximum = new decimal(new int[] { 10000000, 0, 0, 0 });
             nudDropMinAmount.Minimum = new decimal(new int[] { 1, 0, 0, 0 });
@@ -941,7 +913,7 @@ namespace Intersect.Editor.Forms.Editors
             // lblDropMinAmount
             // 
             lblDropMinAmount.AutoSize = true;
-            lblDropMinAmount.Location = new System.Drawing.Point(10, 182);
+            lblDropMinAmount.Location = new System.Drawing.Point(10, 236);
             lblDropMinAmount.Margin = new Padding(4, 0, 4, 0);
             lblDropMinAmount.Name = "lblDropMinAmount";
             lblDropMinAmount.Size = new Size(78, 15);
@@ -950,7 +922,7 @@ namespace Intersect.Editor.Forms.Editors
             // 
             // btnDropRemove
             // 
-            btnDropRemove.Location = new System.Drawing.Point(168, 312);
+            btnDropRemove.Location = new System.Drawing.Point(168, 342);
             btnDropRemove.Margin = new Padding(4, 3, 4, 3);
             btnDropRemove.Name = "btnDropRemove";
             btnDropRemove.Padding = new Padding(6);
@@ -961,7 +933,7 @@ namespace Intersect.Editor.Forms.Editors
             // 
             // btnDropAdd
             // 
-            btnDropAdd.Location = new System.Drawing.Point(10, 312);
+            btnDropAdd.Location = new System.Drawing.Point(10, 342);
             btnDropAdd.Margin = new Padding(4, 3, 4, 3);
             btnDropAdd.Name = "btnDropAdd";
             btnDropAdd.Padding = new Padding(6);
@@ -980,7 +952,7 @@ namespace Intersect.Editor.Forms.Editors
             lstDrops.Location = new System.Drawing.Point(10, 22);
             lstDrops.Margin = new Padding(4, 3, 4, 3);
             lstDrops.Name = "lstDrops";
-            lstDrops.Size = new Size(246, 107);
+            lstDrops.Size = new Size(246, 152);
             lstDrops.TabIndex = 62;
             lstDrops.SelectedIndexChanged += lstDrops_SelectedIndexChanged;
             // 
@@ -988,7 +960,7 @@ namespace Intersect.Editor.Forms.Editors
             // 
             nudDropMaxAmount.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
             nudDropMaxAmount.ForeColor = System.Drawing.Color.Gainsboro;
-            nudDropMaxAmount.Location = new System.Drawing.Point(169, 200);
+            nudDropMaxAmount.Location = new System.Drawing.Point(169, 254);
             nudDropMaxAmount.Margin = new Padding(4, 3, 4, 3);
             nudDropMaxAmount.Maximum = new decimal(new int[] { 10000000, 0, 0, 0 });
             nudDropMaxAmount.Minimum = new decimal(new int[] { 1, 0, 0, 0 });
@@ -1004,7 +976,7 @@ namespace Intersect.Editor.Forms.Editors
             nudDropChance.DecimalPlaces = 2;
             nudDropChance.ForeColor = System.Drawing.Color.Gainsboro;
             nudDropChance.Increment = new decimal(new int[] { 1, 0, 0, 131072 });
-            nudDropChance.Location = new System.Drawing.Point(10, 253);
+            nudDropChance.Location = new System.Drawing.Point(10, 307);
             nudDropChance.Margin = new Padding(4, 3, 4, 3);
             nudDropChance.Name = "nudDropChance";
             nudDropChance.Size = new Size(246, 23);
@@ -1025,7 +997,7 @@ namespace Intersect.Editor.Forms.Editors
             cmbDropItem.FlatStyle = FlatStyle.Flat;
             cmbDropItem.ForeColor = System.Drawing.Color.Gainsboro;
             cmbDropItem.FormattingEnabled = true;
-            cmbDropItem.Location = new System.Drawing.Point(10, 153);
+            cmbDropItem.Location = new System.Drawing.Point(10, 205);
             cmbDropItem.Margin = new Padding(4, 3, 4, 3);
             cmbDropItem.Name = "cmbDropItem";
             cmbDropItem.Size = new Size(246, 24);
@@ -1037,7 +1009,7 @@ namespace Intersect.Editor.Forms.Editors
             // lblDropMaxAmount
             // 
             lblDropMaxAmount.AutoSize = true;
-            lblDropMaxAmount.Location = new System.Drawing.Point(169, 182);
+            lblDropMaxAmount.Location = new System.Drawing.Point(169, 236);
             lblDropMaxAmount.Margin = new Padding(4, 0, 4, 0);
             lblDropMaxAmount.Name = "lblDropMaxAmount";
             lblDropMaxAmount.Size = new Size(80, 15);
@@ -1047,7 +1019,7 @@ namespace Intersect.Editor.Forms.Editors
             // lblDropChance
             // 
             lblDropChance.AutoSize = true;
-            lblDropChance.Location = new System.Drawing.Point(10, 230);
+            lblDropChance.Location = new System.Drawing.Point(10, 284);
             lblDropChance.Margin = new Padding(4, 0, 4, 0);
             lblDropChance.Name = "lblDropChance";
             lblDropChance.Size = new Size(71, 15);
@@ -1057,7 +1029,7 @@ namespace Intersect.Editor.Forms.Editors
             // lblDropItem
             // 
             lblDropItem.AutoSize = true;
-            lblDropItem.Location = new System.Drawing.Point(10, 134);
+            lblDropItem.Location = new System.Drawing.Point(10, 186);
             lblDropItem.Margin = new Padding(4, 0, 4, 0);
             lblDropItem.Name = "lblDropItem";
             lblDropItem.Size = new Size(34, 15);
@@ -1226,6 +1198,7 @@ namespace Intersect.Editor.Forms.Editors
             grpResources.PerformLayout();
             grpGeneral.ResumeLayout(false);
             grpGeneral.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)nudHpRegen).EndInit();
             ((System.ComponentModel.ISupportInitialize)nudMaxHp).EndInit();
             ((System.ComponentModel.ISupportInitialize)nudMinHp).EndInit();
             ((System.ComponentModel.ISupportInitialize)nudSpawnDuration).EndInit();
@@ -1242,9 +1215,6 @@ namespace Intersect.Editor.Forms.Editors
             grpRequirements.PerformLayout();
             grpCommonEvent.ResumeLayout(false);
             grpCommonEvent.PerformLayout();
-            grpRegen.ResumeLayout(false);
-            grpRegen.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)nudHpRegen).EndInit();
             grpDrops.ResumeLayout(false);
             grpDrops.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)nudDropMinAmount).EndInit();
@@ -1300,9 +1270,7 @@ namespace Intersect.Editor.Forms.Editors
         private System.Windows.Forms.Label lblDropMaxAmount;
         private System.Windows.Forms.Label lblDropChance;
         private System.Windows.Forms.Label lblDropItem;
-        private DarkGroupBox grpRegen;
         private DarkNumericUpDown nudHpRegen;
-        private System.Windows.Forms.Label lblRegenHint;
         private DarkGroupBox grpCommonEvent;
         private DarkComboBox cmbEvent;
         private System.Windows.Forms.Label lblEvent;

--- a/Intersect.Editor/Forms/Editors/frmResource.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/frmResource.Designer.cs
@@ -656,7 +656,7 @@ namespace Intersect.Editor.Forms.Editors
             cmbAnimation.TabIndex = 55;
             cmbAnimation.Text = null;
             cmbAnimation.TextPadding = new Padding(2);
-            cmbAnimation.SelectedIndexChanged += UpdateCurrentState;
+            cmbAnimation.SelectedIndexChanged += cmbAnimation_SelectedIndexChanged;
             // 
             // lblAnimation
             // 

--- a/Intersect.Editor/Forms/Editors/frmResource.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/frmResource.Designer.cs
@@ -37,14 +37,15 @@ namespace Intersect.Editor.Forms.Editors
             txtSearch = new DarkTextBox();
             lstGameObjects = new Controls.GameObjectList();
             grpGeneral = new DarkGroupBox();
+            chkUseExplicitMaxHealthForResourceStates = new DarkCheckBox();
             btnAddFolder = new DarkButton();
             lblFolder = new Label();
             cmbFolder = new DarkComboBox();
             nudMaxHp = new DarkNumericUpDown();
             nudMinHp = new DarkNumericUpDown();
             nudSpawnDuration = new DarkNumericUpDown();
-            cmbAnimation = new DarkComboBox();
-            lblAnimation = new Label();
+            cmbDeathAnimation = new DarkComboBox();
+            lblDeathAnimation = new Label();
             lblMaxHp = new Label();
             lblSpawnDuration = new Label();
             chkWalkableAfter = new DarkCheckBox();
@@ -56,18 +57,25 @@ namespace Intersect.Editor.Forms.Editors
             txtName = new DarkTextBox();
             btnRequirements = new DarkButton();
             grpGraphics = new DarkGroupBox();
-            chkExhaustedBelowEntities = new DarkCheckBox();
-            chkInitialBelowEntities = new DarkCheckBox();
-            chkExhaustedFromTileset = new DarkCheckBox();
-            chkInitialFromTileset = new DarkCheckBox();
-            exhaustedGraphicContainer = new Panel();
-            picEndResource = new PictureBox();
-            initalGraphicContainer = new Panel();
-            picInitialResource = new PictureBox();
-            cmbEndSprite = new DarkComboBox();
-            lblPic2 = new Label();
-            cmbInitialSprite = new DarkComboBox();
-            lblPic = new Label();
+            btnRemoveHealthState = new DarkButton();
+            btnAddHealthState = new DarkButton();
+            lblHealthStateName = new Label();
+            lstHealthState = new ListBox();
+            txtHealthStateName = new DarkTextBox();
+            grpGraphicData = new DarkGroupBox();
+            nudHealthRangeMax = new DarkNumericUpDown();
+            nudHealthRangeMin = new DarkNumericUpDown();
+            lblHealthRange = new Label();
+            cmbGraphicFile = new DarkComboBox();
+            lblGraphicFile = new Label();
+            cmbAnimation = new DarkComboBox();
+            lblAnimation = new Label();
+            chkRenderBelowEntity = new DarkCheckBox();
+            cmbGraphicType = new DarkComboBox();
+            lblGraphicType = new Label();
+            lblHealthStates = new Label();
+            graphicContainer = new Panel();
+            picResource = new PictureBox();
             tmrRender = new System.Windows.Forms.Timer(components);
             pnlContainer = new Panel();
             grpRequirements = new DarkGroupBox();
@@ -111,10 +119,11 @@ namespace Intersect.Editor.Forms.Editors
             ((System.ComponentModel.ISupportInitialize)nudMinHp).BeginInit();
             ((System.ComponentModel.ISupportInitialize)nudSpawnDuration).BeginInit();
             grpGraphics.SuspendLayout();
-            exhaustedGraphicContainer.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)picEndResource).BeginInit();
-            initalGraphicContainer.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)picInitialResource).BeginInit();
+            grpGraphicData.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)nudHealthRangeMax).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)nudHealthRangeMin).BeginInit();
+            graphicContainer.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)picResource).BeginInit();
             pnlContainer.SuspendLayout();
             grpRequirements.SuspendLayout();
             grpCommonEvent.SuspendLayout();
@@ -191,14 +200,15 @@ namespace Intersect.Editor.Forms.Editors
             // 
             grpGeneral.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
             grpGeneral.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            grpGeneral.Controls.Add(chkUseExplicitMaxHealthForResourceStates);
             grpGeneral.Controls.Add(btnAddFolder);
             grpGeneral.Controls.Add(lblFolder);
             grpGeneral.Controls.Add(cmbFolder);
             grpGeneral.Controls.Add(nudMaxHp);
             grpGeneral.Controls.Add(nudMinHp);
             grpGeneral.Controls.Add(nudSpawnDuration);
-            grpGeneral.Controls.Add(cmbAnimation);
-            grpGeneral.Controls.Add(lblAnimation);
+            grpGeneral.Controls.Add(cmbDeathAnimation);
+            grpGeneral.Controls.Add(lblDeathAnimation);
             grpGeneral.Controls.Add(lblMaxHp);
             grpGeneral.Controls.Add(lblSpawnDuration);
             grpGeneral.Controls.Add(chkWalkableAfter);
@@ -213,10 +223,20 @@ namespace Intersect.Editor.Forms.Editors
             grpGeneral.Margin = new Padding(4, 3, 4, 3);
             grpGeneral.Name = "grpGeneral";
             grpGeneral.Padding = new Padding(4, 3, 4, 3);
-            grpGeneral.Size = new Size(260, 324);
+            grpGeneral.Size = new Size(260, 353);
             grpGeneral.TabIndex = 15;
             grpGeneral.TabStop = false;
             grpGeneral.Text = "General";
+            // 
+            // chkUseExplicitMaxHealthForResourceStates
+            // 
+            chkUseExplicitMaxHealthForResourceStates.Location = new System.Drawing.Point(7, 319);
+            chkUseExplicitMaxHealthForResourceStates.Margin = new Padding(4, 3, 4, 3);
+            chkUseExplicitMaxHealthForResourceStates.Name = "chkUseExplicitMaxHealthForResourceStates";
+            chkUseExplicitMaxHealthForResourceStates.Size = new Size(246, 20);
+            chkUseExplicitMaxHealthForResourceStates.TabIndex = 53;
+            chkUseExplicitMaxHealthForResourceStates.Text = "Use explicit Max Health for States?";
+            chkUseExplicitMaxHealthForResourceStates.CheckedChanged += chkUseExplicitMaxHealthForResourceStates_CheckedChanged;
             // 
             // btnAddFolder
             // 
@@ -300,37 +320,37 @@ namespace Intersect.Editor.Forms.Editors
             nudSpawnDuration.Value = new decimal(new int[] { 0, 0, 0, 0 });
             nudSpawnDuration.ValueChanged += nudSpawnDuration_ValueChanged;
             // 
-            // cmbAnimation
+            // cmbDeathAnimation
             // 
-            cmbAnimation.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
-            cmbAnimation.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
-            cmbAnimation.BorderStyle = ButtonBorderStyle.Solid;
-            cmbAnimation.ButtonColor = System.Drawing.Color.FromArgb(43, 43, 43);
-            cmbAnimation.DrawDropdownHoverOutline = false;
-            cmbAnimation.DrawFocusRectangle = false;
-            cmbAnimation.DrawMode = DrawMode.OwnerDrawFixed;
-            cmbAnimation.DropDownStyle = ComboBoxStyle.DropDownList;
-            cmbAnimation.FlatStyle = FlatStyle.Flat;
-            cmbAnimation.ForeColor = System.Drawing.Color.Gainsboro;
-            cmbAnimation.FormattingEnabled = true;
-            cmbAnimation.Location = new System.Drawing.Point(88, 207);
-            cmbAnimation.Margin = new Padding(4, 3, 4, 3);
-            cmbAnimation.Name = "cmbAnimation";
-            cmbAnimation.Size = new Size(157, 24);
-            cmbAnimation.TabIndex = 39;
-            cmbAnimation.Text = null;
-            cmbAnimation.TextPadding = new Padding(2);
-            cmbAnimation.SelectedIndexChanged += cmbAnimation_SelectedIndexChanged;
+            cmbDeathAnimation.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            cmbDeathAnimation.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            cmbDeathAnimation.BorderStyle = ButtonBorderStyle.Solid;
+            cmbDeathAnimation.ButtonColor = System.Drawing.Color.FromArgb(43, 43, 43);
+            cmbDeathAnimation.DrawDropdownHoverOutline = false;
+            cmbDeathAnimation.DrawFocusRectangle = false;
+            cmbDeathAnimation.DrawMode = DrawMode.OwnerDrawFixed;
+            cmbDeathAnimation.DropDownStyle = ComboBoxStyle.DropDownList;
+            cmbDeathAnimation.FlatStyle = FlatStyle.Flat;
+            cmbDeathAnimation.ForeColor = System.Drawing.Color.Gainsboro;
+            cmbDeathAnimation.FormattingEnabled = true;
+            cmbDeathAnimation.Location = new System.Drawing.Point(7, 237);
+            cmbDeathAnimation.Margin = new Padding(4, 3, 4, 3);
+            cmbDeathAnimation.Name = "cmbDeathAnimation";
+            cmbDeathAnimation.Size = new Size(239, 24);
+            cmbDeathAnimation.TabIndex = 39;
+            cmbDeathAnimation.Text = null;
+            cmbDeathAnimation.TextPadding = new Padding(2);
+            cmbDeathAnimation.SelectedIndexChanged += cmbDeathAnimation_SelectedIndexChanged;
             // 
-            // lblAnimation
+            // lblDeathAnimation
             // 
-            lblAnimation.AutoSize = true;
-            lblAnimation.Location = new System.Drawing.Point(7, 210);
-            lblAnimation.Margin = new Padding(4, 0, 4, 0);
-            lblAnimation.Name = "lblAnimation";
-            lblAnimation.Size = new Size(66, 15);
-            lblAnimation.TabIndex = 36;
-            lblAnimation.Text = "Animation:";
+            lblDeathAnimation.AutoSize = true;
+            lblDeathAnimation.Location = new System.Drawing.Point(7, 210);
+            lblDeathAnimation.Margin = new Padding(4, 0, 4, 0);
+            lblDeathAnimation.Name = "lblDeathAnimation";
+            lblDeathAnimation.Size = new Size(100, 15);
+            lblDeathAnimation.TabIndex = 36;
+            lblDeathAnimation.Text = "Death Animation:";
             // 
             // lblMaxHp
             // 
@@ -354,7 +374,7 @@ namespace Intersect.Editor.Forms.Editors
             // 
             // chkWalkableAfter
             // 
-            chkWalkableAfter.Location = new System.Drawing.Point(7, 264);
+            chkWalkableAfter.Location = new System.Drawing.Point(7, 293);
             chkWalkableAfter.Margin = new Padding(4, 3, 4, 3);
             chkWalkableAfter.Name = "chkWalkableAfter";
             chkWalkableAfter.Size = new Size(246, 20);
@@ -364,7 +384,7 @@ namespace Intersect.Editor.Forms.Editors
             // 
             // chkWalkableBefore
             // 
-            chkWalkableBefore.Location = new System.Drawing.Point(7, 238);
+            chkWalkableBefore.Location = new System.Drawing.Point(7, 267);
             chkWalkableBefore.Margin = new Padding(4, 3, 4, 3);
             chkWalkableBefore.Name = "chkWalkableBefore";
             chkWalkableBefore.Size = new Size(246, 20);
@@ -451,18 +471,16 @@ namespace Intersect.Editor.Forms.Editors
             // 
             grpGraphics.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
             grpGraphics.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
-            grpGraphics.Controls.Add(chkExhaustedBelowEntities);
-            grpGraphics.Controls.Add(chkInitialBelowEntities);
-            grpGraphics.Controls.Add(chkExhaustedFromTileset);
-            grpGraphics.Controls.Add(chkInitialFromTileset);
-            grpGraphics.Controls.Add(exhaustedGraphicContainer);
-            grpGraphics.Controls.Add(initalGraphicContainer);
-            grpGraphics.Controls.Add(cmbEndSprite);
-            grpGraphics.Controls.Add(lblPic2);
-            grpGraphics.Controls.Add(cmbInitialSprite);
-            grpGraphics.Controls.Add(lblPic);
+            grpGraphics.Controls.Add(btnRemoveHealthState);
+            grpGraphics.Controls.Add(btnAddHealthState);
+            grpGraphics.Controls.Add(lblHealthStateName);
+            grpGraphics.Controls.Add(lstHealthState);
+            grpGraphics.Controls.Add(txtHealthStateName);
+            grpGraphics.Controls.Add(grpGraphicData);
+            grpGraphics.Controls.Add(lblHealthStates);
+            grpGraphics.Controls.Add(graphicContainer);
             grpGraphics.ForeColor = System.Drawing.Color.Gainsboro;
-            grpGraphics.Location = new System.Drawing.Point(0, 325);
+            grpGraphics.Location = new System.Drawing.Point(0, 359);
             grpGraphics.Margin = new Padding(4, 3, 4, 3);
             grpGraphics.Name = "grpGraphics";
             grpGraphics.Padding = new Padding(4, 3, 4, 3);
@@ -471,161 +489,264 @@ namespace Intersect.Editor.Forms.Editors
             grpGraphics.TabStop = false;
             grpGraphics.Text = "Graphics";
             // 
-            // chkExhaustedBelowEntities
+            // btnRemoveHealthState
             // 
-            chkExhaustedBelowEntities.Location = new System.Drawing.Point(696, 15);
-            chkExhaustedBelowEntities.Margin = new Padding(4, 3, 4, 3);
-            chkExhaustedBelowEntities.Name = "chkExhaustedBelowEntities";
-            chkExhaustedBelowEntities.Size = new Size(114, 24);
-            chkExhaustedBelowEntities.TabIndex = 35;
-            chkExhaustedBelowEntities.Text = "Below Entities";
-            chkExhaustedBelowEntities.CheckedChanged += chkExhaustedBelowEntities_CheckedChanged;
+            btnRemoveHealthState.Location = new System.Drawing.Point(172, 187);
+            btnRemoveHealthState.Margin = new Padding(4, 3, 4, 3);
+            btnRemoveHealthState.Name = "btnRemoveHealthState";
+            btnRemoveHealthState.Padding = new Padding(6);
+            btnRemoveHealthState.Size = new Size(88, 27);
+            btnRemoveHealthState.TabIndex = 67;
+            btnRemoveHealthState.Text = "Remove";
+            btnRemoveHealthState.Click += btnRemoveHealthState_Click;
             // 
-            // chkInitialBelowEntities
+            // btnAddHealthState
             // 
-            chkInitialBelowEntities.Location = new System.Drawing.Point(286, 15);
-            chkInitialBelowEntities.Margin = new Padding(4, 3, 4, 3);
-            chkInitialBelowEntities.Name = "chkInitialBelowEntities";
-            chkInitialBelowEntities.Size = new Size(114, 24);
-            chkInitialBelowEntities.TabIndex = 34;
-            chkInitialBelowEntities.Text = "Below Entities";
-            chkInitialBelowEntities.CheckedChanged += chkInitialBelowEntities_CheckedChanged;
+            btnAddHealthState.Location = new System.Drawing.Point(7, 187);
+            btnAddHealthState.Margin = new Padding(4, 3, 4, 3);
+            btnAddHealthState.Name = "btnAddHealthState";
+            btnAddHealthState.Padding = new Padding(6);
+            btnAddHealthState.Size = new Size(88, 27);
+            btnAddHealthState.TabIndex = 67;
+            btnAddHealthState.Text = "Add";
+            btnAddHealthState.Click += btnAddHealthState_Click;
             // 
-            // chkExhaustedFromTileset
+            // lblHealthStateName
             // 
-            chkExhaustedFromTileset.Location = new System.Drawing.Point(696, 37);
-            chkExhaustedFromTileset.Margin = new Padding(4, 3, 4, 3);
-            chkExhaustedFromTileset.Name = "chkExhaustedFromTileset";
-            chkExhaustedFromTileset.Size = new Size(114, 24);
-            chkExhaustedFromTileset.TabIndex = 33;
-            chkExhaustedFromTileset.Text = "From Tileset";
-            chkExhaustedFromTileset.CheckedChanged += chkExhaustedFromTileset_CheckedChanged;
+            lblHealthStateName.AutoSize = true;
+            lblHealthStateName.Location = new System.Drawing.Point(4, 139);
+            lblHealthStateName.Margin = new Padding(4, 0, 4, 0);
+            lblHealthStateName.Name = "lblHealthStateName";
+            lblHealthStateName.Size = new Size(153, 15);
+            lblHealthStateName.TabIndex = 56;
+            lblHealthStateName.Text = "Health Graphic State Name:";
             // 
-            // chkInitialFromTileset
+            // lstHealthState
             // 
-            chkInitialFromTileset.Location = new System.Drawing.Point(286, 37);
-            chkInitialFromTileset.Margin = new Padding(4, 3, 4, 3);
-            chkInitialFromTileset.Name = "chkInitialFromTileset";
-            chkInitialFromTileset.Size = new Size(114, 24);
-            chkInitialFromTileset.TabIndex = 32;
-            chkInitialFromTileset.Text = "From Tileset";
-            chkInitialFromTileset.CheckedChanged += chkInitialFromTileset_CheckedChanged;
+            lstHealthState.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            lstHealthState.BorderStyle = BorderStyle.FixedSingle;
+            lstHealthState.ForeColor = System.Drawing.Color.Gainsboro;
+            lstHealthState.FormattingEnabled = true;
+            lstHealthState.ItemHeight = 15;
+            lstHealthState.Location = new System.Drawing.Point(7, 39);
+            lstHealthState.Margin = new Padding(4, 3, 4, 3);
+            lstHealthState.Name = "lstHealthState";
+            lstHealthState.Size = new Size(253, 92);
+            lstHealthState.TabIndex = 60;
+            lstHealthState.SelectedIndexChanged += lstHealthState_SelectedIndexChanged;
             // 
-            // exhaustedGraphicContainer
+            // txtHealthStateName
             // 
-            exhaustedGraphicContainer.AutoScroll = true;
-            exhaustedGraphicContainer.Controls.Add(picEndResource);
-            exhaustedGraphicContainer.Location = new System.Drawing.Point(426, 72);
-            exhaustedGraphicContainer.Margin = new Padding(4, 3, 4, 3);
-            exhaustedGraphicContainer.Name = "exhaustedGraphicContainer";
-            exhaustedGraphicContainer.Size = new Size(385, 445);
-            exhaustedGraphicContainer.TabIndex = 25;
+            txtHealthStateName.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            txtHealthStateName.BorderStyle = BorderStyle.FixedSingle;
+            txtHealthStateName.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            txtHealthStateName.Location = new System.Drawing.Point(7, 158);
+            txtHealthStateName.Margin = new Padding(4, 3, 4, 3);
+            txtHealthStateName.Name = "txtHealthStateName";
+            txtHealthStateName.Size = new Size(253, 23);
+            txtHealthStateName.TabIndex = 55;
             // 
-            // picEndResource
+            // grpGraphicData
             // 
-            picEndResource.Location = new System.Drawing.Point(0, 0);
-            picEndResource.Margin = new Padding(4, 3, 4, 3);
-            picEndResource.Name = "picEndResource";
-            picEndResource.Size = new Size(212, 335);
-            picEndResource.TabIndex = 2;
-            picEndResource.TabStop = false;
-            picEndResource.MouseDown += picExhustedResource_MouseDown;
-            picEndResource.MouseMove += picExhaustedResource_MouseMove;
-            picEndResource.MouseUp += picExhaustedResource_MouseUp;
+            grpGraphicData.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+            grpGraphicData.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            grpGraphicData.Controls.Add(nudHealthRangeMax);
+            grpGraphicData.Controls.Add(nudHealthRangeMin);
+            grpGraphicData.Controls.Add(lblHealthRange);
+            grpGraphicData.Controls.Add(cmbGraphicFile);
+            grpGraphicData.Controls.Add(lblGraphicFile);
+            grpGraphicData.Controls.Add(cmbAnimation);
+            grpGraphicData.Controls.Add(lblAnimation);
+            grpGraphicData.Controls.Add(chkRenderBelowEntity);
+            grpGraphicData.Controls.Add(cmbGraphicType);
+            grpGraphicData.Controls.Add(lblGraphicType);
+            grpGraphicData.ForeColor = System.Drawing.Color.Gainsboro;
+            grpGraphicData.Location = new System.Drawing.Point(7, 221);
+            grpGraphicData.Margin = new Padding(2);
+            grpGraphicData.Name = "grpGraphicData";
+            grpGraphicData.Padding = new Padding(2);
+            grpGraphicData.Size = new Size(253, 292);
+            grpGraphicData.TabIndex = 34;
+            grpGraphicData.TabStop = false;
+            grpGraphicData.Text = "Graphic Data";
             // 
-            // initalGraphicContainer
+            // nudHealthRangeMax
             // 
-            initalGraphicContainer.AutoScroll = true;
-            initalGraphicContainer.Controls.Add(picInitialResource);
-            initalGraphicContainer.Location = new System.Drawing.Point(15, 72);
-            initalGraphicContainer.Margin = new Padding(4, 3, 4, 3);
-            initalGraphicContainer.Name = "initalGraphicContainer";
-            initalGraphicContainer.Size = new Size(385, 445);
-            initalGraphicContainer.TabIndex = 24;
+            nudHealthRangeMax.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudHealthRangeMax.ForeColor = System.Drawing.Color.Gainsboro;
+            nudHealthRangeMax.Location = new System.Drawing.Point(137, 229);
+            nudHealthRangeMax.Margin = new Padding(4, 3, 4, 3);
+            nudHealthRangeMax.Name = "nudHealthRangeMax";
+            nudHealthRangeMax.Size = new Size(102, 23);
+            nudHealthRangeMax.TabIndex = 68;
+            nudHealthRangeMax.Value = new decimal(new int[] { 0, 0, 0, 0 });
+            nudHealthRangeMax.ValueChanged += nudHealthRangeMax_ValueChanged;
             // 
-            // picInitialResource
+            // nudHealthRangeMin
             // 
-            picInitialResource.Location = new System.Drawing.Point(0, 0);
-            picInitialResource.Margin = new Padding(4, 3, 4, 3);
-            picInitialResource.Name = "picInitialResource";
-            picInitialResource.Size = new Size(210, 335);
-            picInitialResource.TabIndex = 2;
-            picInitialResource.TabStop = false;
-            picInitialResource.MouseDown += picInitialResource_MouseDown;
-            picInitialResource.MouseMove += picInitialResource_MouseMove;
-            picInitialResource.MouseUp += picInitialResource_MouseUp;
+            nudHealthRangeMin.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudHealthRangeMin.ForeColor = System.Drawing.Color.Gainsboro;
+            nudHealthRangeMin.Location = new System.Drawing.Point(12, 229);
+            nudHealthRangeMin.Margin = new Padding(4, 3, 4, 3);
+            nudHealthRangeMin.Name = "nudHealthRangeMin";
+            nudHealthRangeMin.Size = new Size(102, 23);
+            nudHealthRangeMin.TabIndex = 67;
+            nudHealthRangeMin.Value = new decimal(new int[] { 0, 0, 0, 0 });
+            nudHealthRangeMin.ValueChanged += nudHealthRangeMin_ValueChanged;
             // 
-            // cmbEndSprite
+            // lblHealthRange
             // 
-            cmbEndSprite.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
-            cmbEndSprite.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
-            cmbEndSprite.BorderStyle = ButtonBorderStyle.Solid;
-            cmbEndSprite.ButtonColor = System.Drawing.Color.FromArgb(43, 43, 43);
-            cmbEndSprite.DrawDropdownHoverOutline = false;
-            cmbEndSprite.DrawFocusRectangle = false;
-            cmbEndSprite.DrawMode = DrawMode.OwnerDrawFixed;
-            cmbEndSprite.DropDownStyle = ComboBoxStyle.DropDownList;
-            cmbEndSprite.FlatStyle = FlatStyle.Flat;
-            cmbEndSprite.ForeColor = System.Drawing.Color.Gainsboro;
-            cmbEndSprite.FormattingEnabled = true;
-            cmbEndSprite.Items.AddRange(new object[] { "None" });
-            cmbEndSprite.Location = new System.Drawing.Point(426, 37);
-            cmbEndSprite.Margin = new Padding(4, 3, 4, 3);
-            cmbEndSprite.Name = "cmbEndSprite";
-            cmbEndSprite.Size = new Size(228, 24);
-            cmbEndSprite.TabIndex = 16;
-            cmbEndSprite.Text = "None";
-            cmbEndSprite.TextPadding = new Padding(2);
-            cmbEndSprite.SelectedIndexChanged += cmbEndSprite_SelectedIndexChanged;
+            lblHealthRange.AutoSize = true;
+            lblHealthRange.Location = new System.Drawing.Point(12, 208);
+            lblHealthRange.Margin = new Padding(4, 0, 4, 0);
+            lblHealthRange.Name = "lblHealthRange";
+            lblHealthRange.Size = new Size(160, 15);
+            lblHealthRange.TabIndex = 58;
+            lblHealthRange.Text = "Health Range Min - Max (%):";
             // 
-            // lblPic2
+            // cmbGraphicFile
             // 
-            lblPic2.AutoSize = true;
-            lblPic2.Location = new System.Drawing.Point(422, 18);
-            lblPic2.Margin = new Padding(4, 0, 4, 0);
-            lblPic2.Name = "lblPic2";
-            lblPic2.Size = new Size(104, 15);
-            lblPic2.TabIndex = 15;
-            lblPic2.Text = "Removed Graphic:";
+            cmbGraphicFile.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            cmbGraphicFile.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            cmbGraphicFile.BorderStyle = ButtonBorderStyle.Solid;
+            cmbGraphicFile.ButtonColor = System.Drawing.Color.FromArgb(43, 43, 43);
+            cmbGraphicFile.DrawDropdownHoverOutline = false;
+            cmbGraphicFile.DrawFocusRectangle = false;
+            cmbGraphicFile.DrawMode = DrawMode.OwnerDrawFixed;
+            cmbGraphicFile.DropDownStyle = ComboBoxStyle.DropDownList;
+            cmbGraphicFile.FlatStyle = FlatStyle.Flat;
+            cmbGraphicFile.ForeColor = System.Drawing.Color.Gainsboro;
+            cmbGraphicFile.FormattingEnabled = true;
+            cmbGraphicFile.Location = new System.Drawing.Point(12, 119);
+            cmbGraphicFile.Margin = new Padding(4, 3, 4, 3);
+            cmbGraphicFile.Name = "cmbGraphicFile";
+            cmbGraphicFile.Size = new Size(227, 24);
+            cmbGraphicFile.TabIndex = 57;
+            cmbGraphicFile.Text = null;
+            cmbGraphicFile.TextPadding = new Padding(2);
+            cmbGraphicFile.SelectedIndexChanged += cmbGraphicFile_SelectedIndexChanged;
             // 
-            // cmbInitialSprite
+            // lblGraphicFile
             // 
-            cmbInitialSprite.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
-            cmbInitialSprite.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
-            cmbInitialSprite.BorderStyle = ButtonBorderStyle.Solid;
-            cmbInitialSprite.ButtonColor = System.Drawing.Color.FromArgb(43, 43, 43);
-            cmbInitialSprite.DrawDropdownHoverOutline = false;
-            cmbInitialSprite.DrawFocusRectangle = false;
-            cmbInitialSprite.DrawMode = DrawMode.OwnerDrawFixed;
-            cmbInitialSprite.DropDownStyle = ComboBoxStyle.DropDownList;
-            cmbInitialSprite.FlatStyle = FlatStyle.Flat;
-            cmbInitialSprite.ForeColor = System.Drawing.Color.Gainsboro;
-            cmbInitialSprite.FormattingEnabled = true;
-            cmbInitialSprite.Items.AddRange(new object[] { "None" });
-            cmbInitialSprite.Location = new System.Drawing.Point(15, 37);
-            cmbInitialSprite.Margin = new Padding(4, 3, 4, 3);
-            cmbInitialSprite.Name = "cmbInitialSprite";
-            cmbInitialSprite.Size = new Size(227, 24);
-            cmbInitialSprite.TabIndex = 14;
-            cmbInitialSprite.Text = "None";
-            cmbInitialSprite.TextPadding = new Padding(2);
-            cmbInitialSprite.SelectedIndexChanged += cmbInitialSprite_SelectedIndexChanged;
+            lblGraphicFile.AutoSize = true;
+            lblGraphicFile.Location = new System.Drawing.Point(9, 99);
+            lblGraphicFile.Margin = new Padding(4, 0, 4, 0);
+            lblGraphicFile.Name = "lblGraphicFile";
+            lblGraphicFile.Size = new Size(72, 15);
+            lblGraphicFile.TabIndex = 56;
+            lblGraphicFile.Text = "Graphic File:";
             // 
-            // lblPic
+            // cmbAnimation
             // 
-            lblPic.AutoSize = true;
-            lblPic.Location = new System.Drawing.Point(12, 18);
-            lblPic.Margin = new Padding(4, 0, 4, 0);
-            lblPic.Name = "lblPic";
-            lblPic.Size = new Size(83, 15);
-            lblPic.TabIndex = 13;
-            lblPic.Text = "Initial Graphic:";
+            cmbAnimation.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            cmbAnimation.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            cmbAnimation.BorderStyle = ButtonBorderStyle.Solid;
+            cmbAnimation.ButtonColor = System.Drawing.Color.FromArgb(43, 43, 43);
+            cmbAnimation.DrawDropdownHoverOutline = false;
+            cmbAnimation.DrawFocusRectangle = false;
+            cmbAnimation.DrawMode = DrawMode.OwnerDrawFixed;
+            cmbAnimation.DropDownStyle = ComboBoxStyle.DropDownList;
+            cmbAnimation.FlatStyle = FlatStyle.Flat;
+            cmbAnimation.ForeColor = System.Drawing.Color.Gainsboro;
+            cmbAnimation.FormattingEnabled = true;
+            cmbAnimation.Location = new System.Drawing.Point(12, 175);
+            cmbAnimation.Margin = new Padding(4, 3, 4, 3);
+            cmbAnimation.Name = "cmbAnimation";
+            cmbAnimation.Size = new Size(227, 24);
+            cmbAnimation.TabIndex = 55;
+            cmbAnimation.Text = null;
+            cmbAnimation.TextPadding = new Padding(2);
+            cmbAnimation.SelectedIndexChanged += UpdateCurrentState;
+            // 
+            // lblAnimation
+            // 
+            lblAnimation.AutoSize = true;
+            lblAnimation.Location = new System.Drawing.Point(9, 155);
+            lblAnimation.Margin = new Padding(4, 0, 4, 0);
+            lblAnimation.Name = "lblAnimation";
+            lblAnimation.Size = new Size(66, 15);
+            lblAnimation.TabIndex = 54;
+            lblAnimation.Text = "Animation:";
+            // 
+            // chkRenderBelowEntity
+            // 
+            chkRenderBelowEntity.Location = new System.Drawing.Point(12, 71);
+            chkRenderBelowEntity.Margin = new Padding(4, 3, 4, 3);
+            chkRenderBelowEntity.Name = "chkRenderBelowEntity";
+            chkRenderBelowEntity.Size = new Size(227, 20);
+            chkRenderBelowEntity.TabIndex = 53;
+            chkRenderBelowEntity.Text = "Render Below Entity";
+            chkRenderBelowEntity.CheckedChanged += chkRenderBelowEntity_CheckedChanged;
+            // 
+            // cmbGraphicType
+            // 
+            cmbGraphicType.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            cmbGraphicType.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            cmbGraphicType.BorderStyle = ButtonBorderStyle.Solid;
+            cmbGraphicType.ButtonColor = System.Drawing.Color.FromArgb(43, 43, 43);
+            cmbGraphicType.DrawDropdownHoverOutline = false;
+            cmbGraphicType.DrawFocusRectangle = false;
+            cmbGraphicType.DrawMode = DrawMode.OwnerDrawFixed;
+            cmbGraphicType.DropDownStyle = ComboBoxStyle.DropDownList;
+            cmbGraphicType.FlatStyle = FlatStyle.Flat;
+            cmbGraphicType.ForeColor = System.Drawing.Color.Gainsboro;
+            cmbGraphicType.FormattingEnabled = true;
+            cmbGraphicType.Location = new System.Drawing.Point(12, 41);
+            cmbGraphicType.Margin = new Padding(4, 3, 4, 3);
+            cmbGraphicType.Name = "cmbGraphicType";
+            cmbGraphicType.Size = new Size(227, 24);
+            cmbGraphicType.TabIndex = 21;
+            cmbGraphicType.Text = null;
+            cmbGraphicType.TextPadding = new Padding(2);
+            cmbGraphicType.SelectedIndexChanged += cmbGraphicType_SelectedIndexChanged;
+            // 
+            // lblGraphicType
+            // 
+            lblGraphicType.AutoSize = true;
+            lblGraphicType.Location = new System.Drawing.Point(9, 21);
+            lblGraphicType.Margin = new Padding(4, 0, 4, 0);
+            lblGraphicType.Name = "lblGraphicType";
+            lblGraphicType.Size = new Size(78, 15);
+            lblGraphicType.TabIndex = 20;
+            lblGraphicType.Text = "Graphic Type:";
+            // 
+            // lblHealthStates
+            // 
+            lblHealthStates.AutoSize = true;
+            lblHealthStates.Location = new System.Drawing.Point(10, 21);
+            lblHealthStates.Margin = new Padding(4, 0, 4, 0);
+            lblHealthStates.Name = "lblHealthStates";
+            lblHealthStates.Size = new Size(79, 15);
+            lblHealthStates.TabIndex = 55;
+            lblHealthStates.Text = "Health States:";
+            // 
+            // graphicContainer
+            // 
+            graphicContainer.AutoScroll = true;
+            graphicContainer.Controls.Add(picResource);
+            graphicContainer.Location = new System.Drawing.Point(270, 22);
+            graphicContainer.Margin = new Padding(4, 3, 4, 3);
+            graphicContainer.Name = "graphicContainer";
+            graphicContainer.Size = new Size(540, 491);
+            graphicContainer.TabIndex = 24;
+            // 
+            // picResource
+            // 
+            picResource.Location = new System.Drawing.Point(0, 0);
+            picResource.Margin = new Padding(4, 3, 4, 3);
+            picResource.Name = "picResource";
+            picResource.Size = new Size(540, 491);
+            picResource.TabIndex = 2;
+            picResource.TabStop = false;
+            picResource.MouseDown += picResource_MouseDown;
+            picResource.MouseMove += picResource_MouseMove;
+            picResource.MouseUp += picResource_MouseUp;
             // 
             // tmrRender
             // 
             tmrRender.Enabled = true;
             tmrRender.Interval = 10;
-            tmrRender.Tick += tmrRender_Tick;
+            tmrRender.Tick += Render;
             // 
             // pnlContainer
             // 
@@ -655,7 +776,7 @@ namespace Intersect.Editor.Forms.Editors
             grpRequirements.Margin = new Padding(2);
             grpRequirements.Name = "grpRequirements";
             grpRequirements.Padding = new Padding(2);
-            grpRequirements.Size = new Size(285, 106);
+            grpRequirements.Size = new Size(285, 135);
             grpRequirements.TabIndex = 33;
             grpRequirements.TabStop = false;
             grpRequirements.Text = "Requirements";
@@ -798,7 +919,7 @@ namespace Intersect.Editor.Forms.Editors
             grpDrops.Margin = new Padding(4, 3, 4, 3);
             grpDrops.Name = "grpDrops";
             grpDrops.Padding = new Padding(4, 3, 4, 3);
-            grpDrops.Size = new Size(264, 324);
+            grpDrops.Size = new Size(264, 353);
             grpDrops.TabIndex = 31;
             grpDrops.TabStop = false;
             grpDrops.Text = "Drops";
@@ -829,7 +950,7 @@ namespace Intersect.Editor.Forms.Editors
             // 
             // btnDropRemove
             // 
-            btnDropRemove.Location = new System.Drawing.Point(168, 287);
+            btnDropRemove.Location = new System.Drawing.Point(168, 312);
             btnDropRemove.Margin = new Padding(4, 3, 4, 3);
             btnDropRemove.Name = "btnDropRemove";
             btnDropRemove.Padding = new Padding(6);
@@ -840,7 +961,7 @@ namespace Intersect.Editor.Forms.Editors
             // 
             // btnDropAdd
             // 
-            btnDropAdd.Location = new System.Drawing.Point(10, 287);
+            btnDropAdd.Location = new System.Drawing.Point(10, 312);
             btnDropAdd.Margin = new Padding(4, 3, 4, 3);
             btnDropAdd.Name = "btnDropAdd";
             btnDropAdd.Padding = new Padding(6);
@@ -1110,10 +1231,12 @@ namespace Intersect.Editor.Forms.Editors
             ((System.ComponentModel.ISupportInitialize)nudSpawnDuration).EndInit();
             grpGraphics.ResumeLayout(false);
             grpGraphics.PerformLayout();
-            exhaustedGraphicContainer.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)picEndResource).EndInit();
-            initalGraphicContainer.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)picInitialResource).EndInit();
+            grpGraphicData.ResumeLayout(false);
+            grpGraphicData.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)nudHealthRangeMax).EndInit();
+            ((System.ComponentModel.ISupportInitialize)nudHealthRangeMin).EndInit();
+            graphicContainer.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)picResource).EndInit();
             pnlContainer.ResumeLayout(false);
             grpRequirements.ResumeLayout(false);
             grpRequirements.PerformLayout();
@@ -1144,15 +1267,10 @@ namespace Intersect.Editor.Forms.Editors
         private DarkCheckBox chkWalkableBefore;
         private DarkComboBox cmbToolType;
         private System.Windows.Forms.Label lblToolType;
-        private DarkComboBox cmbEndSprite;
-        private System.Windows.Forms.Label lblPic2;
-        private DarkComboBox cmbInitialSprite;
-        private System.Windows.Forms.Label lblPic;
         private System.Windows.Forms.Label lblSpawnDuration;
-        public System.Windows.Forms.PictureBox picEndResource;
-        public System.Windows.Forms.PictureBox picInitialResource;
+        public System.Windows.Forms.PictureBox picResource;
         private System.Windows.Forms.Label lblMaxHp;
-        private System.Windows.Forms.Label lblAnimation;
+        private System.Windows.Forms.Label lblDeathAnimation;
         private System.Windows.Forms.Timer tmrRender;
         private System.Windows.Forms.Panel pnlContainer;
         private DarkButton btnSave;
@@ -1166,10 +1284,9 @@ namespace Intersect.Editor.Forms.Editors
         public System.Windows.Forms.ToolStripButton toolStripItemPaste;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator3;
         public System.Windows.Forms.ToolStripButton toolStripItemUndo;
-        private System.Windows.Forms.Panel exhaustedGraphicContainer;
-        private System.Windows.Forms.Panel initalGraphicContainer;
+        private System.Windows.Forms.Panel graphicContainer;
         private DarkButton btnRequirements;
-        private DarkComboBox cmbAnimation;
+        private DarkComboBox cmbDeathAnimation;
         private DarkNumericUpDown nudSpawnDuration;
         private DarkNumericUpDown nudMaxHp;
         private DarkNumericUpDown nudMinHp;
@@ -1183,8 +1300,6 @@ namespace Intersect.Editor.Forms.Editors
         private System.Windows.Forms.Label lblDropMaxAmount;
         private System.Windows.Forms.Label lblDropChance;
         private System.Windows.Forms.Label lblDropItem;
-        private DarkCheckBox chkExhaustedFromTileset;
-        private DarkCheckBox chkInitialFromTileset;
         private DarkGroupBox grpRegen;
         private DarkNumericUpDown nudHpRegen;
         private System.Windows.Forms.Label lblHpRegen;
@@ -1192,8 +1307,6 @@ namespace Intersect.Editor.Forms.Editors
         private DarkGroupBox grpCommonEvent;
         private DarkComboBox cmbEvent;
         private System.Windows.Forms.Label lblEvent;
-        private DarkCheckBox chkExhaustedBelowEntities;
-        private DarkCheckBox chkInitialBelowEntities;
         private DarkButton btnClearSearch;
         private DarkTextBox txtSearch;
         private DarkButton btnAddFolder;
@@ -1207,5 +1320,23 @@ namespace Intersect.Editor.Forms.Editors
         private DarkTextBox txtCannotHarvest;
         private DarkNumericUpDown nudDropMinAmount;
         private Label lblDropMinAmount;
+        private Label lblHealthStates;
+        private DarkGroupBox grpGraphicData;
+        private DarkComboBox cmbGraphicType;
+        private Label lblGraphicType;
+        private DarkCheckBox chkRenderBelowEntity;
+        private DarkComboBox cmbAnimation;
+        private Label lblAnimation;
+        private DarkComboBox cmbGraphicFile;
+        private Label lblGraphicFile;
+        private ListBox lstHealthState;
+        private DarkButton btnRemoveHealthState;
+        private DarkButton btnAddHealthState;
+        private Label lblHealthStateName;
+        private DarkTextBox txtHealthStateName;
+        private Label lblHealthRange;
+        private DarkNumericUpDown nudHealthRangeMax;
+        private DarkNumericUpDown nudHealthRangeMin;
+        private DarkCheckBox chkUseExplicitMaxHealthForResourceStates;
     }
 }

--- a/Intersect.Editor/Forms/Editors/frmResource.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/frmResource.Designer.cs
@@ -57,23 +57,23 @@ namespace Intersect.Editor.Forms.Editors
             txtName = new DarkTextBox();
             btnRequirements = new DarkButton();
             grpGraphics = new DarkGroupBox();
-            btnRemoveHealthState = new DarkButton();
-            btnAddHealthState = new DarkButton();
-            lblHealthStateName = new Label();
-            lstHealthState = new ListBox();
-            txtHealthStateName = new DarkTextBox();
+            btnRemoveState = new DarkButton();
+            btnAddState = new DarkButton();
+            lblStateName = new Label();
+            lstStates = new ListBox();
+            txtStateName = new DarkTextBox();
             grpGraphicData = new DarkGroupBox();
-            nudHealthRangeMax = new DarkNumericUpDown();
-            nudHealthRangeMin = new DarkNumericUpDown();
-            lblHealthRange = new Label();
-            cmbGraphicFile = new DarkComboBox();
-            lblGraphicFile = new Label();
+            nudStateRangeMax = new DarkNumericUpDown();
+            nudStateRangeMin = new DarkNumericUpDown();
+            lblStateRange = new Label();
+            cmbTextureSource = new DarkComboBox();
+            lblTerxtureSource = new Label();
             cmbAnimation = new DarkComboBox();
             lblAnimation = new Label();
             chkRenderBelowEntity = new DarkCheckBox();
-            cmbGraphicType = new DarkComboBox();
-            lblGraphicType = new Label();
-            lblHealthStates = new Label();
+            cmbTextureType = new DarkComboBox();
+            lblTextureType = new Label();
+            lblStates = new Label();
             graphicContainer = new Panel();
             picResource = new PictureBox();
             tmrRender = new System.Windows.Forms.Timer(components);
@@ -86,6 +86,7 @@ namespace Intersect.Editor.Forms.Editors
             lblEvent = new Label();
             grpRegen = new DarkGroupBox();
             nudHpRegen = new DarkNumericUpDown();
+            lblHpRegen = new Label();
             lblRegenHint = new Label();
             grpDrops = new DarkGroupBox();
             nudDropMinAmount = new DarkNumericUpDown();
@@ -112,7 +113,6 @@ namespace Intersect.Editor.Forms.Editors
             toolStripItemPaste = new ToolStripButton();
             toolStripSeparator3 = new ToolStripSeparator();
             toolStripItemUndo = new ToolStripButton();
-            lblHpRegen = new Label();
             grpResources.SuspendLayout();
             grpGeneral.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)nudMaxHp).BeginInit();
@@ -120,8 +120,8 @@ namespace Intersect.Editor.Forms.Editors
             ((System.ComponentModel.ISupportInitialize)nudSpawnDuration).BeginInit();
             grpGraphics.SuspendLayout();
             grpGraphicData.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)nudHealthRangeMax).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)nudHealthRangeMin).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)nudStateRangeMax).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)nudStateRangeMin).BeginInit();
             graphicContainer.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)picResource).BeginInit();
             pnlContainer.SuspendLayout();
@@ -471,13 +471,13 @@ namespace Intersect.Editor.Forms.Editors
             // 
             grpGraphics.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
             grpGraphics.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
-            grpGraphics.Controls.Add(btnRemoveHealthState);
-            grpGraphics.Controls.Add(btnAddHealthState);
-            grpGraphics.Controls.Add(lblHealthStateName);
-            grpGraphics.Controls.Add(lstHealthState);
-            grpGraphics.Controls.Add(txtHealthStateName);
+            grpGraphics.Controls.Add(btnRemoveState);
+            grpGraphics.Controls.Add(btnAddState);
+            grpGraphics.Controls.Add(lblStateName);
+            grpGraphics.Controls.Add(lstStates);
+            grpGraphics.Controls.Add(txtStateName);
             grpGraphics.Controls.Add(grpGraphicData);
-            grpGraphics.Controls.Add(lblHealthStates);
+            grpGraphics.Controls.Add(lblStates);
             grpGraphics.Controls.Add(graphicContainer);
             grpGraphics.ForeColor = System.Drawing.Color.Gainsboro;
             grpGraphics.Location = new System.Drawing.Point(0, 359);
@@ -489,77 +489,77 @@ namespace Intersect.Editor.Forms.Editors
             grpGraphics.TabStop = false;
             grpGraphics.Text = "Appearance";
             // 
-            // btnRemoveHealthState
+            // btnRemoveState
             // 
-            btnRemoveHealthState.Location = new System.Drawing.Point(172, 187);
-            btnRemoveHealthState.Margin = new Padding(4, 3, 4, 3);
-            btnRemoveHealthState.Name = "btnRemoveHealthState";
-            btnRemoveHealthState.Padding = new Padding(6);
-            btnRemoveHealthState.Size = new Size(88, 27);
-            btnRemoveHealthState.TabIndex = 67;
-            btnRemoveHealthState.Text = "Remove";
-            btnRemoveHealthState.Click += btnRemoveHealthState_Click;
+            btnRemoveState.Location = new System.Drawing.Point(172, 187);
+            btnRemoveState.Margin = new Padding(4, 3, 4, 3);
+            btnRemoveState.Name = "btnRemoveState";
+            btnRemoveState.Padding = new Padding(6);
+            btnRemoveState.Size = new Size(88, 27);
+            btnRemoveState.TabIndex = 67;
+            btnRemoveState.Text = "Remove";
+            btnRemoveState.Click += btnRemoveState_Click;
             // 
-            // btnAddHealthState
+            // btnAddState
             // 
-            btnAddHealthState.Location = new System.Drawing.Point(7, 187);
-            btnAddHealthState.Margin = new Padding(4, 3, 4, 3);
-            btnAddHealthState.Name = "btnAddHealthState";
-            btnAddHealthState.Padding = new Padding(6);
-            btnAddHealthState.Size = new Size(88, 27);
-            btnAddHealthState.TabIndex = 67;
-            btnAddHealthState.Text = "Add";
-            btnAddHealthState.Click += btnAddHealthState_Click;
+            btnAddState.Location = new System.Drawing.Point(7, 187);
+            btnAddState.Margin = new Padding(4, 3, 4, 3);
+            btnAddState.Name = "btnAddState";
+            btnAddState.Padding = new Padding(6);
+            btnAddState.Size = new Size(88, 27);
+            btnAddState.TabIndex = 67;
+            btnAddState.Text = "Add";
+            btnAddState.Click += btnAddState_Click;
             // 
-            // lblHealthStateName
+            // lblStateName
             // 
-            lblHealthStateName.AutoSize = true;
-            lblHealthStateName.Location = new System.Drawing.Point(4, 139);
-            lblHealthStateName.Margin = new Padding(4, 0, 4, 0);
-            lblHealthStateName.Name = "lblHealthStateName";
-            lblHealthStateName.Size = new Size(153, 15);
-            lblHealthStateName.TabIndex = 56;
-            lblHealthStateName.Text = "Health Graphic State Name:";
+            lblStateName.AutoSize = true;
+            lblStateName.Location = new System.Drawing.Point(4, 139);
+            lblStateName.Margin = new Padding(4, 0, 4, 0);
+            lblStateName.Name = "lblStateName";
+            lblStateName.Size = new Size(71, 15);
+            lblStateName.TabIndex = 56;
+            lblStateName.Text = "State Name:";
             // 
-            // lstHealthState
+            // lstStates
             // 
-            lstHealthState.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
-            lstHealthState.BorderStyle = BorderStyle.FixedSingle;
-            lstHealthState.ForeColor = System.Drawing.Color.Gainsboro;
-            lstHealthState.FormattingEnabled = true;
-            lstHealthState.ItemHeight = 15;
-            lstHealthState.Location = new System.Drawing.Point(7, 39);
-            lstHealthState.Margin = new Padding(4, 3, 4, 3);
-            lstHealthState.Name = "lstHealthState";
-            lstHealthState.Size = new Size(253, 92);
-            lstHealthState.TabIndex = 60;
-            lstHealthState.SelectedIndexChanged += lstHealthState_SelectedIndexChanged;
+            lstStates.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            lstStates.BorderStyle = BorderStyle.FixedSingle;
+            lstStates.ForeColor = System.Drawing.Color.Gainsboro;
+            lstStates.FormattingEnabled = true;
+            lstStates.ItemHeight = 15;
+            lstStates.Location = new System.Drawing.Point(7, 39);
+            lstStates.Margin = new Padding(4, 3, 4, 3);
+            lstStates.Name = "lstStates";
+            lstStates.Size = new Size(253, 92);
+            lstStates.TabIndex = 60;
+            lstStates.SelectedIndexChanged += lstStates_SelectedIndexChanged;
             // 
-            // txtHealthStateName
+            // txtStateName
             // 
-            txtHealthStateName.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
-            txtHealthStateName.BorderStyle = BorderStyle.FixedSingle;
-            txtHealthStateName.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
-            txtHealthStateName.Location = new System.Drawing.Point(7, 158);
-            txtHealthStateName.Margin = new Padding(4, 3, 4, 3);
-            txtHealthStateName.Name = "txtHealthStateName";
-            txtHealthStateName.Size = new Size(253, 23);
-            txtHealthStateName.TabIndex = 55;
+            txtStateName.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            txtStateName.BorderStyle = BorderStyle.FixedSingle;
+            txtStateName.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            txtStateName.Location = new System.Drawing.Point(7, 158);
+            txtStateName.Margin = new Padding(4, 3, 4, 3);
+            txtStateName.Name = "txtStateName";
+            txtStateName.Size = new Size(253, 23);
+            txtStateName.TabIndex = 55;
             // 
             // grpGraphicData
             // 
             grpGraphicData.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
             grpGraphicData.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
-            grpGraphicData.Controls.Add(nudHealthRangeMax);
-            grpGraphicData.Controls.Add(nudHealthRangeMin);
-            grpGraphicData.Controls.Add(lblHealthRange);
-            grpGraphicData.Controls.Add(cmbGraphicFile);
-            grpGraphicData.Controls.Add(lblGraphicFile);
+            grpGraphicData.Controls.Add(nudStateRangeMax);
+            grpGraphicData.Controls.Add(nudStateRangeMin);
+            grpGraphicData.Controls.Add(lblStateRange);
+            grpGraphicData.Controls.Add(cmbTextureSource);
+            grpGraphicData.Controls.Add(lblTerxtureSource);
             grpGraphicData.Controls.Add(cmbAnimation);
             grpGraphicData.Controls.Add(lblAnimation);
             grpGraphicData.Controls.Add(chkRenderBelowEntity);
-            grpGraphicData.Controls.Add(cmbGraphicType);
-            grpGraphicData.Controls.Add(lblGraphicType);
+            grpGraphicData.Controls.Add(cmbTextureType);
+            grpGraphicData.Controls.Add(lblTextureType);
             grpGraphicData.ForeColor = System.Drawing.Color.Gainsboro;
             grpGraphicData.Location = new System.Drawing.Point(7, 221);
             grpGraphicData.Margin = new Padding(2);
@@ -570,71 +570,71 @@ namespace Intersect.Editor.Forms.Editors
             grpGraphicData.TabStop = false;
             grpGraphicData.Text = "Graphic Data";
             // 
-            // nudHealthRangeMax
+            // nudStateRangeMax
             // 
-            nudHealthRangeMax.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
-            nudHealthRangeMax.ForeColor = System.Drawing.Color.Gainsboro;
-            nudHealthRangeMax.Location = new System.Drawing.Point(137, 229);
-            nudHealthRangeMax.Margin = new Padding(4, 3, 4, 3);
-            nudHealthRangeMax.Name = "nudHealthRangeMax";
-            nudHealthRangeMax.Size = new Size(102, 23);
-            nudHealthRangeMax.TabIndex = 68;
-            nudHealthRangeMax.Value = new decimal(new int[] { 0, 0, 0, 0 });
-            nudHealthRangeMax.ValueChanged += nudHealthRangeMax_ValueChanged;
+            nudStateRangeMax.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudStateRangeMax.ForeColor = System.Drawing.Color.Gainsboro;
+            nudStateRangeMax.Location = new System.Drawing.Point(137, 229);
+            nudStateRangeMax.Margin = new Padding(4, 3, 4, 3);
+            nudStateRangeMax.Name = "nudStateRangeMax";
+            nudStateRangeMax.Size = new Size(102, 23);
+            nudStateRangeMax.TabIndex = 68;
+            nudStateRangeMax.Value = new decimal(new int[] { 0, 0, 0, 0 });
+            nudStateRangeMax.ValueChanged += nudStateRangeMax_ValueChanged;
             // 
-            // nudHealthRangeMin
+            // nudStateRangeMin
             // 
-            nudHealthRangeMin.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
-            nudHealthRangeMin.ForeColor = System.Drawing.Color.Gainsboro;
-            nudHealthRangeMin.Location = new System.Drawing.Point(12, 229);
-            nudHealthRangeMin.Margin = new Padding(4, 3, 4, 3);
-            nudHealthRangeMin.Name = "nudHealthRangeMin";
-            nudHealthRangeMin.Size = new Size(102, 23);
-            nudHealthRangeMin.TabIndex = 67;
-            nudHealthRangeMin.Value = new decimal(new int[] { 0, 0, 0, 0 });
-            nudHealthRangeMin.ValueChanged += nudHealthRangeMin_ValueChanged;
+            nudStateRangeMin.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudStateRangeMin.ForeColor = System.Drawing.Color.Gainsboro;
+            nudStateRangeMin.Location = new System.Drawing.Point(12, 229);
+            nudStateRangeMin.Margin = new Padding(4, 3, 4, 3);
+            nudStateRangeMin.Name = "nudStateRangeMin";
+            nudStateRangeMin.Size = new Size(102, 23);
+            nudStateRangeMin.TabIndex = 67;
+            nudStateRangeMin.Value = new decimal(new int[] { 0, 0, 0, 0 });
+            nudStateRangeMin.ValueChanged += nudStateRangeMin_ValueChanged;
             // 
-            // lblHealthRange
+            // lblStateRange
             // 
-            lblHealthRange.AutoSize = true;
-            lblHealthRange.Location = new System.Drawing.Point(12, 208);
-            lblHealthRange.Margin = new Padding(4, 0, 4, 0);
-            lblHealthRange.Name = "lblHealthRange";
-            lblHealthRange.Size = new Size(160, 15);
-            lblHealthRange.TabIndex = 58;
-            lblHealthRange.Text = "Health Range Min - Max (%):";
+            lblStateRange.AutoSize = true;
+            lblStateRange.Location = new System.Drawing.Point(12, 208);
+            lblStateRange.Margin = new Padding(4, 0, 4, 0);
+            lblStateRange.Name = "lblStateRange";
+            lblStateRange.Size = new Size(151, 15);
+            lblStateRange.TabIndex = 58;
+            lblStateRange.Text = "State Range Min - Max (%):";
             // 
-            // cmbGraphicFile
+            // cmbTextureSource
             // 
-            cmbGraphicFile.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
-            cmbGraphicFile.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
-            cmbGraphicFile.BorderStyle = ButtonBorderStyle.Solid;
-            cmbGraphicFile.ButtonColor = System.Drawing.Color.FromArgb(43, 43, 43);
-            cmbGraphicFile.DrawDropdownHoverOutline = false;
-            cmbGraphicFile.DrawFocusRectangle = false;
-            cmbGraphicFile.DrawMode = DrawMode.OwnerDrawFixed;
-            cmbGraphicFile.DropDownStyle = ComboBoxStyle.DropDownList;
-            cmbGraphicFile.FlatStyle = FlatStyle.Flat;
-            cmbGraphicFile.ForeColor = System.Drawing.Color.Gainsboro;
-            cmbGraphicFile.FormattingEnabled = true;
-            cmbGraphicFile.Location = new System.Drawing.Point(12, 119);
-            cmbGraphicFile.Margin = new Padding(4, 3, 4, 3);
-            cmbGraphicFile.Name = "cmbGraphicFile";
-            cmbGraphicFile.Size = new Size(227, 24);
-            cmbGraphicFile.TabIndex = 57;
-            cmbGraphicFile.Text = null;
-            cmbGraphicFile.TextPadding = new Padding(2);
-            cmbGraphicFile.SelectedIndexChanged += cmbGraphicFile_SelectedIndexChanged;
+            cmbTextureSource.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            cmbTextureSource.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            cmbTextureSource.BorderStyle = ButtonBorderStyle.Solid;
+            cmbTextureSource.ButtonColor = System.Drawing.Color.FromArgb(43, 43, 43);
+            cmbTextureSource.DrawDropdownHoverOutline = false;
+            cmbTextureSource.DrawFocusRectangle = false;
+            cmbTextureSource.DrawMode = DrawMode.OwnerDrawFixed;
+            cmbTextureSource.DropDownStyle = ComboBoxStyle.DropDownList;
+            cmbTextureSource.FlatStyle = FlatStyle.Flat;
+            cmbTextureSource.ForeColor = System.Drawing.Color.Gainsboro;
+            cmbTextureSource.FormattingEnabled = true;
+            cmbTextureSource.Location = new System.Drawing.Point(12, 119);
+            cmbTextureSource.Margin = new Padding(4, 3, 4, 3);
+            cmbTextureSource.Name = "cmbTextureSource";
+            cmbTextureSource.Size = new Size(227, 24);
+            cmbTextureSource.TabIndex = 57;
+            cmbTextureSource.Text = null;
+            cmbTextureSource.TextPadding = new Padding(2);
+            cmbTextureSource.SelectedIndexChanged += cmbGraphicFile_SelectedIndexChanged;
             // 
-            // lblGraphicFile
+            // lblTerxtureSource
             // 
-            lblGraphicFile.AutoSize = true;
-            lblGraphicFile.Location = new System.Drawing.Point(9, 99);
-            lblGraphicFile.Margin = new Padding(4, 0, 4, 0);
-            lblGraphicFile.Name = "lblGraphicFile";
-            lblGraphicFile.Size = new Size(72, 15);
-            lblGraphicFile.TabIndex = 56;
-            lblGraphicFile.Text = "Graphic File:";
+            lblTerxtureSource.AutoSize = true;
+            lblTerxtureSource.Location = new System.Drawing.Point(9, 99);
+            lblTerxtureSource.Margin = new Padding(4, 0, 4, 0);
+            lblTerxtureSource.Name = "lblTerxtureSource";
+            lblTerxtureSource.Size = new Size(87, 15);
+            lblTerxtureSource.TabIndex = 56;
+            lblTerxtureSource.Text = "Texture Source:";
             // 
             // cmbAnimation
             // 
@@ -678,47 +678,47 @@ namespace Intersect.Editor.Forms.Editors
             chkRenderBelowEntity.Text = "Render Below Entity";
             chkRenderBelowEntity.CheckedChanged += chkRenderBelowEntity_CheckedChanged;
             // 
-            // cmbGraphicType
+            // cmbTextureType
             // 
-            cmbGraphicType.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
-            cmbGraphicType.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
-            cmbGraphicType.BorderStyle = ButtonBorderStyle.Solid;
-            cmbGraphicType.ButtonColor = System.Drawing.Color.FromArgb(43, 43, 43);
-            cmbGraphicType.DrawDropdownHoverOutline = false;
-            cmbGraphicType.DrawFocusRectangle = false;
-            cmbGraphicType.DrawMode = DrawMode.OwnerDrawFixed;
-            cmbGraphicType.DropDownStyle = ComboBoxStyle.DropDownList;
-            cmbGraphicType.FlatStyle = FlatStyle.Flat;
-            cmbGraphicType.ForeColor = System.Drawing.Color.Gainsboro;
-            cmbGraphicType.FormattingEnabled = true;
-            cmbGraphicType.Location = new System.Drawing.Point(12, 41);
-            cmbGraphicType.Margin = new Padding(4, 3, 4, 3);
-            cmbGraphicType.Name = "cmbGraphicType";
-            cmbGraphicType.Size = new Size(227, 24);
-            cmbGraphicType.TabIndex = 21;
-            cmbGraphicType.Text = null;
-            cmbGraphicType.TextPadding = new Padding(2);
-            cmbGraphicType.SelectedIndexChanged += cmbGraphicType_SelectedIndexChanged;
+            cmbTextureType.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            cmbTextureType.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            cmbTextureType.BorderStyle = ButtonBorderStyle.Solid;
+            cmbTextureType.ButtonColor = System.Drawing.Color.FromArgb(43, 43, 43);
+            cmbTextureType.DrawDropdownHoverOutline = false;
+            cmbTextureType.DrawFocusRectangle = false;
+            cmbTextureType.DrawMode = DrawMode.OwnerDrawFixed;
+            cmbTextureType.DropDownStyle = ComboBoxStyle.DropDownList;
+            cmbTextureType.FlatStyle = FlatStyle.Flat;
+            cmbTextureType.ForeColor = System.Drawing.Color.Gainsboro;
+            cmbTextureType.FormattingEnabled = true;
+            cmbTextureType.Location = new System.Drawing.Point(12, 41);
+            cmbTextureType.Margin = new Padding(4, 3, 4, 3);
+            cmbTextureType.Name = "cmbTextureType";
+            cmbTextureType.Size = new Size(227, 24);
+            cmbTextureType.TabIndex = 21;
+            cmbTextureType.Text = null;
+            cmbTextureType.TextPadding = new Padding(2);
+            cmbTextureType.SelectedIndexChanged += cmbGraphicType_SelectedIndexChanged;
             // 
-            // lblGraphicType
+            // lblTextureType
             // 
-            lblGraphicType.AutoSize = true;
-            lblGraphicType.Location = new System.Drawing.Point(9, 21);
-            lblGraphicType.Margin = new Padding(4, 0, 4, 0);
-            lblGraphicType.Name = "lblGraphicType";
-            lblGraphicType.Size = new Size(78, 15);
-            lblGraphicType.TabIndex = 20;
-            lblGraphicType.Text = "Graphic Type:";
+            lblTextureType.AutoSize = true;
+            lblTextureType.Location = new System.Drawing.Point(9, 21);
+            lblTextureType.Margin = new Padding(4, 0, 4, 0);
+            lblTextureType.Name = "lblTextureType";
+            lblTextureType.Size = new Size(73, 15);
+            lblTextureType.TabIndex = 20;
+            lblTextureType.Text = "Terture Type:";
             // 
-            // lblHealthStates
+            // lblStates
             // 
-            lblHealthStates.AutoSize = true;
-            lblHealthStates.Location = new System.Drawing.Point(10, 21);
-            lblHealthStates.Margin = new Padding(4, 0, 4, 0);
-            lblHealthStates.Name = "lblHealthStates";
-            lblHealthStates.Size = new Size(79, 15);
-            lblHealthStates.TabIndex = 55;
-            lblHealthStates.Text = "Health States:";
+            lblStates.AutoSize = true;
+            lblStates.Location = new System.Drawing.Point(10, 21);
+            lblStates.Margin = new Padding(4, 0, 4, 0);
+            lblStates.Name = "lblStates";
+            lblStates.Size = new Size(41, 15);
+            lblStates.TabIndex = 55;
+            lblStates.Text = "States:";
             // 
             // graphicContainer
             // 
@@ -879,6 +879,16 @@ namespace Intersect.Editor.Forms.Editors
             nudHpRegen.TabIndex = 30;
             nudHpRegen.Value = new decimal(new int[] { 0, 0, 0, 0 });
             nudHpRegen.ValueChanged += nudHpRegen_ValueChanged;
+            // 
+            // lblHpRegen
+            // 
+            lblHpRegen.AutoSize = true;
+            lblHpRegen.Location = new System.Drawing.Point(6, 20);
+            lblHpRegen.Margin = new Padding(2, 0, 2, 0);
+            lblHpRegen.Name = "lblHpRegen";
+            lblHpRegen.Size = new Size(47, 15);
+            lblHpRegen.TabIndex = 26;
+            lblHpRegen.Text = "HP: (%)";
             // 
             // lblRegenHint
             // 
@@ -1188,16 +1198,6 @@ namespace Intersect.Editor.Forms.Editors
             toolStripItemUndo.Text = "Undo";
             toolStripItemUndo.Click += toolStripItemUndo_Click;
             // 
-            // lblHpRegen
-            // 
-            lblHpRegen.AutoSize = true;
-            lblHpRegen.Location = new System.Drawing.Point(6, 20);
-            lblHpRegen.Margin = new Padding(2, 0, 2, 0);
-            lblHpRegen.Name = "lblHpRegen";
-            lblHpRegen.Size = new Size(47, 15);
-            lblHpRegen.TabIndex = 26;
-            lblHpRegen.Text = "HP: (%)";
-            // 
             // FrmResource
             // 
             AutoScaleDimensions = new SizeF(7F, 15F);
@@ -1233,8 +1233,8 @@ namespace Intersect.Editor.Forms.Editors
             grpGraphics.PerformLayout();
             grpGraphicData.ResumeLayout(false);
             grpGraphicData.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)nudHealthRangeMax).EndInit();
-            ((System.ComponentModel.ISupportInitialize)nudHealthRangeMin).EndInit();
+            ((System.ComponentModel.ISupportInitialize)nudStateRangeMax).EndInit();
+            ((System.ComponentModel.ISupportInitialize)nudStateRangeMin).EndInit();
             graphicContainer.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)picResource).EndInit();
             pnlContainer.ResumeLayout(false);
@@ -1319,23 +1319,23 @@ namespace Intersect.Editor.Forms.Editors
         private DarkTextBox txtCannotHarvest;
         private DarkNumericUpDown nudDropMinAmount;
         private Label lblDropMinAmount;
-        private Label lblHealthStates;
+        private Label lblStates;
         private DarkGroupBox grpGraphicData;
-        private DarkComboBox cmbGraphicType;
-        private Label lblGraphicType;
+        private DarkComboBox cmbTextureType;
+        private Label lblTextureType;
         private DarkCheckBox chkRenderBelowEntity;
         private DarkComboBox cmbAnimation;
         private Label lblAnimation;
-        private DarkComboBox cmbGraphicFile;
-        private Label lblGraphicFile;
-        private ListBox lstHealthState;
-        private DarkButton btnRemoveHealthState;
-        private DarkButton btnAddHealthState;
-        private Label lblHealthStateName;
-        private DarkTextBox txtHealthStateName;
-        private Label lblHealthRange;
-        private DarkNumericUpDown nudHealthRangeMax;
-        private DarkNumericUpDown nudHealthRangeMin;
+        private DarkComboBox cmbTextureSource;
+        private Label lblTerxtureSource;
+        private ListBox lstStates;
+        private DarkButton btnRemoveState;
+        private DarkButton btnAddState;
+        private Label lblStateName;
+        private DarkTextBox txtStateName;
+        private Label lblStateRange;
+        private DarkNumericUpDown nudStateRangeMax;
+        private DarkNumericUpDown nudStateRangeMin;
         private DarkCheckBox chkUseExplicitMaxHealthForResourceStates;
         private Label lblHpRegen;
     }

--- a/Intersect.Editor/Forms/Editors/frmResource.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/frmResource.Designer.cs
@@ -86,7 +86,6 @@ namespace Intersect.Editor.Forms.Editors
             lblEvent = new Label();
             grpRegen = new DarkGroupBox();
             nudHpRegen = new DarkNumericUpDown();
-            lblHpRegen = new Label();
             lblRegenHint = new Label();
             grpDrops = new DarkGroupBox();
             nudDropMinAmount = new DarkNumericUpDown();
@@ -113,6 +112,7 @@ namespace Intersect.Editor.Forms.Editors
             toolStripItemPaste = new ToolStripButton();
             toolStripSeparator3 = new ToolStripSeparator();
             toolStripItemUndo = new ToolStripButton();
+            lblHpRegen = new Label();
             grpResources.SuspendLayout();
             grpGeneral.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)nudMaxHp).BeginInit();
@@ -487,7 +487,7 @@ namespace Intersect.Editor.Forms.Editors
             grpGraphics.Size = new Size(824, 524);
             grpGraphics.TabIndex = 16;
             grpGraphics.TabStop = false;
-            grpGraphics.Text = "Graphics";
+            grpGraphics.Text = "Appearance";
             // 
             // btnRemoveHealthState
             // 
@@ -880,16 +880,6 @@ namespace Intersect.Editor.Forms.Editors
             nudHpRegen.Value = new decimal(new int[] { 0, 0, 0, 0 });
             nudHpRegen.ValueChanged += nudHpRegen_ValueChanged;
             // 
-            // lblHpRegen
-            // 
-            lblHpRegen.AutoSize = true;
-            lblHpRegen.Location = new System.Drawing.Point(6, 20);
-            lblHpRegen.Margin = new Padding(2, 0, 2, 0);
-            lblHpRegen.Name = "lblHpRegen";
-            lblHpRegen.Size = new Size(47, 15);
-            lblHpRegen.TabIndex = 26;
-            lblHpRegen.Text = "HP: (%)";
-            // 
             // lblRegenHint
             // 
             lblRegenHint.Location = new System.Drawing.Point(119, 32);
@@ -1198,6 +1188,16 @@ namespace Intersect.Editor.Forms.Editors
             toolStripItemUndo.Text = "Undo";
             toolStripItemUndo.Click += toolStripItemUndo_Click;
             // 
+            // lblHpRegen
+            // 
+            lblHpRegen.AutoSize = true;
+            lblHpRegen.Location = new System.Drawing.Point(6, 20);
+            lblHpRegen.Margin = new Padding(2, 0, 2, 0);
+            lblHpRegen.Name = "lblHpRegen";
+            lblHpRegen.Size = new Size(47, 15);
+            lblHpRegen.TabIndex = 26;
+            lblHpRegen.Text = "HP: (%)";
+            // 
             // FrmResource
             // 
             AutoScaleDimensions = new SizeF(7F, 15F);
@@ -1302,7 +1302,6 @@ namespace Intersect.Editor.Forms.Editors
         private System.Windows.Forms.Label lblDropItem;
         private DarkGroupBox grpRegen;
         private DarkNumericUpDown nudHpRegen;
-        private System.Windows.Forms.Label lblHpRegen;
         private System.Windows.Forms.Label lblRegenHint;
         private DarkGroupBox grpCommonEvent;
         private DarkComboBox cmbEvent;
@@ -1338,5 +1337,6 @@ namespace Intersect.Editor.Forms.Editors
         private DarkNumericUpDown nudHealthRangeMax;
         private DarkNumericUpDown nudHealthRangeMin;
         private DarkCheckBox chkUseExplicitMaxHealthForResourceStates;
+        private Label lblHpRegen;
     }
 }

--- a/Intersect.Editor/Forms/Editors/frmResource.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/frmResource.Designer.cs
@@ -233,9 +233,9 @@ namespace Intersect.Editor.Forms.Editors
             chkUseExplicitMaxHealthForResourceStates.Location = new System.Drawing.Point(7, 319);
             chkUseExplicitMaxHealthForResourceStates.Margin = new Padding(4, 3, 4, 3);
             chkUseExplicitMaxHealthForResourceStates.Name = "chkUseExplicitMaxHealthForResourceStates";
-            chkUseExplicitMaxHealthForResourceStates.Size = new Size(246, 20);
+            chkUseExplicitMaxHealthForResourceStates.Size = new Size(246, 34);
             chkUseExplicitMaxHealthForResourceStates.TabIndex = 53;
-            chkUseExplicitMaxHealthForResourceStates.Text = "Use explicit Max Health for States?";
+            chkUseExplicitMaxHealthForResourceStates.Text = "Use explicit Max Health for Resources States?";
             chkUseExplicitMaxHealthForResourceStates.CheckedChanged += chkUseExplicitMaxHealthForResourceStates_CheckedChanged;
             // 
             // btnAddFolder

--- a/Intersect.Editor/Forms/Editors/frmResource.cs
+++ b/Intersect.Editor/Forms/Editors/frmResource.cs
@@ -161,6 +161,11 @@ public partial class FrmResource : EditorForm
         //Send Changed items
         foreach (var item in _changed)
         {
+            item.StatesGraphics = item.StatesGraphics
+                .OrderBy(s => s.Value.MinimumHealth)
+                .ThenBy(s => s.Value.MaximumHealth)
+                .ToDictionary(p => p.Key, p => p.Value);
+
             PacketSender.SendSaveObject(item);
             item.DeleteBackup();
         }
@@ -289,6 +294,12 @@ public partial class FrmResource : EditorForm
             nudHpRegen.Value = _editorItem.VitalRegen;
 
             picResource.Hide();
+
+            _editorItem.StatesGraphics = _editorItem.StatesGraphics
+                .OrderBy(s => s.Value.MinimumHealth)
+                .ThenBy(s => s.Value.MaximumHealth)
+                .ToDictionary(p => p.Key, p => p.Value);
+
             lstStates.Items.Clear();
             foreach (var state in _editorItem.StatesGraphics.Values)
             {
@@ -813,11 +824,22 @@ public partial class FrmResource : EditorForm
 
         var state = new ResourceStateDescriptor
         {
-            Id = Guid.NewGuid()
+            Id = Guid.NewGuid(),
+            Name = txtStateName.Text,
         };
+
         _editorItem.StatesGraphics.Add(state.Id, state);
-        lstStates.Items.Add(txtStateName.Text);
-        lstStates.SelectedIndex = lstStates.Items.Count - 1;
+        _editorItem.StatesGraphics = _editorItem.StatesGraphics
+            .OrderBy(s => s.Value.MinimumHealth)
+            .ThenBy(s => s.Value.MaximumHealth)
+            .ToDictionary(p => p.Key, p => p.Value);
+
+        lstStates.Items.Clear();
+        foreach (var stateName in _editorItem.StatesGraphics.Values.Select(s => s.Name))
+        {
+            lstStates.Items.Add(stateName);
+        }
+        lstStates.SelectedIndex = lstStates.Items.IndexOf(state.Name);
         txtStateName.Text = string.Empty;
     }
 

--- a/Intersect.Editor/Forms/Editors/frmResource.cs
+++ b/Intersect.Editor/Forms/Editors/frmResource.cs
@@ -246,7 +246,7 @@ public partial class FrmResource : EditorForm
         btnDropAdd.Text = Strings.ResourceEditor.dropadd;
         btnDropRemove.Text = Strings.ResourceEditor.dropremove;
 
-        lblHpRegen.Text = Strings.ResourceEditor.hpregen;
+        lblHpRegen.Text = Strings.ResourceEditor.HealthRegenPercent;
         new ToolTip().SetToolTip(lblHpRegen, Strings.ResourceEditor.regenhint);
 
         grpGraphics.Text = Strings.ResourceEditor.Appearance;

--- a/Intersect.Editor/Forms/Editors/frmResource.cs
+++ b/Intersect.Editor/Forms/Editors/frmResource.cs
@@ -392,32 +392,20 @@ public partial class FrmResource : EditorForm
         UpdateGraphicFileControl(currentState);
     }
 
-    private void UpdateCurrentState(object sender, EventArgs e)
-    {
-        if (_editorItem is null)
-        {
-            return;
-        }
-
-        if (!TryGetCurrentHealthState(out var currentState))
-        {
-            return;
-        }
-
-        currentState.GraphicType = (ResourceGraphicType)cmbGraphicType.SelectedIndex;
-        currentState.AnimationId = AnimationDescriptor.IdFromList(cmbAnimation.SelectedIndex - 1);
-    }
-
     private void UpdateGraphicFileControl(ResourceStateDescriptor currentState)
     {
         cmbGraphicFile.Items.Clear();
         cmbGraphicFile.Items.Add(Strings.General.None);
+        cmbAnimation.Items.Clear();
+        cmbAnimation.Items.Add(Strings.General.None);
 
         if (currentState.GraphicType == ResourceGraphicType.Animation)
         {
             cmbGraphicFile.Enabled = false;
             picResource.Visible = false;
             cmbAnimation.Enabled = true;
+            cmbAnimation.Items.AddRange(AnimationDescriptor.Names);
+            cmbAnimation.SelectedIndex = AnimationDescriptor.ListIndex(currentState.AnimationId) + 1;
             return;
         }
 
@@ -873,7 +861,7 @@ public partial class FrmResource : EditorForm
             return;
         }
 
-        UpdateCurrentState(sender, e);
+        currentState.GraphicType = (ResourceGraphicType)cmbGraphicType.SelectedIndex;
         UpdateGraphicFileControl(currentState);
     }
 
@@ -918,6 +906,16 @@ public partial class FrmResource : EditorForm
         }
 
         picResource.Visible = _resourceGraphic != null;
+    }
+
+    private void cmbAnimation_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        if (!TryGetCurrentHealthState(out var currentState))
+        {
+            return;
+        }
+
+        currentState.AnimationId = AnimationDescriptor.IdFromList(cmbAnimation.SelectedIndex - 1);
     }
 
     private void nudHealthRangeMin_ValueChanged(object sender, EventArgs e)

--- a/Intersect.Editor/Forms/Editors/frmResource.cs
+++ b/Intersect.Editor/Forms/Editors/frmResource.cs
@@ -428,9 +428,9 @@ public partial class FrmResource : EditorForm
             return;
         }
 
-        if (currentState.Texture != null && cmbTextureSource.Items.Contains(currentState.Texture))
+        if (currentState.TextureName != null && cmbTextureSource.Items.Contains(currentState.TextureName))
         {
-            cmbTextureSource.SelectedIndex = cmbTextureSource.FindString(TextUtils.NullToNone(currentState.Texture));
+            cmbTextureSource.SelectedIndex = cmbTextureSource.FindString(TextUtils.NullToNone(currentState.TextureName));
             return;
         }
 
@@ -459,7 +459,7 @@ public partial class FrmResource : EditorForm
             return;
         }
 
-        if (currentState.Texture is null)
+        if (currentState.TextureName is null)
         {
             return;
         }
@@ -884,7 +884,7 @@ public partial class FrmResource : EditorForm
 
         if (cmbTextureSource.SelectedIndex > 0)
         {
-            currentState.Texture = cmbTextureSource.Text;
+            currentState.TextureName = cmbTextureSource.Text;
             var graphic = Path.Combine(
                 "resources", currentState.TextureType == ResourceTextureSource.Tileset ? "tilesets" : "resources", cmbTextureSource.Text
             );
@@ -899,7 +899,7 @@ public partial class FrmResource : EditorForm
         }
         else
         {
-            currentState.Texture = null;
+            currentState.TextureName = null;
         }
 
         picResource.Visible = _resourceGraphic != null;

--- a/Intersect.Editor/Forms/Editors/frmResource.cs
+++ b/Intersect.Editor/Forms/Editors/frmResource.cs
@@ -75,16 +75,20 @@ public partial class FrmResource : EditorForm
 
     private void toolStripItemDelete_Click(object sender, EventArgs e)
     {
-        if (_editorItem != null && lstGameObjects.Focused)
+        if (_editorItem == null || !lstGameObjects.Focused)
         {
-            if (DarkMessageBox.ShowWarning(
-                    Strings.ResourceEditor.deleteprompt, Strings.ResourceEditor.deletetitle, DarkDialogButton.YesNo,
+            return;
+        }
+
+        if (DarkMessageBox.ShowWarning(
+                    Strings.ResourceEditor.deleteprompt,
+                    Strings.ResourceEditor.deletetitle,
+                    DarkDialogButton.YesNo,
                     Icon
                 ) ==
                 DialogResult.Yes)
-            {
-                PacketSender.SendDeleteObject(_editorItem);
-            }
+        {
+            PacketSender.SendDeleteObject(_editorItem);
         }
     }
 
@@ -124,10 +128,11 @@ public partial class FrmResource : EditorForm
 
     private void UpdateToolStripItems()
     {
-        toolStripItemCopy.Enabled = _editorItem != null && lstGameObjects.Focused;
-        toolStripItemPaste.Enabled = _editorItem != null && _copiedItem != null && lstGameObjects.Focused;
-        toolStripItemDelete.Enabled = _editorItem != null && lstGameObjects.Focused;
-        toolStripItemUndo.Enabled = _editorItem != null && lstGameObjects.Focused;
+        var shouldEnableToolStripItems = _editorItem != null && lstGameObjects.Focused;
+        toolStripItemCopy.Enabled = shouldEnableToolStripItems;
+        toolStripItemPaste.Enabled = shouldEnableToolStripItems && _copiedItem != null;
+        toolStripItemDelete.Enabled = shouldEnableToolStripItems;
+        toolStripItemUndo.Enabled = shouldEnableToolStripItems;
     }
 
     protected override void GameObjectUpdatedDelegate(GameObjectType type)

--- a/Intersect.Editor/Forms/Editors/frmResource.cs
+++ b/Intersect.Editor/Forms/Editors/frmResource.cs
@@ -18,7 +18,7 @@ namespace Intersect.Editor.Forms.Editors;
 
 public partial class FrmResource : EditorForm
 {
-    private readonly List<ResourceDescriptor> _changed = [];
+    private readonly Dictionary<Guid, ResourceDescriptor> _changed = [];
     private string? _copiedItem;
     private ResourceDescriptor? _editorItem;
     private Bitmap? _graphicBitmap;
@@ -112,7 +112,7 @@ public partial class FrmResource : EditorForm
 
     private void toolStripItemUndo_Click(object sender, EventArgs e)
     {
-        if (_editorItem != null && _changed.Contains(_editorItem) && _editorItem != null)
+        if (_editorItem != null && _changed.ContainsKey(_editorItem.Id) && _editorItem != null)
         {
             if (DarkMessageBox.ShowWarning(
                     Strings.ResourceEditor.undoprompt, Strings.ResourceEditor.undotitle, DarkDialogButton.YesNo,
@@ -150,7 +150,7 @@ public partial class FrmResource : EditorForm
 
     private void btnCancel_Click(object sender, EventArgs e)
     {
-        foreach (var item in _changed)
+        foreach (var item in _changed.Values)
         {
             item.RestoreBackup();
             item.DeleteBackup();
@@ -164,7 +164,7 @@ public partial class FrmResource : EditorForm
     private void btnSave_Click(object sender, EventArgs e)
     {
         //Send Changed items
-        foreach (var item in _changed)
+        foreach (var item in _changed.Values)
         {
             item.States = item.States
                 .OrderBy(s => s.Value.MinimumHealth)
@@ -328,9 +328,9 @@ public partial class FrmResource : EditorForm
 
             UpdateDropValues();
 
-            if (_changed.IndexOf(_editorItem) == -1)
+            if (!_changed.TryGetValue(_editorItem.Id, out var _))
             {
-                _changed.Add(_editorItem);
+                _changed.Add(_editorItem.Id, _editorItem);
                 _editorItem.MakeBackup();
             }
         }

--- a/Intersect.Editor/Forms/Editors/frmResource.cs
+++ b/Intersect.Editor/Forms/Editors/frmResource.cs
@@ -161,7 +161,7 @@ public partial class FrmResource : EditorForm
         //Send Changed items
         foreach (var item in _changed)
         {
-            item.StatesGraphics = item.StatesGraphics
+            item.States = item.States
                 .OrderBy(s => s.Value.MinimumHealth)
                 .ThenBy(s => s.Value.MaximumHealth)
                 .ToDictionary(p => p.Key, p => p.Value);
@@ -295,13 +295,13 @@ public partial class FrmResource : EditorForm
 
             picResource.Hide();
 
-            _editorItem.StatesGraphics = _editorItem.StatesGraphics
+            _editorItem.States = _editorItem.States
                 .OrderBy(s => s.Value.MinimumHealth)
                 .ThenBy(s => s.Value.MaximumHealth)
                 .ToDictionary(p => p.Key, p => p.Value);
 
             lstStates.Items.Clear();
-            foreach (var state in _editorItem.StatesGraphics.Values)
+            foreach (var state in _editorItem.States.Values)
             {
                 lstStates.Items.Add(state.Name);
             }
@@ -360,8 +360,8 @@ public partial class FrmResource : EditorForm
         }
 
         var selectedIndex = lstStates.SelectedIndex;
-        var stateKey = _editorItem.StatesGraphics.Keys.ToList()[selectedIndex];
-        if (!_editorItem.StatesGraphics.TryGetValue(stateKey, out state))
+        var stateKey = _editorItem.States.Keys.ToList()[selectedIndex];
+        if (!_editorItem.States.TryGetValue(stateKey, out state))
         {
             return false;
         }
@@ -828,14 +828,14 @@ public partial class FrmResource : EditorForm
             Name = txtStateName.Text,
         };
 
-        _editorItem.StatesGraphics.Add(state.Id, state);
-        _editorItem.StatesGraphics = _editorItem.StatesGraphics
+        _editorItem.States.Add(state.Id, state);
+        _editorItem.States = _editorItem.States
             .OrderBy(s => s.Value.MinimumHealth)
             .ThenBy(s => s.Value.MaximumHealth)
             .ToDictionary(p => p.Key, p => p.Value);
 
         lstStates.Items.Clear();
-        foreach (var stateName in _editorItem.StatesGraphics.Values.Select(s => s.Name))
+        foreach (var stateName in _editorItem.States.Values.Select(s => s.Name))
         {
             lstStates.Items.Add(stateName);
         }
@@ -856,13 +856,13 @@ public partial class FrmResource : EditorForm
             return;
         }
 
-        var stateKey = _editorItem.StatesGraphics.Keys.ToList()[selectedIndex];
-        if (!_editorItem.StatesGraphics.TryGetValue(stateKey, out _))
+        var stateKey = _editorItem.States.Keys.ToList()[selectedIndex];
+        if (!_editorItem.States.TryGetValue(stateKey, out _))
         {
             return;
         }
 
-        _editorItem.StatesGraphics.Remove(stateKey);
+        _editorItem.States.Remove(stateKey);
         lstStates.Items.RemoveAt(selectedIndex);
         if (lstStates.Items.Count > 0)
         {

--- a/Intersect.Editor/Forms/Editors/frmResource.cs
+++ b/Intersect.Editor/Forms/Editors/frmResource.cs
@@ -168,11 +168,6 @@ public partial class FrmResource : EditorForm
         //Send Changed items
         foreach (var item in _changed.Values)
         {
-            item.States = item.States
-                .OrderBy(s => s.Value.MinimumHealth)
-                .ThenBy(s => s.Value.MaximumHealth)
-                .ToDictionary(p => p.Key, p => p.Value);
-
             PacketSender.SendSaveObject(item);
             item.DeleteBackup();
         }
@@ -298,19 +293,9 @@ public partial class FrmResource : EditorForm
             cmbEvent.SelectedIndex = EventDescriptor.ListIndex(_editorItem.EventId) + 1;
             txtCannotHarvest.Text = _editorItem.CannotHarvestMessage;
             nudHpRegen.Value = _editorItem.VitalRegen;
-
             picResource.Hide();
 
-            _editorItem.States = _editorItem.States
-                .OrderBy(s => s.Value.MinimumHealth)
-                .ThenBy(s => s.Value.MaximumHealth)
-                .ToDictionary(p => p.Key, p => p.Value);
-
-            lstStates.Items.Clear();
-            foreach (var state in _editorItem.States.Values)
-            {
-                lstStates.Items.Add(state.Name);
-            }
+            lstStates.DataSource = new BindingSource(_editorItem.States.Values, nameof(ResourceStateDescriptor.Name));
 
             if (lstStates.Items.Count > 0)
             {
@@ -835,16 +820,6 @@ public partial class FrmResource : EditorForm
         };
 
         _editorItem.States.Add(state.Id, state);
-        _editorItem.States = _editorItem.States
-            .OrderBy(s => s.Value.MinimumHealth)
-            .ThenBy(s => s.Value.MaximumHealth)
-            .ToDictionary(p => p.Key, p => p.Value);
-
-        lstStates.Items.Clear();
-        foreach (var stateName in _editorItem.States.Values.Select(s => s.Name))
-        {
-            lstStates.Items.Add(stateName);
-        }
         lstStates.SelectedIndex = lstStates.Items.IndexOf(state.Name);
         txtStateName.Text = string.Empty;
     }
@@ -942,22 +917,40 @@ public partial class FrmResource : EditorForm
 
     private void nudStateRangeMin_ValueChanged(object sender, EventArgs e)
     {
+        if (_editorItem is null)
+        {
+            return;
+        }
+
         if (!TryGetCurrentState(out var currentState))
         {
             return;
         }
 
         currentState.MinimumHealth = (int)nudStateRangeMin.Value;
+        _editorItem.States = _editorItem.States
+                .OrderBy(s => s.Value.MinimumHealth)
+                .ThenBy(s => s.Value.MaximumHealth)
+                .ToDictionary(p => p.Key, p => p.Value);
     }
 
     private void nudStateRangeMax_ValueChanged(object sender, EventArgs e)
     {
+        if (_editorItem is null)
+        {
+            return;
+        }
+
         if (!TryGetCurrentState(out var currentState))
         {
             return;
         }
 
         currentState.MaximumHealth = (int)nudStateRangeMax.Value;
+        _editorItem.States = _editorItem.States
+                .OrderBy(s => s.Value.MinimumHealth)
+                .ThenBy(s => s.Value.MaximumHealth)
+                .ToDictionary(p => p.Key, p => p.Value);
     }
 
     private void picResource_MouseDown(object sender, MouseEventArgs e)

--- a/Intersect.Editor/Forms/Editors/frmResource.cs
+++ b/Intersect.Editor/Forms/Editors/frmResource.cs
@@ -240,9 +240,8 @@ public partial class FrmResource : EditorForm
         btnDropAdd.Text = Strings.ResourceEditor.dropadd;
         btnDropRemove.Text = Strings.ResourceEditor.dropremove;
 
-        grpRegen.Text = Strings.ResourceEditor.regen;
         lblHpRegen.Text = Strings.ResourceEditor.hpregen;
-        new ToolTip().SetToolTip(grpRegen, Strings.ResourceEditor.regenhint);
+        new ToolTip().SetToolTip(lblHpRegen, Strings.ResourceEditor.regenhint);
 
         grpGraphics.Text = Strings.ResourceEditor.Appearance;
         lblStates.Text = Strings.ResourceEditor.StatesLabel;
@@ -283,7 +282,7 @@ public partial class FrmResource : EditorForm
             cmbFolder.Text = _editorItem.Folder;
             cmbToolType.SelectedIndex = _editorItem.Tool + 1;
             nudSpawnDuration.Value = _editorItem.SpawnDuration;
-            cmbDeathAnimation.SelectedIndex = AnimationDescriptor.ListIndex(_editorItem.AnimationId) + 1;
+            cmbDeathAnimation.SelectedIndex = AnimationDescriptor.ListIndex(_editorItem.DeathAnimationId) + 1;
             nudMinHp.Value = _editorItem.MinHp;
             nudMaxHp.Value = _editorItem.MaxHp;
             chkWalkableBefore.Checked = _editorItem.WalkableBefore;
@@ -592,7 +591,7 @@ public partial class FrmResource : EditorForm
             return;
         }
 
-        _editorItem.Animation = AnimationDescriptor.Get(AnimationDescriptor.IdFromList(cmbDeathAnimation.SelectedIndex - 1));
+        _editorItem.DeathAnimation = AnimationDescriptor.Get(AnimationDescriptor.IdFromList(cmbDeathAnimation.SelectedIndex - 1));
     }
 
     private void chkWalkableBefore_CheckedChanged(object sender, EventArgs e)

--- a/Intersect.Editor/Forms/Editors/frmResource.cs
+++ b/Intersect.Editor/Forms/Editors/frmResource.cs
@@ -426,9 +426,9 @@ public partial class FrmResource : EditorForm
             return;
         }
 
-        if (currentState.Graphic != null && cmbGraphicFile.Items.Contains(currentState.Graphic))
+        if (currentState.Texture != null && cmbGraphicFile.Items.Contains(currentState.Texture))
         {
-            cmbGraphicFile.SelectedIndex = cmbGraphicFile.FindString(TextUtils.NullToNone(currentState.Graphic));
+            cmbGraphicFile.SelectedIndex = cmbGraphicFile.FindString(TextUtils.NullToNone(currentState.Texture));
             return;
         }
 
@@ -457,7 +457,7 @@ public partial class FrmResource : EditorForm
             return;
         }
 
-        if (currentState.Graphic is null)
+        if (currentState.Texture is null)
         {
             return;
         }
@@ -887,7 +887,7 @@ public partial class FrmResource : EditorForm
 
         if (cmbGraphicFile.SelectedIndex > 0)
         {
-            currentState.Graphic = cmbGraphicFile.Text;
+            currentState.Texture = cmbGraphicFile.Text;
             var graphic = Path.Combine(
                 "resources", currentState.GraphicType == ResourceGraphicType.Tileset ? "tilesets" : "resources", cmbGraphicFile.Text
             );
@@ -902,7 +902,7 @@ public partial class FrmResource : EditorForm
         }
         else
         {
-            currentState.Graphic = null;
+            currentState.Texture = null;
         }
 
         picResource.Visible = _resourceGraphic != null;

--- a/Intersect.Editor/Forms/Editors/frmResource.cs
+++ b/Intersect.Editor/Forms/Editors/frmResource.cs
@@ -290,7 +290,7 @@ public partial class FrmResource : EditorForm
 
             picResource.Hide();
             lstHealthState.Items.Clear();
-            foreach (var state in _editorItem.HealthGraphics.Keys)
+            foreach (var state in _editorItem.StatesGraphics.Keys)
             {
                 lstHealthState.Items.Add(state);
             }
@@ -349,8 +349,8 @@ public partial class FrmResource : EditorForm
         }
 
         var selectedIndex = lstHealthState.SelectedIndex;
-        var stateKey = _editorItem.HealthGraphics.Keys.ToList()[selectedIndex];
-        if (!_editorItem.HealthGraphics.TryGetValue(stateKey, out state))
+        var stateKey = _editorItem.StatesGraphics.Keys.ToList()[selectedIndex];
+        if (!_editorItem.StatesGraphics.TryGetValue(stateKey, out state))
         {
             return false;
         }
@@ -811,7 +811,7 @@ public partial class FrmResource : EditorForm
             return;
         }
 
-        if (_editorItem.HealthGraphics.ContainsKey(txtHealthStateName.Text))
+        if (_editorItem.StatesGraphics.ContainsKey(txtHealthStateName.Text))
         {
             DarkMessageBox.ShowError(
                 Strings.ResourceEditor.HealthStateNameExists,
@@ -821,7 +821,7 @@ public partial class FrmResource : EditorForm
         }
 
         var state = new ResourceStateDescriptor();
-        _editorItem.HealthGraphics.Add(txtHealthStateName.Text, state);
+        _editorItem.StatesGraphics.Add(txtHealthStateName.Text, state);
         lstHealthState.Items.Add(txtHealthStateName.Text);
         lstHealthState.SelectedIndex = lstHealthState.Items.Count - 1;
         txtHealthStateName.Text = string.Empty;
@@ -840,13 +840,13 @@ public partial class FrmResource : EditorForm
             return;
         }
 
-        var stateKey = _editorItem.HealthGraphics.Keys.ToList()[selectedIndex];
-        if (!_editorItem.HealthGraphics.TryGetValue(stateKey, out _))
+        var stateKey = _editorItem.StatesGraphics.Keys.ToList()[selectedIndex];
+        if (!_editorItem.StatesGraphics.TryGetValue(stateKey, out _))
         {
             return;
         }
 
-        _editorItem.HealthGraphics.Remove(stateKey);
+        _editorItem.StatesGraphics.Remove(stateKey);
         lstHealthState.Items.RemoveAt(selectedIndex);
         if (lstHealthState.Items.Count > 0)
         {

--- a/Intersect.Editor/Forms/Editors/frmResource.cs
+++ b/Intersect.Editor/Forms/Editors/frmResource.cs
@@ -290,9 +290,9 @@ public partial class FrmResource : EditorForm
 
             picResource.Hide();
             lstStates.Items.Clear();
-            foreach (var state in _editorItem.StatesGraphics.Keys)
+            foreach (var state in _editorItem.StatesGraphics.Values)
             {
-                lstStates.Items.Add(state);
+                lstStates.Items.Add(state.Name);
             }
 
             if (lstStates.Items.Count > 0)

--- a/Intersect.Editor/Forms/Editors/frmResource.cs
+++ b/Intersect.Editor/Forms/Editors/frmResource.cs
@@ -154,7 +154,7 @@ public partial class FrmResource : EditorForm
         }
     }
 
-    private void btnCancel_Click(object sender, EventArgs e)
+    private void btnCancel_Click(object? sender, EventArgs? e)
     {
         foreach (var item in _changed.Values)
         {
@@ -201,7 +201,7 @@ public partial class FrmResource : EditorForm
 
     private void frmResource_FormClosed(object sender, FormClosedEventArgs e)
     {
-        Globals.CurrentEditor = -1;
+        btnCancel_Click(null, null);
     }
 
     private void form_KeyDown(object sender, KeyEventArgs e)
@@ -334,9 +334,7 @@ public partial class FrmResource : EditorForm
             pnlContainer.Hide();
         }
         
-        var hasItem = mEditorItem != null;
-        
-        UpdateEditorButtons(hasItem);
+        UpdateEditorButtons(_editorItem != default);
         UpdateToolStripItems();
     }
 

--- a/Intersect.Editor/Forms/Editors/frmResource.cs
+++ b/Intersect.Editor/Forms/Editors/frmResource.cs
@@ -387,8 +387,8 @@ public partial class FrmResource : EditorForm
 
         cmbGraphicType.SelectedIndex = (int)currentState.TextureType;
         chkRenderBelowEntity.Checked = currentState.RenderBelowEntities;
-        nudHealthRangeMin.Value = currentState.MinHp;
-        nudHealthRangeMax.Value = currentState.MaxHp;
+        nudHealthRangeMin.Value = currentState.MinimumHealth;
+        nudHealthRangeMax.Value = currentState.MaximumHealth;
         UpdateGraphicFileControl(currentState);
     }
 
@@ -925,7 +925,7 @@ public partial class FrmResource : EditorForm
             return;
         }
 
-        currentState.MinHp = (int)nudHealthRangeMin.Value;
+        currentState.MinimumHealth = (int)nudHealthRangeMin.Value;
     }
 
     private void nudHealthRangeMax_ValueChanged(object sender, EventArgs e)
@@ -935,7 +935,7 @@ public partial class FrmResource : EditorForm
             return;
         }
 
-        currentState.MaxHp = (int)nudHealthRangeMax.Value;
+        currentState.MaximumHealth = (int)nudHealthRangeMax.Value;
     }
 
     private void picResource_MouseDown(object sender, MouseEventArgs e)

--- a/Intersect.Editor/Forms/Editors/frmResource.cs
+++ b/Intersect.Editor/Forms/Editors/frmResource.cs
@@ -112,17 +112,19 @@ public partial class FrmResource : EditorForm
 
     private void toolStripItemUndo_Click(object sender, EventArgs e)
     {
-        if (_editorItem != null && _changed.ContainsKey(_editorItem.Id) && _editorItem != null)
+        if (_editorItem == null || !_changed.ContainsKey(_editorItem.Id))
         {
-            if (DarkMessageBox.ShowWarning(
+            return;
+        }
+
+        if (DarkMessageBox.ShowWarning(
                     Strings.ResourceEditor.undoprompt, Strings.ResourceEditor.undotitle, DarkDialogButton.YesNo,
                     Icon
                 ) ==
                 DialogResult.Yes)
-            {
-                _editorItem.RestoreBackup();
-                UpdateEditor();
-            }
+        {
+            _editorItem.RestoreBackup();
+            UpdateEditor();
         }
     }
 

--- a/Intersect.Editor/Forms/Editors/frmResource.cs
+++ b/Intersect.Editor/Forms/Editors/frmResource.cs
@@ -237,19 +237,19 @@ public partial class FrmResource : EditorForm
 
         grpRegen.Text = Strings.ResourceEditor.regen;
         lblHpRegen.Text = Strings.ResourceEditor.hpregen;
-        lblRegenHint.Text = Strings.ResourceEditor.regenhint;
+        new ToolTip().SetToolTip(grpRegen, Strings.ResourceEditor.regenhint);
 
-        grpGraphics.Text = Strings.ResourceEditor.Graphics;
-        lblHealthStates.Text = Strings.ResourceEditor.HealthStatesLabel;
-        lblHealthStateName.Text = Strings.ResourceEditor.HealthStateName;
+        grpGraphics.Text = Strings.ResourceEditor.Appearance;
+        lblHealthStates.Text = Strings.ResourceEditor.StatesLabel;
+        lblHealthStateName.Text = Strings.ResourceEditor.StateName;
         btnAddHealthState.Text = Strings.ResourceEditor.AddHealthState;
         btnRemoveHealthState.Text = Strings.ResourceEditor.RemoveHealthState;
-        grpGraphicData.Text = Strings.ResourceEditor.GraphicData;
-        lblGraphicType.Text = Strings.ResourceEditor.GraphicType;
+        grpGraphicData.Text = Strings.ResourceEditor.StateProperties;
+        lblGraphicType.Text = Strings.ResourceEditor.TextureSource;
         cmbGraphicType.Items.Clear();
-        cmbGraphicType.Items.AddRange([.. Strings.ResourceEditor.GraphicTypes.Values]);
+        cmbGraphicType.Items.AddRange([.. Strings.ResourceEditor.TextureSources.Values]);
         chkRenderBelowEntity.Text = Strings.ResourceEditor.BelowEntities;
-        lblGraphicFile.Text = Strings.ResourceEditor.GraphicFile;
+        lblGraphicFile.Text = Strings.ResourceEditor.TextureName;
         lblAnimation.Text = Strings.ResourceEditor.Animation;
 
         grpCommonEvent.Text = Strings.ResourceEditor.commonevent;
@@ -800,8 +800,8 @@ public partial class FrmResource : EditorForm
         if (txtHealthStateName.Text.Length <= 0)
         {
             DarkMessageBox.ShowError(
-                Strings.ResourceEditor.HealthStateNameError,
-                Strings.ResourceEditor.HealthStateErrorTitle
+                Strings.ResourceEditor.StateNameError,
+                Strings.ResourceEditor.StateErrorTitle
             );
             return;
         }
@@ -811,17 +811,11 @@ public partial class FrmResource : EditorForm
             return;
         }
 
-        if (_editorItem.StatesGraphics.ContainsKey(txtHealthStateName.Text))
+        var state = new ResourceStateDescriptor
         {
-            DarkMessageBox.ShowError(
-                Strings.ResourceEditor.HealthStateNameExists,
-                Strings.ResourceEditor.HealthStateErrorTitle
-            );
-            return;
-        }
-
-        var state = new ResourceStateDescriptor();
-        _editorItem.StatesGraphics.Add(txtHealthStateName.Text, state);
+            Id = Guid.NewGuid()
+        };
+        _editorItem.StatesGraphics.Add(state.Id, state);
         lstHealthState.Items.Add(txtHealthStateName.Text);
         lstHealthState.SelectedIndex = lstHealthState.Items.Count - 1;
         txtHealthStateName.Text = string.Empty;

--- a/Intersect.Editor/Forms/Editors/frmResource.cs
+++ b/Intersect.Editor/Forms/Editors/frmResource.cs
@@ -240,16 +240,16 @@ public partial class FrmResource : EditorForm
         new ToolTip().SetToolTip(grpRegen, Strings.ResourceEditor.regenhint);
 
         grpGraphics.Text = Strings.ResourceEditor.Appearance;
-        lblHealthStates.Text = Strings.ResourceEditor.StatesLabel;
-        lblHealthStateName.Text = Strings.ResourceEditor.StateName;
-        btnAddHealthState.Text = Strings.ResourceEditor.AddHealthState;
-        btnRemoveHealthState.Text = Strings.ResourceEditor.RemoveHealthState;
+        lblStates.Text = Strings.ResourceEditor.StatesLabel;
+        lblStateName.Text = Strings.ResourceEditor.StateName;
+        btnAddState.Text = Strings.ResourceEditor.AddState;
+        btnRemoveState.Text = Strings.ResourceEditor.RemoveState;
         grpGraphicData.Text = Strings.ResourceEditor.StateProperties;
-        lblGraphicType.Text = Strings.ResourceEditor.TextureSource;
-        cmbGraphicType.Items.Clear();
-        cmbGraphicType.Items.AddRange([.. Strings.ResourceEditor.TextureSources.Values]);
+        lblTextureType.Text = Strings.ResourceEditor.TextureSource;
+        cmbTextureType.Items.Clear();
+        cmbTextureType.Items.AddRange([.. Strings.ResourceEditor.TextureSources.Values]);
         chkRenderBelowEntity.Text = Strings.ResourceEditor.BelowEntities;
-        lblGraphicFile.Text = Strings.ResourceEditor.TextureName;
+        lblTerxtureSource.Text = Strings.ResourceEditor.TextureName;
         lblAnimation.Text = Strings.ResourceEditor.Animation;
 
         grpCommonEvent.Text = Strings.ResourceEditor.commonevent;
@@ -289,25 +289,25 @@ public partial class FrmResource : EditorForm
             nudHpRegen.Value = _editorItem.VitalRegen;
 
             picResource.Hide();
-            lstHealthState.Items.Clear();
+            lstStates.Items.Clear();
             foreach (var state in _editorItem.StatesGraphics.Keys)
             {
-                lstHealthState.Items.Add(state);
+                lstStates.Items.Add(state);
             }
 
-            if (lstHealthState.Items.Count > 0)
+            if (lstStates.Items.Count > 0)
             {
-                lstHealthState.SelectedIndex = 0;
+                lstStates.SelectedIndex = 0;
             }
             else
             {
-                txtHealthStateName.Text = string.Empty;
-                cmbGraphicType.SelectedIndex = (int)ResourceTextureSource.Resource;
+                txtStateName.Text = string.Empty;
+                cmbTextureType.SelectedIndex = (int)ResourceTextureSource.Resource;
                 chkRenderBelowEntity.Checked = false;
-                cmbGraphicFile.Items.Clear();
+                cmbTextureSource.Items.Clear();
                 cmbAnimation.Items.Clear();
-                nudHealthRangeMin.Value = 0;
-                nudHealthRangeMax.Value = 0;
+                nudStateRangeMin.Value = 0;
+                nudStateRangeMax.Value = 0;
                 picResource.Hide();
             }
 
@@ -334,7 +334,7 @@ public partial class FrmResource : EditorForm
 
     #region Helpers
 
-    private bool TryGetCurrentHealthState([NotNullWhen(true)] out ResourceStateDescriptor? state)
+    private bool TryGetCurrentState([NotNullWhen(true)] out ResourceStateDescriptor? state)
     {
         state = null;
 
@@ -343,12 +343,12 @@ public partial class FrmResource : EditorForm
             return false;
         }
 
-        if (lstHealthState.SelectedIndex < 0)
+        if (lstStates.SelectedIndex < 0)
         {
             return false;
         }
 
-        var selectedIndex = lstHealthState.SelectedIndex;
+        var selectedIndex = lstStates.SelectedIndex;
         var stateKey = _editorItem.StatesGraphics.Keys.ToList()[selectedIndex];
         if (!_editorItem.StatesGraphics.TryGetValue(stateKey, out state))
         {
@@ -378,30 +378,30 @@ public partial class FrmResource : EditorForm
         }
     }
 
-    private void UpdateHealthStateControls()
+    private void UpdateStateControls()
     {
-        if (!TryGetCurrentHealthState(out var currentState))
+        if (!TryGetCurrentState(out var currentState))
         {
             return;
         }
 
-        cmbGraphicType.SelectedIndex = (int)currentState.TextureType;
+        cmbTextureType.SelectedIndex = (int)currentState.TextureType;
         chkRenderBelowEntity.Checked = currentState.RenderBelowEntities;
-        nudHealthRangeMin.Value = currentState.MinimumHealth;
-        nudHealthRangeMax.Value = currentState.MaximumHealth;
+        nudStateRangeMin.Value = currentState.MinimumHealth;
+        nudStateRangeMax.Value = currentState.MaximumHealth;
         UpdateGraphicFileControl(currentState);
     }
 
     private void UpdateGraphicFileControl(ResourceStateDescriptor currentState)
     {
-        cmbGraphicFile.Items.Clear();
-        cmbGraphicFile.Items.Add(Strings.General.None);
+        cmbTextureSource.Items.Clear();
+        cmbTextureSource.Items.Add(Strings.General.None);
         cmbAnimation.Items.Clear();
         cmbAnimation.Items.Add(Strings.General.None);
 
         if (currentState.TextureType == ResourceTextureSource.Animation)
         {
-            cmbGraphicFile.Enabled = false;
+            cmbTextureSource.Enabled = false;
             picResource.Visible = false;
             cmbAnimation.Enabled = true;
             cmbAnimation.Items.AddRange(AnimationDescriptor.Names);
@@ -409,7 +409,7 @@ public partial class FrmResource : EditorForm
             return;
         }
 
-        cmbGraphicFile.Enabled = true;
+        cmbTextureSource.Enabled = true;
         picResource.Visible = true;
         cmbAnimation.Enabled = false;
 
@@ -419,20 +419,20 @@ public partial class FrmResource : EditorForm
                 : GameContentManager.TextureType.Resource
         );
 
-        cmbGraphicFile.Items.AddRange(resources);
+        cmbTextureSource.Items.AddRange(resources);
 
         if (_editorItem is null)
         {
             return;
         }
 
-        if (currentState.Texture != null && cmbGraphicFile.Items.Contains(currentState.Texture))
+        if (currentState.Texture != null && cmbTextureSource.Items.Contains(currentState.Texture))
         {
-            cmbGraphicFile.SelectedIndex = cmbGraphicFile.FindString(TextUtils.NullToNone(currentState.Texture));
+            cmbTextureSource.SelectedIndex = cmbTextureSource.FindString(TextUtils.NullToNone(currentState.Texture));
             return;
         }
 
-        cmbGraphicFile.SelectedIndex = 0;
+        cmbTextureSource.SelectedIndex = 0;
     }
 
     private void Render(object sender, EventArgs e)
@@ -452,7 +452,7 @@ public partial class FrmResource : EditorForm
             return;
         }
 
-        if (!TryGetCurrentHealthState(out var currentState))
+        if (!TryGetCurrentState(out var currentState))
         {
             return;
         }
@@ -470,7 +470,7 @@ public partial class FrmResource : EditorForm
         var gfx = Graphics.FromImage(_graphicBitmap);
         gfx.FillRectangle(Brushes.Black, new Rectangle(0, 0, picResource.Width, picResource.Height));
 
-        if (cmbGraphicFile.SelectedIndex > 0 && cmbGraphicFile.SelectedIndex > 0)
+        if (cmbTextureSource.SelectedIndex > 0 && cmbTextureSource.SelectedIndex > 0)
         {
             gfx.DrawImage(
                 _resourceGraphic,
@@ -779,25 +779,25 @@ public partial class FrmResource : EditorForm
         _editorItem.CannotHarvestMessage = txtCannotHarvest.Text;
     }
 
-    private void lstHealthState_SelectedIndexChanged(object sender, EventArgs e)
+    private void lstStates_SelectedIndexChanged(object sender, EventArgs e)
     {
         if (_editorItem is null)
         {
             return;
         }
 
-        if (lstHealthState.SelectedIndex < 0)
+        if (lstStates.SelectedIndex < 0)
         {
             return;
         }
 
-        UpdateHealthStateControls();
+        UpdateStateControls();
     }
 
-    private void btnAddHealthState_Click(object sender, EventArgs e)
+    private void btnAddState_Click(object sender, EventArgs e)
     {
         //alert if name is less than 3 characters
-        if (txtHealthStateName.Text.Length <= 0)
+        if (txtStateName.Text.Length <= 0)
         {
             DarkMessageBox.ShowError(
                 Strings.ResourceEditor.StateNameError,
@@ -816,19 +816,19 @@ public partial class FrmResource : EditorForm
             Id = Guid.NewGuid()
         };
         _editorItem.StatesGraphics.Add(state.Id, state);
-        lstHealthState.Items.Add(txtHealthStateName.Text);
-        lstHealthState.SelectedIndex = lstHealthState.Items.Count - 1;
-        txtHealthStateName.Text = string.Empty;
+        lstStates.Items.Add(txtStateName.Text);
+        lstStates.SelectedIndex = lstStates.Items.Count - 1;
+        txtStateName.Text = string.Empty;
     }
 
-    private void btnRemoveHealthState_Click(object sender, EventArgs e)
+    private void btnRemoveState_Click(object sender, EventArgs e)
     {
         if (_editorItem is null)
         {
             return;
         }
 
-        var selectedIndex = lstHealthState.SelectedIndex;
+        var selectedIndex = lstStates.SelectedIndex;
         if (selectedIndex < 0)
         {
             return;
@@ -841,27 +841,27 @@ public partial class FrmResource : EditorForm
         }
 
         _editorItem.StatesGraphics.Remove(stateKey);
-        lstHealthState.Items.RemoveAt(selectedIndex);
-        if (lstHealthState.Items.Count > 0)
+        lstStates.Items.RemoveAt(selectedIndex);
+        if (lstStates.Items.Count > 0)
         {
-            lstHealthState.SelectedIndex = 0;
+            lstStates.SelectedIndex = 0;
         }
     }
 
     private void cmbGraphicType_SelectedIndexChanged(object sender, EventArgs e)
     {
-        if (!TryGetCurrentHealthState(out var currentState))
+        if (!TryGetCurrentState(out var currentState))
         {
             return;
         }
 
-        currentState.TextureType = (ResourceTextureSource)cmbGraphicType.SelectedIndex;
+        currentState.TextureType = (ResourceTextureSource)cmbTextureType.SelectedIndex;
         UpdateGraphicFileControl(currentState);
     }
 
     private void chkRenderBelowEntity_CheckedChanged(object sender, EventArgs e)
     {
-        if (!TryGetCurrentHealthState(out var currentState))
+        if (!TryGetCurrentState(out var currentState))
         {
             return;
         }
@@ -874,16 +874,16 @@ public partial class FrmResource : EditorForm
         _resourceGraphic?.Dispose();
         _resourceGraphic = null;
 
-        if (!TryGetCurrentHealthState(out var currentState))
+        if (!TryGetCurrentState(out var currentState))
         {
             return;
         }
 
-        if (cmbGraphicFile.SelectedIndex > 0)
+        if (cmbTextureSource.SelectedIndex > 0)
         {
-            currentState.Texture = cmbGraphicFile.Text;
+            currentState.Texture = cmbTextureSource.Text;
             var graphic = Path.Combine(
-                "resources", currentState.TextureType == ResourceTextureSource.Tileset ? "tilesets" : "resources", cmbGraphicFile.Text
+                "resources", currentState.TextureType == ResourceTextureSource.Tileset ? "tilesets" : "resources", cmbTextureSource.Text
             );
 
             if (File.Exists(graphic))
@@ -904,7 +904,7 @@ public partial class FrmResource : EditorForm
 
     private void cmbAnimation_SelectedIndexChanged(object sender, EventArgs e)
     {
-        if (!TryGetCurrentHealthState(out var currentState))
+        if (!TryGetCurrentState(out var currentState))
         {
             return;
         }
@@ -912,24 +912,24 @@ public partial class FrmResource : EditorForm
         currentState.AnimationId = AnimationDescriptor.IdFromList(cmbAnimation.SelectedIndex - 1);
     }
 
-    private void nudHealthRangeMin_ValueChanged(object sender, EventArgs e)
+    private void nudStateRangeMin_ValueChanged(object sender, EventArgs e)
     {
-        if (!TryGetCurrentHealthState(out var currentState))
+        if (!TryGetCurrentState(out var currentState))
         {
             return;
         }
 
-        currentState.MinimumHealth = (int)nudHealthRangeMin.Value;
+        currentState.MinimumHealth = (int)nudStateRangeMin.Value;
     }
 
-    private void nudHealthRangeMax_ValueChanged(object sender, EventArgs e)
+    private void nudStateRangeMax_ValueChanged(object sender, EventArgs e)
     {
-        if (!TryGetCurrentHealthState(out var currentState))
+        if (!TryGetCurrentState(out var currentState))
         {
             return;
         }
 
-        currentState.MaximumHealth = (int)nudHealthRangeMax.Value;
+        currentState.MaximumHealth = (int)nudStateRangeMax.Value;
     }
 
     private void picResource_MouseDown(object sender, MouseEventArgs e)
@@ -944,12 +944,12 @@ public partial class FrmResource : EditorForm
             return;
         }
 
-        if ((ResourceTextureSource)cmbGraphicType.SelectedIndex != ResourceTextureSource.Tileset)
+        if ((ResourceTextureSource)cmbTextureType.SelectedIndex != ResourceTextureSource.Tileset)
         {
             return;
         }
 
-        if (!TryGetCurrentHealthState(out var currentState))
+        if (!TryGetCurrentState(out var currentState))
         {
             return;
         }
@@ -973,12 +973,12 @@ public partial class FrmResource : EditorForm
             return;
         }
 
-        if ((ResourceTextureSource)cmbGraphicType.SelectedIndex != ResourceTextureSource.Tileset)
+        if ((ResourceTextureSource)cmbTextureType.SelectedIndex != ResourceTextureSource.Tileset)
         {
             return;
         }
 
-        if (!TryGetCurrentHealthState(out var currentState))
+        if (!TryGetCurrentState(out var currentState))
         {
             return;
         }
@@ -1019,12 +1019,12 @@ public partial class FrmResource : EditorForm
             return;
         }
 
-        if ((ResourceTextureSource)cmbGraphicType.SelectedIndex != ResourceTextureSource.Tileset)
+        if ((ResourceTextureSource)cmbTextureType.SelectedIndex != ResourceTextureSource.Tileset)
         {
             return;
         }
 
-        if (!TryGetCurrentHealthState(out var currentState))
+        if (!TryGetCurrentState(out var currentState))
         {
             return;
         }

--- a/Intersect.Editor/Forms/Editors/frmResource.cs
+++ b/Intersect.Editor/Forms/Editors/frmResource.cs
@@ -18,15 +18,16 @@ namespace Intersect.Editor.Forms.Editors;
 
 public partial class FrmResource : EditorForm
 {
+    private readonly List<string> _knownFolders = [];
+    private readonly BindingList<NotifiableDrop> _dropList = [];
+    private readonly BindingList<ResourceStateDescriptor> _stateList = [];
     private readonly Dictionary<Guid, ResourceDescriptor> _changed = [];
+
     private string? _copiedItem;
     private ResourceDescriptor? _editorItem;
     private Bitmap? _graphicBitmap;
     private Bitmap? _resourceGraphic;
     private bool _mouseDown;
-    private readonly List<string> _knownFolders = [];
-    private readonly BindingList<NotifiableDrop> _dropList = [];
-    private readonly BindingList<ResourceStateDescriptor> _stateList = [];
 
     public FrmResource()
     {

--- a/Intersect.Editor/Forms/Editors/frmResource.cs
+++ b/Intersect.Editor/Forms/Editors/frmResource.cs
@@ -302,7 +302,7 @@ public partial class FrmResource : EditorForm
             else
             {
                 txtHealthStateName.Text = string.Empty;
-                cmbGraphicType.SelectedIndex = (int)ResourceGraphicType.Graphic;
+                cmbGraphicType.SelectedIndex = (int)ResourceTextureSource.Resource;
                 chkRenderBelowEntity.Checked = false;
                 cmbGraphicFile.Items.Clear();
                 cmbAnimation.Items.Clear();
@@ -385,7 +385,7 @@ public partial class FrmResource : EditorForm
             return;
         }
 
-        cmbGraphicType.SelectedIndex = (int)currentState.GraphicType;
+        cmbGraphicType.SelectedIndex = (int)currentState.TextureType;
         chkRenderBelowEntity.Checked = currentState.RenderBelowEntities;
         nudHealthRangeMin.Value = currentState.MinHp;
         nudHealthRangeMax.Value = currentState.MaxHp;
@@ -399,7 +399,7 @@ public partial class FrmResource : EditorForm
         cmbAnimation.Items.Clear();
         cmbAnimation.Items.Add(Strings.General.None);
 
-        if (currentState.GraphicType == ResourceGraphicType.Animation)
+        if (currentState.TextureType == ResourceTextureSource.Animation)
         {
             cmbGraphicFile.Enabled = false;
             picResource.Visible = false;
@@ -414,7 +414,7 @@ public partial class FrmResource : EditorForm
         cmbAnimation.Enabled = false;
 
         var resources = GameContentManager.GetSmartSortedTextureNames(
-            currentState.GraphicType == ResourceGraphicType.Tileset
+            currentState.TextureType == ResourceTextureSource.Tileset
                 ? GameContentManager.TextureType.Tileset
                 : GameContentManager.TextureType.Resource
         );
@@ -462,7 +462,7 @@ public partial class FrmResource : EditorForm
             return;
         }
 
-        if (currentState.GraphicType == ResourceGraphicType.Animation)
+        if (currentState.TextureType == ResourceTextureSource.Animation)
         {
             return;
         }
@@ -480,7 +480,7 @@ public partial class FrmResource : EditorForm
             );
         }
 
-        if (currentState.GraphicType == ResourceGraphicType.Tileset)
+        if (currentState.TextureType == ResourceTextureSource.Tileset)
         {
             var selX = currentState.X;
             var selY = currentState.Y;
@@ -861,7 +861,7 @@ public partial class FrmResource : EditorForm
             return;
         }
 
-        currentState.GraphicType = (ResourceGraphicType)cmbGraphicType.SelectedIndex;
+        currentState.TextureType = (ResourceTextureSource)cmbGraphicType.SelectedIndex;
         UpdateGraphicFileControl(currentState);
     }
 
@@ -889,7 +889,7 @@ public partial class FrmResource : EditorForm
         {
             currentState.Texture = cmbGraphicFile.Text;
             var graphic = Path.Combine(
-                "resources", currentState.GraphicType == ResourceGraphicType.Tileset ? "tilesets" : "resources", cmbGraphicFile.Text
+                "resources", currentState.TextureType == ResourceTextureSource.Tileset ? "tilesets" : "resources", cmbGraphicFile.Text
             );
 
             if (File.Exists(graphic))
@@ -950,7 +950,7 @@ public partial class FrmResource : EditorForm
             return;
         }
 
-        if ((ResourceGraphicType)cmbGraphicType.SelectedIndex != ResourceGraphicType.Tileset)
+        if ((ResourceTextureSource)cmbGraphicType.SelectedIndex != ResourceTextureSource.Tileset)
         {
             return;
         }
@@ -979,7 +979,7 @@ public partial class FrmResource : EditorForm
             return;
         }
 
-        if ((ResourceGraphicType)cmbGraphicType.SelectedIndex != ResourceGraphicType.Tileset)
+        if ((ResourceTextureSource)cmbGraphicType.SelectedIndex != ResourceTextureSource.Tileset)
         {
             return;
         }
@@ -1025,7 +1025,7 @@ public partial class FrmResource : EditorForm
             return;
         }
 
-        if ((ResourceGraphicType)cmbGraphicType.SelectedIndex != ResourceGraphicType.Tileset)
+        if ((ResourceTextureSource)cmbGraphicType.SelectedIndex != ResourceTextureSource.Tileset)
         {
             return;
         }

--- a/Intersect.Editor/Forms/Editors/frmResource.resx
+++ b/Intersect.Editor/Forms/Editors/frmResource.resx
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!--
-    Microsoft ResX Schema 
+    Microsoft ResX Schema
 
     Version 2.0
 
@@ -48,7 +48,7 @@
     value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
     value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter

--- a/Intersect.Editor/Localization/Strings.cs
+++ b/Intersect.Editor/Localization/Strings.cs
@@ -5023,15 +5023,15 @@ Tick timer saved in server config.json.";
 
         public static LocalizedString general = @"General";
 
-        public static LocalizedString Graphics = @"Graphics";
+        public static LocalizedString Appearance = @"Appearance";
 
-        public static LocalizedString GraphicData = @"Graphic Data";
+        public static LocalizedString StateProperties = @"State Properties";
 
-        public static LocalizedString GraphicFile = @"Graphic File:";
+        public static LocalizedString TextureName = @"Texture Name:";
 
-        public static LocalizedString GraphicType = @"Graphic Type:";
+        public static LocalizedString TextureSource = @"Texture Source:";
 
-        public static Dictionary<ResourceTextureSource, LocalizedString> GraphicTypes = new()
+        public static Dictionary<ResourceTextureSource, LocalizedString> TextureSources = new()
         {
             { ResourceTextureSource.Resource, @"Graphic" },
             { ResourceTextureSource.Tileset, @"Tileset" },
@@ -5040,15 +5040,13 @@ Tick timer saved in server config.json.";
 
         public static LocalizedString harvestevent = @"Event:";
 
-        public static LocalizedString HealthStatesLabel = @"Health States";
+        public static LocalizedString StatesLabel = @"States";
 
-        public static LocalizedString HealthStateName = @"Health Graphic State Name:";
+        public static LocalizedString StateName = @"State Name:";
 
-        public static LocalizedString HealthStateErrorTitle = @"Invalid Health Graphic State Name";
+        public static LocalizedString StateErrorTitle = @"Invalid name for a resource state";
 
-        public static LocalizedString HealthStateNameError = @"Health Graphic State Name must be unique and greater than 0 characters.";
-
-        public static LocalizedString HealthStateNameExists = @"Health Graphic State Name already exists.";
+        public static LocalizedString StateNameError = @"State Name must be greater than 0 characters.";
 
         public static LocalizedString hpregen = @"HP (%);";
 

--- a/Intersect.Editor/Localization/Strings.cs
+++ b/Intersect.Editor/Localization/Strings.cs
@@ -4990,7 +4990,7 @@ Tick timer saved in server config.json.";
 
         public static LocalizedString copy = @"Copy Resource";
 
-        public static LocalizedString DeathAnimation = @"Animation:";
+        public static LocalizedString DeathAnimation = @"Death Animation:";
 
         public static LocalizedString delete = @"Delete Resource";
 
@@ -5048,7 +5048,7 @@ Tick timer saved in server config.json.";
 
         public static LocalizedString StateNameError = @"State Name must be greater than 0 characters.";
 
-        public static LocalizedString hpregen = @"HP (%);";
+        public static LocalizedString hpregen = @"HP Regen (%):";
 
         public static LocalizedString maxhp = @"Max HP:";
 
@@ -5059,8 +5059,6 @@ Tick timer saved in server config.json.";
         public static LocalizedString New = @"New Resource";
 
         public static LocalizedString paste = @"Paste Resource";
-
-        public static LocalizedString regen = @"Regen";
 
         public static LocalizedString regenhint = @"% of HP to restore per tick.
 

--- a/Intersect.Editor/Localization/Strings.cs
+++ b/Intersect.Editor/Localization/Strings.cs
@@ -4980,7 +4980,7 @@ Tick timer saved in server config.json.";
     {
         public static LocalizedString Animation = @"Animation";
 
-        public static LocalizedString AddHealthState = @"Add";
+        public static LocalizedString AddState = @"Add";
 
         public static LocalizedString BelowEntities = @"Below Entities";
 
@@ -5066,7 +5066,7 @@ Tick timer saved in server config.json.";
 
 Tick timer saved in server config.json.";
 
-        public static LocalizedString RemoveHealthState = @"Remove";
+        public static LocalizedString RemoveState = @"Remove";
 
         public static LocalizedString requirementsgroup = @"Requirements";
 

--- a/Intersect.Editor/Localization/Strings.cs
+++ b/Intersect.Editor/Localization/Strings.cs
@@ -5048,7 +5048,7 @@ Tick timer saved in server config.json.";
 
         public static LocalizedString StateNameError = @"State Name must be greater than 0 characters.";
 
-        public static LocalizedString hpregen = @"HP Regen (%):";
+        public static LocalizedString HealthRegenPercent = @"HP Regen (%):";
 
         public static LocalizedString maxhp = @"Max HP:";
 

--- a/Intersect.Editor/Localization/Strings.cs
+++ b/Intersect.Editor/Localization/Strings.cs
@@ -5033,7 +5033,7 @@ Tick timer saved in server config.json.";
 
         public static Dictionary<ResourceTextureSource, LocalizedString> TextureSources = new()
         {
-            { ResourceTextureSource.Resource, @"Graphic" },
+            { ResourceTextureSource.Resource, @"Resource" },
             { ResourceTextureSource.Tileset, @"Tileset" },
             { ResourceTextureSource.Animation, @"Animation" },
         };

--- a/Intersect.Editor/Localization/Strings.cs
+++ b/Intersect.Editor/Localization/Strings.cs
@@ -5031,11 +5031,11 @@ Tick timer saved in server config.json.";
 
         public static LocalizedString GraphicType = @"Graphic Type:";
 
-        public static Dictionary<ResourceGraphicType, LocalizedString> GraphicTypes = new()
+        public static Dictionary<ResourceTextureSource, LocalizedString> GraphicTypes = new()
         {
-            { ResourceGraphicType.Graphic, @"Graphic" },
-            { ResourceGraphicType.Tileset, @"Tileset" },
-            { ResourceGraphicType.Animation, @"Animation" },
+            { ResourceTextureSource.Resource, @"Graphic" },
+            { ResourceTextureSource.Tileset, @"Tileset" },
+            { ResourceTextureSource.Animation, @"Animation" },
         };
 
         public static LocalizedString harvestevent = @"Event:";

--- a/Intersect.Editor/Localization/Strings.cs
+++ b/Intersect.Editor/Localization/Strings.cs
@@ -7,6 +7,7 @@ using Intersect.Framework.Core.GameObjects.Items;
 using Intersect.Framework.Core.GameObjects.Maps;
 using Intersect.Framework.Core.GameObjects.NPCs;
 using Intersect.Framework.Core.GameObjects.PlayerClass;
+using Intersect.Framework.Core.GameObjects.Resources;
 using Intersect.Framework.Core.GameObjects.Variables;
 using Intersect.Framework.Reflection;
 using Intersect.GameObjects;
@@ -4977,16 +4978,19 @@ Tick timer saved in server config.json.";
 
     public partial struct ResourceEditor
     {
+        public static LocalizedString Animation = @"Animation";
 
-        public static LocalizedString animation = @"Animation:";
+        public static LocalizedString AddHealthState = @"Add";
 
-        public static LocalizedString belowentities = @"Below Entities";
+        public static LocalizedString BelowEntities = @"Below Entities";
 
         public static LocalizedString cancel = @"Cancel";
 
         public static LocalizedString commonevent = @"Common Event";
 
         public static LocalizedString copy = @"Copy Resource";
+
+        public static LocalizedString DeathAnimation = @"Animation:";
 
         public static LocalizedString delete = @"Delete Resource";
 
@@ -5011,25 +5015,42 @@ Tick timer saved in server config.json.";
 
         public static LocalizedString dropdisplay = @"{00} x{01}-{02} | {03}%";
 
-        public static LocalizedString exhaustedgraphic = @"Exhausted Graphic:";
-
         public static LocalizedString folderlabel = @"Folder:";
 
         public static LocalizedString foldertitle = @"Add Folder";
 
         public static LocalizedString folderprompt = @"Enter a name for the folder you'd like to add:";
 
-        public static LocalizedString fromtileset = @"From Tileset";
-
         public static LocalizedString general = @"General";
 
-        public static LocalizedString graphics = @"Graphics";
+        public static LocalizedString Graphics = @"Graphics";
+
+        public static LocalizedString GraphicData = @"Graphic Data";
+
+        public static LocalizedString GraphicFile = @"Graphic File:";
+
+        public static LocalizedString GraphicType = @"Graphic Type:";
+
+        public static Dictionary<ResourceGraphicType, LocalizedString> GraphicTypes = new()
+        {
+            { ResourceGraphicType.Graphic, @"Graphic" },
+            { ResourceGraphicType.Tileset, @"Tileset" },
+            { ResourceGraphicType.Animation, @"Animation" },
+        };
 
         public static LocalizedString harvestevent = @"Event:";
 
-        public static LocalizedString hpregen = @"HP (%);";
+        public static LocalizedString HealthStatesLabel = @"Health States";
 
-        public static LocalizedString initialgraphic = @"Initial Graphic:";
+        public static LocalizedString HealthStateName = @"Health Graphic State Name:";
+
+        public static LocalizedString HealthStateErrorTitle = @"Invalid Health Graphic State Name";
+
+        public static LocalizedString HealthStateNameError = @"Health Graphic State Name must be unique and greater than 0 characters.";
+
+        public static LocalizedString HealthStateNameExists = @"Health Graphic State Name already exists.";
+
+        public static LocalizedString hpregen = @"HP (%);";
 
         public static LocalizedString maxhp = @"Max HP:";
 
@@ -5046,6 +5067,8 @@ Tick timer saved in server config.json.";
         public static LocalizedString regenhint = @"% of HP to restore per tick.
 
 Tick timer saved in server config.json.";
+
+        public static LocalizedString RemoveHealthState = @"Remove";
 
         public static LocalizedString requirementsgroup = @"Requirements";
 
@@ -5074,6 +5097,8 @@ Tick timer saved in server config.json.";
             @"Are you sure you want to undo changes made to this resource? This action cannot be reverted!";
 
         public static LocalizedString undotitle = @"Undo Changes";
+
+        public static LocalizedString UseExplicitMaxHealthForResourceStates = @"Use Explicit Max Health for Resource States";
 
         public static LocalizedString walkableafter = @"Walkable after resource removal?";
 

--- a/Intersect.Server.Core/Entities/Entity.cs
+++ b/Intersect.Server.Core/Entities/Entity.cs
@@ -1557,7 +1557,7 @@ public abstract partial class Entity : IEntity
         SetVital(vital, GetVital(vital) + safeAmount);
     }
 
-    public virtual void SubVital(Vital vital, long amount)
+    public void SubVital(Vital vital, long amount)
     {
         if (!Enum.IsDefined(vital))
         {

--- a/Intersect.Server.Core/Entities/Entity.cs
+++ b/Intersect.Server.Core/Entities/Entity.cs
@@ -1557,7 +1557,7 @@ public abstract partial class Entity : IEntity
         SetVital(vital, GetVital(vital) + safeAmount);
     }
 
-    public void SubVital(Vital vital, long amount)
+    public virtual void SubVital(Vital vital, long amount)
     {
         if (!Enum.IsDefined(vital))
         {

--- a/Intersect.Server.Core/Entities/Resource.cs
+++ b/Intersect.Server.Core/Entities/Resource.cs
@@ -60,7 +60,7 @@ public partial class Resource : Entity
             return;
         }
 
-        Sprite = currentGraphicState.Graphic;
+        Sprite = currentGraphicState.Texture;
     }
 
     public override void SubVital(Vital vital, long amount)

--- a/Intersect.Server.Core/Entities/Resource.cs
+++ b/Intersect.Server.Core/Entities/Resource.cs
@@ -30,7 +30,6 @@ public partial class Resource : Entity
         );
 
         RestoreVital(Vital.Health);
-        HandleSprite();
         Passable = descriptor.WalkableBefore;
         HideName = true;
     }
@@ -46,29 +45,6 @@ public partial class Resource : Entity
         PacketSender.SendEntityLeave(this);
     }
 
-    private void HandleSprite()
-    {
-        var graphicStates = Descriptor.States.Values.ToList();
-        var currentHealthPercentage = Math.Floor((float)GetVital(Vital.Health) / GetMaxVital(Vital.Health));
-        var currentGraphicState = graphicStates.FirstOrDefault(
-            state => currentHealthPercentage >= state.MinimumHealth && currentHealthPercentage <= state.MaximumHealth
-        );
-
-        if (currentGraphicState is null || currentGraphicState.TextureType == ResourceTextureSource.Animation)
-        {
-            Sprite = default;
-            return;
-        }
-
-        Sprite = currentGraphicState.Texture;
-    }
-
-    public override void SubVital(Vital vital, long amount)
-    {
-        base.SubVital(vital, amount);
-        HandleSprite();
-    }
-
     public override void Die(bool dropItems = true, Entity killer = null)
     {
         lock (EntityLock)
@@ -76,7 +52,6 @@ public partial class Resource : Entity
             base.Die(false, killer);
         }
 
-        HandleSprite();
         Passable = Descriptor.WalkableAfter;
         IsDead = true;
 
@@ -91,7 +66,6 @@ public partial class Resource : Entity
 
     public void Spawn()
     {
-        HandleSprite();
         var minimumHealth = Descriptor.MinHp;
         var maximumHealth = Descriptor.MaxHp;
 

--- a/Intersect.Server.Core/Entities/Resource.cs
+++ b/Intersect.Server.Core/Entities/Resource.cs
@@ -51,7 +51,7 @@ public partial class Resource : Entity
         var graphicStates = Descriptor.HealthGraphics.Values.ToList();
         var currentHealthPercentage = Math.Floor((float)GetVital(Vital.Health) / GetMaxVital(Vital.Health));
         var currentGraphicState = graphicStates.FirstOrDefault(
-            state => currentHealthPercentage >= state.MinHp && currentHealthPercentage <= state.MaxHp
+            state => currentHealthPercentage >= state.MinimumHealth && currentHealthPercentage <= state.MaximumHealth
         );
 
         if (currentGraphicState is null || currentGraphicState.TextureType == ResourceTextureSource.Animation)

--- a/Intersect.Server.Core/Entities/Resource.cs
+++ b/Intersect.Server.Core/Entities/Resource.cs
@@ -54,7 +54,7 @@ public partial class Resource : Entity
             state => currentHealthPercentage >= state.MinHp && currentHealthPercentage <= state.MaxHp
         );
 
-        if (currentGraphicState is null || currentGraphicState.GraphicType == ResourceGraphicType.Animation)
+        if (currentGraphicState is null || currentGraphicState.TextureType == ResourceTextureSource.Animation)
         {
             Sprite = default;
             return;

--- a/Intersect.Server.Core/Entities/Resource.cs
+++ b/Intersect.Server.Core/Entities/Resource.cs
@@ -48,7 +48,7 @@ public partial class Resource : Entity
 
     private void HandleSprite()
     {
-        var graphicStates = Descriptor.HealthGraphics.Values.ToList();
+        var graphicStates = Descriptor.StatesGraphics.Values.ToList();
         var currentHealthPercentage = Math.Floor((float)GetVital(Vital.Health) / GetMaxVital(Vital.Health));
         var currentGraphicState = graphicStates.FirstOrDefault(
             state => currentHealthPercentage >= state.MinimumHealth && currentHealthPercentage <= state.MaximumHealth

--- a/Intersect.Server.Core/Entities/Resource.cs
+++ b/Intersect.Server.Core/Entities/Resource.cs
@@ -48,7 +48,7 @@ public partial class Resource : Entity
 
     private void HandleSprite()
     {
-        var graphicStates = Descriptor.StatesGraphics.Values.ToList();
+        var graphicStates = Descriptor.States.Values.ToList();
         var currentHealthPercentage = Math.Floor((float)GetVital(Vital.Health) / GetMaxVital(Vital.Health));
         var currentGraphicState = graphicStates.FirstOrDefault(
             state => currentHealthPercentage >= state.MinimumHealth && currentHealthPercentage <= state.MaximumHealth

--- a/Intersect.Server.Core/Migrations/Sqlite/Game/20250326125418_ResourceStates.Designer.cs
+++ b/Intersect.Server.Core/Migrations/Sqlite/Game/20250326125418_ResourceStates.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Intersect.Server.Database.GameData;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Intersect.Server.Migrations.Sqlite.Game
 {
     [DbContext(typeof(SqliteGameContext))]
-    partial class SqliteGameContextModelSnapshot : ModelSnapshot
+    [Migration("20250326125418_ResourceStates")]
+    partial class ResourceStates
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "8.0.11");

--- a/Intersect.Server.Core/Migrations/Sqlite/Game/20250326125418_ResourceStates.cs
+++ b/Intersect.Server.Core/Migrations/Sqlite/Game/20250326125418_ResourceStates.cs
@@ -1,0 +1,216 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Intersect.Server.Migrations.Sqlite.Game
+{
+    /// <inheritdoc />
+    public partial class ResourceStates : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "States",
+                table: "Resources",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.Sql($@"
+                UPDATE Resources
+                SET States = json_object(
+                    '00000000-0000-0000-0000-000000000001', json_object(
+                        'Id', '00000000-0000-0000-0000-000000000001',
+                        'Name', 'Exhausted',
+                        'TextureName', Exhausted_Graphic,
+                        'TextureType', Exhausted_GraphicFromTileset,
+                        'RenderBelowEntities', Exhausted_RenderBelowEntities,
+                        'Width', Exhausted_Width,
+                        'Height', Exhausted_Height,
+                        'X', Exhausted_X,
+                        'Y', Exhausted_Y,
+                        'MinimumHealth', 0,
+                        'MaximumHealth', 0
+                    ),
+                    '00000000-0000-0000-0000-000000000002', json_object(
+                        'Id', '00000000-0000-0000-0000-000000000002',
+                        'Name', 'Initial',
+                        'TextureName', Initial_Graphic,
+                        'TextureType', Initial_GraphicFromTileset,
+                        'RenderBelowEntities', Initial_RenderBelowEntities,
+                        'Width', Initial_Width,
+                        'Height', Initial_Height,
+                        'X', Initial_X,
+                        'Y', Initial_Y,
+                        'MinimumHealth', 1,
+                        'MaximumHealth', 100
+                    )
+                );
+            ");
+
+            migrationBuilder.DropColumn(
+                name: "Exhausted_Graphic",
+                table: "Resources");
+
+            migrationBuilder.DropColumn(
+                name: "Exhausted_GraphicFromTileset",
+                table: "Resources");
+
+            migrationBuilder.DropColumn(
+                name: "Exhausted_Height",
+                table: "Resources");
+
+            migrationBuilder.DropColumn(
+                name: "Exhausted_RenderBelowEntities",
+                table: "Resources");
+
+            migrationBuilder.DropColumn(
+                name: "Exhausted_Width",
+                table: "Resources");
+
+            migrationBuilder.DropColumn(
+                name: "Exhausted_X",
+                table: "Resources");
+
+            migrationBuilder.DropColumn(
+                name: "Exhausted_Y",
+                table: "Resources");
+
+            migrationBuilder.DropColumn(
+                name: "Initial_Graphic",
+                table: "Resources");
+
+            migrationBuilder.DropColumn(
+                name: "Initial_GraphicFromTileset",
+                table: "Resources");
+
+            migrationBuilder.DropColumn(
+                name: "Initial_Height",
+                table: "Resources");
+
+            migrationBuilder.DropColumn(
+                name: "Initial_RenderBelowEntities",
+                table: "Resources");
+
+            migrationBuilder.DropColumn(
+                name: "Initial_Width",
+                table: "Resources");
+
+            migrationBuilder.DropColumn(
+                name: "Initial_X",
+                table: "Resources");
+
+            migrationBuilder.DropColumn(
+                name: "Initial_Y",
+                table: "Resources");
+
+            migrationBuilder.RenameColumn(
+                name: "Animation",
+                table: "Resources",
+                newName: "DeathAnimation");
+
+            migrationBuilder.AddColumn<bool>(
+                name: "UseExplicitMaxHealthForResourceStates",
+                table: "Resources",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "UseExplicitMaxHealthForResourceStates",
+                table: "Resources");
+
+            migrationBuilder.RenameColumn(
+                name: "States",
+                table: "Resources",
+                newName: "Initial_Graphic");
+
+            migrationBuilder.RenameColumn(
+                name: "DeathAnimation",
+                table: "Resources",
+                newName: "Animation");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Exhausted_Graphic",
+                table: "Resources",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "Exhausted_GraphicFromTileset",
+                table: "Resources",
+                type: "INTEGER",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Exhausted_Height",
+                table: "Resources",
+                type: "INTEGER",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "Exhausted_RenderBelowEntities",
+                table: "Resources",
+                type: "INTEGER",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Exhausted_Width",
+                table: "Resources",
+                type: "INTEGER",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Exhausted_X",
+                table: "Resources",
+                type: "INTEGER",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Exhausted_Y",
+                table: "Resources",
+                type: "INTEGER",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "Initial_GraphicFromTileset",
+                table: "Resources",
+                type: "INTEGER",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Initial_Height",
+                table: "Resources",
+                type: "INTEGER",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "Initial_RenderBelowEntities",
+                table: "Resources",
+                type: "INTEGER",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Initial_Width",
+                table: "Resources",
+                type: "INTEGER",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Initial_X",
+                table: "Resources",
+                type: "INTEGER",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Initial_Y",
+                table: "Resources",
+                type: "INTEGER",
+                nullable: true);
+        }
+    }
+}

--- a/Intersect.Server/Migrations/MySql/Game/20250326125350_ResourceStates.Designer.cs
+++ b/Intersect.Server/Migrations/MySql/Game/20250326125350_ResourceStates.Designer.cs
@@ -3,40 +3,49 @@ using System;
 using Intersect.Server.Database.GameData;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
 
-namespace Intersect.Server.Migrations.Sqlite.Game
+namespace Intersect.Server.Migrations.MySql.Game
 {
-    [DbContext(typeof(SqliteGameContext))]
-    partial class SqliteGameContextModelSnapshot : ModelSnapshot
+    [DbContext(typeof(MySqlGameContext))]
+    [Migration("20250326125350_ResourceStates")]
+    partial class ResourceStates
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
-            modelBuilder.HasAnnotation("ProductVersion", "8.0.11");
+            modelBuilder
+                .HasAnnotation("ProductVersion", "8.0.11")
+                .HasAnnotation("Relational:MaxIdentifierLength", 64);
+
+            MySqlModelBuilderExtensions.AutoIncrementColumns(modelBuilder);
 
             modelBuilder.Entity("Intersect.Framework.Core.GameObjects.Animations.AnimationDescriptor", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("char(36)")
+                        .UseCollation("ascii_general_ci");
 
                     b.Property<bool>("CompleteSound")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("Folder")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("Name")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnOrder(0);
 
                     b.Property<string>("Sound")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("longtext");
 
                     b.Property<long>("TimeCreated")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.HasKey("Id");
 
@@ -46,44 +55,47 @@ namespace Intersect.Server.Migrations.Sqlite.Game
             modelBuilder.Entity("Intersect.Framework.Core.GameObjects.Crafting.CraftingRecipeDescriptor", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("char(36)")
+                        .UseCollation("ascii_general_ci");
 
                     b.Property<Guid>("EventId")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("Event");
+                        .HasColumnType("char(36)")
+                        .HasColumnName("Event")
+                        .UseCollation("ascii_general_ci");
 
                     b.Property<int>("FailureChance")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("Folder")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("IngredientsJson")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnName("Ingredients");
 
                     b.Property<Guid>("ItemId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("char(36)")
+                        .UseCollation("ascii_general_ci");
 
                     b.Property<int>("ItemLossChance")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("JsonCraftingRequirements")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnName("CraftingRequirements");
 
                     b.Property<string>("Name")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnOrder(0);
 
                     b.Property<int>("Quantity")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("Time")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<long>("TimeCreated")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.HasKey("Id");
 
@@ -93,21 +105,22 @@ namespace Intersect.Server.Migrations.Sqlite.Game
             modelBuilder.Entity("Intersect.Framework.Core.GameObjects.Crafting.CraftingTableDescriptor", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("char(36)")
+                        .UseCollation("ascii_general_ci");
 
                     b.Property<string>("CraftsJson")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnName("Crafts");
 
                     b.Property<string>("Folder")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("Name")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnOrder(0);
 
                     b.Property<long>("TimeCreated")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.HasKey("Id");
 
@@ -117,39 +130,41 @@ namespace Intersect.Server.Migrations.Sqlite.Game
             modelBuilder.Entity("Intersect.Framework.Core.GameObjects.Events.EventDescriptor", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("char(36)")
+                        .UseCollation("ascii_general_ci");
 
                     b.Property<bool>("CanRunInParallel")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<bool>("CommonEvent")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("Folder")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("longtext");
 
                     b.Property<bool>("Global")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<Guid>("MapId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("char(36)")
+                        .UseCollation("ascii_general_ci");
 
                     b.Property<string>("Name")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnOrder(0);
 
                     b.Property<string>("PagesJson")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnName("Pages");
 
                     b.Property<int>("SpawnX")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("SpawnY")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<long>("TimeCreated")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.HasKey("Id");
 
@@ -159,7 +174,8 @@ namespace Intersect.Server.Migrations.Sqlite.Game
             modelBuilder.Entity("Intersect.Framework.Core.GameObjects.Items.EquipmentProperties", b =>
                 {
                     b.Property<Guid>("DescriptorId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("char(36)")
+                        .UseCollation("ascii_general_ci");
 
                     b.HasKey("DescriptorId");
 
@@ -169,205 +185,212 @@ namespace Intersect.Server.Migrations.Sqlite.Game
             modelBuilder.Entity("Intersect.Framework.Core.GameObjects.Items.ItemDescriptor", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("char(36)")
+                        .UseCollation("ascii_general_ci");
 
                     b.Property<Guid>("AnimationId")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("Animation");
+                        .HasColumnType("char(36)")
+                        .HasColumnName("Animation")
+                        .UseCollation("ascii_general_ci");
 
                     b.Property<Guid>("AttackAnimationId")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("AttackAnimation");
+                        .HasColumnType("char(36)")
+                        .HasColumnName("AttackAnimation")
+                        .UseCollation("ascii_general_ci");
 
                     b.Property<int>("AttackSpeedModifier")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("AttackSpeedValue")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("BlockAbsorption")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("BlockAmount")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("BlockChance")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<bool>("CanBag")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<bool>("CanBank")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<bool>("CanDrop")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("tinyint(1)")
                         .HasColumnName("Bound");
 
                     b.Property<bool>("CanGuildBank")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<bool>("CanSell")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<bool>("CanTrade")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("CannotUseMessage")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("longtext");
 
                     b.Property<int>("Cooldown")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("CooldownGroup")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("longtext");
 
                     b.Property<int>("CritChance")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<double>("CritMultiplier")
-                        .HasColumnType("REAL");
+                        .HasColumnType("double");
 
                     b.Property<int>("Damage")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("DamageType")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("Description")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("longtext");
 
                     b.Property<long>("DespawnTime")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<int>("DropChanceOnDeath")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("EffectsJson")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnName("Effects");
 
                     b.Property<Guid>("EquipmentAnimationId")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("EquipmentAnimation");
+                        .HasColumnType("char(36)")
+                        .HasColumnName("EquipmentAnimation")
+                        .UseCollation("ascii_general_ci");
 
                     b.Property<int>("EquipmentSlot")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<Guid>("EventId")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("Event");
+                        .HasColumnType("char(36)")
+                        .HasColumnName("Event")
+                        .UseCollation("ascii_general_ci");
 
                     b.Property<string>("EventTriggersJson")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnName("EventTriggers");
 
                     b.Property<string>("FemalePaperdoll")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("Folder")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("Icon")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("longtext");
 
                     b.Property<bool>("IgnoreCooldownReduction")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<bool>("IgnoreGlobalCooldown")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<int>("ItemType")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("JsonColor")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnName("Color");
 
                     b.Property<string>("JsonUsageRequirements")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnName("UsageRequirements");
 
                     b.Property<string>("MalePaperdoll")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("longtext");
 
                     b.Property<int>("MaxBankStack")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("MaxInventoryStack")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("Name")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnOrder(0);
 
                     b.Property<string>("PercentageStatsJson")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnName("PercentageStatsGiven");
 
                     b.Property<string>("PercentageVitalsJson")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnName("PercentageVitalsGiven");
 
                     b.Property<int>("Price")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<Guid>("ProjectileId")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("Projectile");
+                        .HasColumnType("char(36)")
+                        .HasColumnName("Projectile")
+                        .UseCollation("ascii_general_ci");
 
                     b.Property<bool>("QuickCast")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<int>("Rarity")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("Scaling")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("ScalingStat")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<bool>("SingleUse")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("tinyint(1)")
                         .HasColumnName("DestroySpell");
 
                     b.Property<int>("SlotCount")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("Speed")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<Guid>("SpellId")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("Spell");
+                        .HasColumnType("char(36)")
+                        .HasColumnName("Spell")
+                        .UseCollation("ascii_general_ci");
 
                     b.Property<bool>("Stackable")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("StatsJson")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnName("StatsGiven");
 
                     b.Property<long>("TimeCreated")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<int>("Tool")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<bool>("TwoHanded")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("VitalsJson")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnName("VitalsGiven");
 
                     b.Property<string>("VitalsRegenJson")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnName("VitalsRegen");
 
                     b.Property<string>("WeaponSpriteOverride")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("longtext");
 
                     b.HasKey("Id");
 
@@ -377,13 +400,14 @@ namespace Intersect.Server.Migrations.Sqlite.Game
             modelBuilder.Entity("Intersect.Framework.Core.GameObjects.Mapping.Tilesets.TilesetDescriptor", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("char(36)")
+                        .UseCollation("ascii_general_ci");
 
                     b.Property<string>("Name")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("longtext");
 
                     b.Property<long>("TimeCreated")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.HasKey("Id");
 
@@ -393,10 +417,11 @@ namespace Intersect.Server.Migrations.Sqlite.Game
             modelBuilder.Entity("Intersect.Framework.Core.GameObjects.Maps.MapList.MapList", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("char(36)")
+                        .UseCollation("ascii_general_ci");
 
                     b.Property<string>("JsonData")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnName("JsonData");
 
                     b.HasKey("Id");
@@ -407,145 +432,149 @@ namespace Intersect.Server.Migrations.Sqlite.Game
             modelBuilder.Entity("Intersect.Framework.Core.GameObjects.NPCs.NPCDescriptor", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("char(36)")
+                        .UseCollation("ascii_general_ci");
 
                     b.Property<bool>("Aggressive")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<bool>("AttackAllies")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<Guid>("AttackAnimationId")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("AttackAnimation");
+                        .HasColumnType("char(36)")
+                        .HasColumnName("AttackAnimation")
+                        .UseCollation("ascii_general_ci");
 
                     b.Property<string>("AttackOnSightConditionsJson")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnName("AttackOnSightConditions");
 
                     b.Property<int>("AttackSpeedModifier")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("AttackSpeedValue")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("CraftsJson")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnName("Spells");
 
                     b.Property<int>("CritChance")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<double>("CritMultiplier")
-                        .HasColumnType("REAL");
+                        .HasColumnType("double");
 
                     b.Property<int>("Damage")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("DamageType")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<long>("Experience")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<byte>("FleeHealthPercentage")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("tinyint unsigned");
 
                     b.Property<bool>("FocusHighestDamageDealer")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("Folder")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("ImmunitiesJson")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnName("Immunities");
 
                     b.Property<bool>("IndividualizedLoot")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("JsonAggroList")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnName("AggroList");
 
                     b.Property<string>("JsonColor")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnName("Color");
 
                     b.Property<string>("JsonDrops")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnName("Drops");
 
                     b.Property<string>("JsonMaxVital")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnName("MaxVital");
 
                     b.Property<string>("JsonStat")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnName("Stats");
 
                     b.Property<int>("Level")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<byte>("Movement")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("tinyint unsigned");
 
                     b.Property<string>("Name")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnOrder(0);
 
                     b.Property<bool>("NpcVsNpcEnabled")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<Guid>("OnDeathEventId")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("OnDeathEvent");
+                        .HasColumnType("char(36)")
+                        .HasColumnName("OnDeathEvent")
+                        .UseCollation("ascii_general_ci");
 
                     b.Property<Guid>("OnDeathPartyEventId")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("OnDeathPartyEvent");
+                        .HasColumnType("char(36)")
+                        .HasColumnName("OnDeathPartyEvent")
+                        .UseCollation("ascii_general_ci");
 
                     b.Property<string>("PlayerCanAttackConditionsJson")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnName("PlayerCanAttackConditions");
 
                     b.Property<string>("PlayerFriendConditionsJson")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnName("PlayerFriendConditions");
 
                     b.Property<string>("RegenJson")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnName("VitalRegen");
 
                     b.Property<int>("ResetRadius")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("Scaling")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("ScalingStat")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("SightRange")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("SpawnDuration")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("SpellFrequency")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("Sprite")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("longtext");
 
                     b.Property<bool>("Swarm")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<double>("Tenacity")
-                        .HasColumnType("REAL");
+                        .HasColumnType("double");
 
                     b.Property<long>("TimeCreated")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.HasKey("Id");
 
@@ -555,114 +584,117 @@ namespace Intersect.Server.Migrations.Sqlite.Game
             modelBuilder.Entity("Intersect.Framework.Core.GameObjects.PlayerClass.ClassDescriptor", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("char(36)")
+                        .UseCollation("ascii_general_ci");
 
                     b.Property<Guid>("AttackAnimationId")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("AttackAnimation");
+                        .HasColumnType("char(36)")
+                        .HasColumnName("AttackAnimation")
+                        .UseCollation("ascii_general_ci");
 
                     b.Property<int>("AttackSpeedModifier")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("AttackSpeedValue")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("AttackSpriteOverride")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("longtext");
 
                     b.Property<long>("BaseExp")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<int>("BasePoints")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("CritChance")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<double>("CritMultiplier")
-                        .HasColumnType("REAL");
+                        .HasColumnType("double");
 
                     b.Property<int>("Damage")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("DamageType")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<long>("ExpIncrease")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<string>("ExpOverridesJson")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnName("ExperienceOverrides");
 
                     b.Property<string>("Folder")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("longtext");
 
                     b.Property<bool>("IncreasePercentage")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("JsonBaseStats")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnName("BaseStats");
 
                     b.Property<string>("JsonBaseVitals")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnName("BaseVitals");
 
                     b.Property<string>("JsonItems")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnName("Items");
 
                     b.Property<string>("JsonSpells")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnName("Spells");
 
                     b.Property<string>("JsonSprites")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnName("Sprites");
 
                     b.Property<bool>("Locked")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("Name")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnOrder(0);
 
                     b.Property<int>("PointIncrease")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("RegenJson")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnName("VitalRegen");
 
                     b.Property<int>("Scaling")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("ScalingStat")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("SpawnDir")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<Guid>("SpawnMapId")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("SpawnMap");
+                        .HasColumnType("char(36)")
+                        .HasColumnName("SpawnMap")
+                        .UseCollation("ascii_general_ci");
 
                     b.Property<int>("SpawnX")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("SpawnY")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("StatIncreaseJson")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnName("StatIncreases");
 
                     b.Property<long>("TimeCreated")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<string>("VitalIncreaseJson")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnName("VitalIncreases");
 
                     b.HasKey("Id");
@@ -673,64 +705,67 @@ namespace Intersect.Server.Migrations.Sqlite.Game
             modelBuilder.Entity("Intersect.Framework.Core.GameObjects.Resources.ResourceDescriptor", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("char(36)")
+                        .UseCollation("ascii_general_ci");
 
                     b.Property<string>("CannotHarvestMessage")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("longtext");
 
                     b.Property<Guid>("DeathAnimationId")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("DeathAnimation");
+                        .HasColumnType("char(36)")
+                        .HasColumnName("DeathAnimation")
+                        .UseCollation("ascii_general_ci");
 
                     b.Property<Guid>("EventId")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("Event");
+                        .HasColumnType("char(36)")
+                        .HasColumnName("Event")
+                        .UseCollation("ascii_general_ci");
 
                     b.Property<string>("Folder")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("JsonDrops")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnName("Drops");
 
                     b.Property<string>("JsonHarvestingRequirements")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnName("HarvestingRequirements");
 
                     b.Property<string>("JsonStates")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnName("States");
 
                     b.Property<int>("MaxHp")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("MinHp")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("Name")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnOrder(0);
 
                     b.Property<int>("SpawnDuration")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<long>("TimeCreated")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<int>("Tool")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<bool>("UseExplicitMaxHealthForResourceStates")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<int>("VitalRegen")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<bool>("WalkableAfter")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<bool>("WalkableBefore")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("tinyint(1)");
 
                     b.HasKey("Id");
 
@@ -740,23 +775,24 @@ namespace Intersect.Server.Migrations.Sqlite.Game
             modelBuilder.Entity("Intersect.Framework.Core.GameObjects.Variables.GuildVariableDescriptor", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("char(36)")
+                        .UseCollation("ascii_general_ci");
 
                     b.Property<byte>("DataType")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("tinyint unsigned");
 
                     b.Property<string>("Folder")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("Name")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnOrder(0);
 
                     b.Property<string>("TextId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("longtext");
 
                     b.Property<long>("TimeCreated")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.HasKey("Id");
 
@@ -766,23 +802,24 @@ namespace Intersect.Server.Migrations.Sqlite.Game
             modelBuilder.Entity("Intersect.Framework.Core.GameObjects.Variables.PlayerVariableDescriptor", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("char(36)")
+                        .UseCollation("ascii_general_ci");
 
                     b.Property<byte>("DataType")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("tinyint unsigned");
 
                     b.Property<string>("Folder")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("Name")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnOrder(0);
 
                     b.Property<string>("TextId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("longtext");
 
                     b.Property<long>("TimeCreated")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.HasKey("Id");
 
@@ -792,27 +829,28 @@ namespace Intersect.Server.Migrations.Sqlite.Game
             modelBuilder.Entity("Intersect.Framework.Core.GameObjects.Variables.ServerVariableDescriptor", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("char(36)")
+                        .UseCollation("ascii_general_ci");
 
                     b.Property<byte>("DataType")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("tinyint unsigned");
 
                     b.Property<string>("Folder")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("Json")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnName("Value");
 
                     b.Property<string>("Name")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnOrder(0);
 
                     b.Property<string>("TextId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("longtext");
 
                     b.Property<long>("TimeCreated")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.HasKey("Id");
 
@@ -822,23 +860,24 @@ namespace Intersect.Server.Migrations.Sqlite.Game
             modelBuilder.Entity("Intersect.Framework.Core.GameObjects.Variables.UserVariableDescriptor", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("char(36)")
+                        .UseCollation("ascii_general_ci");
 
                     b.Property<byte>("DataType")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("tinyint unsigned");
 
                     b.Property<string>("Folder")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("Name")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnOrder(0);
 
                     b.Property<string>("TextId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("longtext");
 
                     b.Property<long>("TimeCreated")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.HasKey("Id");
 
@@ -848,20 +887,21 @@ namespace Intersect.Server.Migrations.Sqlite.Game
             modelBuilder.Entity("Intersect.GameObjects.DaylightCycleDescriptor", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("char(36)")
+                        .UseCollation("ascii_general_ci");
 
                     b.Property<string>("DaylightHuesJson")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnName("DaylightHues");
 
                     b.Property<int>("RangeInterval")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<float>("Rate")
-                        .HasColumnType("REAL");
+                        .HasColumnType("float");
 
                     b.Property<bool>("SyncTime")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("tinyint(1)");
 
                     b.HasKey("Id");
 
@@ -871,79 +911,82 @@ namespace Intersect.Server.Migrations.Sqlite.Game
             modelBuilder.Entity("Intersect.GameObjects.ProjectileDescriptor", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("char(36)")
+                        .UseCollation("ascii_general_ci");
 
                     b.Property<Guid>("AmmoItemId")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("Ammo");
+                        .HasColumnType("char(36)")
+                        .HasColumnName("Ammo")
+                        .UseCollation("ascii_general_ci");
 
                     b.Property<int>("AmmoRequired")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("AnimationsJson")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnName("Animations");
 
                     b.Property<int>("Delay")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<bool>("DirectShotBehavior")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("Folder")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("longtext");
 
                     b.Property<bool>("GrappleHook")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("GrappleHookOptionsJson")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnName("GrappleHookOptions");
 
                     b.Property<bool>("HomingBehavior")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<bool>("IgnoreActiveResources")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<bool>("IgnoreExhaustedResources")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<bool>("IgnoreMapBlocks")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<bool>("IgnoreZDimension")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<int>("Knockback")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("Name")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnOrder(0);
 
                     b.Property<bool>("PierceTarget")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<int>("Quantity")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("Range")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("SpawnsJson")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnName("SpawnLocations");
 
                     b.Property<int>("Speed")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<Guid>("SpellId")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("Spell");
+                        .HasColumnType("char(36)")
+                        .HasColumnName("Spell")
+                        .UseCollation("ascii_general_ci");
 
                     b.Property<long>("TimeCreated")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.HasKey("Id");
 
@@ -953,72 +996,75 @@ namespace Intersect.Server.Migrations.Sqlite.Game
             modelBuilder.Entity("Intersect.GameObjects.QuestDescriptor", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("char(36)")
+                        .UseCollation("ascii_general_ci");
 
                     b.Property<string>("BeforeDescription")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("CompletedCategory")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("longtext");
 
                     b.Property<bool>("DoNotShowUnlessRequirementsMet")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("EndDescription")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("longtext");
 
                     b.Property<Guid>("EndEventId")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("EndEvent");
+                        .HasColumnType("char(36)")
+                        .HasColumnName("EndEvent")
+                        .UseCollation("ascii_general_ci");
 
                     b.Property<string>("Folder")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("InProgressCategory")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("InProgressDescription")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("JsonRequirements")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnName("Requirements");
 
                     b.Property<bool>("LogAfterComplete")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<bool>("LogBeforeOffer")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("Name")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnOrder(0);
 
                     b.Property<int>("OrderValue")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<bool>("Quitable")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<bool>("Repeatable")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("StartDescription")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("longtext");
 
                     b.Property<Guid>("StartEventId")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("StartEvent");
+                        .HasColumnType("char(36)")
+                        .HasColumnName("StartEvent")
+                        .UseCollation("ascii_general_ci");
 
                     b.Property<string>("TasksJson")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnName("Tasks");
 
                     b.Property<long>("TimeCreated")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<string>("UnstartedCategory")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("longtext");
 
                     b.HasKey("Id");
 
@@ -1028,38 +1074,40 @@ namespace Intersect.Server.Migrations.Sqlite.Game
             modelBuilder.Entity("Intersect.GameObjects.ShopDescriptor", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("char(36)")
+                        .UseCollation("ascii_general_ci");
 
                     b.Property<string>("BuySound")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("longtext");
 
                     b.Property<bool>("BuyingWhitelist")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<Guid>("DefaultCurrencyId")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("DefaultCurrency");
+                        .HasColumnType("char(36)")
+                        .HasColumnName("DefaultCurrency")
+                        .UseCollation("ascii_general_ci");
 
                     b.Property<string>("Folder")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("JsonBuyingItems")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnName("BuyingItems");
 
                     b.Property<string>("JsonSellingItems")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnName("SellingItems");
 
                     b.Property<string>("Name")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnOrder(0);
 
                     b.Property<string>("SellSound")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("longtext");
 
                     b.Property<long>("TimeCreated")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.HasKey("Id");
 
@@ -1069,73 +1117,78 @@ namespace Intersect.Server.Migrations.Sqlite.Game
             modelBuilder.Entity("Intersect.GameObjects.SpellDescriptor", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("char(36)")
+                        .UseCollation("ascii_general_ci");
 
                     b.Property<bool>("Bound")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("CannotCastMessage")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("longtext");
 
                     b.Property<Guid>("CastAnimationId")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("CastAnimation");
+                        .HasColumnType("char(36)")
+                        .HasColumnName("CastAnimation")
+                        .UseCollation("ascii_general_ci");
 
                     b.Property<int>("CastDuration")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("CastSpriteOverride")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("longtext");
 
                     b.Property<int>("CooldownDuration")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("CooldownGroup")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("Description")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("longtext");
 
                     b.Property<Guid>("EventId")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("Event");
+                        .HasColumnType("char(36)")
+                        .HasColumnName("Event")
+                        .UseCollation("ascii_general_ci");
 
                     b.Property<string>("Folder")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("longtext");
 
                     b.Property<Guid>("HitAnimationId")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("HitAnimation");
+                        .HasColumnType("char(36)")
+                        .HasColumnName("HitAnimation")
+                        .UseCollation("ascii_general_ci");
 
                     b.Property<string>("Icon")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("longtext");
 
                     b.Property<bool>("IgnoreCooldownReduction")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<bool>("IgnoreGlobalCooldown")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("JsonCastRequirements")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnName("CastRequirements");
 
                     b.Property<string>("Name")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnOrder(0);
 
                     b.Property<int>("SpellType")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<Guid>("TickAnimationId")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("TickAnimation");
+                        .HasColumnType("char(36)")
+                        .HasColumnName("TickAnimation")
+                        .UseCollation("ascii_general_ci");
 
                     b.Property<long>("TimeCreated")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<string>("VitalCostJson")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnName("VitalCost");
 
                     b.HasKey("Id");
@@ -1146,122 +1199,128 @@ namespace Intersect.Server.Migrations.Sqlite.Game
             modelBuilder.Entity("Intersect.Server.Maps.MapController", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("char(36)")
+                        .UseCollation("ascii_general_ci");
 
                     b.Property<int>("AHue")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<byte[]>("AttributeData")
-                        .HasColumnType("BLOB")
+                        .HasColumnType("longblob")
                         .HasColumnName("Attributes");
 
                     b.Property<int>("BHue")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("Brightness")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<Guid>("Down")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("char(36)")
+                        .UseCollation("ascii_general_ci");
 
                     b.Property<string>("EventIdsJson")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnName("Events");
 
                     b.Property<string>("Fog")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("longtext");
 
                     b.Property<int>("FogTransparency")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("FogXSpeed")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("FogYSpeed")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("GHue")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<bool>("HideEquipment")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<bool>("IsIndoors")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<Guid>("Left")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("char(36)")
+                        .UseCollation("ascii_general_ci");
 
                     b.Property<string>("LightsJson")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnName("Lights");
 
                     b.Property<string>("Music")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("Name")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnOrder(0);
 
                     b.Property<string>("NpcSpawnsJson")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnName("NpcSpawns");
 
                     b.Property<string>("OverlayGraphic")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("Panorama")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("PlayerLightColorJson")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("longtext")
                         .HasColumnName("PlayerLightColor");
 
                     b.Property<float>("PlayerLightExpand")
-                        .HasColumnType("REAL");
+                        .HasColumnType("float");
 
                     b.Property<byte>("PlayerLightIntensity")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("tinyint unsigned");
 
                     b.Property<int>("PlayerLightSize")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("RHue")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("Revision")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<Guid>("Right")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("char(36)")
+                        .UseCollation("ascii_general_ci");
 
                     b.Property<string>("Sound")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("longtext");
 
                     b.Property<byte[]>("TileData")
-                        .HasColumnType("BLOB");
+                        .HasColumnType("longblob");
 
                     b.Property<long>("TimeCreated")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<Guid>("Up")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("char(36)")
+                        .UseCollation("ascii_general_ci");
 
                     b.Property<Guid>("WeatherAnimationId")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("WeatherAnimation");
+                        .HasColumnType("char(36)")
+                        .HasColumnName("WeatherAnimation")
+                        .UseCollation("ascii_general_ci");
 
                     b.Property<int>("WeatherIntensity")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("WeatherXSpeed")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("WeatherYSpeed")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("ZoneType")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.HasKey("Id");
 
@@ -1273,34 +1332,35 @@ namespace Intersect.Server.Migrations.Sqlite.Game
                     b.OwnsOne("Intersect.Framework.Core.GameObjects.Animations.AnimationLayer", "Lower", b1 =>
                         {
                             b1.Property<Guid>("AnimationDescriptorId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("char(36)")
+                                .UseCollation("ascii_general_ci");
 
                             b1.Property<bool>("AlternateRenderLayer")
-                                .HasColumnType("INTEGER");
+                                .HasColumnType("tinyint(1)");
 
                             b1.Property<bool>("DisableRotations")
-                                .HasColumnType("INTEGER");
+                                .HasColumnType("tinyint(1)");
 
                             b1.Property<int>("FrameCount")
-                                .HasColumnType("INTEGER");
+                                .HasColumnType("int");
 
                             b1.Property<int>("FrameSpeed")
-                                .HasColumnType("INTEGER");
+                                .HasColumnType("int");
 
                             b1.Property<string>("Light")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("longtext");
 
                             b1.Property<int>("LoopCount")
-                                .HasColumnType("INTEGER");
+                                .HasColumnType("int");
 
                             b1.Property<string>("Sprite")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("longtext");
 
                             b1.Property<int>("XFrames")
-                                .HasColumnType("INTEGER");
+                                .HasColumnType("int");
 
                             b1.Property<int>("YFrames")
-                                .HasColumnType("INTEGER");
+                                .HasColumnType("int");
 
                             b1.HasKey("AnimationDescriptorId");
 
@@ -1313,34 +1373,35 @@ namespace Intersect.Server.Migrations.Sqlite.Game
                     b.OwnsOne("Intersect.Framework.Core.GameObjects.Animations.AnimationLayer", "Upper", b1 =>
                         {
                             b1.Property<Guid>("AnimationDescriptorId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("char(36)")
+                                .UseCollation("ascii_general_ci");
 
                             b1.Property<bool>("AlternateRenderLayer")
-                                .HasColumnType("INTEGER");
+                                .HasColumnType("tinyint(1)");
 
                             b1.Property<bool>("DisableRotations")
-                                .HasColumnType("INTEGER");
+                                .HasColumnType("tinyint(1)");
 
                             b1.Property<int>("FrameCount")
-                                .HasColumnType("INTEGER");
+                                .HasColumnType("int");
 
                             b1.Property<int>("FrameSpeed")
-                                .HasColumnType("INTEGER");
+                                .HasColumnType("int");
 
                             b1.Property<string>("Light")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("longtext");
 
                             b1.Property<int>("LoopCount")
-                                .HasColumnType("INTEGER");
+                                .HasColumnType("int");
 
                             b1.Property<string>("Sprite")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("longtext");
 
                             b1.Property<int>("XFrames")
-                                .HasColumnType("INTEGER");
+                                .HasColumnType("int");
 
                             b1.Property<int>("YFrames")
-                                .HasColumnType("INTEGER");
+                                .HasColumnType("int");
 
                             b1.HasKey("AnimationDescriptorId");
 
@@ -1366,13 +1427,14 @@ namespace Intersect.Server.Migrations.Sqlite.Game
                     b.OwnsOne("Intersect.GameObjects.Ranges.ItemRange", "StatRange_AbilityPower", b1 =>
                         {
                             b1.Property<Guid>("EquipmentPropertiesDescriptorId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("char(36)")
+                                .UseCollation("ascii_general_ci");
 
                             b1.Property<int>("HighRange")
-                                .HasColumnType("INTEGER");
+                                .HasColumnType("int");
 
                             b1.Property<int>("LowRange")
-                                .HasColumnType("INTEGER");
+                                .HasColumnType("int");
 
                             b1.HasKey("EquipmentPropertiesDescriptorId");
 
@@ -1385,13 +1447,14 @@ namespace Intersect.Server.Migrations.Sqlite.Game
                     b.OwnsOne("Intersect.GameObjects.Ranges.ItemRange", "StatRange_Attack", b1 =>
                         {
                             b1.Property<Guid>("EquipmentPropertiesDescriptorId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("char(36)")
+                                .UseCollation("ascii_general_ci");
 
                             b1.Property<int>("HighRange")
-                                .HasColumnType("INTEGER");
+                                .HasColumnType("int");
 
                             b1.Property<int>("LowRange")
-                                .HasColumnType("INTEGER");
+                                .HasColumnType("int");
 
                             b1.HasKey("EquipmentPropertiesDescriptorId");
 
@@ -1404,13 +1467,14 @@ namespace Intersect.Server.Migrations.Sqlite.Game
                     b.OwnsOne("Intersect.GameObjects.Ranges.ItemRange", "StatRange_Defense", b1 =>
                         {
                             b1.Property<Guid>("EquipmentPropertiesDescriptorId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("char(36)")
+                                .UseCollation("ascii_general_ci");
 
                             b1.Property<int>("HighRange")
-                                .HasColumnType("INTEGER");
+                                .HasColumnType("int");
 
                             b1.Property<int>("LowRange")
-                                .HasColumnType("INTEGER");
+                                .HasColumnType("int");
 
                             b1.HasKey("EquipmentPropertiesDescriptorId");
 
@@ -1423,13 +1487,14 @@ namespace Intersect.Server.Migrations.Sqlite.Game
                     b.OwnsOne("Intersect.GameObjects.Ranges.ItemRange", "StatRange_MagicResist", b1 =>
                         {
                             b1.Property<Guid>("EquipmentPropertiesDescriptorId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("char(36)")
+                                .UseCollation("ascii_general_ci");
 
                             b1.Property<int>("HighRange")
-                                .HasColumnType("INTEGER");
+                                .HasColumnType("int");
 
                             b1.Property<int>("LowRange")
-                                .HasColumnType("INTEGER");
+                                .HasColumnType("int");
 
                             b1.HasKey("EquipmentPropertiesDescriptorId");
 
@@ -1442,13 +1507,14 @@ namespace Intersect.Server.Migrations.Sqlite.Game
                     b.OwnsOne("Intersect.GameObjects.Ranges.ItemRange", "StatRange_Speed", b1 =>
                         {
                             b1.Property<Guid>("EquipmentPropertiesDescriptorId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("char(36)")
+                                .UseCollation("ascii_general_ci");
 
                             b1.Property<int>("HighRange")
-                                .HasColumnType("INTEGER");
+                                .HasColumnType("int");
 
                             b1.Property<int>("LowRange")
-                                .HasColumnType("INTEGER");
+                                .HasColumnType("int");
 
                             b1.HasKey("EquipmentPropertiesDescriptorId");
 
@@ -1476,16 +1542,17 @@ namespace Intersect.Server.Migrations.Sqlite.Game
                     b.OwnsOne("Intersect.Framework.Core.GameObjects.Items.ConsumableData", "Consumable", b1 =>
                         {
                             b1.Property<Guid>("ItemDescriptorId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("char(36)")
+                                .UseCollation("ascii_general_ci");
 
                             b1.Property<int>("Percentage")
-                                .HasColumnType("INTEGER");
+                                .HasColumnType("int");
 
                             b1.Property<byte>("Type")
-                                .HasColumnType("INTEGER");
+                                .HasColumnType("tinyint unsigned");
 
                             b1.Property<long>("Value")
-                                .HasColumnType("INTEGER");
+                                .HasColumnType("bigint");
 
                             b1.HasKey("ItemDescriptorId");
 
@@ -1503,72 +1570,74 @@ namespace Intersect.Server.Migrations.Sqlite.Game
                     b.OwnsOne("Intersect.GameObjects.SpellCombatDescriptor", "Combat", b1 =>
                         {
                             b1.Property<Guid>("SpellDescriptorId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("char(36)")
+                                .UseCollation("ascii_general_ci");
 
                             b1.Property<int>("CastRange")
-                                .HasColumnType("INTEGER");
+                                .HasColumnType("int");
 
                             b1.Property<int>("CritChance")
-                                .HasColumnType("INTEGER");
+                                .HasColumnType("int");
 
                             b1.Property<double>("CritMultiplier")
-                                .HasColumnType("REAL");
+                                .HasColumnType("double");
 
                             b1.Property<int>("DamageType")
-                                .HasColumnType("INTEGER");
+                                .HasColumnType("int");
 
                             b1.Property<int>("Duration")
-                                .HasColumnType("INTEGER");
+                                .HasColumnType("int");
 
                             b1.Property<int>("Effect")
-                                .HasColumnType("INTEGER");
+                                .HasColumnType("int");
 
                             b1.Property<bool>("Friendly")
-                                .HasColumnType("INTEGER");
+                                .HasColumnType("tinyint(1)");
 
                             b1.Property<int>("HitRadius")
-                                .HasColumnType("INTEGER");
+                                .HasColumnType("int");
 
                             b1.Property<bool>("HoTDoT")
-                                .HasColumnType("INTEGER");
+                                .HasColumnType("tinyint(1)");
 
                             b1.Property<int>("HotDotInterval")
-                                .HasColumnType("INTEGER");
+                                .HasColumnType("int");
 
                             b1.Property<int>("OnHitDuration")
-                                .HasColumnType("INTEGER")
+                                .HasColumnType("int")
                                 .HasColumnName("OnHit");
 
                             b1.Property<string>("PercentageStatDiffJson")
-                                .HasColumnType("TEXT")
+                                .HasColumnType("longtext")
                                 .HasColumnName("PercentageStatDiff");
 
                             b1.Property<Guid>("ProjectileId")
-                                .HasColumnType("TEXT")
-                                .HasColumnName("Projectile");
+                                .HasColumnType("char(36)")
+                                .HasColumnName("Projectile")
+                                .UseCollation("ascii_general_ci");
 
                             b1.Property<int>("Scaling")
-                                .HasColumnType("INTEGER");
+                                .HasColumnType("int");
 
                             b1.Property<int>("ScalingStat")
-                                .HasColumnType("INTEGER");
+                                .HasColumnType("int");
 
                             b1.Property<string>("StatDiffJson")
-                                .HasColumnType("TEXT")
+                                .HasColumnType("longtext")
                                 .HasColumnName("StatDiff");
 
                             b1.Property<int>("TargetType")
-                                .HasColumnType("INTEGER");
+                                .HasColumnType("int");
 
                             b1.Property<string>("TransformSprite")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("longtext");
 
                             b1.Property<int>("TrapDuration")
-                                .HasColumnType("INTEGER")
+                                .HasColumnType("int")
                                 .HasColumnName("Trap");
 
                             b1.Property<string>("VitalDiffJson")
-                                .HasColumnType("TEXT")
+                                .HasColumnType("longtext")
                                 .HasColumnName("VitalDiff");
 
                             b1.HasKey("SpellDescriptorId");
@@ -1582,19 +1651,20 @@ namespace Intersect.Server.Migrations.Sqlite.Game
                     b.OwnsOne("Intersect.GameObjects.SpellDashDescriptor", "Dash", b1 =>
                         {
                             b1.Property<Guid>("SpellDescriptorId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("char(36)")
+                                .UseCollation("ascii_general_ci");
 
                             b1.Property<bool>("IgnoreActiveResources")
-                                .HasColumnType("INTEGER");
+                                .HasColumnType("tinyint(1)");
 
                             b1.Property<bool>("IgnoreInactiveResources")
-                                .HasColumnType("INTEGER");
+                                .HasColumnType("tinyint(1)");
 
                             b1.Property<bool>("IgnoreMapBlocks")
-                                .HasColumnType("INTEGER");
+                                .HasColumnType("tinyint(1)");
 
                             b1.Property<bool>("IgnoreZDimensionAttributes")
-                                .HasColumnType("INTEGER");
+                                .HasColumnType("tinyint(1)");
 
                             b1.HasKey("SpellDescriptorId");
 
@@ -1607,19 +1677,21 @@ namespace Intersect.Server.Migrations.Sqlite.Game
                     b.OwnsOne("Intersect.GameObjects.SpellWarpDescriptor", "Warp", b1 =>
                         {
                             b1.Property<Guid>("SpellDescriptorId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("char(36)")
+                                .UseCollation("ascii_general_ci");
 
                             b1.Property<int>("Dir")
-                                .HasColumnType("INTEGER");
+                                .HasColumnType("int");
 
                             b1.Property<Guid>("MapId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("char(36)")
+                                .UseCollation("ascii_general_ci");
 
                             b1.Property<int>("X")
-                                .HasColumnType("INTEGER");
+                                .HasColumnType("int");
 
                             b1.Property<int>("Y")
-                                .HasColumnType("INTEGER");
+                                .HasColumnType("int");
 
                             b1.HasKey("SpellDescriptorId");
 

--- a/Intersect.Server/Migrations/MySql/Game/20250326125350_ResourceStates.cs
+++ b/Intersect.Server/Migrations/MySql/Game/20250326125350_ResourceStates.cs
@@ -1,0 +1,217 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Intersect.Server.Migrations.MySql.Game
+{
+    /// <inheritdoc />
+    public partial class ResourceStates : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "States",
+                table: "Resources",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.Sql($@"
+                UPDATE Resources
+                SET States = json_object(
+                    '00000000-0000-0000-0000-000000000001', json_object(
+                        'Id', '00000000-0000-0000-0000-000000000001',
+                        'Name', 'Exhausted',
+                        'TextureName', Exhausted_Graphic,
+                        'TextureType', Exhausted_GraphicFromTileset,
+                        'RenderBelowEntities', Exhausted_RenderBelowEntities,
+                        'Width', Exhausted_Width,
+                        'Height', Exhausted_Height,
+                        'X', Exhausted_X,
+                        'Y', Exhausted_Y,
+                        'MinimumHealth', 0,
+                        'MaximumHealth', 0
+                    ),
+                    '00000000-0000-0000-0000-000000000002', json_object(
+                        'Id', '00000000-0000-0000-0000-000000000002',
+                        'Name', 'Initial',
+                        'TextureName', Initial_Graphic,
+                        'TextureType', Initial_GraphicFromTileset,
+                        'RenderBelowEntities', Initial_RenderBelowEntities,
+                        'Width', Initial_Width,
+                        'Height', Initial_Height,
+                        'X', Initial_X,
+                        'Y', Initial_Y,
+                        'MinimumHealth', 1,
+                        'MaximumHealth', 100
+                    )
+                );
+            ");
+
+            migrationBuilder.DropColumn(
+                name: "Exhausted_Graphic",
+                table: "Resources");
+
+            migrationBuilder.DropColumn(
+                name: "Exhausted_GraphicFromTileset",
+                table: "Resources");
+
+            migrationBuilder.DropColumn(
+                name: "Exhausted_Height",
+                table: "Resources");
+
+            migrationBuilder.DropColumn(
+                name: "Exhausted_RenderBelowEntities",
+                table: "Resources");
+
+            migrationBuilder.DropColumn(
+                name: "Exhausted_Width",
+                table: "Resources");
+
+            migrationBuilder.DropColumn(
+                name: "Exhausted_X",
+                table: "Resources");
+
+            migrationBuilder.DropColumn(
+                name: "Exhausted_Y",
+                table: "Resources");
+
+            migrationBuilder.DropColumn(
+                name: "Initial_Graphic",
+                table: "Resources");
+
+            migrationBuilder.DropColumn(
+                name: "Initial_GraphicFromTileset",
+                table: "Resources");
+
+            migrationBuilder.DropColumn(
+                name: "Initial_Height",
+                table: "Resources");
+
+            migrationBuilder.DropColumn(
+                name: "Initial_RenderBelowEntities",
+                table: "Resources");
+
+            migrationBuilder.DropColumn(
+                name: "Initial_Width",
+                table: "Resources");
+
+            migrationBuilder.DropColumn(
+                name: "Initial_X",
+                table: "Resources");
+
+            migrationBuilder.DropColumn(
+                name: "Initial_Y",
+                table: "Resources");
+
+            migrationBuilder.RenameColumn(
+                name: "Animation",
+                table: "Resources",
+                newName: "DeathAnimation");
+
+            migrationBuilder.AddColumn<bool>(
+                name: "UseExplicitMaxHealthForResourceStates",
+                table: "Resources",
+                type: "tinyint(1)",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "UseExplicitMaxHealthForResourceStates",
+                table: "Resources");
+
+            migrationBuilder.RenameColumn(
+                name: "States",
+                table: "Resources",
+                newName: "Initial_Graphic");
+
+            migrationBuilder.RenameColumn(
+                name: "DeathAnimation",
+                table: "Resources",
+                newName: "Animation");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Exhausted_Graphic",
+                table: "Resources",
+                type: "longtext",
+                nullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AddColumn<bool>(
+                name: "Exhausted_GraphicFromTileset",
+                table: "Resources",
+                type: "tinyint(1)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Exhausted_Height",
+                table: "Resources",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "Exhausted_RenderBelowEntities",
+                table: "Resources",
+                type: "tinyint(1)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Exhausted_Width",
+                table: "Resources",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Exhausted_X",
+                table: "Resources",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Exhausted_Y",
+                table: "Resources",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "Initial_GraphicFromTileset",
+                table: "Resources",
+                type: "tinyint(1)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Initial_Height",
+                table: "Resources",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "Initial_RenderBelowEntities",
+                table: "Resources",
+                type: "tinyint(1)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Initial_Width",
+                table: "Resources",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Initial_X",
+                table: "Resources",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Initial_Y",
+                table: "Resources",
+                type: "int",
+                nullable: true);
+        }
+    }
+}

--- a/Intersect.Server/Migrations/MySql/Game/MySqlGameContextModelSnapshot.cs
+++ b/Intersect.Server/Migrations/MySql/Game/MySqlGameContextModelSnapshot.cs
@@ -705,13 +705,13 @@ namespace Intersect.Server.Migrations.MySql.Game
                         .HasColumnType("char(36)")
                         .UseCollation("ascii_general_ci");
 
-                    b.Property<Guid>("AnimationId")
-                        .HasColumnType("char(36)")
-                        .HasColumnName("Animation")
-                        .UseCollation("ascii_general_ci");
-
                     b.Property<string>("CannotHarvestMessage")
                         .HasColumnType("longtext");
+
+                    b.Property<Guid>("DeathAnimationId")
+                        .HasColumnType("char(36)")
+                        .HasColumnName("DeathAnimation")
+                        .UseCollation("ascii_general_ci");
 
                     b.Property<Guid>("EventId")
                         .HasColumnType("char(36)")
@@ -728,6 +728,10 @@ namespace Intersect.Server.Migrations.MySql.Game
                     b.Property<string>("JsonHarvestingRequirements")
                         .HasColumnType("longtext")
                         .HasColumnName("HarvestingRequirements");
+
+                    b.Property<string>("JsonStates")
+                        .HasColumnType("longtext")
+                        .HasColumnName("States");
 
                     b.Property<int>("MaxHp")
                         .HasColumnType("int");
@@ -747,6 +751,9 @@ namespace Intersect.Server.Migrations.MySql.Game
 
                     b.Property<int>("Tool")
                         .HasColumnType("int");
+
+                    b.Property<bool>("UseExplicitMaxHealthForResourceStates")
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<int>("VitalRegen")
                         .HasColumnType("int");
@@ -1553,83 +1560,6 @@ namespace Intersect.Server.Migrations.MySql.Game
                         });
 
                     b.Navigation("Consumable");
-                });
-
-            modelBuilder.Entity("Intersect.Framework.Core.GameObjects.Resources.ResourceDescriptor", b =>
-                {
-                    b.OwnsOne("Intersect.Framework.Core.GameObjects.Resources.ResourceStateDescriptor", "Exhausted", b1 =>
-                        {
-                            b1.Property<Guid>("ResourceDescriptorId")
-                                .HasColumnType("char(36)")
-                                .UseCollation("ascii_general_ci");
-
-                            b1.Property<string>("Graphic")
-                                .HasColumnType("longtext");
-
-                            b1.Property<bool>("GraphicFromTileset")
-                                .HasColumnType("tinyint(1)");
-
-                            b1.Property<int>("Height")
-                                .HasColumnType("int");
-
-                            b1.Property<bool>("RenderBelowEntities")
-                                .HasColumnType("tinyint(1)");
-
-                            b1.Property<int>("Width")
-                                .HasColumnType("int");
-
-                            b1.Property<int>("X")
-                                .HasColumnType("int");
-
-                            b1.Property<int>("Y")
-                                .HasColumnType("int");
-
-                            b1.HasKey("ResourceDescriptorId");
-
-                            b1.ToTable("Resources");
-
-                            b1.WithOwner()
-                                .HasForeignKey("ResourceDescriptorId");
-                        });
-
-                    b.OwnsOne("Intersect.Framework.Core.GameObjects.Resources.ResourceStateDescriptor", "Initial", b1 =>
-                        {
-                            b1.Property<Guid>("ResourceDescriptorId")
-                                .HasColumnType("char(36)")
-                                .UseCollation("ascii_general_ci");
-
-                            b1.Property<string>("Graphic")
-                                .HasColumnType("longtext");
-
-                            b1.Property<bool>("GraphicFromTileset")
-                                .HasColumnType("tinyint(1)");
-
-                            b1.Property<int>("Height")
-                                .HasColumnType("int");
-
-                            b1.Property<bool>("RenderBelowEntities")
-                                .HasColumnType("tinyint(1)");
-
-                            b1.Property<int>("Width")
-                                .HasColumnType("int");
-
-                            b1.Property<int>("X")
-                                .HasColumnType("int");
-
-                            b1.Property<int>("Y")
-                                .HasColumnType("int");
-
-                            b1.HasKey("ResourceDescriptorId");
-
-                            b1.ToTable("Resources");
-
-                            b1.WithOwner()
-                                .HasForeignKey("ResourceDescriptorId");
-                        });
-
-                    b.Navigation("Exhausted");
-
-                    b.Navigation("Initial");
                 });
 
             modelBuilder.Entity("Intersect.GameObjects.SpellDescriptor", b =>


### PR DESCRIPTION
resolves #2686 | #1767

This feature aims to add custom states to resources based on their life.
works like in videos, and also supports animated resources

The only detail to pay attention to is that it will be considered a "dead state" when the maxhp of the state is 0%
if there is no state that fits the min-max hp percentages, nothing will be rendered
The current resources that already exist in the old model are migrated correctly (as far as testing) and already serve as a model for everyone who already has resources to understand how the system works.

resource rendering can be based on the resource's maximum lifetime or the resource object's maximum lifetime, which can provide a more dynamic mapping, but that is not the intent of this feature.


https://github.com/user-attachments/assets/48e39eb2-b417-429a-934c-d9bcf223182e



https://github.com/user-attachments/assets/d423ad7c-f0ed-4f60-87f5-6cd894525598


https://github.com/user-attachments/assets/06e6cfd8-1652-44ed-b7c2-3415aa042c97

