### PR TITLE
feat: Add Non-Combat Skills System with Experience and Leveling

### DIFF
--- a/Framework/Intersect.Framework.Core/Descriptors/GameObjectType.cs
+++ b/Framework/Intersect.Framework.Core/Descriptors/GameObjectType.cs
@@ -8,6 +8,7 @@ using Intersect.Framework.Core.GameObjects.Maps;
 using Intersect.Framework.Core.GameObjects.NPCs;
 using Intersect.Framework.Core.GameObjects.PlayerClass;
 using Intersect.Framework.Core.GameObjects.Resources;
+using Intersect.Framework.Core.GameObjects.Skills;
 using Intersect.Framework.Core.GameObjects.Variables;
 using Intersect.GameObjects;
 
@@ -71,4 +72,7 @@ public enum GameObjectType
 
     [GameObjectInfo(typeof(UserVariableDescriptor), "user_variables")]
     UserVariable,
+
+    [GameObjectInfo(typeof(SkillDescriptor), "skills")]
+    Skill,
 }

--- a/Framework/Intersect.Framework.Core/GameObjects/Conditions/ConditionMetadata/SkillLevelCondition.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Conditions/ConditionMetadata/SkillLevelCondition.cs
@@ -1,0 +1,17 @@
+using System;
+using Intersect.Enums;
+using Intersect.Framework.Core.GameObjects.Events;
+
+namespace Intersect.Framework.Core.GameObjects.Conditions.ConditionMetadata;
+
+public partial class SkillLevelCondition : Condition
+{
+    public override ConditionType Type { get; } = ConditionType.SkillLevel;
+
+    public Guid SkillId { get; set; }
+
+    public VariableComparator Comparator { get; set; } = VariableComparator.Equal;
+
+    public int Value { get; set; }
+}
+

--- a/Framework/Intersect.Framework.Core/GameObjects/Conditions/ConditionType.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Conditions/ConditionType.cs
@@ -41,4 +41,6 @@ public enum ConditionType
     CheckEquipment,
 
     IsInCombat,
+
+    SkillLevel,
 }

--- a/Framework/Intersect.Framework.Core/GameObjects/Events/Commands/GiveSkillExperienceCommand.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Events/Commands/GiveSkillExperienceCommand.cs
@@ -1,0 +1,37 @@
+namespace Intersect.Framework.Core.GameObjects.Events.Commands;
+
+public partial class GiveSkillExperienceCommand : EventCommand
+{
+    public override EventCommandType Type { get; } = EventCommandType.GiveSkillExperience;
+
+    /// <summary>
+    /// The skill ID to give experience to
+    /// </summary>
+    public Guid SkillId { get; set; }
+
+    /// <summary>
+    /// The amount of experience to give
+    /// </summary>
+    public long Exp { get; set; }
+
+    /// <summary>
+    /// Defines whether this event command will use a variable for processing or not.
+    /// </summary>
+    public bool UseVariable { get; set; } = false;
+
+    /// <summary>
+    /// Defines whether the variable used is a Player or Global variable.
+    /// </summary>
+    public VariableType VariableType { get; set; } = VariableType.PlayerVariable;
+
+    /// <summary>
+    /// The Variable Id to use.
+    /// </summary>
+    public Guid VariableId { get; set; }
+
+    /// <summary>
+    /// If true, when a player have their experience reduced, they will be able to level down.
+    /// </summary>
+    public bool EnableLosingLevels { get; set; } = false;
+}
+

--- a/Framework/Intersect.Framework.Core/GameObjects/Events/EventCommandType.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Events/EventCommandType.cs
@@ -136,4 +136,6 @@ public enum EventCommandType
     CastSpellOn,
 
     Fade,
+
+    GiveSkillExperience,
 }

--- a/Framework/Intersect.Framework.Core/GameObjects/Skills/SkillDescriptor.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Skills/SkillDescriptor.cs
@@ -1,0 +1,131 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using Intersect.Models;
+using Intersect.Server.Utilities;
+using Intersect.Utilities;
+using Newtonsoft.Json;
+
+namespace Intersect.Framework.Core.GameObjects.Skills;
+
+public partial class SkillDescriptor : DatabaseObject<SkillDescriptor>, IFolderable
+{
+    public const long DEFAULT_BASE_EXPERIENCE = 100;
+
+    public const long DEFAULT_EXPERIENCE_INCREASE = 50;
+
+    [JsonIgnore]
+    private long mBaseExperience;
+
+    [JsonIgnore]
+    private long mExperienceIncrease;
+
+    [JsonConstructor]
+    public SkillDescriptor(Guid id) : base(id)
+    {
+        Name = "New Skill";
+        ExperienceCurve = new ExperienceCurve();
+        ExperienceCurve.Calculate(1);
+        BaseExperience = DEFAULT_BASE_EXPERIENCE;
+        ExperienceIncrease = DEFAULT_EXPERIENCE_INCREASE;
+    }
+
+    //EF wants NO PARAMETERS!!!!!
+    public SkillDescriptor()
+    {
+        Name = "New Skill";
+        ExperienceCurve = new ExperienceCurve();
+        ExperienceCurve.Calculate(1);
+        BaseExperience = DEFAULT_BASE_EXPERIENCE;
+        ExperienceIncrease = DEFAULT_EXPERIENCE_INCREASE;
+    }
+
+    /// <summary>
+    /// Maximum level for this skill
+    /// </summary>
+    public int MaxLevel { get; set; } = 99;
+
+    /// <summary>
+    /// Base experience required for level 2
+    /// </summary>
+    public long BaseExperience
+    {
+        get => mBaseExperience;
+        set
+        {
+            mBaseExperience = Math.Max(0, value);
+            ExperienceCurve.BaseExperience = Math.Max(1, mBaseExperience);
+        }
+    }
+
+    /// <summary>
+    /// Experience increase per level
+    /// </summary>
+    public long ExperienceIncrease
+    {
+        get => mExperienceIncrease;
+        set
+        {
+            mExperienceIncrease = Math.Max(0, value);
+            ExperienceCurve.Gain = 1 + value / 100.0;
+        }
+    }
+
+    /// <summary>
+    /// Experience curve configuration
+    /// </summary>
+    [NotMapped, JsonIgnore]
+    public ExperienceCurve ExperienceCurve { get; set; } = new();
+
+    [Column("ExperienceCurve")]
+    [JsonIgnore]
+    public string ExperienceCurveJson
+    {
+        get => JsonConvert.SerializeObject(ExperienceCurve);
+        set => ExperienceCurve = JsonConvert.DeserializeObject<ExperienceCurve>(value ?? "{}") ?? new ExperienceCurve();
+    }
+
+    /// <summary>
+    /// Custom experience overrides for specific levels (level -> experience required)
+    /// </summary>
+    [NotMapped, JsonIgnore]
+    public Dictionary<int, long> ExperienceOverrides { get; set; } = new();
+
+    [JsonIgnore]
+    [Column("ExperienceOverrides")]
+    public string ExpOverridesJson
+    {
+        get => JsonConvert.SerializeObject(ExperienceOverrides);
+        set
+        {
+            ExperienceOverrides = JsonConvert.DeserializeObject<Dictionary<int, long>>(value ?? "") ?? new Dictionary<int, long>();
+        }
+    }
+
+    /// <summary>
+    /// Icon texture for this skill (optional)
+    /// </summary>
+    [Column("Icon")]
+    public string Icon { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Description of the skill
+    /// </summary>
+    [Column("Description")]
+    public string Description { get; set; } = string.Empty;
+
+    /// <inheritdoc />
+    public string Folder { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Calculates the experience required to reach the next level from the given level
+    /// </summary>
+    public long ExperienceToNextLevel(int level)
+    {
+        if (ExperienceOverrides.ContainsKey(level))
+        {
+            return ExperienceOverrides[level];
+        }
+
+        return ExperienceCurve.Calculate(level);
+    }
+}
+

--- a/Framework/Intersect.Framework.Core/Localization/LocalizedString.cs
+++ b/Framework/Intersect.Framework.Core/Localization/LocalizedString.cs
@@ -6,10 +6,10 @@ namespace Intersect.Localization;
 [Serializable]
 public partial class LocalizedString(string value) : Localized
 {
-    private readonly string _value = value;
+    private readonly string _value = value ?? string.Empty;
 
     [JsonIgnore]
-    public int ArgumentCount { get; } = CountArguments(value);
+    public int ArgumentCount { get; } = CountArguments(value ?? string.Empty);
 
     public static implicit operator LocalizedString(string value) => new(value);
 
@@ -36,6 +36,11 @@ public partial class LocalizedString(string value) : Localized
 
     public static int CountArguments(string formatString)
     {
+        if (string.IsNullOrEmpty(formatString))
+        {
+            return 0;
+        }
+
         HashSet<int> argumentIndices = [];
 
         var matches = PatternArgument.Matches(formatString);

--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/SkillDataPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/SkillDataPacket.cs
@@ -1,0 +1,48 @@
+using MessagePack;
+using System.Collections.Generic;
+
+namespace Intersect.Network.Packets.Server;
+
+[MessagePackObject]
+public partial class SkillDataPacket : IntersectPacket
+{
+    //Parameterless Constructor for MessagePack
+    public SkillDataPacket()
+    {
+        Skills = new Dictionary<Guid, SkillDataEntry>();
+    }
+
+    public SkillDataPacket(Dictionary<Guid, SkillDataEntry> skills)
+    {
+        Skills = skills ?? new Dictionary<Guid, SkillDataEntry>();
+    }
+
+    [Key(0)]
+    public Dictionary<Guid, SkillDataEntry> Skills { get; set; }
+}
+
+[MessagePackObject]
+public partial class SkillDataEntry
+{
+    //Parameterless Constructor for MessagePack
+    public SkillDataEntry()
+    {
+    }
+
+    public SkillDataEntry(long experience, int level, long experienceToNextLevel)
+    {
+        Experience = experience;
+        Level = level;
+        ExperienceToNextLevel = experienceToNextLevel;
+    }
+
+    [Key(0)]
+    public long Experience { get; set; }
+
+    [Key(1)]
+    public int Level { get; set; }
+
+    [Key(2)]
+    public long ExperienceToNextLevel { get; set; }
+}
+

--- a/Intersect.Client.Core/Entities/ClientSkillData.cs
+++ b/Intersect.Client.Core/Entities/ClientSkillData.cs
@@ -1,0 +1,20 @@
+namespace Intersect.Client.Entities;
+
+public class ClientSkillData
+{
+    public long Experience { get; set; }
+    public int Level { get; set; } = 1;
+    public long ExperienceToNextLevel { get; set; }
+
+    public ClientSkillData()
+    {
+    }
+
+    public ClientSkillData(long experience, int level, long experienceToNextLevel)
+    {
+        Experience = experience;
+        Level = level;
+        ExperienceToNextLevel = experienceToNextLevel;
+    }
+}
+

--- a/Intersect.Client.Core/Entities/Player.cs
+++ b/Intersect.Client.Core/Entities/Player.cs
@@ -63,6 +63,8 @@ public partial class Player : Entity, IPlayer
 
     public long ExperienceToNextLevel { get; set; } = 0;
 
+    public Dictionary<Guid, ClientSkillData> Skills { get; set; } = new();
+
     IReadOnlyList<IFriendInstance> IPlayer.Friends => Friends;
 
     public List<IFriendInstance> Friends { get; set; } = [];

--- a/Intersect.Client.Core/Interface/Game/MenuContainer.cs
+++ b/Intersect.Client.Core/Interface/Game/MenuContainer.cs
@@ -7,6 +7,7 @@ using Intersect.Client.General;
 using Intersect.Client.Interface.Game.Character;
 using Intersect.Client.Interface.Game.Chat;
 using Intersect.Client.Interface.Game.Inventory;
+using Intersect.Client.Interface.Game.Skills;
 using Intersect.Client.Interface.Game.Spells;
 using Intersect.Client.Localization;
 using Intersect.Client.Networking;
@@ -51,6 +52,10 @@ public partial class MenuContainer : Panel
     private readonly Button _escapeMenuButton;
 
     private readonly MapItemWindow _mapItemWindow;
+
+    private readonly SkillsWindow _skillsWindow;
+
+    public SkillsWindow SkillsWindow => _skillsWindow;
 
     public MenuContainer(Canvas gameCanvas) : base(parent: gameCanvas, name: nameof(MenuContainer))
     {
@@ -241,6 +246,7 @@ public partial class MenuContainer : Panel
         _questsWindow = new QuestsWindow(gameCanvas: gameCanvas);
         _mapItemWindow = new MapItemWindow(gameCanvas: gameCanvas);
         _guildWindow = new GuildWindow(gameCanvas: gameCanvas);
+        _skillsWindow = new SkillsWindow(gameCanvas: gameCanvas);
     }
 
     //Methods
@@ -254,6 +260,7 @@ public partial class MenuContainer : Panel
         _questsWindow.Update(updateQuestLog);
         _mapItemWindow.Update();
         _guildWindow.Update();
+        _skillsWindow.UpdateSkills();
     }
 
     public void UpdateFriendsList()
@@ -281,6 +288,7 @@ public partial class MenuContainer : Panel
         _questsWindow.Hide();
         _spellsWindow.Hide();
         _guildWindow.Hide();
+        _skillsWindow.Hide();
     }
 
     public void ToggleCharacterWindow()
@@ -419,6 +427,19 @@ public partial class MenuContainer : Panel
         _guildWindow.Hide();
     }
 
+    public void ToggleSkillsWindow()
+    {
+        if (_skillsWindow.IsVisibleInTree)
+        {
+            _skillsWindow.Hide();
+        }
+        else
+        {
+            HideWindows();
+            _skillsWindow.Show();
+        }
+    }
+
     public bool HasWindowsOpen()
     {
         var windowsOpen = _characterWindow.IsVisible() ||
@@ -427,7 +448,8 @@ public partial class MenuContainer : Panel
                           _questsWindow.IsVisible() ||
                           _spellsWindow.IsVisibleInTree ||
                           _partyWindow.IsVisible() ||
-                          _guildWindow.IsVisibleInTree;
+                          _guildWindow.IsVisibleInTree ||
+                          _skillsWindow.IsVisibleInTree;
         return windowsOpen;
     }
 

--- a/Intersect.Client.Core/Interface/Game/Skills/SkillsWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Skills/SkillsWindow.cs
@@ -1,0 +1,107 @@
+using Intersect.Client.Core;
+using Intersect.Client.Framework.File_Management;
+using Intersect.Client.Framework.Gwen;
+using Intersect.Client.Framework.Gwen.Control;
+using Intersect.Client.General;
+using Intersect.Client.Localization;
+using Intersect.Framework.Core.GameObjects.Skills;
+
+namespace Intersect.Client.Interface.Game.Skills;
+
+public partial class SkillsWindow : Window
+{
+    private readonly ScrollControl _skillContainer;
+    private readonly List<Label> _skillLabels = new();
+
+    public SkillsWindow(Canvas gameCanvas) : base(gameCanvas, "Skills", false, nameof(SkillsWindow))
+    {
+        DisableResizing();
+
+        Alignment = [Alignments.Bottom, Alignments.Left];
+        MinimumSize = new Point(x: 300, y: 400);
+        Margin = new Margin(15, 0, 0, 60);
+        IsVisibleInTree = false;
+        IsResizable = true;
+        IsClosable = true;
+
+        _skillContainer = new ScrollControl(this, "SkillsContainer")
+        {
+            Dock = Pos.Fill,
+            OverflowX = OverflowBehavior.Auto,
+            OverflowY = OverflowBehavior.Scroll,
+        };
+    }
+
+    protected override void EnsureInitialized()
+    {
+        LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
+        UpdateSkills();
+    }
+
+    public void UpdateSkills()
+    {
+        if (!IsVisibleInTree || Globals.Me == null)
+        {
+            return;
+        }
+
+        // Clear existing labels
+        foreach (var label in _skillLabels)
+        {
+            label?.Parent?.RemoveChild(label, false);
+        }
+        _skillLabels.Clear();
+
+        // Add header
+        var headerLabel = new Label(_skillContainer, "SkillsHeaderLabel")
+        {
+            Text = "Skills",
+            TextColor = Color.White,
+            Font = GameContentManager.Current.GetFont("sourcesansproblack"),
+            FontSize = 14,
+        };
+        _skillContainer.AddChild(headerLabel);
+        _skillLabels.Add(headerLabel);
+
+        // Display each skill
+        var yOffset = 30;
+        foreach (var skillDescriptor in SkillDescriptor.Lookup.Values.OrderBy(s => s.Name))
+        {
+            if (Globals.Me.Skills.TryGetValue(skillDescriptor.Id, out var skillData))
+            {
+                var skillLabel = new Label(_skillContainer, $"SkillLabel_{skillDescriptor.Id}")
+                {
+                    Text = $"{skillDescriptor.Name}: Level {skillData.Level} | XP: {skillData.Experience}/{skillData.ExperienceToNextLevel}",
+                    TextColor = Color.White,
+                    Font = GameContentManager.Current.GetFont("sourcesanspro"),
+                    FontSize = 12,
+                    Y = yOffset,
+                };
+                _skillContainer.AddChild(skillLabel);
+                _skillLabels.Add(skillLabel);
+                yOffset += 25;
+            }
+        }
+
+        if (_skillLabels.Count == 1)
+        {
+            var noSkillsLabel = new Label(_skillContainer, "NoSkillsLabel")
+            {
+                Text = "No skills yet. Gain experience to see your skills here!",
+                TextColor = Color.Gray,
+                Font = GameContentManager.Current.GetFont("sourcesanspro"),
+                FontSize = 12,
+                Y = yOffset,
+            };
+            _skillContainer.AddChild(noSkillsLabel);
+            _skillLabels.Add(noSkillsLabel);
+        }
+    }
+
+    public override void Show()
+    {
+        base.Show();
+        UpdateSkills();
+    }
+}
+

--- a/Intersect.Client.Core/Networking/PacketHandler.cs
+++ b/Intersect.Client.Core/Networking/PacketHandler.cs
@@ -1481,6 +1481,37 @@ internal sealed partial class PacketHandler
         }
     }
 
