### PR TITLE
fix 2559

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Bag/BagItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Bag/BagItem.cs
@@ -7,7 +7,6 @@ using Intersect.Client.Framework.Gwen.DragDrop;
 using Intersect.Client.Framework.Gwen.Input;
 using Intersect.Client.Framework.Input;
 using Intersect.Client.General;
-using Intersect.Client.Interface.Game.DescriptionWindows;
 using Intersect.Client.Interface.Game.Inventory;
 using Intersect.Client.Localization;
 using Intersect.Client.Networking;
@@ -21,7 +20,6 @@ public partial class BagItem : SlotItem
     // Controls
     private readonly Label _quantityLabel;
     private readonly BagWindow _bagWindow;
-    private ItemDescriptionWindow? _descriptionWindow;
 
     // Context Menu Handling
     private readonly MenuItem _withdrawContextItem;
@@ -99,9 +97,6 @@ public partial class BagItem : SlotItem
             return;
         }
 
-        _descriptionWindow?.Dispose();
-        _descriptionWindow = default;
-
         if (Globals.BagSlots is not { Length: > 0 } bagSlots)
         {
             return;
@@ -113,19 +108,12 @@ public partial class BagItem : SlotItem
         }
 
         var item = bagSlots[SlotIndex];
-        _descriptionWindow = new ItemDescriptionWindow(
-            item.Descriptor,
-            item.Quantity,
-            _bagWindow.X,
-            _bagWindow.Y,
-            item.ItemProperties
-        );
+        Interface.GameUi.ItemDescriptionWindow.Show(item.Descriptor, item.Quantity, item.ItemProperties);
     }
 
     private void Icon_HoverLeave(Base sender, EventArgs arguments)
     {
-        _descriptionWindow?.Dispose();
-        _descriptionWindow = default;
+        Interface.GameUi.ItemDescriptionWindow.Hide();
     }
 
     private void Icon_Clicked(Base sender, MouseButtonState arguments)
@@ -232,8 +220,5 @@ public partial class BagItem : SlotItem
                 Icon.IsVisibleInParent = false;
             }
         }
-
-        _descriptionWindow?.Dispose();
-        _descriptionWindow = default;
     }
 }

--- a/Intersect.Client.Core/Interface/Game/Bag/BagItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Bag/BagItem.cs
@@ -108,12 +108,12 @@ public partial class BagItem : SlotItem
         }
 
         var item = bagSlots[SlotIndex];
-        Interface.GameUi.ItemDescriptionWindow.Show(item.Descriptor, item.Quantity, item.ItemProperties);
+        Interface.GameUi.ItemDescriptionWindow?.Show(item.Descriptor, item.Quantity, item.ItemProperties);
     }
 
     private void Icon_HoverLeave(Base sender, EventArgs arguments)
     {
-        Interface.GameUi.ItemDescriptionWindow.Hide();
+        Interface.GameUi.ItemDescriptionWindow?.Hide();
     }
 
     private void Icon_Clicked(Base sender, MouseButtonState arguments)

--- a/Intersect.Client.Core/Interface/Game/Bank/BankItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Bank/BankItem.cs
@@ -109,12 +109,12 @@ public partial class BankItem : SlotItem
         }
 
         var item = bankSlots[SlotIndex];
-        Interface.GameUi.ItemDescriptionWindow.Show(item.Descriptor, item.Quantity, item.ItemProperties);
+        Interface.GameUi.ItemDescriptionWindow?.Show(item.Descriptor, item.Quantity, item.ItemProperties);
     }
 
     private void Icon_HoverLeave(Base sender, EventArgs arguments)
     {
-        Interface.GameUi.ItemDescriptionWindow.Hide();
+        Interface.GameUi.ItemDescriptionWindow?.Hide();
     }
 
     private void Icon_Clicked(Base sender, MouseButtonState arguments)

--- a/Intersect.Client.Core/Interface/Game/Bank/BankItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Bank/BankItem.cs
@@ -9,7 +9,6 @@ using Intersect.Client.Framework.Gwen.Input;
 using Intersect.Client.Framework.Input;
 using Intersect.Client.General;
 using Intersect.Client.Interface.Game.Chat;
-using Intersect.Client.Interface.Game.DescriptionWindows;
 using Intersect.Client.Interface.Game.Inventory;
 using Intersect.Client.Localization;
 using Intersect.Client.Networking;
@@ -24,7 +23,6 @@ public partial class BankItem : SlotItem
     // Controls
     private readonly Label _quantityLabel;
     private BankWindow _bankWindow;
-    private ItemDescriptionWindow? _descriptionWindow;
 
     // Context Menu Handling
     private MenuItem _withdrawContextItem;
@@ -100,10 +98,6 @@ public partial class BankItem : SlotItem
             return;
         }
 
-
-        _descriptionWindow?.Dispose();
-        _descriptionWindow = null;
-
         if (Globals.BankSlots is not { Length: > 0 } bankSlots)
         {
             return;
@@ -115,19 +109,12 @@ public partial class BankItem : SlotItem
         }
 
         var item = bankSlots[SlotIndex];
-        _descriptionWindow = new ItemDescriptionWindow(
-            item.Descriptor,
-            item.Quantity,
-            _bankWindow.X,
-            _bankWindow.Y,
-            item.ItemProperties
-        );
+        Interface.GameUi.ItemDescriptionWindow.Show(item.Descriptor, item.Quantity, item.ItemProperties);
     }
 
     private void Icon_HoverLeave(Base sender, EventArgs arguments)
     {
-        _descriptionWindow?.Dispose();
-        _descriptionWindow = default;
+        Interface.GameUi.ItemDescriptionWindow.Hide();
     }
 
     private void Icon_Clicked(Base sender, MouseButtonState arguments)
@@ -298,8 +285,5 @@ public partial class BankItem : SlotItem
                 Icon.IsVisibleInParent = false;
             }
         }
-
-        _descriptionWindow?.Dispose();
-        _descriptionWindow = default;
     }
 }

--- a/Intersect.Client.Core/Interface/Game/Character/EquipmentItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Character/EquipmentItem.cs
@@ -71,7 +71,7 @@ public partial class EquipmentItem
 
     void pnl_HoverLeave(Base sender, EventArgs arguments)
     {
-        Interface.GameUi.ItemDescriptionWindow.Hide();
+        Interface.GameUi.ItemDescriptionWindow?.Hide();
     }
 
     void pnl_HoverEnter(Base sender, EventArgs arguments)
@@ -92,7 +92,7 @@ public partial class EquipmentItem
             return;
         }
 
-        Interface.GameUi.ItemDescriptionWindow.Show(item, 1, mItemProperties);
+        Interface.GameUi.ItemDescriptionWindow?.Show(item, 1, mItemProperties);
     }
 
     public FloatRect RenderBounds()

--- a/Intersect.Client.Core/Interface/Game/Character/EquipmentItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Character/EquipmentItem.cs
@@ -4,26 +4,19 @@ using Intersect.Client.Framework.Gwen.Control.EventArguments;
 using Intersect.Client.Framework.Gwen.Input;
 using Intersect.Client.Framework.Input;
 using Intersect.Client.General;
-using Intersect.Client.Interface.Game.DescriptionWindows;
 using Intersect.Client.Networking;
 using Intersect.Configuration;
 using Intersect.Framework.Core.GameObjects.Items;
-using Intersect.GameObjects;
-using Intersect.Network.Packets.Server;
 
 namespace Intersect.Client.Interface.Game.Character;
 
-
 public partial class EquipmentItem
 {
-
     public ImagePanel ContentPanel;
 
     private WindowControl mCharacterWindow;
 
     private Guid mCurrentItemId;
-
-    private ItemDescriptionWindow mDescWindow;
 
     private ItemProperties mItemProperties = null;
 
@@ -78,11 +71,7 @@ public partial class EquipmentItem
 
     void pnl_HoverLeave(Base sender, EventArgs arguments)
     {
-        if (mDescWindow != null)
-        {
-            mDescWindow.Dispose();
-            mDescWindow = null;
-        }
+        Interface.GameUi.ItemDescriptionWindow.Hide();
     }
 
     void pnl_HoverEnter(Base sender, EventArgs arguments)
@@ -97,19 +86,13 @@ public partial class EquipmentItem
             return;
         }
 
-        if (mDescWindow != null)
-        {
-            mDescWindow.Dispose();
-            mDescWindow = null;
-        }
-
         var item = ItemDescriptor.Get(mCurrentItemId);
         if (item == null)
         {
             return;
         }
 
-        mDescWindow = new ItemDescriptionWindow(item, 1, mCharacterWindow.X, mCharacterWindow.Y, mItemProperties, item.Name);
+        Interface.GameUi.ItemDescriptionWindow.Show(item, 1, mItemProperties);
     }
 
     public FloatRect RenderBounds()

--- a/Intersect.Client.Core/Interface/Game/Crafting/CraftingWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Crafting/CraftingWindow.cs
@@ -160,7 +160,7 @@ public partial class CraftingWindow : Window
                 RemoveChild(container, true);
             }
 
-            Interface.GameUi.ItemDescriptionWindow.Hide();
+            Interface.GameUi.ItemDescriptionWindow?.Hide();
         }
 
         var craftedItemDescriptorId = craftDescriptor.ItemId;
@@ -188,7 +188,7 @@ public partial class CraftingWindow : Window
         foreach (var recipeItem in mItems)
         {
             //Clear the old item description box
-            Interface.GameUi.ItemDescriptionWindow.Hide();
+            Interface.GameUi.ItemDescriptionWindow?.Hide();
             if (recipeItem.Container is { } container)
             {
                 mItemContainer.RemoveChild(container, true);

--- a/Intersect.Client.Core/Interface/Game/Crafting/CraftingWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Crafting/CraftingWindow.cs
@@ -160,10 +160,7 @@ public partial class CraftingWindow : Window
                 RemoveChild(container, true);
             }
 
-            if (craftedItem.DescWindow is { } descriptionWindow)
-            {
-                descriptionWindow.Dispose();
-            }
+            Interface.GameUi.ItemDescriptionWindow.Hide();
         }
 
         var craftedItemDescriptorId = craftDescriptor.ItemId;
@@ -191,7 +188,7 @@ public partial class CraftingWindow : Window
         foreach (var recipeItem in mItems)
         {
             //Clear the old item description box
-            recipeItem.DescWindow?.Dispose();
+            Interface.GameUi.ItemDescriptionWindow.Hide();
             if (recipeItem.Container is { } container)
             {
                 mItemContainer.RemoveChild(container, true);

--- a/Intersect.Client.Core/Interface/Game/Crafting/RecipeItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Crafting/RecipeItem.cs
@@ -83,7 +83,7 @@ public partial class RecipeItem
         mMouseOver = false;
         mMouseX = -1;
         mMouseY = -1;
-        Interface.GameUi.ItemDescriptionWindow.Hide();
+        Interface.GameUi.ItemDescriptionWindow?.Hide();
     }
 
     void pnl_HoverEnter(Base sender, EventArgs arguments)
@@ -104,7 +104,7 @@ public partial class RecipeItem
 
         if (mIngredient != null && ItemDescriptor.TryGet(mIngredient.ItemId, out var itemDescriptor))
         {
-            Interface.GameUi.ItemDescriptionWindow.Show(itemDescriptor, mIngredient.Quantity);
+            Interface.GameUi.ItemDescriptionWindow?.Show(itemDescriptor, mIngredient.Quantity);
         }
     }
 

--- a/Intersect.Client.Core/Interface/Game/Crafting/RecipeItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Crafting/RecipeItem.cs
@@ -2,7 +2,6 @@ using Intersect.Client.Framework.Gwen.Control;
 using Intersect.Client.Framework.Gwen.Input;
 using Intersect.Client.Framework.Input;
 using Intersect.Client.General;
-using Intersect.Client.Interface.Game.DescriptionWindows;
 using Intersect.Framework.Core.GameObjects.Crafting;
 using Intersect.Framework.Core.GameObjects.Items;
 using Intersect.GameObjects;
@@ -14,8 +13,6 @@ public partial class RecipeItem
 {
 
     public ImagePanel? Container;
-
-    public ItemDescriptionWindow? DescWindow;
 
     public bool IsDragging;
 
@@ -86,11 +83,7 @@ public partial class RecipeItem
         mMouseOver = false;
         mMouseX = -1;
         mMouseY = -1;
-        if (DescWindow != null)
-        {
-            DescWindow.Dispose();
-            DescWindow = null;
-        }
+        Interface.GameUi.ItemDescriptionWindow.Hide();
     }
 
     void pnl_HoverEnter(Base sender, EventArgs arguments)
@@ -109,17 +102,9 @@ public partial class RecipeItem
             return;
         }
 
-        if (DescWindow != null)
-        {
-            DescWindow.Dispose();
-            DescWindow = null;
-        }
-
         if (mIngredient != null && ItemDescriptor.TryGet(mIngredient.ItemId, out var itemDescriptor))
         {
-            DescWindow = new ItemDescriptionWindow(
-                itemDescriptor, mIngredient.Quantity, mCraftingWindow.X, mCraftingWindow.Y, null
-            );
+            Interface.GameUi.ItemDescriptionWindow.Show(itemDescriptor, mIngredient.Quantity);
         }
     }
 

