### PR TITLE
fix: Fix crash when logging out during dialogue

### DIFF
--- a/Intersect.Client.Framework/Gwen/Control/Base.cs
+++ b/Intersect.Client.Framework/Gwen/Control/Base.cs
@@ -1391,7 +1391,7 @@ public partial class Base : IDisposable
         var children = @this._children.ToArray();
         try
         {
-            foreach (var child in @this._children)
+            foreach (var child in children)
             {
                 child.Dispose();
             }


### PR DESCRIPTION
Resolves #2751 

This appears to be a typo/oversight. The snapshot array is created correctly but forgot to use it in the foreach loop. Changed line 1394 to iterate over the snapshot copy.