### PR TITLE
fix: client loading asset packs

### DIFF
--- a/Intersect.Client.Core/MonoGame/File Management/MonoContentManager.cs
+++ b/Intersect.Client.Core/MonoGame/File Management/MonoContentManager.cs
@@ -54,15 +54,16 @@ public partial class MonoContentManager : GameContentManager
         foreach (var t in tilesetnames)
         {
             var realFilename = tilesetFiles.FirstOrDefault(file => t.Equals(file, StringComparison.InvariantCultureIgnoreCase)) ?? t;
+            var assetName = Path.Combine(ClientConfiguration.ResourcesDirectory, "tilesets", t.ToLower()).Replace('\\', '/');
             if (!string.IsNullOrWhiteSpace(t) &&
                 (!string.IsNullOrWhiteSpace(realFilename) ||
-                 AtlasReference.TryGet(Path.Combine(ClientConfiguration.ResourcesDirectory, "tilesets", t.ToLower()), out _) != null) &&
+                 AtlasReference.TryGet(assetName, out _)) &&
                 !mTilesetDict.ContainsKey(t.ToLower()))
             {
                 mTilesetDict.Add(
                     t.ToLower(),
                     Core.Graphics.Renderer.LoadTexture(
-                        Path.Combine(ClientConfiguration.ResourcesDirectory, "tilesets", t),
+                        assetName,
                         Path.Combine(ClientConfiguration.ResourcesDirectory, "tilesets", realFilename)
                     )
                 );

--- a/Intersect.Client.Core/MonoGame/Graphics/MonoRenderer.Texture.cs
+++ b/Intersect.Client.Core/MonoGame/Graphics/MonoRenderer.Texture.cs
@@ -148,9 +148,13 @@ internal partial class MonoRenderer
         {
         }
 
-        public override int Width => PlatformTexture?.Width ?? 0;
+        public override int Width => AtlasReference?.IsRotated == true
+            ? AtlasReference.Bounds.Height
+            : AtlasReference?.Bounds.Width ?? PlatformTexture?.Width ?? 0;
 
-        public override int Height => PlatformTexture?.Height ?? 0;
+        public override int Height => AtlasReference?.IsRotated == true
+            ? AtlasReference.Bounds.Width
+            : AtlasReference?.Bounds.Height ?? PlatformTexture?.Height ?? 0;
 
         protected override Texture2D? CreatePlatformTextureFromStream(Stream stream)
         {

--- a/Intersect.Client.Framework/Graphics/AtlasReference.cs
+++ b/Intersect.Client.Framework/Graphics/AtlasReference.cs
@@ -61,7 +61,8 @@ public record AtlasReference(
 
     public static bool TryGet(string assetName, [NotNullWhen(true)] out AtlasReference? atlasReference)
     {
-        return _atlasReferences.TryGetValue(assetName, out atlasReference) ||
-               _atlasReferences.TryGetValue(assetName.ToLowerInvariant(), out atlasReference);
+        var normalizedAssetName = assetName.Replace('\\', '/');
+        return _atlasReferences.TryGetValue(normalizedAssetName, out atlasReference) ||
+               _atlasReferences.TryGetValue(normalizedAssetName.ToLowerInvariant(), out atlasReference);
     }
 }

--- a/Intersect.Client.Framework/Graphics/GameTexture.cs
+++ b/Intersect.Client.Framework/Graphics/GameTexture.cs
@@ -257,6 +257,12 @@ public abstract partial class GameTexture<TPlatformTexture, TPlatformRenderer> :
             }
 
             atlasTexture.LoadPlatformTexture(force);
+            IsMissingOrCorrupt = atlasTexture.IsMissingOrCorrupt;
+            if (!IsMissingOrCorrupt)
+            {
+                UpdateAccessTime();
+                EmitLoaded();
+            }
             return;
         }
 

--- a/Intersect.Client.Framework/Gwen/Skin/Texturing/Bordered.cs
+++ b/Intersect.Client.Framework/Gwen/Skin/Texturing/Bordered.cs
@@ -1,4 +1,4 @@
-﻿using Intersect.Client.Framework.GenericClasses;
+using Intersect.Client.Framework.GenericClasses;
 using Intersect.Client.Framework.Graphics;
 
 namespace Intersect.Client.Framework.Gwen.Skin.Texturing;
@@ -185,7 +185,7 @@ public partial struct Bordered : IEquatable<Bordered>, IAtlasDrawable
 
     public bool Equals(Bordered other)
     {
-        return _texture.Equals(other._texture) && _subRects.Equals(other._subRects) && _margin.Equals(other._margin) && _width.Equals(other._width) && _height.Equals(other._height);
+        return (_texture?.Equals(other._texture) ?? false) && _subRects.Equals(other._subRects) && _margin.Equals(other._margin) && _width.Equals(other._width) && _height.Equals(other._height);
     }
 
     public override bool Equals(object? obj)


### PR DESCRIPTION
Fixes #2748  loading of assets from asset packs in windows by normalizing the file paths to use forward slashes during lookup.

Also fixes width/height calculation of those assets when packed and accounts for situations where graphics were rotated in order to fit in the texture.

Updated atlas textures to emit that they've loaded like non-packed textures.

Also minor NRE fix.