--- a/Intersect.Client.Core/Interface/Game/DescriptionWindows/Components/ComponentBase.cs
+++ b/Intersect.Client.Core/Interface/Game/DescriptionWindows/Components/ComponentBase.cs
@@ -1,115 +1,19 @@
-using Intersect.Client.Core;
 using Intersect.Client.Framework.Gwen.Control;
 
 namespace Intersect.Client.Interface.Game.DescriptionWindows.Components;
 
-public partial class ComponentBase : IDisposable
+public partial class ComponentBase(Base parent, string name = "") : ImagePanel(parent, name)
 {
-    protected Base mParent;
-
-    protected string mName;
-
-    protected ImagePanel mContainer;
-
-    public ComponentBase(Base parent, string name = "")
-    {
-        mParent = parent;
-        mName = name;
-    }
-
-    protected virtual void GenerateComponents()
-    {
-        mContainer = new ImagePanel(mParent, mName);
-    }
-
-    /// <summary>
-    /// The name of this control.
-    /// </summary>
-    public string Name { get { return mName; } }
-
-    /// <summary>
-    /// The base container of this control.
-    /// </summary>
-    public ImagePanel Container => mContainer;
-
-    /// <summary>
-    /// Is this component current visible?
-    /// </summary>
-    public bool IsVisible => mContainer.IsVisibleInTree;
-
-    /// <summary>
-    /// The current X location of the control.
-    /// </summary>
-    public int X => mContainer.X;
-
-    /// <summary>
-    /// The current Y location of the control.
-    /// </summary>
-    public int Y => mContainer.Y;
-
-    /// <summary>
-    /// The current width of the control.
-    /// </summary>
-    public int Width => mContainer.Width;
-
-    /// <summary>
-    /// The current Height of the control.
-    /// </summary>
-    public int Height => mContainer.Height;
-
-    /// <summary>
-    /// Hide the control.
-    /// </summary>
-    public void Hide() => mContainer.Hide();
-
-    /// <summary>
-    /// Show the control.
-    /// </summary>
-    public void Show() => mContainer.Show();
-
-    /// <summary>
-    /// Sets the control position.
-    /// </summary>
-    /// <param name="x">The X position to move the control to.</param>
-    /// <param name="y">The Y position to move the control to.</param>
-    /// <param name="itemDecriptionContainer">The container for the item description.</param>
-    public virtual void SetPosition(int x, int y, ImagePanel? itemDecriptionContainer = null) => mContainer.SetPosition(x, y);
-
-    /// <summary>
-    /// Sets the control position based on ImagePanel.
-    /// </summary>
-    public virtual void SetPosition(Base _icon, SpellDescriptionWindow _descriptionWindow) => mContainer.SetPosition(_icon);
-
-    /// <summary>
-    /// Resizes the control to fit its children.
-    /// </summary>
-    /// <param name="width">Allow the control to resize its width.</param>
-    /// <param name="height">Allow the control to resize its height.</param>
-    public void SizeToChildren(bool width = true, bool height = true) => mContainer.SizeToChildren(width, height);
-
-    /// <summary>
-    /// Dispose of the object.
-    /// </summary>
-    public virtual void Dispose()
-    {
-        if(!mParent.Children.Contains(mContainer))
-        {
-            return;
-        }
-
-        mParent.RemoveChild(mContainer, true);
-    }
-
-    /// <summary>
-    /// Load the Json layout of the current component.
-    /// </summary>
-    public void LoadLayout() => mContainer.LoadJsonUi(Framework.File_Management.GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
-
     /// <summary>
     /// Corrects the width of the component compared to the parent size.
     /// </summary>
     public virtual void CorrectWidth()
     {
-        mContainer.SetSize(mParent.InnerWidth, mContainer.InnerHeight);
+        if (Parent == default)
+        {
+            return;
+        }
+
+        SetSize(Parent.InnerWidth, InnerHeight);
     }
 }

--- a/Intersect.Client.Core/Interface/Game/DescriptionWindows/Components/DescriptionComponent.cs
+++ b/Intersect.Client.Core/Interface/Game/DescriptionWindows/Components/DescriptionComponent.cs
@@ -1,23 +1,15 @@
-﻿using Intersect.Client.Framework.Gwen.Control;
+using Intersect.Client.Framework.Gwen.Control;
 
 namespace Intersect.Client.Interface.Game.DescriptionWindows.Components;
 
 public partial class DescriptionComponent : ComponentBase
 {
-    protected RichLabel mDescription;
+    private readonly RichLabel _description;
 
     public DescriptionComponent(Base parent, string name) : base(parent, name)
     {
-        GenerateComponents();
-    }
-
-    protected override void GenerateComponents()
-    {
-        base.GenerateComponents();
-
-        mDescription = new RichLabel(mContainer, "Description");
-        mDescription.SizeChanged += (_, _) => mContainer.SizeToChildren();
-
+        _description = new RichLabel(this, "Description");
+        _description.SizeChanged += (_, _) => SizeToChildren();
     }
 
     /// <summary>
@@ -27,26 +19,31 @@ public partial class DescriptionComponent : ComponentBase
     /// <param name="color">The <see cref="Color"/> the description text should render with.</param>
     public void AddText(string description, Color color)
     {
-        mDescription.AddText(description, color);
-        mDescription.SizeToChildren(false, true);
-        mContainer.SizeToChildren(false, true);
+        _description.AddText(description, color);
+        _description.SizeToChildren(false, true);
+        SizeToChildren(false, true);
     }
 
     /// <summary>
     /// Adds a line break to the description.
     /// </summary>
-    public void AddLineBreak() => mDescription.AddLineBreak();
+    public void AddLineBreak() => _description.AddLineBreak();
 
     /// <inheritdoc/>
     public override void CorrectWidth()
     {
         base.CorrectWidth();
-        var margins = mDescription.Margin;
 
-        mDescription.SetSize(mContainer.InnerWidth - margins.Right, mContainer.InnerHeight);
-        mDescription.ForceImmediateRebuild();
-        mDescription.SizeToChildren(false, true);
-        mDescription.SetSize(mDescription.Width, mDescription.Height + margins.Bottom);
-        mContainer.SizeToChildren(false, true);
+        if (Parent == default)
+        {
+            return;
+        }
+
+        var margins = _description.Margin;
+        _description.SetSize(InnerWidth - margins.Right, InnerHeight);
+        _description.ForceImmediateRebuild();
+        _description.SizeToChildren(false, true);
+        _description.SetSize(_description.Width, _description.Height + margins.Bottom);
+        SizeToChildren(false, true);
     }
 }

--- a/Intersect.Client.Core/Interface/Game/DescriptionWindows/Components/DividerComponent.cs
+++ b/Intersect.Client.Core/Interface/Game/DescriptionWindows/Components/DividerComponent.cs
@@ -1,11 +1,7 @@
-﻿using Intersect.Client.Framework.Gwen.Control;
+using Intersect.Client.Framework.Gwen.Control;
 
 namespace Intersect.Client.Interface.Game.DescriptionWindows.Components;
 
-public partial class DividerComponent : ComponentBase
+public partial class DividerComponent(Base parent, string name) : ComponentBase(parent, name)
 {
-    public DividerComponent(Base parent, string name) : base(parent, name)
-    {
-        GenerateComponents();
-    }
 }

--- a/Intersect.Client.Core/Interface/Game/DescriptionWindows/Components/HeaderComponent.cs
+++ b/Intersect.Client.Core/Interface/Game/DescriptionWindows/Components/HeaderComponent.cs
@@ -1,4 +1,4 @@
-﻿using Intersect.Client.Framework.Gwen;
+using Intersect.Client.Framework.Gwen;
 using Intersect.Client.Framework.Graphics;
 using Intersect.Client.Framework.Gwen.Control;
 
@@ -6,30 +6,18 @@ namespace Intersect.Client.Interface.Game.DescriptionWindows.Components;
 
 public partial class HeaderComponent : ComponentBase
 {
-    protected ImagePanel mIconContainer;
-
-    protected ImagePanel mIcon;
-
-    protected Label mTitle;
-
-    protected Label mSubtitle;
-
-    protected Label mDescription;
+    private readonly ImagePanel _icon;
+    private readonly Label _title;
+    private readonly Label _subtitle;
+    private readonly Label _description;
 
     public HeaderComponent(Base parent, string name) : base(parent, name)
     {
-        GenerateComponents();
-    }
-
-    protected override void GenerateComponents()
-    {
-        base.GenerateComponents();
-
-        mIconContainer = new ImagePanel(mContainer, "IconContainer");
-        mIcon = new ImagePanel(mIconContainer, "Icon");
-        mTitle = new Label(mContainer, "Title");
-        mSubtitle = new Label(mContainer, "Subtitle");
-        mDescription = new Label(mContainer, "Description");
+        var _iconContainer = new ImagePanel(this, "IconContainer");
+        _icon = new ImagePanel(_iconContainer, "Icon");
+        _title = new Label(this, "Title");
+        _subtitle = new Label(this, "Subtitle");
+        _description = new Label(this, "Description");
     }
 
     /// <summary>
@@ -39,10 +27,10 @@ public partial class HeaderComponent : ComponentBase
     /// <param name="color">The <see cref="Color"/> to use to display the texture.</param>
     public void SetIcon(IGameTexture texture, Color color)
     {
-        mIcon.Texture = texture;
-        mIcon.RenderColor = color;
-        mIcon.SizeToContents();
-        Align.Center(mIcon);
+        _icon.Texture = texture;
+        _icon.RenderColor = color;
+        _icon.SizeToContents();
+        Align.Center(_icon);
     }
 
     /// <summary>
@@ -52,8 +40,8 @@ public partial class HeaderComponent : ComponentBase
     /// <param name="color">The <see cref="Color"/> to use to display this title.</param>
     public void SetTitle(string title, Color color)
     {
-        mTitle.SetText(title);
-        mTitle.SetTextColor(color, ComponentState.Normal);
+        _title.SetText(title);
+        _title.SetTextColor(color, ComponentState.Normal);
     }
 
     /// <summary>
@@ -63,8 +51,8 @@ public partial class HeaderComponent : ComponentBase
     /// <param name="color">The <see cref="Color"/> to use to display this subtitle.</param>
     public void SetSubtitle(string subtitle, Color color)
     {
-        mSubtitle.SetText(subtitle);
-        mSubtitle.SetTextColor(color, ComponentState.Normal);
+        _subtitle.SetText(subtitle);
+        _subtitle.SetTextColor(color, ComponentState.Normal);
     }
 
     /// <summary>
@@ -74,7 +62,7 @@ public partial class HeaderComponent : ComponentBase
     /// <param name="color">The <see cref="Color"/> to use to display this description.</param>
     public void SetDescription(string description, Color color)
     {
-        mDescription.SetText(description);
-        mDescription.SetTextColor(color, ComponentState.Normal);
+        _description.SetText(description);
+        _description.SetTextColor(color, ComponentState.Normal);
     }
 }

--- a/Intersect.Client.Core/Interface/Game/DescriptionWindows/Components/KeyValueRowComponent.cs
+++ b/Intersect.Client.Core/Interface/Game/DescriptionWindows/Components/KeyValueRowComponent.cs
@@ -1,0 +1,31 @@
+using Intersect.Client.Framework.Gwen.Control;
+
+namespace Intersect.Client.Interface.Game.DescriptionWindows.Components;
+
+public partial class KeyValueRowComponent : ComponentBase
+{
+    private readonly Label _keyLabel;
+    private readonly Label _valueLabel;
+
+    public KeyValueRowComponent(Base parent) : this(parent, string.Empty, string.Empty)
+    {
+    }
+
+    public KeyValueRowComponent(Base parent, string key, string value) : base(parent, "KeyValueRow")
+    {
+        _keyLabel = new Label(this, "Key") { Text = key };
+        _valueLabel = new Label(this, "Value") { Text = value };
+    }
+
+    /// <summary>
+    /// Set the <see cref="Color"/> of the key text.
+    /// </summary>
+    /// <param name="color">The <see cref="Color"/> to draw the key text in.</param>
+    public void SetKeyTextColor(Color color) => _keyLabel.SetTextColor(color, ComponentState.Normal);
+
+    /// <summary>
+    /// Set the <see cref="Color"/> of the value text.
+    /// </summary>
+    /// <param name="color">The <see cref="Color"/> to draw the value text in.</param>
+    public void SetValueTextColor(Color color) => _valueLabel.SetTextColor(color, ComponentState.Normal);
+}

--- a/Intersect.Client.Core/Interface/Game/DescriptionWindows/Components/RowContainerComponent.cs
+++ b/Intersect.Client.Core/Interface/Game/DescriptionWindows/Components/RowContainerComponent.cs
@@ -1,56 +1,37 @@
-﻿using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Linq;
 using Intersect.Client.Framework.Gwen.Control;
 using Intersect.Core;
 using Microsoft.Extensions.Logging;
+using Intersect.Client.Core;
 
 namespace Intersect.Client.Interface.Game.DescriptionWindows.Components;
 
 public partial class RowContainerComponent : ComponentBase
 {
-    protected KeyValueRowComponent mKeyValueRow;
+    private readonly JObject _keyValueRowLayout;
 
-    protected JObject KeyValueRowLayout;
-
-    private int mComponentY = 0;
+    private int _componentY = 0;
 
     public RowContainerComponent(Base parent, string name) : base(parent, name)
     {
-        GenerateComponents();
-        LoadLayout();
-        GetLayoutTemplates();
-        DestroyLayoutComponents();
-    }
-
-    protected override void GenerateComponents()
-    {
-        base.GenerateComponents();
-
-        mKeyValueRow = new KeyValueRowComponent(mContainer);
-    }
-
-    private void GetLayoutTemplates()
-    {
-        KeyValueRowLayout = mKeyValueRow.GetJson();
-    }
-
-    private void DestroyLayoutComponents()
-    {
-        mKeyValueRow.Dispose();
+        var _keyValueRow = new KeyValueRowComponent(this);
+        LoadJsonUi(Framework.File_Management.GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
+        _keyValueRowLayout = _keyValueRow.GetJson() ?? throw new Exception($"Failed to load {nameof(KeyValueRowComponent)} layout for {Name}.");
+        RemoveChild(_keyValueRow, true);
     }
 
     private void PositionComponent(ComponentBase component)
     {
-        component.SetPosition(component.X, mComponentY);
-        mComponentY += component.Height;
+        component.SetPosition(component.X, _componentY);
+        _componentY += component.Height;
     }
 
     /// <inheritdoc/>
     public override void CorrectWidth()
     {
         base.CorrectWidth();
-        var margins = mContainer.Margin;
-
-        mContainer.SetSize(mContainer.Width, mContainer.Height + margins.Bottom);
+        var margins = Margin;
+        SetSize(Width, Height + margins.Bottom);
     }
 
     /// <summary>
@@ -61,70 +42,20 @@ public partial class RowContainerComponent : ComponentBase
     /// <returns>Returns a new instance of <see cref="KeyValueRowComponent"/> with the provided settings.</returns>
     public KeyValueRowComponent AddKeyValueRow(string key, string value)
     {
-        var row = new KeyValueRowComponent(mContainer, key, value);
+        var row = new KeyValueRowComponent(this, key, value);
 
         // Since we're pulling some trickery here, catch any errors doing this ourselves and log them.
         try
         {
-            row.LoadJson(KeyValueRowLayout);
+            row.LoadJson(_keyValueRowLayout);
         }
         catch (Exception ex)
         {
-            ApplicationContext.Context.Value?.Logger.LogError(ex, $"An error occured while loading {nameof(KeyValueRowComponent)} Json for {mName}");
+            ApplicationContext.Context.Value?.Logger.LogError(ex, $"An error occured while loading {nameof(KeyValueRowComponent)} Json for {Name}");
         }
 
         row.SizeToChildren(true, false);
         PositionComponent(row);
         return row;
     }
-}
-
-public partial class KeyValueRowComponent : ComponentBase
-{
-    protected Label mKeyLabel;
-
-    protected Label mValueLabel;
-
-    public KeyValueRowComponent(Base parent) : this(parent, string.Empty, string.Empty)
-    {
-    }
-
-    public KeyValueRowComponent(Base parent, string key, string value) : base(parent, "KeyValueRow")
-    {
-        GenerateComponents();
-        mKeyLabel.SetText(key);
-        mValueLabel.SetText(value);
-    }
-
-    protected override void GenerateComponents()
-    {
-        base.GenerateComponents();
-
-        mKeyLabel = new Label(mContainer, "Key");
-        mValueLabel = new Label(mContainer, "Value");
-    }
-
-    /// <summary>
-    /// Set the <see cref="Color"/> of the key text.
-    /// </summary>
-    /// <param name="color">The <see cref="Color"/> to draw the key text in.</param>
-    public void SetKeyTextColor(Color color) => mKeyLabel.SetTextColor(color, ComponentState.Normal);
-
-    /// <summary>
-    /// Set the <see cref="Color"/> of the value text.
-    /// </summary>
-    /// <param name="color">The <see cref="Color"/> to draw the value text in.</param>
-    public void SetValueTextColor(Color color) => mValueLabel.SetTextColor(color, ComponentState.Normal);
-
-    /// <summary>
-    /// Get the Json layout of the current component.
-    /// </summary>
-    /// <returns>Returns a <see cref="JObject"/> containing the layout of the current component.</returns>
-    public JObject GetJson() => mContainer.GetJson();
-
-    /// <summary>
-    /// Set the Json layout of the current component.
-    /// </summary>
-    /// <param name="json">The new layout to apply to this component in <see cref="JObject"/> format.</param>
-    public void LoadJson(JObject json) => mContainer.LoadJson(json);
 }

--- a/Intersect.Client.Core/Interface/Game/DescriptionWindows/DescriptionWindowBase.cs
+++ b/Intersect.Client.Core/Interface/Game/DescriptionWindows/DescriptionWindowBase.cs
@@ -19,16 +19,6 @@ public partial class DescriptionWindowBase : ComponentBase
         LoadJsonUi(Framework.File_Management.GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
     }
 
-    protected override void OnVisibilityChanged(object? sender, VisibilityChangedEventArgs eventArgs)
-    {
-        base.OnVisibilityChanged(sender, eventArgs);
-
-        if (!eventArgs.IsVisibleInTree)
-        {
-            ClearChildren();
-        }
-    }
-
     protected override void OnPreDraw(Framework.Gwen.Skin.Base skin)
     {
         base.OnPreDraw(skin);

--- a/Intersect.Client.Core/Interface/Game/DescriptionWindows/DescriptionWindowBase.cs
+++ b/Intersect.Client.Core/Interface/Game/DescriptionWindows/DescriptionWindowBase.cs
@@ -1,4 +1,6 @@
+using Intersect.Client.Core;
 using Intersect.Client.Framework.Gwen.Control;
+using Intersect.Client.Framework.Gwen.Control.EventArguments;
 using Intersect.Client.Framework.Gwen.Input;
 using Intersect.Client.Interface.Game.DescriptionWindows.Components;
 
@@ -7,25 +9,34 @@ namespace Intersect.Client.Interface.Game.DescriptionWindows;
 public partial class DescriptionWindowBase : ComponentBase
 {
     // Track current Y height for placing components.
-    private int mComponentY = 0;
+    private int _componentY = 0;
 
     // Our internal list of components.
-    private List<ComponentBase> mComponents;
+    private readonly List<ComponentBase> _components = [];
 
     public DescriptionWindowBase(Base parent, string name) : base(parent, name)
     {
-        // Set up our internal component list we use for re-ordering.
-        mComponents = new List<ComponentBase>();
-
-        GenerateComponents();
+        LoadJsonUi(Framework.File_Management.GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
     }
 
-    protected override void GenerateComponents()
+    protected override void OnVisibilityChanged(object? sender, VisibilityChangedEventArgs eventArgs)
     {
-        base.GenerateComponents();
+        base.OnVisibilityChanged(sender, eventArgs);
 
-        // Load layout prior to adding components so we can retrieve padding information.
-        LoadLayout();
+        if (!eventArgs.IsVisibleInTree)
+        {
+            ClearChildren();
+        }
+    }
+
+    protected override void OnPreDraw(Framework.Gwen.Skin.Base skin)
+    {
+        base.OnPreDraw(skin);
+
+        if (!IsOnTop)
+        {
+            BringToFront();
+        }
     }
 
     /// <summary>
@@ -36,12 +47,12 @@ public partial class DescriptionWindowBase : ComponentBase
     /// <returns>Returns a new instance of the <see cref="HeaderComponent"/> class</returns>
     public HeaderComponent AddHeader(string name = "DescriptionWindowHeader", bool loadLayout = true)
     {
-        var component = new HeaderComponent(mContainer, name);
+        var component = new HeaderComponent(this, name);
         if (loadLayout)
         {
-            component.LoadLayout();
+            component.LoadJsonUi(Framework.File_Management.GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
         }
-        mComponents.Add(component);
+        _components.Add(component);
         return component;
     }
 
@@ -53,12 +64,12 @@ public partial class DescriptionWindowBase : ComponentBase
     /// <returns>Returns a new instance of the <see cref="DividerComponent"/> class</returns>
     public DividerComponent AddDivider(string name = "DescriptionWindowDivider", bool loadLayout = true)
     {
-        var component = new DividerComponent(mContainer, name);
+        var component = new DividerComponent(this, name);
         if (loadLayout)
         {
-            component.LoadLayout();
+            component.LoadJsonUi(Framework.File_Management.GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
         }
-        mComponents.Add(component);
+        _components.Add(component);
         return component;
     }
 
@@ -70,12 +81,12 @@ public partial class DescriptionWindowBase : ComponentBase
     /// <returns>Returns a new instance of the <see cref="DescriptionComponent"/> class</returns>
     public DescriptionComponent AddDescription(string name = "DescriptionWindowDescription", bool loadLayout = true)
     {
-        var component = new DescriptionComponent(mContainer, name);
+        var component = new DescriptionComponent(this, name);
         if (loadLayout)
         {
-            component.LoadLayout();
+            component.LoadJsonUi(Framework.File_Management.GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
         }
-        mComponents.Add(component);
+        _components.Add(component);
         return component;
     }
 
@@ -86,8 +97,8 @@ public partial class DescriptionWindowBase : ComponentBase
     /// <returns>Returns a new instance of the <see cref="DescriptionComponent"/> class</returns>
     public RowContainerComponent AddRowContainer(string name = "DescriptionWindowRowContainer")
     {
-        var component = new RowContainerComponent(mContainer, name);
-        mComponents.Add(component);
+        var component = new RowContainerComponent(this, name);
+        _components.Add(component);
         return component;
     }
 
@@ -102,8 +113,8 @@ public partial class DescriptionWindowBase : ComponentBase
             return;
         }
 
-        component.SetPosition(component.X, mComponentY);
-        mComponentY += component.Height;
+        component.SetPosition(component.X, _componentY);
+        _componentY += component.Height;
     }
 
     /// <summary>
@@ -112,73 +123,55 @@ public partial class DescriptionWindowBase : ComponentBase
     protected void FinalizeWindow()
     {
         // Reset our componentY so we start from scratch!
-        mComponentY = 0;
+        _componentY = 0;
 
         // Correctly set our container width to the largest child start with, this way our other child components will have a width to work with.
-        mContainer.SizeToChildren(true, false);
+        SizeToChildren(true, false);
 
         // Resize and relocate our components to properly display on our window.
-        foreach (var component in mComponents)
+        foreach (var component in _components)
         {
             component.CorrectWidth();
             PositionComponent(component);
         }
 
         // Correctly set our container height so we display everything.
-        mContainer.SizeToChildren(false, true);
+        SizeToChildren(false, true);
     }
 
     /// <inheritdoc/>
-    public override void SetPosition(int x, int y, ImagePanel? itemDecriptionContainer = null)
+    public void PositionToHoveredControl()
     {
-        if (mContainer == null || mContainer.Canvas == null)
+        if (Canvas == default)
+        {
+            return;
+        }
+
+        if (InputHandler.HoveredControl == default)
         {
             return;
         }
 
         int newX, newY;
-        int HoveredControlX, HoveredControlY;
+        var hoveredPos = InputHandler.HoveredControl.ToCanvas(new Point(0, 0));
+        int HoveredControlX = hoveredPos.X;
+        int HoveredControlY = hoveredPos.Y;
 
-        // Bind description window to the HoveredControl position.
-        HoveredControlX = InputHandler.HoveredControl.ToCanvas(new Point(0, 0)).X;
-        HoveredControlY = InputHandler.HoveredControl.ToCanvas(new Point(0, 0)).Y;
+        // Bind description window to the right, bottom of HoveredControl.
         newX = HoveredControlX + InputHandler.HoveredControl.Width;
-        newY = itemDecriptionContainer != null ? itemDecriptionContainer.Bottom : HoveredControlY + InputHandler.HoveredControl.Height;
+        newY = HoveredControlY + InputHandler.HoveredControl.Height;
 
         // Do not allow it to render outside of the screen canvas.
-        if (newX > mContainer.Canvas.Width - mContainer.Width)
+        if (newX > Canvas.Width - Width)
         {
-            newX = HoveredControlX - mContainer.Width;
+            newX = HoveredControlX - Width;
         }
 
-        if (newY > mContainer.Canvas.Height - mContainer.Height)
+        if (newY > Canvas.Height - Height)
         {
-            newY = itemDecriptionContainer != null ? itemDecriptionContainer.Y - mContainer.Height : HoveredControlY - mContainer.Height;
+            newY = HoveredControlY - Height;
         }
 
-        mContainer.MoveTo(newX, newY);
-    }
-
-    public override void SetPosition(Base _icon, SpellDescriptionWindow _descriptionWindow)
-    {
-        var X = _icon.ToCanvas(new Point(0, 0)).X;
-        var Y = _icon.ToCanvas(new Point(0, 0)).Y;
-
-        X = X + _descriptionWindow.Width + _icon.Height;
-        Y = Y + _icon.Height;
-
-        // Do not allow it to render outside of the screen canvas while based on the _icon position.
-        // Prevents flickering when _icon is hovered near the edge of the screen.
-        if (X > Interface.GameUi.GameCanvas.Width - _descriptionWindow.Width)
-        {
-            X = X - _descriptionWindow.Width - _icon.Height;
-        }
-
-        if (Y > Interface.GameUi.GameCanvas.Height - _descriptionWindow.Height)
-        {
-            Y = Y - _descriptionWindow.Height - _icon.Height;
-        }
-
-        _descriptionWindow.SetPosition(X, Y);
+        MoveTo(newX, newY);
     }
 }

--- a/Intersect.Client.Core/Interface/Game/DescriptionWindows/ItemDescriptionWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/DescriptionWindows/ItemDescriptionWindow.cs
@@ -88,8 +88,10 @@ public partial class ItemDescriptionWindow() : DescriptionWindowBase(Interface.G
 
     public override void Hide()
     {
-        Interface.GameUi.SpellDescriptionWindow?.Hide();
-        base.Hide();
+        Interface.GameUi.ItemDescriptionWindow?.Dispose();
+        Interface.GameUi.ItemDescriptionWindow = default;
+        Interface.GameUi.SpellDescriptionWindow?.Dispose();
+        Interface.GameUi.SpellDescriptionWindow = default;
     }
 
     protected void SetupDescriptionWindow()

--- a/Intersect.Client.Core/Interface/Game/DescriptionWindows/ItemDescriptionWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/DescriptionWindows/ItemDescriptionWindow.cs
@@ -1,60 +1,100 @@
 using Intersect.Enums;
-using Intersect.GameObjects;
 using Intersect.Client.General;
 using Intersect.Client.Localization;
 using Intersect.Core;
 using Intersect.Framework.Core.GameObjects.Items;
 using Intersect.GameObjects.Ranges;
-using Intersect.Network.Packets.Server;
 using Intersect.Utilities;
 using Microsoft.Extensions.Logging;
+using Intersect.Client.Framework.File_Management;
+using Intersect.Client.Framework.Gwen.Input;
 
 namespace Intersect.Client.Interface.Game.DescriptionWindows;
 
-public partial class ItemDescriptionWindow : DescriptionWindowBase
+public partial class ItemDescriptionWindow() : DescriptionWindowBase(Interface.GameUi.GameCanvas, "DescriptionWindow")
 {
-    protected ItemDescriptor mItem;
+    private ItemDescriptor? _itemDescriptor;
+    private ItemProperties? _itemProperties;
+    private int _amount;
+    private string? _valueLabel;
 
-    protected int mAmount;
-
-    protected ItemProperties? mItemProperties;
-
-    protected string mTitleOverride;
-
-    protected string mValueLabel;
-
-    protected SpellDescriptionWindow? mSpellDescWindow;
-
-    public ItemDescriptionWindow(
+    public void Show(
         ItemDescriptor item,
         int amount,
-        int x,
-        int y,
-        ItemProperties? itemProperties,
-        string titleOverride = "",
+        ItemProperties? itemProperties = default,
         string valueLabel = ""
-    ) : base(Interface.GameUi.GameCanvas, "DescriptionWindow")
+    )
     {
-        mItem = item;
-        mAmount = amount;
-        mItemProperties = itemProperties;
-        mTitleOverride = titleOverride;
-        mValueLabel = valueLabel;
+        _itemDescriptor = item;
+        _amount = amount;
+        _itemProperties = itemProperties;
+        _valueLabel = valueLabel;
 
-        GenerateComponents();
         SetupDescriptionWindow();
-        SetPosition(x, y);
+        PositionToHoveredControl();
 
         // If a spell, also display the spell description!
-        if (mItem.ItemType == ItemType.Spell)
+        if (_itemDescriptor.ItemType == ItemType.Spell && _itemDescriptor.SpellId != Guid.Empty)
         {
-            mSpellDescWindow = new SpellDescriptionWindow(mItem.SpellId, x, y, mContainer);
+            if (Canvas == default || InputHandler.HoveredControl is not { } hoveredControl)
+            {
+                return;
+            }
+
+            var spellDesc = Interface.GameUi.SpellDescriptionWindow;
+            spellDesc.Show(_itemDescriptor.SpellId);
+
+            // we need to control the spell desc window position here
+            var hoveredPos = InputHandler.HoveredControl.ToCanvas(new Point(0, 0));
+            var windowX = 0;
+            var windowY = Y;
+
+            // if spell desc is out of screen
+            if (Y + spellDesc.Height > Canvas.Height)
+            {
+                windowY = Canvas.Height - spellDesc.Height;
+            }
+
+            // let consider some situations
+            // item desc is on right side of hovered icon
+            if (X >= hoveredPos.X + hoveredControl.Width)
+            {
+                // lets try to put spell desc on left side of hovered icon
+                windowX = hoveredPos.X - spellDesc.Width;
+
+                // ops, our spell desc is out of screen
+                if (windowX < 0)
+                {
+                    windowX = X + Width;
+                }
+            }
+            else
+            {
+                // lets try to put spell desc on right side of hovered icon
+                windowX = hoveredPos.X + hoveredControl.Width;
+
+                // ops, our spell desc is out of screen
+                if (windowX + spellDesc.Width > Canvas.Width)
+                {
+                    windowX = X - spellDesc.Width;
+                }
+            }
+
+            spellDesc.SetPosition(windowX, windowY);
         }
+
+        base.Show();
+    }
+
+    public override void Hide()
+    {
+        Interface.GameUi.SpellDescriptionWindow?.Hide();
+        base.Hide();
     }
 
     protected void SetupDescriptionWindow()
     {
-        if (mItem == null)
+        if (_itemDescriptor == default)
         {
             return;
         }
@@ -66,13 +106,13 @@ public partial class ItemDescriptionWindow : DescriptionWindowBase
         SetupItemLimits();
 
         // if we have a description, set that up.
-        if (!string.IsNullOrWhiteSpace(mItem.Description))
+        if (!string.IsNullOrWhiteSpace(_itemDescriptor.Description))
         {
             SetupDescription();
         }
 
         // Set up information depending on the item type.
-        switch (mItem.ItemType)
+        switch (_itemDescriptor.ItemType)
         {
             case ItemType.Equipment:
                 SetupEquipmentInfo();
@@ -100,29 +140,33 @@ public partial class ItemDescriptionWindow : DescriptionWindowBase
 
     protected void SetupHeader()
     {
+        if (_itemDescriptor == default)
+        {
+            return;
+        }
+
         // Create our header, but do not load our layout yet since we're adding components manually.
         var header = AddHeader();
 
         // Set up the icon, if we can load it.
-        var tex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Item, mItem.Icon);
+        var tex = GameContentManager.Current.GetTexture(Framework.Content.TextureType.Item, _itemDescriptor.Icon);
         if (tex != null)
         {
-            header.SetIcon(tex, mItem.Color);
+            header.SetIcon(tex, _itemDescriptor.Color);
         }
 
         // Set up the header as the item name.
-        CustomColors.Items.Rarities.TryGetValue(mItem.Rarity, out var rarityColor);
-        var name = !string.IsNullOrWhiteSpace(mTitleOverride) ? mTitleOverride : mItem.Name;
-        header.SetTitle(name, rarityColor ?? Color.White);
+        CustomColors.Items.Rarities.TryGetValue(_itemDescriptor.Rarity, out var rarityColor);
+        header.SetTitle(_itemDescriptor.Name, rarityColor ?? Color.White);
 
         // Set up the description telling us what type of item this is.
         // if equipment, also list what kind.
-        Strings.ItemDescription.ItemTypes.TryGetValue((int)mItem.ItemType, out var typeDesc);
-        if (mItem.ItemType == ItemType.Equipment)
+        Strings.ItemDescription.ItemTypes.TryGetValue((int)_itemDescriptor.ItemType, out var typeDesc);
+        if (_itemDescriptor.ItemType == ItemType.Equipment)
         {
-            var equipSlot = Options.Instance.Equipment.Slots[mItem.EquipmentSlot];
+            var equipSlot = Options.Instance.Equipment.Slots[_itemDescriptor.EquipmentSlot];
             var extraInfo = equipSlot;
-            if (mItem.EquipmentSlot == Options.Instance.Equipment.WeaponSlot && mItem.TwoHanded)
+            if (_itemDescriptor.EquipmentSlot == Options.Instance.Equipment.WeaponSlot && _itemDescriptor.TwoHanded)
             {
                 extraInfo = $"{Strings.ItemDescription.TwoHand} {equipSlot}";
             }
@@ -136,7 +180,7 @@ public partial class ItemDescriptionWindow : DescriptionWindowBase
         // Set up the item rarity label.
         try
         {
-            if (Options.Instance.Items.TryGetRarityName(mItem.Rarity, out var rarityName))
+            if (Options.Instance.Items.TryGetRarityName(_itemDescriptor.Rarity, out var rarityName))
             {
                 _ = Strings.ItemDescription.Rarity.TryGetValue(rarityName, out var rarityLabel);
                 header.SetDescription(rarityLabel, rarityColor ?? Color.White);
@@ -147,7 +191,7 @@ public partial class ItemDescriptionWindow : DescriptionWindowBase
             ApplicationContext.Context.Value?.Logger.LogError(
                 exception,
                 "Error setting rarity description for rarity {Rarity}",
-                mItem.Rarity
+                _itemDescriptor.Rarity
             );
             throw;
         }
@@ -157,29 +201,34 @@ public partial class ItemDescriptionWindow : DescriptionWindowBase
 
     protected void SetupItemLimits()
     {
+        if (_itemDescriptor == default)
+        {
+            return;
+        }
+
         // Gather up what limitations apply to this item.
         var limits = new List<string>();
-        if (!mItem.CanBank)
+        if (!_itemDescriptor.CanBank)
         {
             limits.Add(Strings.ItemDescription.Banked);
         }
-        if (!mItem.CanGuildBank)
+        if (!_itemDescriptor.CanGuildBank)
         {
             limits.Add(Strings.ItemDescription.GuildBanked);
         }
-        if (!mItem.CanBag)
+        if (!_itemDescriptor.CanBag)
         {
             limits.Add(Strings.ItemDescription.Bagged);
         }
-        if (!mItem.CanTrade)
+        if (!_itemDescriptor.CanTrade)
         {
             limits.Add(Strings.ItemDescription.Traded);
         }
-        if (!mItem.CanDrop)
+        if (!_itemDescriptor.CanDrop)
         {
             limits.Add(Strings.ItemDescription.Dropped);
         }
-        if (!mItem.CanSell)
+        if (!_itemDescriptor.CanSell)
         {
             limits.Add(Strings.ItemDescription.Sold);
         }
@@ -200,16 +249,31 @@ public partial class ItemDescriptionWindow : DescriptionWindowBase
 
     protected void SetupDescription()
     {
+        if (_itemDescriptor == default)
+        {
+            return;
+        }
+
         // Add a divider.
         AddDivider();
 
         // Add the actual description.
         var description = AddDescription();
-        description.AddText(Strings.ItemDescription.Description.ToString(mItem.Description), Color.White);
+        description.AddText(Strings.ItemDescription.Description.ToString(_itemDescriptor.Description), Color.White);
     }
 
     protected void SetupEquipmentInfo()
     {
+        if (_itemDescriptor == default)
+        {
+            return;
+        }
+
+        if (Globals.Me is not { } player)
+        {
+            return;
+        }
+
         // Add a divider.
         AddDivider();
 
@@ -217,42 +281,42 @@ public partial class ItemDescriptionWindow : DescriptionWindowBase
         var rows = AddRowContainer();
 
         // Is this a weapon?
-        if (mItem.EquipmentSlot == Options.Instance.Equipment.WeaponSlot)
+        if (_itemDescriptor.EquipmentSlot == Options.Instance.Equipment.WeaponSlot)
         {
             // Base Damage:
-            rows.AddKeyValueRow(Strings.ItemDescription.BaseDamage, mItem.Damage.ToString());
+            rows.AddKeyValueRow(Strings.ItemDescription.BaseDamage, _itemDescriptor.Damage.ToString());
 
             // Damage Type:
-            Strings.ItemDescription.DamageTypes.TryGetValue(mItem.DamageType, out var damageType);
+            Strings.ItemDescription.DamageTypes.TryGetValue(_itemDescriptor.DamageType, out var damageType);
             rows.AddKeyValueRow(Strings.ItemDescription.BaseDamageType, damageType);
 
-            if (mItem.Scaling > 0)
+            if (_itemDescriptor.Scaling > 0)
             {
-                Strings.ItemDescription.Stats.TryGetValue(mItem.ScalingStat, out var stat);
+                Strings.ItemDescription.Stats.TryGetValue(_itemDescriptor.ScalingStat, out var stat);
                 rows.AddKeyValueRow(Strings.ItemDescription.ScalingStat, stat);
-                rows.AddKeyValueRow(Strings.ItemDescription.ScalingPercentage, Strings.ItemDescription.Percentage.ToString(mItem.Scaling));
+                rows.AddKeyValueRow(Strings.ItemDescription.ScalingPercentage, Strings.ItemDescription.Percentage.ToString(_itemDescriptor.Scaling));
             }
 
             // Crit Chance
-            if (mItem.CritChance > 0)
+            if (_itemDescriptor.CritChance > 0)
             {
-                rows.AddKeyValueRow(Strings.ItemDescription.CritChance, Strings.ItemDescription.Percentage.ToString(mItem.CritChance));
-                rows.AddKeyValueRow(Strings.ItemDescription.CritMultiplier, Strings.ItemDescription.Multiplier.ToString(mItem.CritMultiplier));
+                rows.AddKeyValueRow(Strings.ItemDescription.CritChance, Strings.ItemDescription.Percentage.ToString(_itemDescriptor.CritChance));
+                rows.AddKeyValueRow(Strings.ItemDescription.CritMultiplier, Strings.ItemDescription.Multiplier.ToString(_itemDescriptor.CritMultiplier));
             }
 
             // Attack Speed
             // Are we supposed to change our attack time based on a modifier?
-            if (mItem.AttackSpeedModifier == 0)
+            if (_itemDescriptor.AttackSpeedModifier == 0)
             {
                 // No modifier, assuming base attack rate? We have to calculate the speed stat manually here though..!
-                var speed = Globals.Me.Stat[(int)Stat.Speed];
+                var speed = player.Stat[(int)Stat.Speed];
 
                 // Remove currently equipped weapon stats.. We want to create a fair display!
-                var weaponSlot = Globals.Me.MyEquipment[Options.Instance.Equipment.WeaponSlot];
+                var weaponSlot = player.MyEquipment[Options.Instance.Equipment.WeaponSlot];
                 if (weaponSlot != -1)
                 {
-                    var randomStats = Globals.Me.Inventory[weaponSlot].ItemProperties.StatModifiers;
-                    var weapon = ItemDescriptor.Get(Globals.Me.Inventory[weaponSlot].ItemId);
+                    var randomStats = player.Inventory[weaponSlot].ItemProperties.StatModifiers;
+                    var weapon = ItemDescriptor.Get(player.Inventory[weaponSlot].ItemId);
                     if (weapon != null && randomStats != null)
                     {
                         speed = (int)Math.Round(speed / ((100 + weapon.PercentageStatsGiven[(int)Stat.Speed]) / 100f));
@@ -262,85 +326,85 @@ public partial class ItemDescriptionWindow : DescriptionWindowBase
                 }
 
                 // Add current item's speed stats!
-                if (mItemProperties?.StatModifiers != default)
+                if (_itemProperties?.StatModifiers != default)
                 {
-                    speed += mItem.StatsGiven[(int)Stat.Speed];
-                    speed += mItemProperties.StatModifiers[(int)Stat.Speed];
-                    speed += (int)Math.Floor(speed * (mItem.PercentageStatsGiven[(int)Stat.Speed] / 100f));
+                    speed += _itemDescriptor.StatsGiven[(int)Stat.Speed];
+                    speed += _itemProperties.StatModifiers[(int)Stat.Speed];
+                    speed += (int)Math.Floor(speed * (_itemDescriptor.PercentageStatsGiven[(int)Stat.Speed] / 100f));
                 }
 
                 // Display the actual speed this weapon would have based off of our calculated speed stat.
-                rows.AddKeyValueRow(Strings.ItemDescription.AttackSpeed, TimeSpan.FromMilliseconds(Globals.Me.CalculateAttackTime(speed)).WithSuffix());
+                rows.AddKeyValueRow(Strings.ItemDescription.AttackSpeed, TimeSpan.FromMilliseconds(player.CalculateAttackTime(speed)).WithSuffix());
             }
-            else if (mItem.AttackSpeedModifier == 1)
+            else if (_itemDescriptor.AttackSpeedModifier == 1)
             {
                 // Static, so this weapon's attack speed.
-                rows.AddKeyValueRow(Strings.ItemDescription.AttackSpeed, TimeSpan.FromMilliseconds(mItem.AttackSpeedValue).WithSuffix());
+                rows.AddKeyValueRow(Strings.ItemDescription.AttackSpeed, TimeSpan.FromMilliseconds(_itemDescriptor.AttackSpeedValue).WithSuffix());
             }
-            else if (mItem.AttackSpeedModifier == 2)
+            else if (_itemDescriptor.AttackSpeedModifier == 2)
             {
                 // Percentage based.
-                rows.AddKeyValueRow(Strings.ItemDescription.AttackSpeed, Strings.ItemDescription.Percentage.ToString(mItem.AttackSpeedValue));
+                rows.AddKeyValueRow(Strings.ItemDescription.AttackSpeed, Strings.ItemDescription.Percentage.ToString(_itemDescriptor.AttackSpeedValue));
             }
         }
 
         //Blocking options
-        if (mItem.EquipmentSlot == Options.Instance.Equipment.ShieldSlot)
+        if (_itemDescriptor.EquipmentSlot == Options.Instance.Equipment.ShieldSlot)
         {
-            if (mItem.BlockChance > 0)
+            if (_itemDescriptor.BlockChance > 0)
             {
-                rows.AddKeyValueRow(Strings.ItemDescription.BlockChance, Strings.ItemDescription.Percentage.ToString(mItem.BlockChance));
+                rows.AddKeyValueRow(Strings.ItemDescription.BlockChance, Strings.ItemDescription.Percentage.ToString(_itemDescriptor.BlockChance));
             }
 
-            if (mItem.BlockAmount > 0)
+            if (_itemDescriptor.BlockAmount > 0)
             {
-                rows.AddKeyValueRow(Strings.ItemDescription.BlockAmount, Strings.ItemDescription.Percentage.ToString(mItem.BlockAmount));
+                rows.AddKeyValueRow(Strings.ItemDescription.BlockAmount, Strings.ItemDescription.Percentage.ToString(_itemDescriptor.BlockAmount));
             }
 
-            if (mItem.BlockAbsorption > 0)
+            if (_itemDescriptor.BlockAbsorption > 0)
             {
-                rows.AddKeyValueRow(Strings.ItemDescription.BlockAbsorption, Strings.ItemDescription.Percentage.ToString(mItem.BlockAbsorption));
+                rows.AddKeyValueRow(Strings.ItemDescription.BlockAbsorption, Strings.ItemDescription.Percentage.ToString(_itemDescriptor.BlockAbsorption));
             }
         }
 
         // Vitals
         for (var i = 0; i < Enum.GetValues<Vital>().Length; i++)
         {
-            if (mItem.VitalsGiven[i] != 0 && mItem.PercentageVitalsGiven[i] != 0)
+            if (_itemDescriptor.VitalsGiven[i] != 0 && _itemDescriptor.PercentageVitalsGiven[i] != 0)
             {
-                rows.AddKeyValueRow(Strings.ItemDescription.Vitals[i], Strings.ItemDescription.RegularAndPercentage.ToString(mItem.VitalsGiven[i], mItem.PercentageVitalsGiven[i]));
+                rows.AddKeyValueRow(Strings.ItemDescription.Vitals[i], Strings.ItemDescription.RegularAndPercentage.ToString(_itemDescriptor.VitalsGiven[i], _itemDescriptor.PercentageVitalsGiven[i]));
             }
-            else if (mItem.VitalsGiven[i] != 0)
+            else if (_itemDescriptor.VitalsGiven[i] != 0)
             {
-                rows.AddKeyValueRow(Strings.ItemDescription.Vitals[i], mItem.VitalsGiven[i].ToString());
+                rows.AddKeyValueRow(Strings.ItemDescription.Vitals[i], _itemDescriptor.VitalsGiven[i].ToString());
             }
-            else if (mItem.PercentageVitalsGiven[i] != 0)
+            else if (_itemDescriptor.PercentageVitalsGiven[i] != 0)
             {
-                rows.AddKeyValueRow(Strings.ItemDescription.Vitals[i], Strings.ItemDescription.Percentage.ToString(mItem.PercentageVitalsGiven[i]));
+                rows.AddKeyValueRow(Strings.ItemDescription.Vitals[i], Strings.ItemDescription.Percentage.ToString(_itemDescriptor.PercentageVitalsGiven[i]));
             }
         }
 
         // Vitals Regen
         for (var i = 0; i < Enum.GetValues<Vital>().Length; i++)
         {
-            if (mItem.VitalsRegen[i] != 0)
+            if (_itemDescriptor.VitalsRegen[i] != 0)
             {
-                rows.AddKeyValueRow(Strings.ItemDescription.VitalsRegen[i], Strings.ItemDescription.Percentage.ToString(mItem.VitalsRegen[i]));
+                rows.AddKeyValueRow(Strings.ItemDescription.VitalsRegen[i], Strings.ItemDescription.Percentage.ToString(_itemDescriptor.VitalsRegen[i]));
             }
         }
 
         // Stats
-        var statModifiers = mItemProperties?.StatModifiers;
+        var statModifiers = _itemProperties?.StatModifiers;
         for (var statIndex = 0; statIndex < Enum.GetValues<Stat>().Length; statIndex++)
         {
             var stat = (Stat)statIndex;
             // Do we have item properties, if so this is a finished item. Otherwise does this item not have growing stats?
             var statLabel = Strings.ItemDescription.StatCounts[statIndex];
             ItemRange? rangeForStat = default;
-            var percentageGivenForStat = mItem.PercentageStatsGiven[statIndex];
-            if (statModifiers != default || !mItem.TryGetRangeFor(stat, out rangeForStat) || rangeForStat.LowRange == rangeForStat.HighRange)
+            var percentageGivenForStat = _itemDescriptor.PercentageStatsGiven[statIndex];
+            if (statModifiers != default || !_itemDescriptor.TryGetRangeFor(stat, out rangeForStat) || rangeForStat.LowRange == rangeForStat.HighRange)
             {
-                var flatValueGivenForStat = mItem.StatsGiven[statIndex];
+                var flatValueGivenForStat = _itemDescriptor.StatsGiven[statIndex];
                 if (statModifiers != default)
                 {
                     flatValueGivenForStat += statModifiers[statIndex];
@@ -369,9 +433,9 @@ public partial class ItemDescriptionWindow : DescriptionWindowBase
                 }
             }
             // We do not have item properties and have growing stats! So don't display a finished stat but a range instead.
-            else if (mItem.TryGetRangeFor(stat, out var range))
+            else if (_itemDescriptor.TryGetRangeFor(stat, out var range))
             {
-                var statGiven = mItem.StatsGiven[statIndex];
+                var statGiven = _itemDescriptor.StatsGiven[statIndex];
                 var percentageStatGiven = percentageGivenForStat;
                 var statLow = statGiven + range.LowRange;
                 var statHigh = statGiven + range.HighRange;
@@ -391,7 +455,7 @@ public partial class ItemDescriptionWindow : DescriptionWindowBase
         }
 
         // Bonus Effect
-        foreach (var effect in mItem.Effects)
+        foreach (var effect in _itemDescriptor.Effects)
         {
             if (effect.Type != ItemEffect.None && effect.Percentage != 0)
             {
@@ -405,6 +469,11 @@ public partial class ItemDescriptionWindow : DescriptionWindowBase
 
     protected void SetupConsumableInfo()
     {
+        if (_itemDescriptor == default)
+        {
+            return;
+        }
+
         // Add a divider.
         AddDivider();
 
@@ -412,19 +481,19 @@ public partial class ItemDescriptionWindow : DescriptionWindowBase
         var rows = AddRowContainer();
 
         // Consumable data.
-        if (mItem.Consumable != null)
+        if (_itemDescriptor.Consumable != null)
         {
-            if (mItem.Consumable.Value > 0 && mItem.Consumable.Percentage > 0)
+            if (_itemDescriptor.Consumable.Value > 0 && _itemDescriptor.Consumable.Percentage > 0)
             {
-                rows.AddKeyValueRow(Strings.ItemDescription.ConsumableTypes[(int)mItem.Consumable.Type], Strings.ItemDescription.RegularAndPercentage.ToString(mItem.Consumable.Value, mItem.Consumable.Percentage));
+                rows.AddKeyValueRow(Strings.ItemDescription.ConsumableTypes[(int)_itemDescriptor.Consumable.Type], Strings.ItemDescription.RegularAndPercentage.ToString(_itemDescriptor.Consumable.Value, _itemDescriptor.Consumable.Percentage));
             }
-            else if (mItem.Consumable.Value > 0)
+            else if (_itemDescriptor.Consumable.Value > 0)
             {
-                rows.AddKeyValueRow(Strings.ItemDescription.ConsumableTypes[(int)mItem.Consumable.Type], mItem.Consumable.Value.ToString());
+                rows.AddKeyValueRow(Strings.ItemDescription.ConsumableTypes[(int)_itemDescriptor.Consumable.Type], _itemDescriptor.Consumable.Value.ToString());
             }
-            else if (mItem.Consumable.Percentage > 0)
+            else if (_itemDescriptor.Consumable.Percentage > 0)
             {
-                rows.AddKeyValueRow(Strings.ItemDescription.ConsumableTypes[(int)mItem.Consumable.Type], Strings.ItemDescription.Percentage.ToString(mItem.Consumable.Percentage));
+                rows.AddKeyValueRow(Strings.ItemDescription.ConsumableTypes[(int)_itemDescriptor.Consumable.Type], Strings.ItemDescription.Percentage.ToString(_itemDescriptor.Consumable.Percentage));
             }
         }
 
@@ -434,6 +503,11 @@ public partial class ItemDescriptionWindow : DescriptionWindowBase
 
     protected void SetupSpellInfo()
     {
+        if (_itemDescriptor == default)
+        {
+            return;
+        }
+
         // Add a divider.
         AddDivider();
 
@@ -441,18 +515,18 @@ public partial class ItemDescriptionWindow : DescriptionWindowBase
         var rows = AddRowContainer();
 
         // Spell data.
-        if (mItem.Spell != null)
+        if (_itemDescriptor.Spell != null)
         {
-            if (mItem.QuickCast)
+            if (_itemDescriptor.QuickCast)
             {
-                rows.AddKeyValueRow(Strings.ItemDescription.CastSpell.ToString(mItem.Spell.Name), string.Empty);
+                rows.AddKeyValueRow(Strings.ItemDescription.CastSpell.ToString(_itemDescriptor.Spell.Name), string.Empty);
             }
             else
             {
-                rows.AddKeyValueRow(Strings.ItemDescription.TeachSpell.ToString(mItem.Spell.Name), string.Empty);
+                rows.AddKeyValueRow(Strings.ItemDescription.TeachSpell.ToString(_itemDescriptor.Spell.Name), string.Empty);
             }
 
-            if (mItem.SingleUse)
+            if (_itemDescriptor.SingleUse)
             {
                 rows.AddKeyValueRow(Strings.ItemDescription.SingleUse, string.Empty);
             }
@@ -464,6 +538,11 @@ public partial class ItemDescriptionWindow : DescriptionWindowBase
 
     protected void SetupBagInfo()
     {
+        if (_itemDescriptor == default)
+        {
+            return;
+        }
+
         // Add a divider.
         AddDivider();
 
@@ -471,7 +550,7 @@ public partial class ItemDescriptionWindow : DescriptionWindowBase
         var rows = AddRowContainer();
 
         // Bag data.
-        rows.AddKeyValueRow(Strings.ItemDescription.BagSlots, mItem.SlotCount.ToString());
+        rows.AddKeyValueRow(Strings.ItemDescription.BagSlots, _itemDescriptor.SlotCount.ToString());
 
         // Resize and position the container.
         rows.SizeToChildren(true, true);
@@ -479,25 +558,30 @@ public partial class ItemDescriptionWindow : DescriptionWindowBase
 
     protected void SetupExtraInfo()
     {
+        if (_itemDescriptor == default)
+        {
+            return;
+        }
+
         // Our list of data to add, should we need to.
         var data = new List<Tuple<string, string>>();
 
         // Display our amount, but only if we are stackable and have more than one.
-        if (mItem.IsStackable && mAmount > 1)
+        if (_itemDescriptor.IsStackable && _amount > 1)
         {
-            data.Add(new Tuple<string, string>(Strings.ItemDescription.Amount, mAmount.ToString("N0").Replace(",", Strings.Numbers.Comma)));
+            data.Add(new Tuple<string, string>(Strings.ItemDescription.Amount, _amount.ToString("N0").Replace(",", Strings.Numbers.Comma)));
         }
 
         // Display item drop chance if configured.
-        if (mItem.DropChanceOnDeath > 0)
+        if (_itemDescriptor.DropChanceOnDeath > 0)
         {
-            data.Add(new Tuple<string, string>(Strings.ItemDescription.DropOnDeath, Strings.ItemDescription.Percentage.ToString(mItem.DropChanceOnDeath)));
+            data.Add(new Tuple<string, string>(Strings.ItemDescription.DropOnDeath, Strings.ItemDescription.Percentage.ToString(_itemDescriptor.DropChanceOnDeath)));
         }
 
         // Display shop value if we have one.
-        if (!string.IsNullOrWhiteSpace(mValueLabel))
+        if (!string.IsNullOrWhiteSpace(_valueLabel))
         {
-            data.Add(new Tuple<string, string>(mValueLabel, string.Empty));
+            data.Add(new Tuple<string, string>(_valueLabel, string.Empty));
         }
 
         // Do we have any data to display? If so, generate the element and add the data to it.
@@ -517,12 +601,5 @@ public partial class ItemDescriptionWindow : DescriptionWindowBase
             // Resize and position the container.
             rows.SizeToChildren(true, true);
         }
-    }
-
-    /// <inheritdoc/>
-    public override void Dispose()
-    {
-        base.Dispose();
-        mSpellDescWindow?.Dispose();
     }
 }

--- a/Intersect.Client.Core/Interface/Game/DescriptionWindows/ItemDescriptionWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/DescriptionWindows/ItemDescriptionWindow.cs
@@ -88,10 +88,17 @@ public partial class ItemDescriptionWindow() : DescriptionWindowBase(Interface.G
 
     public override void Hide()
     {
-        Interface.GameUi.ItemDescriptionWindow?.Dispose();
-        Interface.GameUi.ItemDescriptionWindow = default;
-        Interface.GameUi.SpellDescriptionWindow?.Dispose();
-        Interface.GameUi.SpellDescriptionWindow = default;
+        if (Interface.GameUi.ItemDescriptionWindow == this)
+        {
+            Interface.GameUi.GameCanvas.RemoveChild(Interface.GameUi.ItemDescriptionWindow, true);
+            Interface.GameUi.ItemDescriptionWindow = default;
+        }
+
+        if (Interface.GameUi.SpellDescriptionWindow != default)
+        {
+            Interface.GameUi.GameCanvas.RemoveChild(Interface.GameUi.SpellDescriptionWindow, true);
+            Interface.GameUi.SpellDescriptionWindow = default;
+        }
     }
 
     protected void SetupDescriptionWindow()

--- a/Intersect.Client.Core/Interface/Game/DescriptionWindows/SpellDescriptionWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/DescriptionWindows/SpellDescriptionWindow.cs
@@ -30,8 +30,11 @@ public partial class SpellDescriptionWindow() : DescriptionWindowBase(Interface.
 
     public override void Hide()
     {
-        Interface.GameUi.SpellDescriptionWindow?.Dispose();
-        Interface.GameUi.SpellDescriptionWindow = default;
+        if (Interface.GameUi.SpellDescriptionWindow == this)
+        {
+            Interface.GameUi.GameCanvas.RemoveChild(Interface.GameUi.SpellDescriptionWindow, true);
+            Interface.GameUi.SpellDescriptionWindow = default;
+        }
     }
 
     protected void SetupDescriptionWindow()

--- a/Intersect.Client.Core/Interface/Game/DescriptionWindows/SpellDescriptionWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/DescriptionWindows/SpellDescriptionWindow.cs
@@ -28,6 +28,12 @@ public partial class SpellDescriptionWindow() : DescriptionWindowBase(Interface.
         base.Show();
     }
 
+    public override void Hide()
+    {
+        Interface.GameUi.SpellDescriptionWindow?.Dispose();
+        Interface.GameUi.SpellDescriptionWindow = default;
+    }
+
     protected void SetupDescriptionWindow()
     {
         if (_spellDescriptor == default)

--- a/Intersect.Client.Core/Interface/Game/EntityPanel/SpellStatus.cs
+++ b/Intersect.Client.Core/Interface/Game/EntityPanel/SpellStatus.cs
@@ -40,12 +40,12 @@ public partial class SpellStatus
 
     public void pnl_HoverLeave(Base sender, EventArgs arguments)
     {
-        Interface.GameUi.SpellDescriptionWindow.Hide();
+        Interface.GameUi.SpellDescriptionWindow?.Hide();
     }
 
     void pnl_HoverEnter(Base sender, EventArgs arguments)
     {
-        Interface.GameUi.SpellDescriptionWindow.Show(_status.SpellId);
+        Interface.GameUi.SpellDescriptionWindow?.Show(_status.SpellId);
     }
 
     public void UpdateStatus(Status status)

--- a/Intersect.Client.Core/Interface/Game/EntityPanel/SpellStatus.cs
+++ b/Intersect.Client.Core/Interface/Game/EntityPanel/SpellStatus.cs
@@ -1,10 +1,9 @@
-﻿using Intersect.Client.Core;
+using Intersect.Client.Core;
 using Intersect.Client.Entities;
 using Intersect.Client.Framework.Entities;
 using Intersect.Client.Framework.File_Management;
 using Intersect.Client.Framework.Gwen.Control;
 using Intersect.Client.General;
-using Intersect.Client.Interface.Game.DescriptionWindows;
 using Intersect.GameObjects;
 using Intersect.Utilities;
 using Label = Intersect.Client.Framework.Gwen.Control.Label;
@@ -15,8 +14,6 @@ namespace Intersect.Client.Interface.Game.EntityPanel;
 public partial class SpellStatus
 {
     private Guid _currentSpellId;
-
-    private SpellDescriptionWindow? _descriptionWindow;
 
     private Label _durationLabel;
 
@@ -43,25 +40,12 @@ public partial class SpellStatus
 
     public void pnl_HoverLeave(Base sender, EventArgs arguments)
     {
-        if (_descriptionWindow != null)
-        {
-            _descriptionWindow.Dispose();
-            _descriptionWindow = null;
-        }
+        Interface.GameUi.SpellDescriptionWindow.Hide();
     }
 
     void pnl_HoverEnter(Base sender, EventArgs arguments)
     {
-        if (_descriptionWindow != null)
-        {
-            _descriptionWindow.Dispose();
-            _descriptionWindow = null;
-        }
-
-        var X = _statusIcon.ToCanvas(new Point(0, 0)).X;
-        var Y = _statusIcon.ToCanvas(new Point(0, 0)).Y;
-
-        _descriptionWindow = new SpellDescriptionWindow(_status.SpellId, _statusIcon);
+        Interface.GameUi.SpellDescriptionWindow.Show(_status.SpellId);
     }
 
     public void UpdateStatus(Status status)

--- a/Intersect.Client.Core/Interface/Game/GameInterface.cs
+++ b/Intersect.Client.Core/Interface/Game/GameInterface.cs
@@ -52,9 +52,9 @@ public partial class GameInterface : MutableInterface
 
     private SettingsWindow? _settingsWindow;
 
-    private ItemDescriptionWindow _itemDescriptionWindow;
+    private ItemDescriptionWindow? _itemDescriptionWindow;
 
-    private SpellDescriptionWindow _spellDescriptionWindow;
+    private SpellDescriptionWindow? _spellDescriptionWindow;
 
     private bool mShouldCloseBag;
 
@@ -131,9 +131,17 @@ public partial class GameInterface : MutableInterface
 
     public AnnouncementWindow AnnouncementWindow => _announcementWindow ??= new AnnouncementWindow(GameCanvas) { IsHidden = true };
 
-    public ItemDescriptionWindow ItemDescriptionWindow => _itemDescriptionWindow ??= new ItemDescriptionWindow() { IsHidden = true };
+    public ItemDescriptionWindow? ItemDescriptionWindow
+    {
+        get => _itemDescriptionWindow ??= new ItemDescriptionWindow();
+        set => _itemDescriptionWindow = value;
+    }
 
-    public SpellDescriptionWindow SpellDescriptionWindow => _spellDescriptionWindow ??= new SpellDescriptionWindow() { IsHidden = true };
+    public SpellDescriptionWindow? SpellDescriptionWindow
+    {
+        get => _spellDescriptionWindow ??= new SpellDescriptionWindow();
+        set => _spellDescriptionWindow = value;
+    }
 
     public MenuContainer GameMenu { get; private set; }
 

--- a/Intersect.Client.Core/Interface/Game/GameInterface.cs
+++ b/Intersect.Client.Core/Interface/Game/GameInterface.cs
@@ -5,6 +5,7 @@ using Intersect.Client.Interface.Game.Bag;
 using Intersect.Client.Interface.Game.Bank;
 using Intersect.Client.Interface.Game.Chat;
 using Intersect.Client.Interface.Game.Crafting;
+using Intersect.Client.Interface.Game.DescriptionWindows;
 using Intersect.Client.Interface.Game.EntityPanel;
 using Intersect.Client.Interface.Game.Hotbar;
 using Intersect.Client.Interface.Game.Inventory;
@@ -20,10 +21,8 @@ using Microsoft.Extensions.Logging;
 
 namespace Intersect.Client.Interface.Game;
 
-
 public partial class GameInterface : MutableInterface
 {
-
     public bool FocusChat;
 
     public bool UnfocusChat;
@@ -52,6 +51,10 @@ public partial class GameInterface : MutableInterface
     private MapItemWindow mMapItemWindow;
 
     private SettingsWindow? _settingsWindow;
+
+    private ItemDescriptionWindow _itemDescriptionWindow;
+
+    private SpellDescriptionWindow _spellDescriptionWindow;
 
     private bool mShouldCloseBag;
 
@@ -127,6 +130,10 @@ public partial class GameInterface : MutableInterface
     public TargetContextMenu TargetContextMenu => _targetContextMenu ??= new TargetContextMenu(GameCanvas) {IsHidden = true};
 
     public AnnouncementWindow AnnouncementWindow => _announcementWindow ??= new AnnouncementWindow(GameCanvas) { IsHidden = true };
+
+    public ItemDescriptionWindow ItemDescriptionWindow => _itemDescriptionWindow ??= new ItemDescriptionWindow() { IsHidden = true };
+
+    public SpellDescriptionWindow SpellDescriptionWindow => _spellDescriptionWindow ??= new SpellDescriptionWindow() { IsHidden = true };
 
     public MenuContainer GameMenu { get; private set; }
 
@@ -612,5 +619,4 @@ public partial class GameInterface : MutableInterface
         CloseTrading();
         GameCanvas.Dispose();
     }
-
 }

--- a/Intersect.Client.Core/Interface/Game/Hotbar/HotbarItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Hotbar/HotbarItem.cs
@@ -8,7 +8,6 @@ using Intersect.Client.Framework.Gwen.DragDrop;
 using Intersect.Client.Framework.Gwen.Input;
 using Intersect.Client.Framework.Input;
 using Intersect.Client.General;
-using Intersect.Client.Interface.Game.DescriptionWindows;
 using Intersect.Client.Items;
 using Intersect.Client.Localization;
 using Intersect.Client.Spells;
@@ -34,10 +33,8 @@ public partial class HotbarItem : SlotItem
     private ControlBinding? _hotKey;
     private Item? _inventoryItem = null;
     private int _inventoryItemIndex = -1;
-    private ItemDescriptionWindow? _itemDescriptionWindow;
     private Label _quantityLabel;
     private Spell? _spellBookItem = null;
-    private SpellDescriptionWindow? _spellDescriptionWindow;
     private bool _textureLoaded;
 
     public HotbarItem(int hotbarSlotIndex, Base hotbarWindow)
@@ -173,11 +170,7 @@ public partial class HotbarItem : SlotItem
 
     private void Icon_HoverLeave(Base sender, EventArgs arguments)
     {
-        _itemDescriptionWindow?.Dispose();
-        _itemDescriptionWindow = null;
-
-        _spellDescriptionWindow?.Dispose();
-        _spellDescriptionWindow = null;
+        Interface.GameUi.ItemDescriptionWindow.Hide();
     }
 
     private void Icon_HoverEnter(Base sender, EventArgs arguments)
@@ -194,9 +187,6 @@ public partial class HotbarItem : SlotItem
 
         if (_currentItem != null && _inventoryItem != null)
         {
-            _itemDescriptionWindow?.Dispose();
-            _itemDescriptionWindow = null;
-
             var quantityOfItem = 1;
 
             if (_currentItem.IsStackable)
@@ -204,19 +194,11 @@ public partial class HotbarItem : SlotItem
                 quantityOfItem = Globals.Me.GetQuantityOfItemInInventory(_currentItem.Id);
             }
 
-            _itemDescriptionWindow = new ItemDescriptionWindow(
-                _currentItem, quantityOfItem, _hotbarWindow.X + (_hotbarWindow.Width / 2), _hotbarWindow.Y + _hotbarWindow.Height + 2,
-                _inventoryItem.ItemProperties, _currentItem.Name, ""
-            );
+            Interface.GameUi.ItemDescriptionWindow.Show(_currentItem, quantityOfItem, _inventoryItem.ItemProperties);
         }
         else if (_currentSpell != null)
         {
-            _spellDescriptionWindow?.Dispose();
-            _spellDescriptionWindow = null;
-
-            _spellDescriptionWindow = new SpellDescriptionWindow(
-                _currentSpell.Id, _hotbarWindow.X + (_hotbarWindow.Width / 2), _hotbarWindow.Y + _hotbarWindow.Height + 2
-            );
+            Interface.GameUi.SpellDescriptionWindow.Show(_currentSpell.Id);
         }
     }
 

--- a/Intersect.Client.Core/Interface/Game/Hotbar/HotbarItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Hotbar/HotbarItem.cs
@@ -170,7 +170,7 @@ public partial class HotbarItem : SlotItem
 
     private void Icon_HoverLeave(Base sender, EventArgs arguments)
     {
-        Interface.GameUi.ItemDescriptionWindow.Hide();
+        Interface.GameUi.ItemDescriptionWindow?.Hide();
     }
 
     private void Icon_HoverEnter(Base sender, EventArgs arguments)
@@ -194,11 +194,11 @@ public partial class HotbarItem : SlotItem
                 quantityOfItem = Globals.Me.GetQuantityOfItemInInventory(_currentItem.Id);
             }
 
-            Interface.GameUi.ItemDescriptionWindow.Show(_currentItem, quantityOfItem, _inventoryItem.ItemProperties);
+            Interface.GameUi.ItemDescriptionWindow?.Show(_currentItem, quantityOfItem, _inventoryItem.ItemProperties);
         }
         else if (_currentSpell != null)
         {
-            Interface.GameUi.SpellDescriptionWindow.Show(_currentSpell.Id);
+            Interface.GameUi.SpellDescriptionWindow?.Show(_currentSpell.Id);
         }
     }
 

--- a/Intersect.Client.Core/Interface/Game/Inventory/InventoryItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Inventory/InventoryItem.cs
@@ -298,7 +298,7 @@ public partial class InventoryItem : SlotItem
 
     private void Icon_HoverLeave(Base sender, EventArgs arguments)
     {
-        Interface.GameUi.ItemDescriptionWindow.Hide();
+        Interface.GameUi.ItemDescriptionWindow?.Hide();
     }
 
     void Icon_HoverEnter(Base? sender, EventArgs? arguments)
@@ -326,7 +326,7 @@ public partial class InventoryItem : SlotItem
 
         if (Globals.GameShop == null)
         {
-            Interface.GameUi.ItemDescriptionWindow.Show(inventorySlotDescriptor, inventorySlot.Quantity, inventorySlot.ItemProperties);
+            Interface.GameUi.ItemDescriptionWindow?.Show(inventorySlotDescriptor, inventorySlot.Quantity, inventorySlot.ItemProperties);
         }
         else
         {
@@ -348,7 +348,7 @@ public partial class InventoryItem : SlotItem
                     return;
                 }
 
-                Interface.GameUi.ItemDescriptionWindow.Show(
+                Interface.GameUi.ItemDescriptionWindow?.Show(
                     inventorySlotDescriptor,
                     inventorySlot.Quantity,
                     inventorySlot.ItemProperties,
@@ -363,7 +363,7 @@ public partial class InventoryItem : SlotItem
                     return;
                 }
 
-                Interface.GameUi.ItemDescriptionWindow.Show(
+                Interface.GameUi.ItemDescriptionWindow?.Show(
                     inventorySlotDescriptor,
                     inventorySlot.Quantity,
                     inventorySlot.ItemProperties,
@@ -372,7 +372,7 @@ public partial class InventoryItem : SlotItem
             }
             else
             {
-                Interface.GameUi.ItemDescriptionWindow.Show(
+                Interface.GameUi.ItemDescriptionWindow?.Show(
                     inventorySlotDescriptor,
                     inventorySlot.Quantity,
                     inventorySlot.ItemProperties,

--- a/Intersect.Client.Core/Interface/Game/Inventory/InventoryItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Inventory/InventoryItem.cs
@@ -10,7 +10,6 @@ using Intersect.Client.Framework.Input;
 using Intersect.Client.General;
 using Intersect.Client.Interface.Game.Bag;
 using Intersect.Client.Interface.Game.Bank;
-using Intersect.Client.Interface.Game.DescriptionWindows;
 using Intersect.Client.Interface.Game.Hotbar;
 using Intersect.Client.Interface.Game.Shop;
 using Intersect.Client.Localization;
@@ -30,7 +29,6 @@ public partial class InventoryItem : SlotItem
     private readonly Label _cooldownLabel;
     private readonly ImagePanel _equipImageBackground;
     private readonly InventoryWindow _inventoryWindow;
-    private ItemDescriptionWindow? _descriptionWindow;
 
     // Context Menu Handling
     private readonly MenuItem _useItemMenuItem;
@@ -300,8 +298,7 @@ public partial class InventoryItem : SlotItem
 
     private void Icon_HoverLeave(Base sender, EventArgs arguments)
     {
-        _descriptionWindow?.Dispose();
-        _descriptionWindow = null;
+        Interface.GameUi.ItemDescriptionWindow.Hide();
     }
 
     void Icon_HoverEnter(Base? sender, EventArgs? arguments)
@@ -314,12 +311,6 @@ public partial class InventoryItem : SlotItem
         if (Globals.InputManager.IsMouseButtonDown(MouseButton.Left))
         {
             return;
-        }
-
-        if (_descriptionWindow != null)
-        {
-            _descriptionWindow.Dispose();
-            _descriptionWindow = null;
         }
 
         if (Globals.Me?.Inventory[SlotIndex] is not { } inventorySlot)
@@ -335,13 +326,7 @@ public partial class InventoryItem : SlotItem
 
         if (Globals.GameShop == null)
         {
-            _descriptionWindow = new ItemDescriptionWindow(
-                inventorySlotDescriptor,
-                inventorySlot.Quantity,
-                _inventoryWindow.X,
-                _inventoryWindow.Y,
-                inventorySlot.ItemProperties
-            );
+            Interface.GameUi.ItemDescriptionWindow.Show(inventorySlotDescriptor, inventorySlot.Quantity, inventorySlot.ItemProperties);
         }
         else
         {
@@ -363,41 +348,34 @@ public partial class InventoryItem : SlotItem
                     return;
                 }
 
-                _descriptionWindow = new ItemDescriptionWindow(
+                Interface.GameUi.ItemDescriptionWindow.Show(
                     inventorySlotDescriptor,
                     inventorySlot.Quantity,
-                    _inventoryWindow.X,
-                    _inventoryWindow.Y,
                     inventorySlot.ItemProperties,
-                    "",
                     Strings.Shop.SellsFor.ToString(shopItemDescriptor.CostItemQuantity, hoveredItem.Name)
                 );
             }
             else if (shopItemDescriptor == null)
             {
                 var costItem = Globals.GameShop.DefaultCurrency;
-                if (inventorySlotDescriptor != null && costItem != null)
+                if (inventorySlotDescriptor == null || costItem == null)
                 {
-                    _descriptionWindow = new ItemDescriptionWindow(
-                        inventorySlotDescriptor,
-                        inventorySlot.Quantity,
-                        _inventoryWindow.X,
-                        _inventoryWindow.Y,
-                        inventorySlot.ItemProperties,
-                        "",
-                        Strings.Shop.SellsFor.ToString(inventorySlotDescriptor.Price.ToString(), costItem.Name)
-                    );
+                    return;
                 }
+
+                Interface.GameUi.ItemDescriptionWindow.Show(
+                    inventorySlotDescriptor,
+                    inventorySlot.Quantity,
+                    inventorySlot.ItemProperties,
+                    Strings.Shop.SellsFor.ToString(inventorySlotDescriptor.Price.ToString(), costItem.Name)
+                );
             }
             else
             {
-                _descriptionWindow = new ItemDescriptionWindow(
+                Interface.GameUi.ItemDescriptionWindow.Show(
                     inventorySlotDescriptor,
                     inventorySlot.Quantity,
-                    _inventoryWindow.X,
-                    _inventoryWindow.Y,
                     inventorySlot.ItemProperties,
-                    "",
                     Strings.Shop.WontBuy
                 );
             }
@@ -564,13 +542,6 @@ public partial class InventoryItem : SlotItem
                 Icon.IsVisibleInParent = false;
             }
         }
-
-        if (_descriptionWindow != null)
-        {
-            _descriptionWindow.Dispose();
-            _descriptionWindow = null;
-            Icon_HoverEnter(null, null);
-        }
     }
 
     private void _reset()
@@ -581,7 +552,5 @@ public partial class InventoryItem : SlotItem
         _quantityLabel.IsVisibleInParent = false;
         _equipLabel.IsVisibleInParent = false;
         _cooldownLabel.IsVisibleInParent = false;
-        _descriptionWindow?.Dispose();
-        _descriptionWindow = default;
     }
 }

--- a/Intersect.Client.Core/Interface/Game/MapItem/MapItemIcon.cs
+++ b/Intersect.Client.Core/Interface/Game/MapItem/MapItemIcon.cs
@@ -49,7 +49,7 @@ public partial class MapItemIcon
 
     void pnl_HoverLeave(Base sender, EventArgs arguments)
     {
-        Interface.GameUi.ItemDescriptionWindow.Hide();
+        Interface.GameUi.ItemDescriptionWindow?.Hide();
     }
 
     void pnl_HoverEnter(Base? sender, EventArgs? arguments)
@@ -69,7 +69,7 @@ public partial class MapItemIcon
             return;
         }
 
-        Interface.GameUi.ItemDescriptionWindow.Show(ItemDescriptor.Get(MyItem.ItemId), MyItem.Quantity, MyItem.ItemProperties);
+        Interface.GameUi.ItemDescriptionWindow?.Show(ItemDescriptor.Get(MyItem.ItemId), MyItem.Quantity, MyItem.ItemProperties);
     }
 
     public FloatRect RenderBounds()

--- a/Intersect.Client.Core/Interface/Game/MapItem/MapItemIcon.cs
+++ b/Intersect.Client.Core/Interface/Game/MapItem/MapItemIcon.cs
@@ -5,17 +5,13 @@ using Intersect.Client.Framework.Gwen.Control.EventArguments;
 using Intersect.Client.Framework.Gwen.Input;
 using Intersect.Client.Framework.Input;
 using Intersect.Client.General;
-using Intersect.Client.Interface.Game.DescriptionWindows;
 using Intersect.Client.Items;
 using Intersect.Framework.Core.GameObjects.Items;
-using Intersect.GameObjects;
 
 namespace Intersect.Client.Interface.Game.Inventory;
 
-
 public partial class MapItemIcon
 {
-
     public ImagePanel Container;
 
     public MapItemInstance? MyItem;
@@ -27,8 +23,6 @@ public partial class MapItemIcon
     public ImagePanel Pnl;
 
     private MapItemWindow mMapItemWindow;
-
-    private ItemDescriptionWindow mDescWindow;
 
     public MapItemIcon(MapItemWindow window)
     {
@@ -55,14 +49,10 @@ public partial class MapItemIcon
 
     void pnl_HoverLeave(Base sender, EventArgs arguments)
     {
-        if (mDescWindow != null)
-        {
-            mDescWindow.Dispose();
-            mDescWindow = null;
-        }
+        Interface.GameUi.ItemDescriptionWindow.Hide();
     }
 
-    void pnl_HoverEnter(Base sender, EventArgs arguments)
+    void pnl_HoverEnter(Base? sender, EventArgs? arguments)
     {
         if (MyItem == null)
         {
@@ -79,15 +69,7 @@ public partial class MapItemIcon
             return;
         }
 
-        if (mDescWindow != null)
-        {
-            mDescWindow.Dispose();
-            mDescWindow = null;
-        }
-        mDescWindow = new ItemDescriptionWindow(
-            ItemDescriptor.Get(MyItem.ItemId), MyItem.Quantity, mMapItemWindow.X,
-            mMapItemWindow.Y, MyItem.ItemProperties
-       );
+        Interface.GameUi.ItemDescriptionWindow.Show(ItemDescriptor.Get(MyItem.ItemId), MyItem.Quantity, MyItem.ItemProperties);
     }
 
     public FloatRect RenderBounds()
@@ -136,11 +118,6 @@ public partial class MapItemIcon
 
         }
 
-        if (mDescWindow != null)
-        {
-            mDescWindow.Dispose();
-            mDescWindow = null;
-            pnl_HoverEnter(null, null);
-        }
+        pnl_HoverEnter(null, null);
     }
 }

--- a/Intersect.Client.Core/Interface/Game/Shop/ShopItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Shop/ShopItem.cs
@@ -70,7 +70,7 @@ public partial class ShopItem : SlotItem
                 StatModifiers = item.StatsGiven,
             };
 
-            Interface.GameUi.ItemDescriptionWindow.Show(
+            Interface.GameUi.ItemDescriptionWindow?.Show(
                 gameShop.SellingItems[_mySlot].Item,
                 amount: 1,
                 itemProperties: itemProperty,
@@ -81,7 +81,7 @@ public partial class ShopItem : SlotItem
 
     private void Icon_HoverLeave(Base sender, EventArgs arguments)
     {
-        Interface.GameUi.ItemDescriptionWindow.Hide();
+        Interface.GameUi.ItemDescriptionWindow?.Hide();
     }
 
     private void Icon_RightClicked(Base sender, MouseButtonState arguments)

--- a/Intersect.Client.Core/Interface/Game/Shop/ShopItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Shop/ShopItem.cs
@@ -6,7 +6,6 @@ using Intersect.Client.Framework.Gwen.DragDrop;
 using Intersect.Client.Framework.Gwen.Input;
 using Intersect.Client.Framework.Input;
 using Intersect.Client.General;
-using Intersect.Client.Interface.Game.DescriptionWindows;
 using Intersect.Client.Interface.Game.Inventory;
 using Intersect.Client.Localization;
 using Intersect.Configuration;
@@ -19,7 +18,6 @@ public partial class ShopItem : SlotItem
     private readonly int _mySlot;
     private readonly ShopWindow _shopWindow;
     private readonly MenuItem _buyMenuItem;
-    private ItemDescriptionWindow? _descriptionWindow;
 
     public ShopItem(ShopWindow shopWindow, Base parent, int index, ContextMenu contextMenu)
         : base(parent, nameof(ShopItem), index, contextMenu)
@@ -55,12 +53,6 @@ public partial class ShopItem : SlotItem
             return;
         }
 
-        if (_descriptionWindow != default)
-        {
-            _descriptionWindow.Dispose();
-            _descriptionWindow = default;
-        }
-
         if (Globals.GameShop is not { SellingItems.Count: > 0 } gameShop)
         {
             return;
@@ -78,24 +70,18 @@ public partial class ShopItem : SlotItem
                 StatModifiers = item.StatsGiven,
             };
 
-            _descriptionWindow = new ItemDescriptionWindow(
-                item: gameShop.SellingItems[_mySlot].Item,
+            Interface.GameUi.ItemDescriptionWindow.Show(
+                gameShop.SellingItems[_mySlot].Item,
                 amount: 1,
-                x: _shopWindow.X,
-                y: _shopWindow.Y,
                 itemProperties: itemProperty,
-                valueLabel: Strings.Shop.Costs.ToString(gameShop.SellingItems[_mySlot].CostItemQuantity, item.Name)
+                Strings.Shop.Costs.ToString(gameShop.SellingItems[_mySlot].CostItemQuantity, item.Name)
             );
         }
     }
 
     private void Icon_HoverLeave(Base sender, EventArgs arguments)
     {
-        if (_descriptionWindow != null)
-        {
-            _descriptionWindow.Dispose();
-            _descriptionWindow = null;
-        }
+        Interface.GameUi.ItemDescriptionWindow.Hide();
     }
 
     private void Icon_RightClicked(Base sender, MouseButtonState arguments)

--- a/Intersect.Client.Core/Interface/Game/Spells/SpellItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Spells/SpellItem.cs
@@ -8,7 +8,6 @@ using Intersect.Client.Framework.Gwen.DragDrop;
 using Intersect.Client.Framework.Gwen.Input;
 using Intersect.Client.Framework.Input;
 using Intersect.Client.General;
-using Intersect.Client.Interface.Game.DescriptionWindows;
 using Intersect.Client.Interface.Game.Hotbar;
 using Intersect.Client.Localization;
 using Intersect.Configuration;
@@ -22,7 +21,6 @@ public partial class SpellItem : SlotItem
     // Controls
     private readonly Label _cooldownLabel;
     private readonly SpellsWindow _spellWindow;
-    private SpellDescriptionWindow? _descriptionWindow;
 
     // Context Menu Handling
     private readonly MenuItem _useSpellMenuItem;
@@ -118,21 +116,17 @@ public partial class SpellItem : SlotItem
             return;
         }
 
-        _descriptionWindow?.Dispose();
-        _descriptionWindow = null;
-
         if (Globals.Me?.Spells is not { Length: > 0 } spellSlots)
         {
             return;
         }
 
-        _descriptionWindow = new SpellDescriptionWindow(spellSlots[SlotIndex].Id, _spellWindow.X, _spellWindow.Y);
+        Interface.GameUi.SpellDescriptionWindow.Show(spellSlots[SlotIndex].Id);
     }
 
     private void Icon_HoverLeave(Base sender, EventArgs arguments)
     {
-        _descriptionWindow?.Dispose();
-        _descriptionWindow = null;
+        Interface.GameUi.SpellDescriptionWindow.Hide();
     }
 
     private void Icon_Clicked(Base sender, MouseButtonState arguments)
@@ -242,9 +236,6 @@ public partial class SpellItem : SlotItem
                     Icon.IsVisibleInParent = false;
                 }
             }
-
-            _descriptionWindow?.Dispose();
-            _descriptionWindow = null;
         }
     }
 }

--- a/Intersect.Client.Core/Interface/Game/Spells/SpellItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Spells/SpellItem.cs
@@ -121,12 +121,12 @@ public partial class SpellItem : SlotItem
             return;
         }
 
-        Interface.GameUi.SpellDescriptionWindow.Show(spellSlots[SlotIndex].Id);
+        Interface.GameUi.SpellDescriptionWindow?.Show(spellSlots[SlotIndex].Id);
     }
 
     private void Icon_HoverLeave(Base sender, EventArgs arguments)
     {
-        Interface.GameUi.SpellDescriptionWindow.Hide();
+        Interface.GameUi.SpellDescriptionWindow?.Hide();
     }
 
     private void Icon_Clicked(Base sender, MouseButtonState arguments)

--- a/Intersect.Client.Core/Interface/Game/Trades/TradeItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Trades/TradeItem.cs
@@ -4,7 +4,6 @@ using Intersect.Client.Framework.Gwen.Control.EventArguments;
 using Intersect.Client.Framework.Gwen.Input;
 using Intersect.Client.Framework.Input;
 using Intersect.Client.General;
-using Intersect.Client.Interface.Game.DescriptionWindows;
 using Intersect.Configuration;
 using Intersect.Framework.Core.GameObjects.Items;
 using Intersect.GameObjects;
@@ -22,8 +21,6 @@ public partial class TradeItem
     public ImagePanel Container;
 
     private Guid mCurrentItemId;
-
-    private ItemDescriptionWindow mDescWindow;
 
     private Draggable mDragIcon;
 
@@ -102,11 +99,7 @@ public partial class TradeItem
         mMouseOver = false;
         mMouseX = -1;
         mMouseY = -1;
-        if (mDescWindow != null)
-        {
-            mDescWindow.Dispose();
-            mDescWindow = null;
-        }
+        Interface.GameUi.ItemDescriptionWindow.Hide();
     }
 
     void pnl_HoverEnter(Base sender, EventArgs arguments)
@@ -118,19 +111,17 @@ public partial class TradeItem
 
         mMouseOver = true;
 
-        if (mDescWindow != null)
+        if (Globals.Trade[mMySide, mMySlot] is not { } tradeItem)
         {
-            mDescWindow.Dispose();
-            mDescWindow = null;
+            return;
         }
 
-        if (ItemDescriptor.Get(Globals.Trade[mMySide, mMySlot].ItemId) != null)
+        if (!ItemDescriptor.TryGet(Globals.Trade[mMySide, mMySlot].ItemId, out var descriptor))
         {
-            mDescWindow = new ItemDescriptionWindow(
-                Globals.Trade[mMySide, mMySlot].Descriptor, Globals.Trade[mMySide, mMySlot].Quantity, mTradeWindow.X,
-                mTradeWindow.Y, Globals.Trade[mMySide, mMySlot].ItemProperties
-            );
+            return;
         }
+
+        Interface.GameUi.ItemDescriptionWindow.Show(descriptor, tradeItem.Quantity, tradeItem.ItemProperties);
     }
 
     public FloatRect RenderBounds()

--- a/Intersect.Client.Core/Interface/Game/Trades/TradeItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Trades/TradeItem.cs
@@ -99,7 +99,7 @@ public partial class TradeItem
         mMouseOver = false;
         mMouseX = -1;
         mMouseY = -1;
-        Interface.GameUi.ItemDescriptionWindow.Hide();
+        Interface.GameUi.ItemDescriptionWindow?.Hide();
     }
 
     void pnl_HoverEnter(Base sender, EventArgs arguments)
@@ -121,7 +121,7 @@ public partial class TradeItem
             return;
         }
 
-        Interface.GameUi.ItemDescriptionWindow.Show(descriptor, tradeItem.Quantity, tradeItem.ItemProperties);
+        Interface.GameUi.ItemDescriptionWindow?.Show(descriptor, tradeItem.Quantity, tradeItem.ItemProperties);
     }
 
     public FloatRect RenderBounds()