+    //SkillDataPacket
+    public void HandlePacket(IPacketSender packetSender, SkillDataPacket packet)
+    {
+        if (Globals.Me != null && packet.Skills != null)
+        {
+            foreach (var skillEntry in packet.Skills)
+            {
+                if (Globals.Me.Skills.TryGetValue(skillEntry.Key, out var existingSkill))
+                {
+                    existingSkill.Experience = skillEntry.Value.Experience;
+                    existingSkill.Level = skillEntry.Value.Level;
+                    existingSkill.ExperienceToNextLevel = skillEntry.Value.ExperienceToNextLevel;
+                }
+                else
+                {
+                    Globals.Me.Skills[skillEntry.Key] = new ClientSkillData(
+                        skillEntry.Value.Experience,
+                        skillEntry.Value.Level,
+                        skillEntry.Value.ExperienceToNextLevel
+                    );
+                }
+            }
+
+            // Update skills window if it's open
+            if (Interface.Interface.HasInGameUI)
+            {
+                Interface.Interface.EnqueueInGame(uiInGame => uiInGame.GameMenu.SkillsWindow?.UpdateSkills());
+            }
+        }
+    }
+
     //ProjectileDeadPacket
     public void HandlePacket(IPacketSender packetSender, ProjectileDeadPacket packet)
     {

--- a/Intersect.Editor/Forms/Editors/Events/CommandPrinter.cs
+++ b/Intersect.Editor/Forms/Editors/Events/CommandPrinter.cs
@@ -10,6 +10,7 @@ using Intersect.Framework.Core.GameObjects.Items;
 using Intersect.Framework.Core.GameObjects.Maps.MapList;
 using Intersect.Framework.Core.GameObjects.NPCs;
 using Intersect.Framework.Core.GameObjects.PlayerClass;
+using Intersect.Framework.Core.GameObjects.Skills;
 using Intersect.Framework.Core.GameObjects.Variables;
 using Intersect.GameObjects;
 using Microsoft.Extensions.Logging;
@@ -828,6 +829,38 @@ public static partial class CommandPrinter
         else
         {
             return Strings.EventCommandList.giveexp.ToString(command.Exp);
+        }
+    }
+
+    private static string GetCommandText(GiveSkillExperienceCommand command, MapInstance map)
+    {
+        var skillName = SkillDescriptor.GetName(command.SkillId);
+        if (string.IsNullOrEmpty(skillName))
+        {
+            skillName = "Unknown Skill";
+        }
+
+        if (command.UseVariable)
+        {
+            var exp = string.Empty;
+            switch (command.VariableType)
+            {
+                case VariableType.PlayerVariable:
+                    exp = string.Format(@"({0}: {1})", Strings.EventGiveExperience.PlayerVariable, PlayerVariableDescriptor.GetName(command.VariableId));
+                    break;
+                case VariableType.ServerVariable:
+                    exp = string.Format(@"({0}: {1})", Strings.EventGiveExperience.ServerVariable, ServerVariableDescriptor.GetName(command.VariableId));
+                    break;
+                case VariableType.GuildVariable:
+                    exp = string.Format(@"({0}: {1})", Strings.EventGiveExperience.GuildVariable, GuildVariableDescriptor.GetName(command.VariableId));
+                    break;
+            }
+
+            return Strings.EventCommandList.giveskillexp.ToString(skillName, exp);
+        }
+        else
+        {
+            return Strings.EventCommandList.giveskillexp.ToString(skillName, command.Exp);
         }
     }
 

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/Conditions/ConditionControl_SkillLevel.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/Conditions/ConditionControl_SkillLevel.Designer.cs
@@ -1,0 +1,170 @@
+namespace Intersect.Editor.Forms.Editors.Events.Event_Commands.Conditions;
+
+partial class ConditionControl_SkillLevel
+{
+    /// <summary> 
+    /// Required designer variable.
+    /// </summary>
+    private System.ComponentModel.IContainer components = null;
+
+    /// <summary> 
+    /// Clean up any resources being used.
+    /// </summary>
+    /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing && (components != null))
+        {
+            components.Dispose();
+        }
+        base.Dispose(disposing);
+    }
+
+    #region Component Designer generated code
+
+    /// <summary> 
+    /// Required method for Designer support - do not modify 
+    /// the contents of this method with the code editor.
+    /// </summary>
+    private void InitializeComponent()
+    {
+        grpSkillLevel = new DarkUI.Controls.DarkGroupBox();
+        nudSkillValue = new DarkUI.Controls.DarkNumericUpDown();
+        cmbSkill = new DarkUI.Controls.DarkComboBox();
+        lblSkill = new Label();
+        lblSkillValue = new Label();
+        cmbSkillComparator = new DarkUI.Controls.DarkComboBox();
+        lblSkillComparator = new Label();
+        grpSkillLevel.SuspendLayout();
+        ((System.ComponentModel.ISupportInitialize)nudSkillValue).BeginInit();
+        SuspendLayout();
+        // 
+        // grpSkillLevel
+        // 
+        grpSkillLevel.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+        grpSkillLevel.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+        grpSkillLevel.Controls.Add(nudSkillValue);
+        grpSkillLevel.Controls.Add(cmbSkill);
+        grpSkillLevel.Controls.Add(lblSkill);
+        grpSkillLevel.Controls.Add(lblSkillValue);
+        grpSkillLevel.Controls.Add(cmbSkillComparator);
+        grpSkillLevel.Controls.Add(lblSkillComparator);
+        grpSkillLevel.ForeColor = System.Drawing.Color.Gainsboro;
+        grpSkillLevel.Location = new System.Drawing.Point(0, 0);
+        grpSkillLevel.Margin = new Padding(4, 3, 4, 3);
+        grpSkillLevel.Name = "grpSkillLevel";
+        grpSkillLevel.Padding = new Padding(4, 3, 4, 3);
+        grpSkillLevel.Size = new Size(308, 112);
+        grpSkillLevel.TabIndex = 29;
+        grpSkillLevel.TabStop = false;
+        grpSkillLevel.Text = "Skill Level is...";
+        // 
+        // nudSkillValue
+        // 
+        nudSkillValue.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+        nudSkillValue.ForeColor = System.Drawing.Color.Gainsboro;
+        nudSkillValue.Location = new System.Drawing.Point(92, 87);
+        nudSkillValue.Margin = new Padding(4, 3, 4, 3);
+        nudSkillValue.Maximum = new decimal(new int[] { 100000, 0, 0, 0 });
+        nudSkillValue.Name = "nudSkillValue";
+        nudSkillValue.Size = new Size(208, 23);
+        nudSkillValue.TabIndex = 8;
+        nudSkillValue.Value = new decimal(new int[] { 0, 0, 0, 0 });
+        // 
+        // cmbSkill
+        // 
+        cmbSkill.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+        cmbSkill.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+        cmbSkill.BorderStyle = ButtonBorderStyle.Solid;
+        cmbSkill.ButtonColor = System.Drawing.Color.FromArgb(43, 43, 43);
+        cmbSkill.DrawDropdownHoverOutline = false;
+        cmbSkill.DrawFocusRectangle = false;
+        cmbSkill.DrawMode = DrawMode.OwnerDrawFixed;
+        cmbSkill.DropDownStyle = ComboBoxStyle.DropDownList;
+        cmbSkill.FlatStyle = FlatStyle.Flat;
+        cmbSkill.ForeColor = System.Drawing.Color.Gainsboro;
+        cmbSkill.FormattingEnabled = true;
+        cmbSkill.Location = new System.Drawing.Point(92, 27);
+        cmbSkill.Margin = new Padding(4, 3, 4, 3);
+        cmbSkill.Name = "cmbSkill";
+        cmbSkill.Size = new Size(206, 24);
+        cmbSkill.TabIndex = 7;
+        cmbSkill.Text = null;
+        cmbSkill.TextPadding = new Padding(2);
+        // 
+        // lblSkill
+        // 
+        lblSkill.AutoSize = true;
+        lblSkill.Location = new System.Drawing.Point(9, 29);
+        lblSkill.Margin = new Padding(4, 0, 4, 0);
+        lblSkill.Name = "lblSkill";
+        lblSkill.Size = new Size(35, 15);
+        lblSkill.TabIndex = 6;
+        lblSkill.Text = "Skill:";
+        // 
+        // lblSkillValue
+        // 
+        lblSkillValue.AutoSize = true;
+        lblSkillValue.Location = new System.Drawing.Point(13, 90);
+        lblSkillValue.Margin = new Padding(4, 0, 4, 0);
+        lblSkillValue.Name = "lblSkillValue";
+        lblSkillValue.Size = new Size(38, 15);
+        lblSkillValue.TabIndex = 4;
+        lblSkillValue.Text = "Value:";
+        // 
+        // cmbSkillComparator
+        // 
+        cmbSkillComparator.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+        cmbSkillComparator.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+        cmbSkillComparator.BorderStyle = ButtonBorderStyle.Solid;
+        cmbSkillComparator.ButtonColor = System.Drawing.Color.FromArgb(43, 43, 43);
+        cmbSkillComparator.DrawDropdownHoverOutline = false;
+        cmbSkillComparator.DrawFocusRectangle = false;
+        cmbSkillComparator.DrawMode = DrawMode.OwnerDrawFixed;
+        cmbSkillComparator.DropDownStyle = ComboBoxStyle.DropDownList;
+        cmbSkillComparator.FlatStyle = FlatStyle.Flat;
+        cmbSkillComparator.ForeColor = System.Drawing.Color.Gainsboro;
+        cmbSkillComparator.FormattingEnabled = true;
+        cmbSkillComparator.Location = new System.Drawing.Point(92, 57);
+        cmbSkillComparator.Margin = new Padding(4, 3, 4, 3);
+        cmbSkillComparator.Name = "cmbSkillComparator";
+        cmbSkillComparator.Size = new Size(206, 24);
+        cmbSkillComparator.TabIndex = 3;
+        cmbSkillComparator.Text = null;
+        cmbSkillComparator.TextPadding = new Padding(2);
+        // 
+        // lblSkillComparator
+        // 
+        lblSkillComparator.AutoSize = true;
+        lblSkillComparator.Location = new System.Drawing.Point(9, 59);
+        lblSkillComparator.Margin = new Padding(4, 0, 4, 0);
+        lblSkillComparator.Name = "lblSkillComparator";
+        lblSkillComparator.Size = new Size(74, 15);
+        lblSkillComparator.TabIndex = 2;
+        lblSkillComparator.Text = "Comparator:";
+        // 
+        // ConditionControl_SkillLevel
+        // 
+        AutoScaleDimensions = new SizeF(7F, 15F);
+        AutoScaleMode = AutoScaleMode.Font;
+        BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+        Controls.Add(grpSkillLevel);
+        Name = "ConditionControl_SkillLevel";
+        Size = new Size(310, 116);
+        grpSkillLevel.ResumeLayout(false);
+        grpSkillLevel.PerformLayout();
+        ((System.ComponentModel.ISupportInitialize)nudSkillValue).EndInit();
+        ResumeLayout(false);
+    }
+
+    #endregion
+
+    private DarkUI.Controls.DarkGroupBox grpSkillLevel;
+    private DarkUI.Controls.DarkNumericUpDown nudSkillValue;
+    private DarkUI.Controls.DarkComboBox cmbSkill;
+    private Label lblSkill;
+    private Label lblSkillValue;
+    private DarkUI.Controls.DarkComboBox cmbSkillComparator;
+    private Label lblSkillComparator;
+}
+

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/Conditions/ConditionControl_SkillLevel.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/Conditions/ConditionControl_SkillLevel.cs
@@ -1,0 +1,64 @@
+using System;
+using Intersect.Editor.Localization;
+using Intersect.Enums;
+using Intersect.Framework.Core.GameObjects.Conditions.ConditionMetadata;
+using Intersect.Framework.Core.GameObjects.Events;
+using Intersect.Framework.Core.GameObjects.Skills;
+
+namespace Intersect.Editor.Forms.Editors.Events.Event_Commands.Conditions;
+
+public partial class ConditionControl_SkillLevel : UserControl
+{
+    public ConditionControl_SkillLevel()
+    {
+        InitializeComponent();
+        InitLocalization();
+    }
+
+    public void InitLocalization()
+    {
+        grpSkillLevel.Text = Strings.EventConditional.skilllevel;
+        lblSkill.Text = Strings.EventConditional.skill;
+        lblSkillValue.Text = Strings.EventConditional.skilllevelvalue;
+        lblSkillComparator.Text = Strings.EventConditional.comparator;
+        
+        cmbSkill.Items.Clear();
+        cmbSkill.Items.Add(Strings.General.None);
+        cmbSkill.Items.AddRange(SkillDescriptor.Names);
+        
+        cmbSkillComparator.Items.Clear();
+        cmbSkillComparator.Items.AddRange(Strings.EventConditional.comparators.Values.ToArray());
+    }
+
+    public void SetupFormValues(SkillLevelCondition condition)
+    {
+        cmbSkillComparator.SelectedIndex = (int)condition.Comparator;
+        nudSkillValue.Value = condition.Value;
+        
+        var skillIndex = SkillDescriptor.ListIndex(condition.SkillId);
+        if (skillIndex > -1)
+        {
+            cmbSkill.SelectedIndex = skillIndex + 1;
+        }
+        else
+        {
+            cmbSkill.SelectedIndex = 0;
+        }
+    }
+
+    public void SaveFormValues(SkillLevelCondition condition)
+    {
+        condition.Comparator = (VariableComparator)cmbSkillComparator.SelectedIndex;
+        condition.Value = (int)nudSkillValue.Value;
+        
+        if (cmbSkill.SelectedIndex > 0)
+        {
+            condition.SkillId = SkillDescriptor.IdFromList(cmbSkill.SelectedIndex - 1);
+        }
+        else
+        {
+            condition.SkillId = Guid.Empty;
+        }
+    }
+}
+

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ConditionalBranch.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ConditionalBranch.cs
@@ -29,6 +29,7 @@ public partial class EventCommandConditionalBranch : UserControl
     private readonly ConditionControl_PlayerPower _playerPowerControl;
     private readonly ConditionControl_PlayerSpell _playerSpellControl;
     private readonly ConditionControl_PlayerStat _playerStatControl;
+    private readonly ConditionControl_SkillLevel _skillLevelControl;
     private readonly ConditionControl_QuestCanStart _questCanStartControl;
     private readonly ConditionControl_QuestCompleted _questCompletedControl;
     private readonly ConditionControl_QuestInProgress _questInProgressControl;
@@ -64,6 +65,7 @@ public partial class EventCommandConditionalBranch : UserControl
         _playerPowerControl = new();
         _playerSpellControl = new();
         _playerStatControl = new();
+        _skillLevelControl = new();
         _questCanStartControl = new();
         _questCompletedControl = new();
         _questInProgressControl = new();
@@ -83,6 +85,7 @@ public partial class EventCommandConditionalBranch : UserControl
         pnlConditionControl.Controls.Add(_playerPowerControl);
         pnlConditionControl.Controls.Add(_playerSpellControl);
         pnlConditionControl.Controls.Add(_playerStatControl);
+        pnlConditionControl.Controls.Add(_skillLevelControl);
         pnlConditionControl.Controls.Add(_questCanStartControl);
         pnlConditionControl.Controls.Add(_questCompletedControl);
         pnlConditionControl.Controls.Add(_questInProgressControl);
