### PR TITLE
fix-2698

### DIFF
--- a/Intersect.Server.Core/Entities/Npc.cs
+++ b/Intersect.Server.Core/Entities/Npc.cs
@@ -1011,7 +1011,9 @@ public partial class Npc : Entity
                                                 {
                                                     if (CanAttack(blockingEntity, default))
                                                     {
-                                                        ApplicationContext.Context.Value?.Logger.LogDebug($"Trying to attack {blockingEntity.Name} because they're blocking the path to {Target.Name}");
+                                                        var blockingEntityName = blockingEntity?.Name ?? "Unknown Blocking Entity";
+                                                        var targetName = Target?.Name ?? "Unknown Target";
+                                                        ApplicationContext.Context.Value?.Logger.LogDebug($"Trying to attack {blockingEntityName} because they're blocking the path to {targetName}");
                                                         ChangeDir(nextPathDirection);
                                                         TryAttack(blockingEntity);
                                                         blockerAttacked = true;


### PR DESCRIPTION
fix #2698 

I couldn't reproduce the bug because "Let the game run or spawn an NPC" is not a worthwhile reproduction method, so I'm assuming that blockingTarget or target is null, and I'm adding a fallback for the name so we don't lose the log.