### PR TITLE
fix: double-dispose in WeatherParticle

### DIFF
--- a/Intersect.Client.Core/Maps/WeatherParticle.cs
+++ b/Intersect.Client.Core/Maps/WeatherParticle.cs
@@ -41,6 +41,8 @@ public partial class WeatherParticle : IWeatherParticle
 
     private int yVelocity;
 
+    private bool _disposed = false;
+
     public WeatherParticle(List<IWeatherParticle> RemoveParticle, int xvelocity, int yvelocity, AnimationDescriptor anim)
     {
         TransmittionTimer = Timing.Global.MillisecondsUtc;
@@ -150,7 +152,13 @@ public partial class WeatherParticle : IWeatherParticle
 
     public void Dispose()
     {
-        animInstance.Dispose();
+        if (_disposed) return;
+
+        _disposed = true;
+
+        animInstance?.Dispose();
+
+        GC.SuppressFinalize(this);
     }
 
     ~WeatherParticle()


### PR DESCRIPTION
Resolves #2691

Fixes a crash caused by the `WeatherParticle` class calling `Dispose()` on its `Animation` instance more than once once manually and once from the finalzer.