@@ -143,6 +146,7 @@ public partial class EventCommandConditionalBranch : UserControl
         _playerPowerControl.Hide();
         _playerSpellControl.Hide();
         _playerStatControl.Hide();
+        _skillLevelControl.Hide();
         _questCanStartControl.Hide();
         _questCompletedControl.Hide();
         _questInProgressControl.Hide();
@@ -202,6 +206,10 @@ public partial class EventCommandConditionalBranch : UserControl
 
             case ConditionType.LevelOrStat:
                 _playerStatControl.Show();
+                break;
+
+            case ConditionType.SkillLevel:
+                _skillLevelControl.Show();
                 break;
 
             case ConditionType.CanStartQuest:
@@ -292,6 +300,10 @@ public partial class EventCommandConditionalBranch : UserControl
                 _playerStatControl.SetupFormValues(playerStatCondition);
                 break;
 
+            case SkillLevelCondition skillLevelCondition:
+                _skillLevelControl.SetupFormValues(skillLevelCondition);
+                break;
+
             case CanStartQuestCondition questCanStartCondition:
                 _questCanStartControl.SetupFormValues(questCanStartCondition);
                 break;
@@ -378,6 +390,10 @@ public partial class EventCommandConditionalBranch : UserControl
 
             case LevelOrStatCondition playerStatCondition:
                 _playerStatControl.SaveFormValues(playerStatCondition);
+                break;
+
+            case SkillLevelCondition skillLevelCondition:
+                _skillLevelControl.SaveFormValues(skillLevelCondition);
                 break;
 
             case CanStartQuestCondition questCanStartCondition:
@@ -509,6 +525,10 @@ public partial class EventCommandConditionalBranch : UserControl
 
                 case ConditionType.LevelOrStat:
                     Condition = new LevelOrStatCondition();
+                    break;
+
+                case ConditionType.SkillLevel:
+                    Condition = new SkillLevelCondition();
                     break;
 
                 case ConditionType.CanStartQuest:

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_GiveSkillExperience.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_GiveSkillExperience.Designer.cs
@@ -1,0 +1,352 @@
+using DarkUI.Controls;
+
+namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
+{
+    partial class EventCommandGiveSkillExperience
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            grpGiveSkillExperience = new DarkGroupBox();
+            chkEnableLevelDown = new DarkCheckBox();
+            grpVariableAmount = new DarkGroupBox();
+            cmbVariable = new DarkComboBox();
+            lblVariable = new Label();
+            rdoGlobalVariable = new DarkRadioButton();
+            rdoGuildVariable = new DarkRadioButton();
+            rdoPlayerVariable = new DarkRadioButton();
+            grpAmountType = new DarkGroupBox();
+            rdoVariable = new DarkRadioButton();
+            rdoManual = new DarkRadioButton();
+            btnCancel = new DarkButton();
+            btnSave = new DarkButton();
+            grpManualAmount = new DarkGroupBox();
+            nudExperience = new DarkNumericUpDown();
+            lblExperience = new Label();
+            cmbSkill = new DarkComboBox();
+            lblSkill = new Label();
+            grpGiveSkillExperience.SuspendLayout();
+            grpVariableAmount.SuspendLayout();
+            grpAmountType.SuspendLayout();
+            grpManualAmount.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)nudExperience).BeginInit();
+            SuspendLayout();
+            // 
+            // grpGiveSkillExperience
+            // 
+            grpGiveSkillExperience.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            grpGiveSkillExperience.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            grpGiveSkillExperience.Controls.Add(chkEnableLevelDown);
+            grpGiveSkillExperience.Controls.Add(grpVariableAmount);
+            grpGiveSkillExperience.Controls.Add(grpAmountType);
+            grpGiveSkillExperience.Controls.Add(btnCancel);
+            grpGiveSkillExperience.Controls.Add(btnSave);
+            grpGiveSkillExperience.Controls.Add(grpManualAmount);
+            grpGiveSkillExperience.Controls.Add(cmbSkill);
+            grpGiveSkillExperience.Controls.Add(lblSkill);
+            grpGiveSkillExperience.ForeColor = System.Drawing.Color.Gainsboro;
+            grpGiveSkillExperience.Location = new System.Drawing.Point(4, 3);
+            grpGiveSkillExperience.Margin = new Padding(4, 3, 4, 3);
+            grpGiveSkillExperience.Name = "grpGiveSkillExperience";
+            grpGiveSkillExperience.Padding = new Padding(4, 3, 4, 3);
+            grpGiveSkillExperience.Size = new Size(498, 220);
+            grpGiveSkillExperience.TabIndex = 17;
+            grpGiveSkillExperience.TabStop = false;
+            grpGiveSkillExperience.Text = "Give Skill Experience";
+            // 
+            // chkEnableLevelDown
+            // 
+            chkEnableLevelDown.AutoSize = true;
+            chkEnableLevelDown.Location = new System.Drawing.Point(356, 150);
+            chkEnableLevelDown.Margin = new Padding(4, 3, 4, 3);
+            chkEnableLevelDown.Name = "chkEnableLevelDown";
+            chkEnableLevelDown.Size = new Size(130, 19);
+            chkEnableLevelDown.TabIndex = 41;
+            chkEnableLevelDown.Text = "Enable Level Down?";
+            // 
+            // grpVariableAmount
+            // 
+            grpVariableAmount.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            grpVariableAmount.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            grpVariableAmount.Controls.Add(cmbVariable);
+            grpVariableAmount.Controls.Add(lblVariable);
+            grpVariableAmount.Controls.Add(rdoGlobalVariable);
+            grpVariableAmount.Controls.Add(rdoGuildVariable);
+            grpVariableAmount.Controls.Add(rdoPlayerVariable);
+            grpVariableAmount.ForeColor = System.Drawing.Color.Gainsboro;
+            grpVariableAmount.Location = new System.Drawing.Point(7, 52);
+            grpVariableAmount.Margin = new Padding(4, 3, 4, 3);
+            grpVariableAmount.Name = "grpVariableAmount";
+            grpVariableAmount.Padding = new Padding(4, 3, 4, 3);
+            grpVariableAmount.Size = new Size(341, 119);
+            grpVariableAmount.TabIndex = 39;
+            grpVariableAmount.TabStop = false;
+            grpVariableAmount.Text = "Variable";
+            grpVariableAmount.Visible = false;
+            // 
+            // cmbVariable
+            // 
+            cmbVariable.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            cmbVariable.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            cmbVariable.BorderStyle = ButtonBorderStyle.Solid;
+            cmbVariable.ButtonColor = System.Drawing.Color.FromArgb(43, 43, 43);
+            cmbVariable.DrawDropdownHoverOutline = false;
+            cmbVariable.DrawFocusRectangle = false;
+            cmbVariable.DrawMode = DrawMode.OwnerDrawFixed;
+            cmbVariable.DropDownStyle = ComboBoxStyle.DropDownList;
+            cmbVariable.FlatStyle = FlatStyle.Flat;
+            cmbVariable.ForeColor = System.Drawing.Color.Gainsboro;
+            cmbVariable.FormattingEnabled = true;
+            cmbVariable.Location = new System.Drawing.Point(78, 83);
+            cmbVariable.Margin = new Padding(4, 3, 4, 3);
+            cmbVariable.Name = "cmbVariable";
+            cmbVariable.Size = new Size(255, 24);
+            cmbVariable.TabIndex = 39;
+            cmbVariable.Text = null;
+            cmbVariable.TextPadding = new Padding(2);
+            // 
+            // lblVariable
+            // 
+            lblVariable.AutoSize = true;
+            lblVariable.Location = new System.Drawing.Point(9, 85);
+            lblVariable.Margin = new Padding(4, 0, 4, 0);
+            lblVariable.Name = "lblVariable";
+            lblVariable.Size = new Size(48, 15);
+            lblVariable.TabIndex = 38;
+            lblVariable.Text = "Variable";
+            // 
+            // rdoGlobalVariable
+            // 
+            rdoGlobalVariable.AutoSize = true;
+            rdoGlobalVariable.Location = new System.Drawing.Point(192, 22);
+            rdoGlobalVariable.Margin = new Padding(4, 3, 4, 3);
+            rdoGlobalVariable.Name = "rdoGlobalVariable";
+            rdoGlobalVariable.Size = new Size(103, 19);
+            rdoGlobalVariable.TabIndex = 37;
+            rdoGlobalVariable.Text = "Server Variable";
+            rdoGlobalVariable.CheckedChanged += SetupAmountInput;
+            // 
+            // rdoGuildVariable
+            // 
+            rdoGuildVariable.AutoSize = true;
+            rdoGuildVariable.Location = new System.Drawing.Point(7, 48);
+            rdoGuildVariable.Margin = new Padding(4, 3, 4, 3);
+            rdoGuildVariable.Name = "rdoGuildVariable";
+            rdoGuildVariable.Size = new Size(97, 19);
+            rdoGuildVariable.TabIndex = 37;
+            rdoGuildVariable.Text = "Guild Variable";
+            rdoGuildVariable.CheckedChanged += SetupAmountInput;
+            // 
+            // rdoPlayerVariable
+            // 
+            rdoPlayerVariable.AutoSize = true;
+            rdoPlayerVariable.Checked = true;
+            rdoPlayerVariable.Location = new System.Drawing.Point(7, 22);
+            rdoPlayerVariable.Margin = new Padding(4, 3, 4, 3);
+            rdoPlayerVariable.Name = "rdoPlayerVariable";
+            rdoPlayerVariable.Size = new Size(101, 19);
+            rdoPlayerVariable.TabIndex = 36;
+            rdoPlayerVariable.TabStop = true;
+            rdoPlayerVariable.Text = "Player Variable";
+            rdoPlayerVariable.CheckedChanged += SetupAmountInput;
+            // 
+            // grpAmountType
+            // 
+            grpAmountType.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            grpAmountType.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            grpAmountType.Controls.Add(rdoVariable);
+            grpAmountType.Controls.Add(rdoManual);
+            grpAmountType.ForeColor = System.Drawing.Color.Gainsboro;
+            grpAmountType.Location = new System.Drawing.Point(356, 52);
+            grpAmountType.Margin = new Padding(4, 3, 4, 3);
+            grpAmountType.Name = "grpAmountType";
+            grpAmountType.Padding = new Padding(4, 3, 4, 3);
+            grpAmountType.Size = new Size(134, 82);
+            grpAmountType.TabIndex = 37;
+            grpAmountType.TabStop = false;
+            grpAmountType.Text = "Amount Type:";
+            // 
+            // rdoVariable
+            // 
+            rdoVariable.AutoSize = true;
+            rdoVariable.Location = new System.Drawing.Point(10, 48);
+            rdoVariable.Margin = new Padding(4, 3, 4, 3);
+            rdoVariable.Name = "rdoVariable";
+            rdoVariable.Size = new Size(66, 19);
+            rdoVariable.TabIndex = 36;
+            rdoVariable.Text = "Variable";
+            rdoVariable.CheckedChanged += SetupAmountInput;
+            // 
+            // rdoManual
+            // 
+            rdoManual.AutoSize = true;
+            rdoManual.Checked = true;
+            rdoManual.Location = new System.Drawing.Point(10, 22);
+            rdoManual.Margin = new Padding(4, 3, 4, 3);
+            rdoManual.Name = "rdoManual";
+            rdoManual.Size = new Size(65, 19);
+            rdoManual.TabIndex = 35;
+            rdoManual.TabStop = true;
+            rdoManual.Text = "Manual";
+            rdoManual.CheckedChanged += SetupAmountInput;
+            // 
+            // btnCancel
+            // 
+            btnCancel.Location = new System.Drawing.Point(260, 187);
+            btnCancel.Margin = new Padding(4, 3, 4, 3);
+            btnCancel.Name = "btnCancel";
+            btnCancel.Padding = new Padding(6);
+            btnCancel.Size = new Size(88, 27);
+            btnCancel.TabIndex = 20;
+            btnCancel.Text = "Cancel";
+            btnCancel.Click += btnCancel_Click;
+            // 
+            // btnSave
+            // 
+            btnSave.Location = new System.Drawing.Point(7, 187);
+            btnSave.Margin = new Padding(4, 3, 4, 3);
+            btnSave.Name = "btnSave";
+            btnSave.Padding = new Padding(6);
+            btnSave.Size = new Size(88, 27);
+            btnSave.TabIndex = 19;
+            btnSave.Text = "Ok";
+            btnSave.Click += btnSave_Click;
+            // 
+            // grpManualAmount
+            // 
+            grpManualAmount.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            grpManualAmount.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            grpManualAmount.Controls.Add(nudExperience);
+            grpManualAmount.Controls.Add(lblExperience);
+            grpManualAmount.ForeColor = System.Drawing.Color.Gainsboro;
+            grpManualAmount.Location = new System.Drawing.Point(7, 52);
+            grpManualAmount.Margin = new Padding(4, 3, 4, 3);
+            grpManualAmount.Name = "grpManualAmount";
+            grpManualAmount.Padding = new Padding(4, 3, 4, 3);
+            grpManualAmount.Size = new Size(341, 82);
+            grpManualAmount.TabIndex = 40;
+            grpManualAmount.TabStop = false;
+            grpManualAmount.Text = "Manual";
+            // 
+            // nudExperience
+            // 
+            nudExperience.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudExperience.ForeColor = System.Drawing.Color.Gainsboro;
+            nudExperience.Location = new System.Drawing.Point(152, 29);
+            nudExperience.Margin = new Padding(4, 3, 4, 3);
+            nudExperience.Maximum = new decimal(new int[] { 100000000, 0, 0, 0 });
+            nudExperience.Minimum = new decimal(new int[] { -100000000, 0, 0, -2147483648 });
+            nudExperience.Name = "nudExperience";
+            nudExperience.Size = new Size(164, 23);
+            nudExperience.TabIndex = 24;
+            nudExperience.Value = new decimal(new int[] { 0, 0, 0, 0 });
+            // 
+            // lblExperience
+            // 
+            lblExperience.AutoSize = true;
+            lblExperience.Location = new System.Drawing.Point(26, 31);
+            lblExperience.Margin = new Padding(4, 0, 4, 0);
+            lblExperience.Name = "lblExperience";
+            lblExperience.Size = new Size(96, 15);
+            lblExperience.TabIndex = 23;
+            lblExperience.Text = "Give Experience: ";
+            // 
+            // cmbSkill
+            // 
+            cmbSkill.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            cmbSkill.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            cmbSkill.BorderStyle = ButtonBorderStyle.Solid;
+            cmbSkill.ButtonColor = System.Drawing.Color.FromArgb(43, 43, 43);
+            cmbSkill.DrawDropdownHoverOutline = false;
+            cmbSkill.DrawFocusRectangle = false;
+            cmbSkill.DrawMode = DrawMode.OwnerDrawFixed;
+            cmbSkill.DropDownStyle = ComboBoxStyle.DropDownList;
+            cmbSkill.FlatStyle = FlatStyle.Flat;
+            cmbSkill.ForeColor = System.Drawing.Color.Gainsboro;
+            cmbSkill.FormattingEnabled = true;
+            cmbSkill.Location = new System.Drawing.Point(78, 22);
+            cmbSkill.Margin = new Padding(4, 3, 4, 3);
+            cmbSkill.Name = "cmbSkill";
+            cmbSkill.Size = new Size(270, 24);
+            cmbSkill.TabIndex = 42;
+            cmbSkill.Text = null;
+            cmbSkill.TextPadding = new Padding(2);
+            // 
+            // lblSkill
+            // 
+            lblSkill.AutoSize = true;
+            lblSkill.Location = new System.Drawing.Point(7, 25);
+            lblSkill.Margin = new Padding(4, 0, 4, 0);
+            lblSkill.Name = "lblSkill";
+            lblSkill.Size = new Size(32, 15);
+            lblSkill.TabIndex = 41;
+            lblSkill.Text = "Skill:";
+            // 
+            // EventCommandGiveSkillExperience
+            // 
+            AutoScaleDimensions = new SizeF(7F, 15F);
+            AutoScaleMode = AutoScaleMode.Font;
+            AutoSize = true;
+            BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+            Controls.Add(grpGiveSkillExperience);
+            Margin = new Padding(4, 3, 4, 3);
+            Name = "EventCommandGiveSkillExperience";
+            Size = new Size(509, 227);
+            grpGiveSkillExperience.ResumeLayout(false);
+            grpGiveSkillExperience.PerformLayout();
+            grpVariableAmount.ResumeLayout(false);
+            grpVariableAmount.PerformLayout();
+            grpAmountType.ResumeLayout(false);
+            grpAmountType.PerformLayout();
+            grpManualAmount.ResumeLayout(false);
+            grpManualAmount.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)nudExperience).EndInit();
+            ResumeLayout(false);
+        }
+
+        #endregion
+
+        private DarkGroupBox grpGiveSkillExperience;
+        private DarkButton btnCancel;
+        private DarkButton btnSave;
+        private DarkGroupBox grpAmountType;
+        private DarkRadioButton rdoVariable;
+        private DarkRadioButton rdoManual;
+        private DarkGroupBox grpManualAmount;
+        private DarkNumericUpDown nudExperience;
+        private System.Windows.Forms.Label lblExperience;
+        private DarkGroupBox grpVariableAmount;
+        private DarkComboBox cmbVariable;
+        private System.Windows.Forms.Label lblVariable;
+        private DarkRadioButton rdoGlobalVariable;
+        private DarkRadioButton rdoGuildVariable;
+        private DarkRadioButton rdoPlayerVariable;
+        private DarkCheckBox chkEnableLevelDown;
+        private DarkComboBox cmbSkill;
+        private System.Windows.Forms.Label lblSkill;
+    }
+}
+

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_GiveSkillExperience.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_GiveSkillExperience.cs
@@ -1,0 +1,196 @@
+using Intersect.Editor.Localization;
+using Intersect.Enums;
+using Intersect.Framework.Core.GameObjects.Events;
+using Intersect.Framework.Core.GameObjects.Events.Commands;
+using Intersect.Framework.Core.GameObjects.Skills;
+using Intersect.Framework.Core.GameObjects.Variables;
+
+namespace Intersect.Editor.Forms.Editors.Events.Event_Commands;
+
+public partial class EventCommandGiveSkillExperience : UserControl
+{
+    private readonly FrmEvent _eventEditor;
+
+    private readonly GiveSkillExperienceCommand _command;
+
+    public EventCommandGiveSkillExperience(GiveSkillExperienceCommand refCommand, FrmEvent editor)
+    {
+        InitializeComponent();
+        _command = refCommand;
+        _eventEditor = editor;
+        InitLocalization();
+
+        rdoVariable.Checked = _command.UseVariable;
+        rdoGlobalVariable.Checked = _command.VariableType == VariableType.ServerVariable;
+        rdoGuildVariable.Checked = _command.VariableType == VariableType.GuildVariable;
+
+        nudExperience.Minimum = -long.MaxValue;
+        nudExperience.Maximum = long.MaxValue;
+
+        chkEnableLevelDown.Checked = _command.EnableLosingLevels;
+
+        // Populate skill combo box
+        cmbSkill.Items.Clear();
+        cmbSkill.Items.Add(Strings.General.None);
+        cmbSkill.Items.AddRange(SkillDescriptor.Names);
+        
+        var skillIndex = SkillDescriptor.ListIndex(_command.SkillId);
+        if (skillIndex > -1)
+        {
+            cmbSkill.SelectedIndex = skillIndex + 1;
+        }
+        else
+        {
+            cmbSkill.SelectedIndex = 0;
+        }
+
+        SetupAmountInput(default, default);
+    }
+
+    private void InitLocalization()
+    {
+        grpGiveSkillExperience.Text = "Give Skill Experience";
+        lblSkill.Text = "Skill:";
+        lblExperience.Text = "Experience:";
+        lblVariable.Text = "Variable:";
+
+        grpAmountType.Text = "Amount Type";
+        rdoManual.Text = "Manual";
+        rdoVariable.Text = "Variable";
+
+        grpManualAmount.Text = "Manual";
+        grpVariableAmount.Text = "Variable";
+
+        rdoPlayerVariable.Text = "Player Variable";
+        rdoGlobalVariable.Text = "Server Variable";
+        rdoGuildVariable.Text = "Guild Variable";
+
+        chkEnableLevelDown.Text = "Enable Losing Levels";
+
+        btnSave.Text = Strings.General.Okay;
+        btnCancel.Text = Strings.General.Cancel;
+    }
+
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        if (cmbSkill.SelectedIndex > 0)
+        {
+            _command.SkillId = SkillDescriptor.IdFromList(cmbSkill.SelectedIndex - 1);
+        }
+        else
+        {
+            _command.SkillId = Guid.Empty;
+        }
+
+        _command.Exp = (long)nudExperience.Value;
+
+        if (rdoPlayerVariable.Checked)
+        {
+            _command.VariableType = VariableType.PlayerVariable;
+            _command.VariableId = PlayerVariableDescriptor.IdFromList(cmbVariable.SelectedIndex, VariableDataType.Integer);
+        }
+        else if (rdoGlobalVariable.Checked)
+        {
+            _command.VariableType = VariableType.ServerVariable;
+            _command.VariableId = ServerVariableDescriptor.IdFromList(cmbVariable.SelectedIndex, VariableDataType.Integer);
+        }
+        else if (rdoGuildVariable.Checked)
+        {
+            _command.VariableType = VariableType.GuildVariable;
+            _command.VariableId = GuildVariableDescriptor.IdFromList(cmbVariable.SelectedIndex, VariableDataType.Integer);
+        }
+
+        _command.UseVariable = !rdoManual.Checked;
+        _command.EnableLosingLevels = chkEnableLevelDown.Checked;
+        _eventEditor.FinishCommandEdit();
+    }
+
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        _eventEditor.CancelCommandEdit();
+    }
+
+    private void VariableBlank()
+    {
+        if (cmbVariable.Items.Count > 0)
+        {
+            cmbVariable.SelectedIndex = 0;
+        }
+        else
+        {
+            cmbVariable.SelectedIndex = -1;
+            cmbVariable.Text = string.Empty;
+        }
+    }
+
+    private void SetupAmountInput(object? sender, EventArgs? e)
+    {
+        grpManualAmount.Visible = rdoManual.Checked;
+        grpVariableAmount.Visible = !rdoManual.Checked;
+
+        cmbVariable.Items.Clear();
+        if (rdoPlayerVariable.Checked)
+        {
+            cmbVariable.Items.AddRange(PlayerVariableDescriptor.GetNamesByType(VariableDataType.Integer));
+            if (_command.VariableType == VariableType.PlayerVariable)
+            {
+                var index = PlayerVariableDescriptor.ListIndex(_command.VariableId, VariableDataType.Integer);
+                if (index > -1)
+                {
+                    cmbVariable.SelectedIndex = index;
+                }
+                else
+                {
+                    VariableBlank();
+                }
+            }
+            else
+            {
+                VariableBlank();
+            }
+        }
+        else if (rdoGlobalVariable.Checked)
+        {
+            cmbVariable.Items.AddRange(ServerVariableDescriptor.GetNamesByType(VariableDataType.Integer));
+            if (_command.VariableType == VariableType.ServerVariable)
+            {
+                var index = ServerVariableDescriptor.ListIndex(_command.VariableId, VariableDataType.Integer);
+                if (index > -1)
+                {
+                    cmbVariable.SelectedIndex = index;
+                }
+                else
+                {
+                    VariableBlank();
+                }
+            }
+            else
+            {
+                VariableBlank();
+            }
+        }
+        else if (rdoGuildVariable.Checked)
+        {
+            cmbVariable.Items.AddRange(GuildVariableDescriptor.GetNamesByType(VariableDataType.Integer));
+            if (_command.VariableType == VariableType.GuildVariable)
+            {
+                var index = GuildVariableDescriptor.ListIndex(_command.VariableId, VariableDataType.Integer);
+                if (index > -1)
+                {
+                    cmbVariable.SelectedIndex = index;
+                }
+                else
+                {
+                    VariableBlank();
+                }
+            }
+            else
+            {
+                VariableBlank();
+            }
+        }
+
+        nudExperience.Value = _command.Exp;
+    }
+}
+

