### PR TITLE
fix: generate version-specific network keys

### DIFF
--- a/Framework/Intersect.Framework.Core/Compression/GzipCompression.cs
+++ b/Framework/Intersect.Framework.Core/Compression/GzipCompression.cs
@@ -1,4 +1,4 @@
-﻿using System.IO.Compression;
+using System.IO.Compression;
 using System.Security.Cryptography;
 using System.Text;
 
@@ -23,8 +23,8 @@ public static partial class GzipCompression
 
         // Take a few bytes out of this delicious morsel and grow stronk.
         var keyBytes = ASCIIEncoding.ASCII.GetBytes(cryptoKey);
-        cryptoProvider.Key = keyBytes.Take(16).ToArray();
-        cryptoProvider.IV = keyBytes.Reverse().Take(16).ToArray();
+        cryptoProvider.Key = [.. keyBytes.Take(16)];
+        cryptoProvider.IV = [.. ((IEnumerable<byte>)keyBytes).Reverse().Take(16)];
     }
 
     /// <summary>


### PR DESCRIPTION
This pull request introduces a minor update to the `GzipCompression.cs` file in the compression module. The change adds a explicit cast to (IEnumerable<byte>), which may be required for fix:

Operator '.' cannot be applied to operand of type 'void' .. GzipCompression.cs(27,47)

making Reverse() use linq, and not array.reverse