--- a/Intersect.Client.Core/Interface/Interface.cs
+++ b/Intersect.Client.Core/Interface/Interface.cs
@@ -292,6 +292,14 @@ public static partial class Interface
         _canvasMainMenu = null;
         _uiMainMenu = null;
 
+        // Destroy our target UI as well! Above code does NOT appear to clear this properly.
+        if (Globals.Me != null)
+        {
+            Globals.Me.ClearTarget();
+            Globals.Me.TargetBox?.Dispose();
+            Globals.Me.TargetBox = null;
+        }
+
         if (_uiInGame is { } gameUi)
         {
             gameUi.Dispose();
@@ -303,14 +311,6 @@ public static partial class Interface
 
         _canvasInGame = null;
         _uiInGame = null;
-
-        // Destroy our target UI as well! Above code does NOT appear to clear this properly.
-        if (Globals.Me != null)
-        {
-            Globals.Me.ClearTarget();
-            Globals.Me.TargetBox?.Dispose();
-            Globals.Me.TargetBox = null;
-        }
 
         _initialized = false;
     }

--- a/Intersect.Client.Framework/Gwen/Control/Base.cs
+++ b/Intersect.Client.Framework/Gwen/Control/Base.cs
@@ -2729,14 +2729,6 @@ public partial class Base : IDisposable
     }
 
     /// <summary>
-    ///     Sets the control position based on ImagePanel
-    /// </summary>
-    public virtual void SetPosition(Base _icon)
-    {
-        SetPosition((int)_icon.ToCanvas(new Point(0, 0)).X, (int)_icon.ToCanvas(new Point(0, 0)).Y);
-    }
-
-    /// <summary>
     ///     Sets the control position.
     /// </summary>
     /// <param name="x">Target x coordinate.</param>


### PR DESCRIPTION
fix #2559 

Assets  - https://github.com/AscensionGameDev/Intersect-Assets/pull/69

I changed the logic, so that description windows are "at the root" along with the windows and other things, only one instance of the active windows is needed at a time

I changed the inheritance to simplify the code

I solved the bug by making the description windows always stay on top

Finally, I changed the logic of the positioning of the spells to always be on the opposite side of the desc item when possible, but staying next to the desc item when not possible, leaving the icon always in evidence.


https://github.com/user-attachments/assets/422d0911-48d0-461c-bfc5-1499d73dae70