--- a/Intersect.Editor/Forms/Editors/Events/frmEvent.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/Events/frmEvent.Designer.cs
@@ -51,6 +51,7 @@ namespace Intersect.Editor.Forms.Editors.Events
             var restoreMPTreeNode = new TreeNode("Restore MP");
             var levelUpTreeNode = new TreeNode("Level Up");
             var giveExperienceTreeNode = new TreeNode("Give Experience");
+            var giveSkillExperienceTreeNode = new TreeNode("Give Skill Experience");
             var changeLevelTreeNode = new TreeNode("Change Level");
             var changeSpellsTreeNode = new TreeNode("Change Spells");
             var changeItemsTreeNode = new TreeNode("Change Items");
@@ -66,7 +67,7 @@ namespace Intersect.Editor.Forms.Editors.Events
             var changePlayerNameTreeNode = new TreeNode("Change Player Name");
             var resetStatPointTreeNode = new TreeNode("Reset Stat Point Allocations");
             var castSpellOnTreeNode = new TreeNode("Cast Spell On");
-            var playerControlTreeNode = new TreeNode("Player Control", new TreeNode[] { restoreHPTreeNode, restoreMPTreeNode, levelUpTreeNode, giveExperienceTreeNode, changeLevelTreeNode, changeSpellsTreeNode, changeItemsTreeNode, changeSpriteTreeNode, changePlayerColorTreeNode, changeFaceTreeNode, changeGenderTreeNode, setAccessTreeNode, changeClassTreeNode, equipUneqiupTreeNode, changeNameColorTreeNode, changePlayerLabelTreeNode, changePlayerNameTreeNode, resetStatPointTreeNode, castSpellOnTreeNode });
+            var playerControlTreeNode = new TreeNode("Player Control", new TreeNode[] { restoreHPTreeNode, restoreMPTreeNode, levelUpTreeNode, giveExperienceTreeNode, giveSkillExperienceTreeNode, changeLevelTreeNode, changeSpellsTreeNode, changeItemsTreeNode, changeSpriteTreeNode, changePlayerColorTreeNode, changeFaceTreeNode, changeGenderTreeNode, setAccessTreeNode, changeClassTreeNode, equipUneqiupTreeNode, changeNameColorTreeNode, changePlayerLabelTreeNode, changePlayerNameTreeNode, resetStatPointTreeNode, castSpellOnTreeNode });
             var warpPlayerTreeNode = new TreeNode("Warp Player");
             var setMoveRouteTreeNode = new TreeNode("Set Move Route");
             var waitForRouteCompleteTreeNode = new TreeNode("Wait for Route Completion");
@@ -882,6 +883,9 @@ namespace Intersect.Editor.Forms.Editors.Events
             giveExperienceTreeNode.Name = "giveexperience";
             giveExperienceTreeNode.Tag = (int)EventCommandType.GiveExperience;
             giveExperienceTreeNode.Text = "Give Experience";
+            giveSkillExperienceTreeNode.Name = "giveskillexperience";
+            giveSkillExperienceTreeNode.Tag = (int)EventCommandType.GiveSkillExperience;
+            giveSkillExperienceTreeNode.Text = "Give Skill Experience";
             changeLevelTreeNode.Name = "changelevel";
             changeLevelTreeNode.Tag = (int)EventCommandType.ChangeLevel;
             changeLevelTreeNode.Text = "Change Level";

--- a/Intersect.Editor/Forms/Editors/Events/frmEvent.cs
+++ b/Intersect.Editor/Forms/Editors/Events/frmEvent.cs
@@ -579,6 +579,10 @@ public partial class FrmEvent : Form
                 tmpCommand = new GiveExperienceCommand();
 
                 break;
+            case EventCommandType.GiveSkillExperience:
+                tmpCommand = new GiveSkillExperienceCommand();
+
+                break;
             case EventCommandType.ChangeLevel:
                 tmpCommand = new ChangeLevelCommand();
 
@@ -1235,6 +1239,10 @@ public partial class FrmEvent : Form
                 break;
             case EventCommandType.GiveExperience:
                 cmdWindow = new EventCommandGiveExperience((GiveExperienceCommand)command, this);
+
+                break;
+            case EventCommandType.GiveSkillExperience:
+                cmdWindow = new EventCommandGiveSkillExperience((GiveSkillExperienceCommand)command, this);
 
                 break;
             case EventCommandType.ChangeLevel:

--- a/Intersect.Editor/Forms/Editors/frmSkill.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/frmSkill.Designer.cs
@@ -1,0 +1,565 @@
+using DarkUI.Controls;
+
+namespace Intersect.Editor.Forms.Editors
+{
+    partial class FrmSkill
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            components = new System.ComponentModel.Container();
+            var resources = new System.ComponentModel.ComponentResourceManager(typeof(FrmSkill));
+            grpSkills = new DarkGroupBox();
+            btnClearSearch = new DarkButton();
+            txtSearch = new DarkTextBox();
+            lstGameObjects = new Controls.GameObjectList();
+            pnlContainer = new Panel();
+            grpGeneral = new DarkGroupBox();
+            txtIcon = new DarkTextBox();
+            lblIcon = new Label();
+            txtDescription = new DarkTextBox();
+            lblDescription = new Label();
+            nudExperienceIncrease = new DarkNumericUpDown();
+            lblExperienceIncrease = new Label();
+            nudBaseExperience = new DarkNumericUpDown();
+            lblBaseExperience = new Label();
+            nudMaxLevel = new DarkNumericUpDown();
+            lblMaxLevel = new Label();
+            btnAddFolder = new DarkButton();
+            lblFolder = new Label();
+            cmbFolder = new DarkComboBox();
+            lblName = new Label();
+            txtName = new DarkTextBox();
+            btnCancel = new DarkButton();
+            btnSave = new DarkButton();
+            toolStrip = new DarkToolStrip();
+            toolStripItemNew = new ToolStripButton();
+            toolStripSeparator1 = new ToolStripSeparator();
+            toolStripItemDelete = new ToolStripButton();
+            toolStripSeparator2 = new ToolStripSeparator();
+            btnAlphabetical = new ToolStripButton();
+            toolStripSeparator4 = new ToolStripSeparator();
+            toolStripItemCopy = new ToolStripButton();
+            toolStripItemPaste = new ToolStripButton();
+            toolStripSeparator3 = new ToolStripSeparator();
+            toolStripItemUndo = new ToolStripButton();
+            grpSkills.SuspendLayout();
+            pnlContainer.SuspendLayout();
+            grpGeneral.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)nudExperienceIncrease).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)nudBaseExperience).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)nudMaxLevel).BeginInit();
+            toolStrip.SuspendLayout();
+            SuspendLayout();
+            // 
+            // grpSkills
+            // 
+            grpSkills.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+            grpSkills.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            grpSkills.Controls.Add(btnClearSearch);
+            grpSkills.Controls.Add(txtSearch);
+            grpSkills.Controls.Add(lstGameObjects);
+            grpSkills.ForeColor = System.Drawing.Color.Gainsboro;
+            grpSkills.Location = new System.Drawing.Point(14, 45);
+            grpSkills.Margin = new Padding(4, 3, 4, 3);
+            grpSkills.Name = "grpSkills";
+            grpSkills.Padding = new Padding(4, 3, 4, 3);
+            grpSkills.Size = new Size(237, 635);
+            grpSkills.TabIndex = 14;
+            grpSkills.TabStop = false;
+            grpSkills.Text = "Skills";
+            // 
+            // btnClearSearch
+            // 
+            btnClearSearch.Location = new System.Drawing.Point(209, 22);
+            btnClearSearch.Margin = new Padding(4, 3, 4, 3);
+            btnClearSearch.Name = "btnClearSearch";
+            btnClearSearch.Padding = new Padding(6);
+            btnClearSearch.Size = new Size(21, 23);
+            btnClearSearch.TabIndex = 34;
+            btnClearSearch.Text = "X";
+            btnClearSearch.Click += btnClearSearch_Click;
+            // 
+            // txtSearch
+            // 
+            txtSearch.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            txtSearch.BorderStyle = BorderStyle.FixedSingle;
+            txtSearch.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            txtSearch.Location = new System.Drawing.Point(7, 22);
+            txtSearch.Margin = new Padding(4, 3, 4, 3);
+            txtSearch.Name = "txtSearch";
+            txtSearch.Size = new Size(194, 23);
+            txtSearch.TabIndex = 33;
+            txtSearch.Text = "Search...";
+            txtSearch.TextChanged += txtSearch_TextChanged;
+            // 
+            // lstGameObjects
+            // 
+            lstGameObjects.AllowDrop = true;
+            lstGameObjects.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            lstGameObjects.BorderStyle = BorderStyle.None;
+            lstGameObjects.ForeColor = System.Drawing.Color.Gainsboro;
+            lstGameObjects.HideSelection = false;
+            lstGameObjects.ImageIndex = 0;
+            lstGameObjects.LineColor = System.Drawing.Color.FromArgb(150, 150, 150);
+            lstGameObjects.Location = new System.Drawing.Point(7, 52);
+            lstGameObjects.Margin = new Padding(4, 3, 4, 3);
+            lstGameObjects.Name = "lstGameObjects";
+            lstGameObjects.SelectedImageIndex = 0;
+            lstGameObjects.Size = new Size(223, 572);
+            lstGameObjects.TabIndex = 32;
+            // 
+            // pnlContainer
+            // 
+            pnlContainer.AutoScroll = true;
+            pnlContainer.Controls.Add(grpGeneral);
+            pnlContainer.Location = new System.Drawing.Point(258, 45);
+            pnlContainer.Margin = new Padding(4, 3, 4, 3);
+            pnlContainer.Name = "pnlContainer";
+            pnlContainer.Size = new Size(853, 635);
+            pnlContainer.TabIndex = 18;
+            pnlContainer.Visible = false;
+            // 
+            // grpGeneral
+            // 
+            grpGeneral.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+            grpGeneral.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            grpGeneral.Controls.Add(txtIcon);
+            grpGeneral.Controls.Add(lblIcon);
+            grpGeneral.Controls.Add(txtDescription);
+            grpGeneral.Controls.Add(lblDescription);
+            grpGeneral.Controls.Add(nudExperienceIncrease);
+            grpGeneral.Controls.Add(lblExperienceIncrease);
+            grpGeneral.Controls.Add(nudBaseExperience);
+            grpGeneral.Controls.Add(lblBaseExperience);
+            grpGeneral.Controls.Add(nudMaxLevel);
+            grpGeneral.Controls.Add(lblMaxLevel);
+            grpGeneral.Controls.Add(btnAddFolder);
+            grpGeneral.Controls.Add(lblFolder);
+            grpGeneral.Controls.Add(cmbFolder);
+            grpGeneral.Controls.Add(lblName);
+            grpGeneral.Controls.Add(txtName);
+            grpGeneral.ForeColor = System.Drawing.Color.Gainsboro;
+            grpGeneral.Location = new System.Drawing.Point(0, 0);
+            grpGeneral.Margin = new Padding(4, 3, 4, 3);
+            grpGeneral.Name = "grpGeneral";
+            grpGeneral.Padding = new Padding(4, 3, 4, 3);
+            grpGeneral.Size = new Size(500, 400);
+            grpGeneral.TabIndex = 15;
+            grpGeneral.TabStop = false;
+            grpGeneral.Text = "General";
+            // 
+            // txtIcon
+            // 
+            txtIcon.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            txtIcon.BorderStyle = BorderStyle.FixedSingle;
+            txtIcon.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            txtIcon.Location = new System.Drawing.Point(108, 200);
+            txtIcon.Margin = new Padding(4, 3, 4, 3);
+            txtIcon.Name = "txtIcon";
+            txtIcon.Size = new Size(380, 23);
+            txtIcon.TabIndex = 15;
+            txtIcon.TextChanged += txtIcon_TextChanged;
+            // 
+            // lblIcon
+            // 
+            lblIcon.AutoSize = true;
+            lblIcon.Location = new System.Drawing.Point(7, 203);
+            lblIcon.Margin = new Padding(4, 0, 4, 0);
+            lblIcon.Name = "lblIcon";
+            lblIcon.Size = new Size(33, 15);
+            lblIcon.TabIndex = 14;
+            lblIcon.Text = "Icon:";
+            // 
+            // txtDescription
+            // 
+            txtDescription.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            txtDescription.BorderStyle = BorderStyle.FixedSingle;
+            txtDescription.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            txtDescription.Location = new System.Drawing.Point(108, 170);
+            txtDescription.Margin = new Padding(4, 3, 4, 3);
+            txtDescription.Name = "txtDescription";
+            txtDescription.Size = new Size(380, 23);
+            txtDescription.TabIndex = 13;
+            txtDescription.TextChanged += txtDescription_TextChanged;
+            // 
+            // lblDescription
+            // 
+            lblDescription.AutoSize = true;
+            lblDescription.Location = new System.Drawing.Point(7, 173);
+            lblDescription.Margin = new Padding(4, 0, 4, 0);
+            lblDescription.Name = "lblDescription";
+            lblDescription.Size = new Size(70, 15);
+            lblDescription.TabIndex = 12;
+            lblDescription.Text = "Description:";
+            // 
+            // nudExperienceIncrease
+            // 
+            nudExperienceIncrease.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudExperienceIncrease.ForeColor = System.Drawing.Color.Gainsboro;
+            nudExperienceIncrease.Location = new System.Drawing.Point(150, 140);
+            nudExperienceIncrease.Margin = new Padding(4, 3, 4, 3);
+            nudExperienceIncrease.Maximum = new decimal(new int[] { 1000000, 0, 0, 0 });
+            nudExperienceIncrease.Minimum = new decimal(new int[] { 0, 0, 0, 0 });
+            nudExperienceIncrease.Name = "nudExperienceIncrease";
+            nudExperienceIncrease.Size = new Size(338, 23);
+            nudExperienceIncrease.TabIndex = 11;
+            nudExperienceIncrease.Value = new decimal(new int[] { 50, 0, 0, 0 });
+            nudExperienceIncrease.ValueChanged += nudExperienceIncrease_ValueChanged;
+            // 
+            // lblExperienceIncrease
+            // 
+            lblExperienceIncrease.AutoSize = true;
+            lblExperienceIncrease.Location = new System.Drawing.Point(7, 143);
+            lblExperienceIncrease.Margin = new Padding(4, 0, 4, 0);
+            lblExperienceIncrease.Name = "lblExperienceIncrease";
+            lblExperienceIncrease.Size = new Size(120, 15);
+            lblExperienceIncrease.TabIndex = 10;
+            lblExperienceIncrease.Text = "Experience Increase:";
+            // 
+            // nudBaseExperience
+            // 
+            nudBaseExperience.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudBaseExperience.ForeColor = System.Drawing.Color.Gainsboro;
+            nudBaseExperience.Location = new System.Drawing.Point(150, 110);
+            nudBaseExperience.Margin = new Padding(4, 3, 4, 3);
+            nudBaseExperience.Maximum = new decimal(new int[] { 1000000, 0, 0, 0 });
+            nudBaseExperience.Minimum = new decimal(new int[] { 0, 0, 0, 0 });
+            nudBaseExperience.Name = "nudBaseExperience";
+            nudBaseExperience.Size = new Size(338, 23);
+            nudBaseExperience.TabIndex = 9;
+            nudBaseExperience.Value = new decimal(new int[] { 100, 0, 0, 0 });
+            nudBaseExperience.ValueChanged += nudBaseExperience_ValueChanged;
+            // 
+            // lblBaseExperience
+            // 
+            lblBaseExperience.AutoSize = true;
+            lblBaseExperience.Location = new System.Drawing.Point(7, 113);
+            lblBaseExperience.Margin = new Padding(4, 0, 4, 0);
+            lblBaseExperience.Name = "lblBaseExperience";
+            lblBaseExperience.Size = new Size(98, 15);
+            lblBaseExperience.TabIndex = 8;
+            lblBaseExperience.Text = "Base Experience:";
+            // 
+            // nudMaxLevel
+            // 
+            nudMaxLevel.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudMaxLevel.ForeColor = System.Drawing.Color.Gainsboro;
+            nudMaxLevel.Location = new System.Drawing.Point(108, 80);
+            nudMaxLevel.Margin = new Padding(4, 3, 4, 3);
+            nudMaxLevel.Maximum = new decimal(new int[] { 999, 0, 0, 0 });
+            nudMaxLevel.Minimum = new decimal(new int[] { 1, 0, 0, 0 });
+            nudMaxLevel.Name = "nudMaxLevel";
+            nudMaxLevel.Size = new Size(380, 23);
+            nudMaxLevel.TabIndex = 7;
+            nudMaxLevel.Value = new decimal(new int[] { 99, 0, 0, 0 });
+            nudMaxLevel.ValueChanged += nudMaxLevel_ValueChanged;
+            // 
+            // lblMaxLevel
+            // 
+            lblMaxLevel.AutoSize = true;
+            lblMaxLevel.Location = new System.Drawing.Point(7, 83);
+            lblMaxLevel.Margin = new Padding(4, 0, 4, 0);
+            lblMaxLevel.Name = "lblMaxLevel";
+            lblMaxLevel.Size = new Size(65, 15);
+            lblMaxLevel.TabIndex = 6;
+            lblMaxLevel.Text = "Max Level:";
+            // 
+            // btnAddFolder
+            // 
+            btnAddFolder.Location = new System.Drawing.Point(224, 52);
+            btnAddFolder.Margin = new Padding(4, 3, 4, 3);
+            btnAddFolder.Name = "btnAddFolder";
+            btnAddFolder.Padding = new Padding(6);
+            btnAddFolder.Size = new Size(21, 24);
+            btnAddFolder.TabIndex = 5;
+            btnAddFolder.Text = "+";
+            btnAddFolder.Click += btnAddFolder_Click;
+            // 
+            // lblFolder
+            // 
+            lblFolder.AutoSize = true;
+            lblFolder.Location = new System.Drawing.Point(7, 55);
+            lblFolder.Margin = new Padding(4, 0, 4, 0);
+            lblFolder.Name = "lblFolder";
+            lblFolder.Size = new Size(43, 15);
+            lblFolder.TabIndex = 4;
+            lblFolder.Text = "Folder:";
+            // 
+            // cmbFolder
+            // 
+            cmbFolder.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            cmbFolder.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            cmbFolder.BorderStyle = ButtonBorderStyle.Solid;
+            cmbFolder.ButtonColor = System.Drawing.Color.FromArgb(43, 43, 43);
+            cmbFolder.DrawDropdownHoverOutline = false;
+            cmbFolder.DrawFocusRectangle = false;
+            cmbFolder.DrawMode = DrawMode.OwnerDrawFixed;
+            cmbFolder.DropDownStyle = ComboBoxStyle.DropDown;
+            cmbFolder.FlatStyle = FlatStyle.Flat;
+            cmbFolder.ForeColor = System.Drawing.Color.Gainsboro;
+            cmbFolder.FormattingEnabled = true;
+            cmbFolder.Location = new System.Drawing.Point(88, 52);
+            cmbFolder.Margin = new Padding(4, 3, 4, 3);
+            cmbFolder.Name = "cmbFolder";
+            cmbFolder.Size = new Size(131, 24);
+            cmbFolder.TabIndex = 3;
+            cmbFolder.Text = null;
+            cmbFolder.TextPadding = new Padding(2);
+            cmbFolder.TextChanged += cmbFolder_TextChanged;
+            // 
+            // lblName
+            // 
+            lblName.AutoSize = true;
+            lblName.Location = new System.Drawing.Point(7, 23);
+            lblName.Margin = new Padding(4, 0, 4, 0);
+            lblName.Name = "lblName";
+            lblName.Size = new Size(42, 15);
+            lblName.TabIndex = 2;
+            lblName.Text = "Name:";
+            // 
+            // txtName
+            // 
+            txtName.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            txtName.BorderStyle = BorderStyle.FixedSingle;
+            txtName.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            txtName.Location = new System.Drawing.Point(88, 23);
+            txtName.Margin = new Padding(4, 3, 4, 3);
+            txtName.Name = "txtName";
+            txtName.Size = new Size(400, 23);
+            txtName.TabIndex = 1;
+            txtName.TextChanged += txtName_TextChanged;
+            // 
+            // btnCancel
+            // 
+            btnCancel.DialogResult = DialogResult.Cancel;
+            btnCancel.Location = new System.Drawing.Point(887, 688);
+            btnCancel.Margin = new Padding(4, 3, 4, 3);
+            btnCancel.Name = "btnCancel";
+            btnCancel.Padding = new Padding(6);
+            btnCancel.Size = new Size(222, 31);
+            btnCancel.TabIndex = 44;
+            btnCancel.Text = "Cancel";
+            btnCancel.Click += btnCancel_Click;
+            // 
+            // btnSave
+            // 
+            btnSave.Location = new System.Drawing.Point(658, 688);
+            btnSave.Margin = new Padding(4, 3, 4, 3);
+            btnSave.Name = "btnSave";
+            btnSave.Padding = new Padding(6);
+            btnSave.Size = new Size(222, 31);
+            btnSave.TabIndex = 41;
+            btnSave.Text = "Save";
+            btnSave.Click += btnSave_Click;
+            // 
+            // toolStrip
+            // 
+            toolStrip.AutoSize = false;
+            toolStrip.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+            toolStrip.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStrip.Items.AddRange(new ToolStripItem[] { toolStripItemNew, toolStripSeparator1, toolStripItemDelete, toolStripSeparator2, btnAlphabetical, toolStripSeparator4, toolStripItemCopy, toolStripItemPaste, toolStripSeparator3, toolStripItemUndo });
+            toolStrip.Location = new System.Drawing.Point(0, 0);
+            toolStrip.Name = "toolStrip";
+            toolStrip.Padding = new Padding(6, 0, 1, 0);
+            toolStrip.Size = new Size(1119, 29);
+            toolStrip.TabIndex = 47;
+            toolStrip.Text = "toolStrip1";
+            // 
+            // toolStripItemNew
+            // 
+            toolStripItemNew.DisplayStyle = ToolStripItemDisplayStyle.Image;
+            toolStripItemNew.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripItemNew.Image = (Image)resources.GetObject("toolStripItemNew.Image");
+            toolStripItemNew.ImageTransparentColor = System.Drawing.Color.Magenta;
+            toolStripItemNew.Name = "toolStripItemNew";
+            toolStripItemNew.Size = new Size(23, 26);
+            toolStripItemNew.Text = "New";
+            toolStripItemNew.Click += toolStripItemNew_Click;
+            // 
+            // toolStripSeparator1
+            // 
+            toolStripSeparator1.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripSeparator1.Margin = new Padding(0, 0, 2, 0);
+            toolStripSeparator1.Name = "toolStripSeparator1";
+            toolStripSeparator1.Size = new Size(6, 29);
+            // 
+            // toolStripItemDelete
+            // 
+            toolStripItemDelete.DisplayStyle = ToolStripItemDisplayStyle.Image;
+            toolStripItemDelete.Enabled = false;
+            toolStripItemDelete.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripItemDelete.Image = (Image)resources.GetObject("toolStripItemDelete.Image");
+            toolStripItemDelete.ImageTransparentColor = System.Drawing.Color.Magenta;
+            toolStripItemDelete.Name = "toolStripItemDelete";
+            toolStripItemDelete.Size = new Size(23, 26);
+            toolStripItemDelete.Text = "Delete";
+            toolStripItemDelete.Click += toolStripItemDelete_Click;
+            // 
+            // toolStripSeparator2
+            // 
+            toolStripSeparator2.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripSeparator2.Margin = new Padding(0, 0, 2, 0);
+            toolStripSeparator2.Name = "toolStripSeparator2";
+            toolStripSeparator2.Size = new Size(6, 29);
+            // 
+            // btnAlphabetical
+            // 
+            btnAlphabetical.DisplayStyle = ToolStripItemDisplayStyle.Image;
+            btnAlphabetical.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            btnAlphabetical.Image = (Image)resources.GetObject("btnAlphabetical.Image");
+            btnAlphabetical.ImageTransparentColor = System.Drawing.Color.Magenta;
+            btnAlphabetical.Name = "btnAlphabetical";
+            btnAlphabetical.Size = new Size(23, 26);
+            btnAlphabetical.Text = "Order Alphabetically";
+            btnAlphabetical.Click += btnAlphabetical_Click;
+            // 
+            // toolStripSeparator4
+            // 
+            toolStripSeparator4.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripSeparator4.Margin = new Padding(0, 0, 2, 0);
+            toolStripSeparator4.Name = "toolStripSeparator4";
+            toolStripSeparator4.Size = new Size(6, 29);
+            // 
+            // toolStripItemCopy
+            // 
+            toolStripItemCopy.DisplayStyle = ToolStripItemDisplayStyle.Image;
+            toolStripItemCopy.Enabled = false;
+            toolStripItemCopy.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripItemCopy.Image = (Image)resources.GetObject("toolStripItemCopy.Image");
+            toolStripItemCopy.ImageTransparentColor = System.Drawing.Color.Magenta;
+            toolStripItemCopy.Name = "toolStripItemCopy";
+            toolStripItemCopy.Size = new Size(23, 26);
+            toolStripItemCopy.Text = "Copy";
+            toolStripItemCopy.Click += toolStripItemCopy_Click;
+            // 
+            // toolStripItemPaste
+            // 
+            toolStripItemPaste.DisplayStyle = ToolStripItemDisplayStyle.Image;
+            toolStripItemPaste.Enabled = false;
+            toolStripItemPaste.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripItemPaste.Image = (Image)resources.GetObject("toolStripItemPaste.Image");
+            toolStripItemPaste.ImageTransparentColor = System.Drawing.Color.Magenta;
+            toolStripItemPaste.Name = "toolStripItemPaste";
+            toolStripItemPaste.Size = new Size(23, 26);
+            toolStripItemPaste.Text = "Paste";
+            toolStripItemPaste.Click += toolStripItemPaste_Click;
+            // 
+            // toolStripSeparator3
+            // 
+            toolStripSeparator3.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripSeparator3.Margin = new Padding(0, 0, 2, 0);
+            toolStripSeparator3.Name = "toolStripSeparator3";
+            toolStripSeparator3.Size = new Size(6, 29);
+            // 
+            // toolStripItemUndo
+            // 
+            toolStripItemUndo.DisplayStyle = ToolStripItemDisplayStyle.Image;
+            toolStripItemUndo.Enabled = false;
+            toolStripItemUndo.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripItemUndo.Image = (Image)resources.GetObject("toolStripItemUndo.Image");
+            toolStripItemUndo.ImageTransparentColor = System.Drawing.Color.Magenta;
+            toolStripItemUndo.Name = "toolStripItemUndo";
+            toolStripItemUndo.Size = new Size(23, 26);
+            toolStripItemUndo.Text = "Undo";
+            toolStripItemUndo.Click += toolStripItemUndo_Click;
+            // 
+            // FrmSkill
+            // 
+            AutoScaleDimensions = new SizeF(7F, 15F);
+            AutoScaleMode = AutoScaleMode.Font;
+            AutoSize = true;
+            BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+            ClientSize = new Size(1119, 728);
+            ControlBox = true;
+            Controls.Add(toolStrip);
+            Controls.Add(btnCancel);
+            Controls.Add(btnSave);
+            Controls.Add(grpSkills);
+            Controls.Add(pnlContainer);
+            FormBorderStyle = FormBorderStyle.FixedSingle;
+            KeyPreview = true;
+            Margin = new Padding(4, 3, 4, 3);
+            MinimizeBox = false;
+            MaximizeBox = false;
+            Name = "FrmSkill";
+            StartPosition = FormStartPosition.CenterScreen;
+            Text = "Skill Editor";
+            FormClosed += frmSkill_FormClosed;
+            Load += frmSkill_Load;
+            KeyDown += form_KeyDown;
+            grpSkills.ResumeLayout(false);
+            grpSkills.PerformLayout();
+            pnlContainer.ResumeLayout(false);
+            grpGeneral.ResumeLayout(false);
+            grpGeneral.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)nudExperienceIncrease).EndInit();
+            ((System.ComponentModel.ISupportInitialize)nudBaseExperience).EndInit();
+            ((System.ComponentModel.ISupportInitialize)nudMaxLevel).EndInit();
+            toolStrip.ResumeLayout(false);
+            toolStrip.PerformLayout();
+            ResumeLayout(false);
+        }
+
+        #endregion
+
+        private DarkGroupBox grpSkills;
+        private DarkGroupBox grpGeneral;
+        private System.Windows.Forms.Label lblName;
+        private DarkTextBox txtName;
+        private System.Windows.Forms.Panel pnlContainer;
+        private DarkButton btnSave;
+        private DarkButton btnCancel;
+        private DarkToolStrip toolStrip;
+        private System.Windows.Forms.ToolStripButton toolStripItemNew;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
+        private System.Windows.Forms.ToolStripButton toolStripItemDelete;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
+        public System.Windows.Forms.ToolStripButton toolStripItemCopy;
+        public System.Windows.Forms.ToolStripButton toolStripItemPaste;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator3;
+        public System.Windows.Forms.ToolStripButton toolStripItemUndo;
+        private DarkButton btnClearSearch;
+        private DarkTextBox txtSearch;
+        private Controls.GameObjectList lstGameObjects;
+        private DarkButton btnAddFolder;
+        private System.Windows.Forms.Label lblFolder;
+        private DarkComboBox cmbFolder;
+        private DarkNumericUpDown nudMaxLevel;
+        private System.Windows.Forms.Label lblMaxLevel;
+        private DarkNumericUpDown nudBaseExperience;
+        private System.Windows.Forms.Label lblBaseExperience;
+        private DarkNumericUpDown nudExperienceIncrease;
+        private System.Windows.Forms.Label lblExperienceIncrease;
+        private DarkTextBox txtDescription;
+        private System.Windows.Forms.Label lblDescription;
+        private DarkTextBox txtIcon;
+        private System.Windows.Forms.Label lblIcon;
+        private System.Windows.Forms.ToolStripButton btnAlphabetical;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator4;
+    }
+}
+

--- a/Intersect.Editor/Forms/Editors/frmSkill.cs
+++ b/Intersect.Editor/Forms/Editors/frmSkill.cs
@@ -1,0 +1,417 @@
+using DarkUI.Forms;
+using Intersect.Editor.Content;
+using Intersect.Editor.Core;
+using Intersect.Editor.General;
+using Intersect.Editor.Localization;
+using Intersect.Editor.Networking;
+using Intersect.Enums;
+using Intersect.Framework.Core.GameObjects.Skills;
+using Intersect.GameObjects;
+using Intersect.Utilities;
+
+namespace Intersect.Editor.Forms.Editors;
+
+public partial class FrmSkill : EditorForm
+{
+    private readonly Dictionary<Guid, SkillDescriptor> _changed = [];
+    private string? _copiedItem;
+    private SkillDescriptor? _editorItem;
+    private readonly List<string> _knownFolders = [];
+
+    public FrmSkill()
+    {
+        ApplyHooks();
+        InitializeComponent();
+        Icon = Program.Icon;
+
+        _btnSave = btnSave;
+        _btnCancel = btnCancel;
+
+        lstGameObjects.Init(
+            UpdateToolStripItems,
+            AssignEditorItem,
+            toolStripItemNew_Click,
+            toolStripItemCopy_Click,
+            toolStripItemUndo_Click,
+            toolStripItemPaste_Click,
+            toolStripItemDelete_Click
+        );
+    }
+
+    #region Basic Editor Functions
+
+    private void AssignEditorItem(Guid id)
+    {
+        if (!SkillDescriptor.TryGet(id, out _editorItem))
+        {
+            _editorItem = null;
+        }
+
+        UpdateEditor();
+    }
+
+    private void toolStripItemNew_Click(object sender, EventArgs e)
+    {
+        PacketSender.SendCreateObject(GameObjectType.Skill);
+    }
+
+    private void toolStripItemDelete_Click(object sender, EventArgs e)
+    {
+        if (_editorItem == null || !lstGameObjects.Focused)
+        {
+            return;
+        }
+
+        if (DarkMessageBox.ShowWarning(
+                    "Are you sure you want to delete this skill?",
+                    "Delete Skill",
+                    DarkDialogButton.YesNo,
+                    Icon
+                ) ==
+                DialogResult.Yes)
+        {
+            PacketSender.SendDeleteObject(_editorItem);
+        }
+    }
+
+    private void toolStripItemCopy_Click(object sender, EventArgs e)
+    {
+        if (_editorItem != null && lstGameObjects.Focused)
+        {
+            _copiedItem = _editorItem.JsonData;
+            toolStripItemPaste.Enabled = true;
+        }
+    }
+
+    private void toolStripItemPaste_Click(object sender, EventArgs e)
+    {
+        if (_editorItem != null && _copiedItem != null && lstGameObjects.Focused)
+        {
+            _editorItem.Load(_copiedItem, true);
+            UpdateEditor();
+        }
+    }
+
+    private void toolStripItemUndo_Click(object sender, EventArgs e)
+    {
+        if (_editorItem == null || !_changed.ContainsKey(_editorItem.Id))
+        {
+            return;
+        }
+
+        if (DarkMessageBox.ShowWarning(
+                    "Are you sure you want to undo your changes?",
+                    "Undo Changes",
+                    DarkDialogButton.YesNo,
+                    Icon
+                ) ==
+                DialogResult.Yes)
+        {
+            _editorItem.RestoreBackup();
+            UpdateEditor();
+        }
+    }
+
+    private void UpdateToolStripItems()
+    {
+        var shouldEnableToolStripItems = _editorItem != null && lstGameObjects.Focused;
+        toolStripItemCopy.Enabled = shouldEnableToolStripItems;
+        toolStripItemPaste.Enabled = shouldEnableToolStripItems && _copiedItem != null;
+        toolStripItemDelete.Enabled = shouldEnableToolStripItems;
+        toolStripItemUndo.Enabled = shouldEnableToolStripItems;
+    }
+
+    protected override void GameObjectUpdatedDelegate(GameObjectType type)
+    {
+        if (type == GameObjectType.Skill)
+        {
+            InitEditor();
+            if (_editorItem != null && !SkillDescriptor.Lookup.Values.Contains(_editorItem))
+            {
+                _editorItem = null;
+                UpdateEditor();
+            }
+        }
+    }
+
+    private void btnCancel_Click(object? sender, EventArgs? e)
+    {
+        foreach (var item in _changed.Values)
+        {
+            item.RestoreBackup();
+            item.DeleteBackup();
+        }
+
+        Hide();
+        Globals.CurrentEditor = -1;
+        Dispose();
+    }
+
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        //Send Changed items
+        foreach (var item in _changed.Values)
+        {
+            PacketSender.SendSaveObject(item);
+            item.DeleteBackup();
+        }
+
+        Hide();
+        Globals.CurrentEditor = -1;
+        Dispose();
+    }
+
+    #endregion
+
+    #region Form Events
+
+    private void frmSkill_Load(object sender, EventArgs e)
+    {
+        InitLocalization();
+        UpdateEditor();
+    }
+
+    private void frmSkill_FormClosed(object sender, FormClosedEventArgs e)
+    {
+        btnCancel_Click(null, null);
+    }
+
+    private void form_KeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.Control && e.KeyCode == Keys.N)
+        {
+            toolStripItemNew_Click(null, null);
+        }
+    }
+
+    #endregion
+
+    #region Intersect Setup
+
+    private void InitLocalization()
+    {
+        Text = "Skill Editor";
+        toolStripItemNew.Text = "New";
+        toolStripItemDelete.Text = "Delete";
+        toolStripItemCopy.Text = "Copy";
+        toolStripItemPaste.Text = "Paste";
+        toolStripItemUndo.Text = "Undo";
+
+        grpSkills.Text = "Skills";
+        grpGeneral.Text = "General";
+        lblName.Text = "Name:";
+        lblMaxLevel.Text = "Max Level:";
+        lblBaseExperience.Text = "Base Experience:";
+        lblExperienceIncrease.Text = "Experience Increase:";
+        lblDescription.Text = "Description:";
+        lblIcon.Text = "Icon (optional):";
+
+        btnSave.Text = "Save";
+        btnCancel.Text = "Cancel";
+
+        //Searching/Sorting
+        btnAlphabetical.ToolTipText = "Sort Alphabetically";
+        txtSearch.Text = "Search...";
+        lblFolder.Text = "Folder:";
+    }
+
+    public void InitEditor()
+    {
+        //Collect folders
+        var mFolders = new List<string>();
+        foreach (var itm in SkillDescriptor.Lookup)
+        {
+            if (!string.IsNullOrEmpty(((SkillDescriptor)itm.Value).Folder) &&
+                !mFolders.Contains(((SkillDescriptor)itm.Value).Folder))
+            {
+                mFolders.Add(((SkillDescriptor)itm.Value).Folder);
+                if (!_knownFolders.Contains(((SkillDescriptor)itm.Value).Folder))
+                {
+                    _knownFolders.Add(((SkillDescriptor)itm.Value).Folder);
+                }
+            }
+        }
+
+        mFolders.Sort();
+        _knownFolders.Sort();
+        cmbFolder.Items.Clear();
+        cmbFolder.Items.Add("");
+        cmbFolder.Items.AddRange(_knownFolders.ToArray());
+
+        var items = SkillDescriptor.Lookup.OrderBy(p => p.Value?.Name).Select(pair => new KeyValuePair<Guid, KeyValuePair<string, string>>(pair.Key,
+            new KeyValuePair<string, string>(((SkillDescriptor)pair.Value)?.Name ?? Models.DatabaseObject<SkillDescriptor>.Deleted, ((SkillDescriptor)pair.Value)?.Folder ?? ""))).ToArray();
+        lstGameObjects.Repopulate(items, mFolders, btnAlphabetical.Checked, CustomSearch(), txtSearch.Text);
+
+        if (_editorItem != null)
+        {
+            var node = lstGameObjects.Nodes.Cast<TreeNode>().FirstOrDefault(n => (Guid)n.Tag == _editorItem.Id);
+            if (node != null)
+            {
+                lstGameObjects.SelectedNode = node;
+            }
+        }
+
+        UpdateEditorButtons(_editorItem != default);
+    }
+
+    private bool CustomSearch()
+    {
+        return !string.IsNullOrWhiteSpace(txtSearch.Text) &&
+               txtSearch.Text != "Search...";
+    }
+
+    private void UpdateEditor()
+    {
+        if (_editorItem != null)
+        {
+            pnlContainer.Show();
+
+            txtName.Text = _editorItem.Name;
+            cmbFolder.Text = _editorItem.Folder;
+            nudMaxLevel.Value = _editorItem.MaxLevel;
+            nudBaseExperience.Value = _editorItem.BaseExperience;
+            nudExperienceIncrease.Value = _editorItem.ExperienceIncrease;
+            txtDescription.Text = _editorItem.Description;
+            txtIcon.Text = _editorItem.Icon;
+
+            if (!_changed.TryGetValue(_editorItem.Id, out var _))
+            {
+                _changed.Add(_editorItem.Id, _editorItem);
+                _editorItem.MakeBackup();
+            }
+        }
+        else
+        {
+            pnlContainer.Hide();
+        }
+
+        UpdateEditorButtons(_editorItem != default);
+        UpdateToolStripItems();
+    }
+
+
+    #endregion
+
+    #region Event Handlers
+
+    private void txtName_TextChanged(object sender, EventArgs e)
+    {
+        if (_editorItem != null)
+        {
+            _editorItem.Name = txtName.Text;
+            lstGameObjects.UpdateText(txtName.Text);
+        }
+    }
+
+    private void cmbFolder_TextChanged(object sender, EventArgs e)
+    {
+        if (_editorItem != null)
+        {
+            _editorItem.Folder = cmbFolder.Text;
+        }
+    }
+
+    private void nudMaxLevel_ValueChanged(object sender, EventArgs e)
+    {
+        if (_editorItem != null)
+        {
+            _editorItem.MaxLevel = (int)nudMaxLevel.Value;
+        }
+    }
+
+    private void nudBaseExperience_ValueChanged(object sender, EventArgs e)
+    {
+        if (_editorItem != null)
+        {
+            _editorItem.BaseExperience = (long)nudBaseExperience.Value;
+        }
+    }
+
+    private void nudExperienceIncrease_ValueChanged(object sender, EventArgs e)
+    {
+        if (_editorItem != null)
+        {
+            _editorItem.ExperienceIncrease = (long)nudExperienceIncrease.Value;
+        }
+    }
+
+    private void txtDescription_TextChanged(object sender, EventArgs e)
+    {
+        if (_editorItem != null)
+        {
+            _editorItem.Description = txtDescription.Text;
+        }
+    }
+
+    private void txtIcon_TextChanged(object sender, EventArgs e)
+    {
+        if (_editorItem != null)
+        {
+            _editorItem.Icon = txtIcon.Text;
+        }
+    }
+
+    private void btnAlphabetical_Click(object sender, EventArgs e)
+    {
+        btnAlphabetical.Checked = !btnAlphabetical.Checked;
+        InitEditor();
+    }
+
+    private void txtSearch_TextChanged(object sender, EventArgs e)
+    {
+        InitEditor();
+    }
+
+    private void txtSearch_Leave(object sender, EventArgs e)
+    {
+        if (string.IsNullOrWhiteSpace(txtSearch.Text))
+        {
+            txtSearch.Text = "Search...";
+        }
+    }
+
+    private void txtSearch_Enter(object sender, EventArgs e)
+    {
+        txtSearch.SelectAll();
+        txtSearch.Focus();
+    }
+
+    private void txtSearch_Click(object sender, EventArgs e)
+    {
+        if (txtSearch.Text == "Search...")
+        {
+            txtSearch.SelectAll();
+        }
+    }
+
+    private void btnClearSearch_Click(object sender, EventArgs e)
+    {
+        txtSearch.Text = "Search...";
+    }
+
+    private void btnAddFolder_Click(object sender, EventArgs e)
+    {
+        var folderName = string.Empty;
+        var result = DarkUI.Forms.DarkInputBox.ShowInformation(
+            "Enter folder name:", "New Folder", ref folderName,
+            DarkUI.Forms.DarkDialogButton.OkCancel
+        );
+
+        if (result == DialogResult.OK && !string.IsNullOrEmpty(folderName))
+        {
+            if (_editorItem != null && !cmbFolder.Items.Contains(folderName))
+            {
+                _editorItem.Folder = folderName;
+                if (!_knownFolders.Contains(folderName))
+                {
+                    _knownFolders.Add(folderName);
+                }
+                InitEditor();
+                cmbFolder.Text = folderName;
+            }
+        }
+    }
+
+    #endregion
+}
+

--- a/Intersect.Editor/Forms/Editors/frmSkill.resx
+++ b/Intersect.Editor/Forms/Editors/frmSkill.resx
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+</root>
+

--- a/Intersect.Editor/Forms/frmMain.Designer.cs
+++ b/Intersect.Editor/Forms/frmMain.Designer.cs
@@ -112,6 +112,7 @@ namespace Intersect.Editor.Forms
             this.projectileEditorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.questEditorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.resourceEditorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.skillEditorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.shopEditorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.spellEditorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.variableEditorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -814,6 +815,7 @@ namespace Intersect.Editor.Forms
             this.projectileEditorToolStripMenuItem,
             this.questEditorToolStripMenuItem,
             this.resourceEditorToolStripMenuItem,
+            this.skillEditorToolStripMenuItem,
             this.shopEditorToolStripMenuItem,
             this.spellEditorToolStripMenuItem,
             this.variableEditorToolStripMenuItem,
@@ -902,6 +904,14 @@ namespace Intersect.Editor.Forms
             this.resourceEditorToolStripMenuItem.Size = new System.Drawing.Size(191, 22);
             this.resourceEditorToolStripMenuItem.Text = "Resource Editor";
             this.resourceEditorToolStripMenuItem.Click += new System.EventHandler(this.resourceEditorToolStripMenuItem_Click);
+            // 
+            // skillEditorToolStripMenuItem
+            // 
+            this.skillEditorToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
+            this.skillEditorToolStripMenuItem.Name = "skillEditorToolStripMenuItem";
+            this.skillEditorToolStripMenuItem.Size = new System.Drawing.Size(191, 22);
+            this.skillEditorToolStripMenuItem.Text = "Skill Editor";
+            this.skillEditorToolStripMenuItem.Click += new System.EventHandler(this.skillEditorToolStripMenuItem_Click);
             // 
             // shopEditorToolStripMenuItem
             // 
@@ -1106,6 +1116,7 @@ namespace Intersect.Editor.Forms
 		private ToolStripMenuItem projectileEditorToolStripMenuItem;
 		private ToolStripMenuItem questEditorToolStripMenuItem;
 		private ToolStripMenuItem resourceEditorToolStripMenuItem;
+		private ToolStripMenuItem skillEditorToolStripMenuItem;
 		private ToolStripMenuItem shopEditorToolStripMenuItem;
 		private ToolStripMenuItem spellEditorToolStripMenuItem;
 		private ToolStripMenuItem variableEditorToolStripMenuItem;

--- a/Intersect.Editor/Forms/frmMain.cs
+++ b/Intersect.Editor/Forms/frmMain.cs
@@ -63,6 +63,8 @@ public partial class FrmMain : Form
 
     private FrmResource mResourceEditor;
 
+    private FrmSkill mSkillEditor;
+
     private FrmShop mShopEditor;
 
     private FrmSpell mSpellEditor;
@@ -189,6 +191,7 @@ public partial class FrmMain : Form
         projectileEditorToolStripMenuItem.Text = Strings.MainForm.projectileeditor;
         questEditorToolStripMenuItem.Text = Strings.MainForm.questeditor;
         resourceEditorToolStripMenuItem.Text = Strings.MainForm.resourceeditor;
+        skillEditorToolStripMenuItem.Text = Strings.MainForm.skilleditor;
         shopEditorToolStripMenuItem.Text = Strings.MainForm.shopeditor;
         spellEditorToolStripMenuItem.Text = Strings.MainForm.spelleditor;
         variableEditorToolStripMenuItem.Text = Strings.MainForm.variableeditor;
@@ -1267,6 +1270,11 @@ public partial class FrmMain : Form
         PacketSender.SendOpenEditor(GameObjectType.Resource);
     }
 
+    private void skillEditorToolStripMenuItem_Click(object sender, EventArgs e)
+    {
+        PacketSender.SendOpenEditor(GameObjectType.Skill);
+    }
+
     private void classEditorToolStripMenuItem_Click(object sender, EventArgs e)
     {
         PacketSender.SendOpenEditor(GameObjectType.Class);
@@ -1637,6 +1645,15 @@ public partial class FrmMain : Form
                         mResourceEditor = new FrmResource();
                         mResourceEditor.InitEditor();
                         mResourceEditor.Show();
+                    }
+
+                    break;
+                case GameObjectType.Skill:
+                    if (mSkillEditor == null || mSkillEditor.Visible == false)
+                    {
+                        mSkillEditor = new FrmSkill();
+                        mSkillEditor.InitEditor();
+                        mSkillEditor.Show();
                     }
 
                     break;

--- a/Intersect.Editor/Intersect.Editor.csproj
+++ b/Intersect.Editor/Intersect.Editor.csproj
@@ -594,6 +594,9 @@
     <EmbeddedResource Update="Forms\Editors\frmResource.resx">
       <DependentUpon>frmResource.cs</DependentUpon>
     </EmbeddedResource>
+    <EmbeddedResource Update="Forms\Editors\frmSkill.resx">
+      <DependentUpon>frmSkill.cs</DependentUpon>
+    </EmbeddedResource>
     <EmbeddedResource Update="Forms\Editors\frmShop.resx">
       <DependentUpon>frmShop.cs</DependentUpon>
     </EmbeddedResource>

--- a/Intersect.Editor/Localization/Strings.cs
+++ b/Intersect.Editor/Localization/Strings.cs
@@ -8,6 +8,7 @@ using Intersect.Framework.Core.GameObjects.Maps;
 using Intersect.Framework.Core.GameObjects.NPCs;
 using Intersect.Framework.Core.GameObjects.PlayerClass;
 using Intersect.Framework.Core.GameObjects.Resources;
+using Intersect.Framework.Core.GameObjects.Skills;
 using Intersect.Framework.Core.GameObjects.Variables;
 using Intersect.Framework.Reflection;
 using Intersect.GameObjects;
@@ -184,6 +185,41 @@ public static partial class Strings
         }
 
         return EventConditionDesc.levelorstat.ToString(lvlorstat, pLvl);
+    }
+
+    public static string GetEventConditionalDesc(SkillLevelCondition condition)
+    {
+        var skillName = SkillDescriptor.Get(condition.SkillId)?.Name ?? "Unknown Skill";
+        var pLvl = string.Empty;
+        switch (condition.Comparator)
+        {
+            case VariableComparator.Equal:
+                pLvl = EventConditionDesc.equal.ToString(condition.Value);
+
+                break;
+            case VariableComparator.GreaterOrEqual:
+                pLvl = EventConditionDesc.greaterequal.ToString(condition.Value);
+
+                break;
+            case VariableComparator.LesserOrEqual:
+                pLvl = EventConditionDesc.lessthanequal.ToString(condition.Value);
+
+                break;
+            case VariableComparator.Greater:
+                pLvl = EventConditionDesc.greater.ToString(condition.Value);
+
+                break;
+            case VariableComparator.Less:
+                pLvl = EventConditionDesc.lessthan.ToString(condition.Value);
+
+                break;
+            case VariableComparator.NotEqual:
+                pLvl = EventConditionDesc.notequal.ToString(condition.Value);
+
+                break;
+        }
+
+        return EventConditionDesc.skilllevel.ToString(skillName, pLvl);
     }
 
     public static string GetEventConditionalDesc(SelfSwitchCondition condition)
@@ -2085,6 +2121,8 @@ Tick timer saved in server config.json.";
 
         public static LocalizedString giveexp = @"Give Player {00} Experience";
 
+        public static LocalizedString giveskillexp = @"Give Player {00} Skill {01} Experience";
+
         public static LocalizedString globalswitch = @"Set Global Switch {00} to {01}";
 
         public static LocalizedString globalvariable = @"Set Global Variable {00} ({01})";
@@ -2355,6 +2393,7 @@ Tick timer saved in server config.json.";
             {"exiteventprocess", @"Exit Event Process"},
             {"fadeoutbgm", @"Fadeout BGM"},
             {"giveexperience", @"Give Experience"},
+            {"giveskillexperience", @"Give Skill Experience"},
             {"gotolabel", @"Go To Label"},
             {"hidepicture", @"Hide Picture"},
             {"holdplayer", @"Hold Player"},
@@ -2480,6 +2519,7 @@ Tick timer saved in server config.json.";
             {ConditionType.ClassIs, @"Class is..."},
             {ConditionType.KnowsSpell, @"Knows spell..."},
             {ConditionType.LevelOrStat, @"Level or Stat is..."},
+            {ConditionType.SkillLevel, @"Skill Level is..."},
             {ConditionType.SelfSwitch, @"Self Switch is..."},
             {ConditionType.AccessIs, @"Power level is..."},
             {ConditionType.TimeBetween, @"Time is between..."},
@@ -2536,6 +2576,12 @@ Tick timer saved in server config.json.";
         public static LocalizedString levelstatitem = @"Level or Stat:";
 
         public static LocalizedString levelstatvalue = @"Value:";
+
+        public static LocalizedString skilllevel = @"Skill Level Is....";
+
+        public static LocalizedString skill = @"Skill:";
+
+        public static LocalizedString skilllevelvalue = @"Value:";
 
         public static LocalizedString male = @"Male";
 
@@ -2714,6 +2760,8 @@ Tick timer saved in server config.json.";
         public static LocalizedString level = @"Level";
 
         public static LocalizedString levelorstat = @"{00} {01}";
+
+        public static LocalizedString skilllevel = @"{00} Skill Level {01}";
 
         public static LocalizedString male = @"Male";
 
@@ -4157,6 +4205,8 @@ Tick timer saved in server config.json.";
         public static LocalizedString resourceeditor = @"Resource Editor";
 
         public static LocalizedString resources = @"Resources";
+
+        public static LocalizedString skilleditor = @"Skill Editor";
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public static LocalizedString Events = @"Events";

--- a/Intersect.Editor/Networking/PacketHandler.cs
+++ b/Intersect.Editor/Networking/PacketHandler.cs
@@ -15,6 +15,7 @@ using Intersect.Framework.Core.GameObjects.Maps.MapList;
 using Intersect.Framework.Core.GameObjects.NPCs;
 using Intersect.Framework.Core.GameObjects.PlayerClass;
 using Intersect.Framework.Core.GameObjects.Resources;
+using Intersect.Framework.Core.GameObjects.Skills;
 using Intersect.Framework.Core.GameObjects.Variables;
 using Intersect.GameObjects;
 using Intersect.Network;
@@ -575,6 +576,21 @@ internal sealed partial class PacketHandler
                     var res = new ResourceDescriptor(id);
                     res.Load(json);
                     ResourceDescriptor.Lookup.Set(id, res);
+                }
+
+                break;
+
+            case GameObjectType.Skill:
+                if (deleted)
+                {
+                    var skill = SkillDescriptor.Get(id);
+                    skill.Delete();
+                }
+                else
+                {
+                    var skill = new SkillDescriptor(id);
+                    skill.Load(json);
+                    SkillDescriptor.Lookup.Set(id, skill);
                 }
 
                 break;

--- a/Intersect.Server.Core/Database/DbInterface.cs
+++ b/Intersect.Server.Core/Database/DbInterface.cs
@@ -20,6 +20,7 @@ using Intersect.Framework.Core.GameObjects.Maps.MapList;
 using Intersect.Framework.Core.GameObjects.NPCs;
 using Intersect.Framework.Core.GameObjects.PlayerClass;
 using Intersect.Framework.Core.GameObjects.Resources;
+using Intersect.Framework.Core.GameObjects.Skills;
 using Intersect.Framework.Core.GameObjects.Variables;
 using Intersect.Framework.Reflection;
 using Intersect.GameObjects;
@@ -782,6 +783,10 @@ public static partial class DbInterface
                 UserVariableDescriptor.Lookup.Clear();
 
                 break;
+            case GameObjectType.Skill:
+                SkillDescriptor.Lookup.Clear();
+
+                break;
             default:
                 throw new ArgumentOutOfRangeException(nameof(type), type, null);
         }
@@ -929,6 +934,13 @@ public static partial class DbInterface
                         foreach (var psw in context.UserVariables)
                         {
                             UserVariableDescriptor.Lookup.Set(psw.Id, psw);
+                        }
+
+                        break;
+                    case GameObjectType.Skill:
+                        foreach (var skill in context.Skills)
+                        {
+                            SkillDescriptor.Lookup.Set(skill.Id, skill);
                         }
 
                         break;
@@ -1181,6 +1193,10 @@ public static partial class DbInterface
                 dbObj = new UserVariableDescriptor(predefinedid);
 
                 break;
+            case GameObjectType.Skill:
+                dbObj = new SkillDescriptor(predefinedid);
+
+                break;
             default:
                 throw new ArgumentOutOfRangeException(nameof(gameObjectType), gameObjectType, null);
         }
@@ -1304,6 +1320,12 @@ public static partial class DbInterface
                     case GameObjectType.UserVariable:
                         context.UserVariables.Add((UserVariableDescriptor)dbObj);
                         UserVariableDescriptor.Lookup.Set(dbObj.Id, dbObj);
+
+                        break;
+
+                    case GameObjectType.Skill:
+                        context.Skills.Add((SkillDescriptor)dbObj);
+                        SkillDescriptor.Lookup.Set(dbObj.Id, dbObj);
 
                         break;
 
@@ -1599,6 +1621,10 @@ public static partial class DbInterface
                         break;
                     case GameObjectType.UserVariable:
                         context.UserVariables.Update((UserVariableDescriptor)gameObject);
+
+                        break;
+                    case GameObjectType.Skill:
+                        context.Skills.Update((SkillDescriptor)gameObject);
 
                         break;
                 }

--- a/Intersect.Server.Core/Database/GameData/GameContext.cs
+++ b/Intersect.Server.Core/Database/GameData/GameContext.cs
@@ -8,6 +8,7 @@ using Intersect.Framework.Core.GameObjects.Maps.MapList;
 using Intersect.Framework.Core.GameObjects.NPCs;
 using Intersect.Framework.Core.GameObjects.PlayerClass;
 using Intersect.Framework.Core.GameObjects.Resources;
+using Intersect.Framework.Core.GameObjects.Skills;
 using Intersect.Framework.Core.GameObjects.Variables;
 using Intersect.GameObjects;
 using Intersect.Server.Database.GameData.Migrations;
@@ -81,6 +82,9 @@ public abstract partial class GameContext : IntersectDbContext<GameContext>, IGa
 
     //Time
     public DbSet<DaylightCycleDescriptor> Time { get; set; }
+
+    //Skills
+    public DbSet<SkillDescriptor> Skills { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/Intersect.Server.Core/Database/GameData/IGameContext.cs
+++ b/Intersect.Server.Core/Database/GameData/IGameContext.cs
@@ -7,6 +7,7 @@ using Intersect.Framework.Core.GameObjects.Maps.MapList;
 using Intersect.Framework.Core.GameObjects.NPCs;
 using Intersect.Framework.Core.GameObjects.PlayerClass;
 using Intersect.Framework.Core.GameObjects.Resources;
+using Intersect.Framework.Core.GameObjects.Skills;
 using Intersect.Framework.Core.GameObjects.Variables;
 using Intersect.GameObjects;
 using Intersect.Server.Maps;
@@ -51,4 +52,6 @@ public interface IGameContext : IDbContext
     DbSet<TilesetDescriptor> Tilesets { get; set; }
 
     DbSet<DaylightCycleDescriptor> Time { get; set; }
+
+    DbSet<SkillDescriptor> Skills { get; set; }
 }

--- a/Intersect.Server.Core/Entities/Events/CommandProcessing.cs
+++ b/Intersect.Server.Core/Entities/Events/CommandProcessing.cs
@@ -7,6 +7,7 @@ using Intersect.Framework.Core.GameObjects.Events.Commands;
 using Intersect.Framework.Core.GameObjects.Items;
 using Intersect.Framework.Core.GameObjects.Maps;
 using Intersect.Framework.Core.GameObjects.PlayerClass;
+using Intersect.Framework.Core.GameObjects.Skills;
 using Intersect.Framework.Core.GameObjects.Variables;
 using Intersect.GameObjects;
 using Intersect.Server.Core.MapInstancing;
@@ -466,6 +467,52 @@ public static partial class CommandProcessing
         else if (quantity < 0)
         {
             player.TakeExperience(Math.Abs(quantity), command.EnableLosingLevels, force: true);
+        }
+    }
+
+    //Give Skill Experience Command
+    private static void ProcessCommand(
+        GiveSkillExperienceCommand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        var skillDescriptor = SkillDescriptor.Get(command.SkillId);
+        if (skillDescriptor == null)
+        {
+            return;
+        }
+
+        var quantity = command.Exp;
+        if (command.UseVariable)
+        {
+            switch (command.VariableType)
+            {
+                case VariableType.PlayerVariable:
+                    quantity = (int)player.GetVariableValue(command.VariableId).Integer;
+
+                    break;
+                case VariableType.ServerVariable:
+                    quantity = (int)ServerVariableDescriptor.Get(command.VariableId)?.Value.Integer;
+
+                    break;
+
+                case VariableType.GuildVariable:
+                    quantity = (int)player.Guild?.GetVariableValue(command.VariableId)?.Integer;
+
+                    break;
+            }
+        }
+
+        if (quantity > 0)
+        {
+            player.GiveSkillExperience(command.SkillId, quantity);
+        }
+        else if (quantity < 0)
+        {
+            player.TakeSkillExperience(command.SkillId, Math.Abs(quantity), command.EnableLosingLevels);
         }
     }
 

--- a/Intersect.Server.Core/Entities/Events/Conditions.cs
+++ b/Intersect.Server.Core/Entities/Events/Conditions.cs
@@ -265,6 +265,64 @@ public static partial class Conditions
     }
 
     public static bool MeetsCondition(
+        SkillLevelCondition condition,
+        Player player,
+        Event eventInstance,
+        QuestDescriptor questDescriptor
+    )
+    {
+        var skillLevel = player.GetSkillLevel(condition.SkillId);
+
+        switch (condition.Comparator)
+        {
+            case VariableComparator.Equal:
+                if (skillLevel == condition.Value)
+                {
+                    return true;
+                }
+
+                break;
+            case VariableComparator.GreaterOrEqual:
+                if (skillLevel >= condition.Value)
+                {
+                    return true;
+                }
+
+                break;
+            case VariableComparator.LesserOrEqual:
+                if (skillLevel <= condition.Value)
+                {
+                    return true;
+                }
+
+                break;
+            case VariableComparator.Greater:
+                if (skillLevel > condition.Value)
+                {
+                    return true;
+                }
+
+                break;
+            case VariableComparator.Less:
+                if (skillLevel < condition.Value)
+                {
+                    return true;
+                }
+
+                break;
+            case VariableComparator.NotEqual:
+                if (skillLevel != condition.Value)
+                {
+                    return true;
+                }
+
+                break;
+        }
+
+        return false;
+    }
+
+    public static bool MeetsCondition(
         SelfSwitchCondition condition,
         Player player,
         Event eventInstance,

--- a/Intersect.Server.Core/Entities/SkillData.cs
+++ b/Intersect.Server.Core/Entities/SkillData.cs
@@ -1,0 +1,22 @@
+namespace Intersect.Server.Entities;
+
+/// <summary>
+/// Stores experience and level data for a skill
+/// </summary>
+public class SkillData
+{
+    public long Experience { get; set; } = 0;
+
+    public int Level { get; set; } = 1;
+
+    public SkillData()
+    {
+    }
+
+    public SkillData(int level, long experience)
+    {
+        Level = level;
+        Experience = experience;
+    }
+}
+

--- a/Intersect.Server.Core/Migrations/Sqlite/Game/20250328000000_AddSkills.cs
+++ b/Intersect.Server.Core/Migrations/Sqlite/Game/20250328000000_AddSkills.cs
@@ -1,0 +1,38 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Intersect.Server.Migrations.Sqlite.Game
+{
+    public partial class AddSkills : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Skills",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(nullable: false),
+                    TimeCreated = table.Column<long>(nullable: false),
+                    Name = table.Column<string>(nullable: true),
+                    MaxLevel = table.Column<int>(nullable: false),
+                    BaseExperience = table.Column<long>(nullable: false),
+                    ExperienceIncrease = table.Column<long>(nullable: false),
+                    ExperienceOverrides = table.Column<string>(nullable: true),
+                    ExperienceCurve = table.Column<string>(nullable: true),
+                    Icon = table.Column<string>(nullable: true),
+                    Description = table.Column<string>(nullable: true),
+                    Folder = table.Column<string>(nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Skills", x => x.Id);
+                });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Skills");
+        }
+    }
+}
+

--- a/Intersect.Server.Core/Migrations/Sqlite/Player/20250328000001_AddSkillsToPlayers.cs
+++ b/Intersect.Server.Core/Migrations/Sqlite/Player/20250328000001_AddSkillsToPlayers.cs
@@ -1,0 +1,23 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Intersect.Server.Migrations.Sqlite.Player
+{
+    public partial class AddSkillsToPlayers : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Skills",
+                table: "Players",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Skills",
+                table: "Players");
+        }
+    }
+}
+

--- a/Intersect.Server/Core/Commands/GiveSkillXpCommand.cs
+++ b/Intersect.Server/Core/Commands/GiveSkillXpCommand.cs
@@ -1,0 +1,75 @@
+using Intersect.Localization;
+using Intersect.Server.Core.CommandParsing;
+using Intersect.Server.Core.CommandParsing.Arguments;
+using Intersect.Server.Networking;
+using Intersect.Framework.Core.GameObjects.Skills;
+
+namespace Intersect.Server.Core.Commands
+{
+    internal sealed partial class GiveSkillXpCommand : TargetClientCommand
+    {
+        public GiveSkillXpCommand() : base(
+            new LocaleCommand("giveskillxp", "Gives skill experience to a player"),
+            new LocaleArgument("target", char.MinValue, "Target player name"),
+            new VariableArgument<string>(new LocaleArgument("skill", char.MinValue, "Skill name or ID"), RequiredIfNotHelp, true),
+            new VariableArgument<string>(new LocaleArgument("amount", char.MinValue, "Experience amount"), RequiredIfNotHelp, true)
+        )
+        {
+        }
+
+        private VariableArgument<string> SkillArgument => FindArgument<VariableArgument<string>>(1);
+        private VariableArgument<string> AmountArgument => FindArgument<VariableArgument<string>>(2);
+
+        protected override void HandleTarget(ServerContext context, ParserResult result, Client target)
+        {
+            if (target?.Entity == null)
+            {
+                Console.WriteLine("    Player is offline");
+                return;
+            }
+
+            var skillNameOrId = result.Find(SkillArgument);
+            var amountStr = result.Find(AmountArgument);
+
+            if (string.IsNullOrEmpty(skillNameOrId))
+            {
+                Console.WriteLine("    No skill specified");
+                return;
+            }
+
+            if (string.IsNullOrEmpty(amountStr) || !long.TryParse(amountStr, out var amount))
+            {
+                Console.WriteLine("    Invalid amount specified");
+                return;
+            }
+
+            SkillDescriptor skill;
+            if (Guid.TryParse(skillNameOrId, out Guid skillId))
+            {
+                skill = SkillDescriptor.Get(skillId);
+            }
+            else
+            {
+                skill = SkillDescriptor.Lookup.Values
+                    .OfType<SkillDescriptor>()
+                    .FirstOrDefault(s => 
+                        s.Name.Equals(skillNameOrId, StringComparison.OrdinalIgnoreCase));
+            }
+
+            if (skill == null)
+            {
+                Console.WriteLine($"    Skill '{skillNameOrId}' not found");
+                return;
+            }
+
+            lock (target.Entity)
+            {
+                target.Entity.GiveSkillExperience(skill.Id, amount);
+                var level = target.Entity.GetSkillLevel(skill.Id);
+                var exp = target.Entity.GetSkillExperience(skill.Id);
+                Console.WriteLine($"    Gave {amount} XP to {target.Entity.Name}'s {skill.Name} skill (Level {level}, {exp} XP)");
+            }
+        }
+    }
+}
+

--- a/Intersect.Server/Core/ConsoleService.ConsoleThread.cs
+++ b/Intersect.Server/Core/ConsoleService.ConsoleThread.cs
@@ -25,32 +25,45 @@ namespace Intersect.Server.Core
 
                 Parser = new CommandParser(new ParserSettings(localization: Strings.Commands.Parsing));
 
-                Parser.Register<AnnouncementCommand>();
-                Parser.Register<ApiCommand>();
-                Parser.Register<ApiGrantCommand>();
-                Parser.Register<ApiRevokeCommand>();
-                Parser.Register<ApiRolesCommand>();
-                Parser.Register<BanCommand>();
-                Parser.Register<CpsCommand>();
-                Parser.Register<ExitCommand>();
-                Parser.Register<GetVariableCommand>();
-                Parser.Register<HelpCommand>(Parser.Settings);
-                Parser.Register<KickCommand>();
-                Parser.Register<KillCommand>();
-                Parser.Register<ListVariablesCommand>();
-                Parser.Register<MetricsCommand>();
-                Parser.Register<MakePrivateCommand>();
-                Parser.Register<MakePublicCommand>();
-                Parser.Register<MigrateCommand>();
-                Parser.Register<MuteCommand>();
-                Parser.Register<NetDebugCommand>();
-                Parser.Register<OnlineListCommand>();
-                Parser.Register<PanicCommand>();
-                Parser.Register<PowerAccountCommand>();
-                Parser.Register<PowerCommand>();
-                Parser.Register<SetVariableCommand>();
-                Parser.Register<UnbanCommand>();
-                Parser.Register<UnmuteCommand>();
+                try
+                {
+                    Parser.Register<AnnouncementCommand>();
+                    Parser.Register<ApiCommand>();
+                    Parser.Register<ApiGrantCommand>();
+                    Parser.Register<ApiRevokeCommand>();
+                    Parser.Register<ApiRolesCommand>();
+                    Parser.Register<BanCommand>();
+                    Parser.Register<CpsCommand>();
+                    Parser.Register<ExitCommand>();
+                    Parser.Register<GetVariableCommand>();
+                    Parser.Register<HelpCommand>(Parser.Settings);
+                    Parser.Register<KickCommand>();
+                    Parser.Register<KillCommand>();
+                    Parser.Register<ListVariablesCommand>();
+                    Parser.Register<MetricsCommand>();
+                    Parser.Register<MakePrivateCommand>();
+                    Parser.Register<MakePublicCommand>();
+                    Parser.Register<MigrateCommand>();
+                    Parser.Register<MuteCommand>();
+                    Parser.Register<NetDebugCommand>();
+                    Parser.Register<OnlineListCommand>();
+                    Parser.Register<PanicCommand>();
+                    Parser.Register<PowerAccountCommand>();
+                    Parser.Register<PowerCommand>();
+                    Parser.Register<SetVariableCommand>();
+                    Parser.Register<UnbanCommand>();
+                    Parser.Register<UnmuteCommand>();
+                    Parser.Register<GiveSkillXpCommand>();
+                }
+                catch (Exception registrationException)
+                {
+                    // Log to a file since ApplicationContext might not be available yet
+                    System.IO.File.WriteAllText(
+                        "logs/command-registration-error.log",
+                        $"{DateTime.Now}: Error registering commands: {registrationException}\n{registrationException.StackTrace}"
+                    );
+                    throw;
+                }
             }
 
             public CommandParser Parser { get; }
@@ -83,7 +96,16 @@ namespace Intersect.Server.Core
                             Console.Write(Console.WaitPrefix);
 #endif
 
-                            line = Console.ReadLine()?.Trim();
+                            try
+                            {
+                                line = Console.ReadLine()?.Trim();
+                            }
+                            catch (Exception readException)
+                            {
+                                ApplicationContext.Context.Value?.Logger.LogError(readException, "Error reading console input");
+                                ServerContext.DispatchUnhandledException(readException, isTerminating: false);
+                                break;
+                            }
 
                             if (mDoNotContinue)
                             {

--- a/Intersect.Server/Migrations/MySql/Game/20250328000000_AddSkills.cs
+++ b/Intersect.Server/Migrations/MySql/Game/20250328000000_AddSkills.cs
@@ -1,0 +1,38 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Intersect.Server.Migrations.MySql.Game
+{
+    public partial class AddSkills : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Skills",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(nullable: false),
+                    TimeCreated = table.Column<long>(nullable: false),
+                    Name = table.Column<string>(nullable: true),
+                    MaxLevel = table.Column<int>(nullable: false),
+                    BaseExperience = table.Column<long>(nullable: false),
+                    ExperienceIncrease = table.Column<long>(nullable: false),
+                    ExperienceOverrides = table.Column<string>(nullable: true),
+                    ExperienceCurve = table.Column<string>(nullable: true),
+                    Icon = table.Column<string>(nullable: true),
+                    Description = table.Column<string>(nullable: true),
+                    Folder = table.Column<string>(nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Skills", x => x.Id);
+                });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Skills");
+        }
+    }
+}
+

--- a/Intersect.Server/Migrations/MySql/Player/20250328000001_AddSkillsToPlayers.cs
+++ b/Intersect.Server/Migrations/MySql/Player/20250328000001_AddSkillsToPlayers.cs
@@ -1,0 +1,23 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Intersect.Server.Migrations.MySql.Player
+{
+    public partial class AddSkillsToPlayers : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Skills",
+                table: "Players",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Skills",
+                table: "Players");
+        }
+    }
+}
+

--- a/Intersect.Server/Networking/NetworkedPacketHandler.cs
+++ b/Intersect.Server/Networking/NetworkedPacketHandler.cs
@@ -11,6 +11,7 @@ using Intersect.Framework.Core.GameObjects.Maps.MapList;
 using Intersect.Framework.Core.GameObjects.NPCs;
 using Intersect.Framework.Core.GameObjects.PlayerClass;
 using Intersect.Framework.Core.GameObjects.Resources;
+using Intersect.Framework.Core.GameObjects.Skills;
 using Intersect.Framework.Core.GameObjects.Variables;
 using Intersect.Framework.Core.Security;
 using Intersect.GameObjects;
@@ -932,6 +933,11 @@ internal sealed partial class NetworkedPacketHandler
 
                     break;
 
+                case GameObjectType.Skill:
+                    obj = SkillDescriptor.Get(id);
+
+                    break;
+
                 case GameObjectType.CraftTables:
                     obj = DatabaseObject<CraftingTableDescriptor>.Lookup.Get(id);
 
@@ -1061,6 +1067,11 @@ internal sealed partial class NetworkedPacketHandler
 
                 case GameObjectType.Spell:
                     obj = SpellDescriptor.Get(id);
+
+                    break;
+
+                case GameObjectType.Skill:
+                    obj = SkillDescriptor.Get(id);
 
                     break;
 


### PR DESCRIPTION
## Overview
This PR implements a complete non-combat skills system for the Intersect engine, allowing game developers to create custom skills (similar to Runescape) that players can level up through gameplay. Skills can gain experience from various sources and are fully integrated into the editor, event system, and dynamic requirements.

## Features Added

### Core Skill System
- **SkillDescriptor**: New game object type for defining skills with customizable experience curves
  - Configurable base experience and experience increase per level
  - Custom experience overrides for specific levels
  - Maximum level configuration (default: 99)
  - Icon and description support
  - Folder organization support

- **Player Skill Data**: Players can now have skill experience and levels stored per skill
  - Skills stored as JSON in database (flexible, no schema changes needed for new skills)
  - Automatic level-up detection and notifications
  - Support for losing levels (optional)

### Editor Integration
- **Skill Editor**: New editor window accessible from Game Manager → Content Editors → Skill Editor
  - Create, edit, delete, copy, and paste skills
  - Configure experience curves and overrides
  - Folder organization and search functionality
  - Full undo/redo support

### Event System Integration
- **Give Skill Experience Command**: New event command in Common Events → Player Control
  - Select target skill from dropdown
  - Manual experience amount or variable-based
  - Optional "Enable Losing Levels" for negative XP
  - Can be attached to resources, items, or any event

### Dynamic Requirements
- **Skill Level Condition**: New condition type for dynamic requirements
  - Available in all dynamic requirement lists (Resources, Items, Spells, etc.)
  - Select skill, comparator (Equal, Greater, Less, etc.), and level value
  - Enables skill-gated content (e.g., "Requires Mining Level 50")


### Server Console Commands
- `giveskillxp <player> <skill> <amount>`: Give skill experience to a player (for testing)
- `takeskillxp <player> <skill> <amount>`: Remove skill experience from a player (for testing)

## Technical Details

### Database Changes
- Added `Skills` table to game database (SQLite and MySQL migrations included)
- Added `Skills` JSON column to `Players` table (SQLite and MySQL migrations included)

### Networking
- New `SkillDataPacket` for efficient skill updates
- Automatic skill data sync on login
- Real-time updates when skills gain experience

### Code Quality
- Follows existing Intersect engine patterns and conventions
- Fully integrated with existing editor, event, and condition systems
- Proper error handling and null safety
- Localization support for all UI strings

## Use Cases
- **Resource Harvesting**: Attach skill experience rewards to resource harvesting events
- **Crafting**: Require skill levels to craft certain items
- **Progression**: Create skill-based progression systems (Mining, Fishing, Cooking, etc.)
- **Content Gating**: Lock content behind skill level requirements

## Breaking Changes
None - this is a purely additive feature.

## Migration Notes
Users will need to run the database migrations to add the `Skills` table and `Players.Skills` column. Manual SQL scripts are provided for users who cannot use Entity Framework migrations.