### PR TITLE
Fixes out of bounds exception on world scale slider

### DIFF
--- a/Intersect.Client.Core/Interface/Shared/SettingsWindow.cs
+++ b/Intersect.Client.Core/Interface/Shared/SettingsWindow.cs
@@ -829,28 +829,27 @@ public partial class SettingsWindow : Window
 
     private void UpdateWorldScaleControls()
     {
+        if (!Options.IsLoaded)
+        {
+            _worldScale.IsHidden = true;
+            return;
+        }
+
+        _worldScale.IsHidden = false;
+        _worldScale.IsDisabled = false;
+        _worldScale.SetToolTipText(null);
+
         var worldScaleNotches = new double[] { 1, 2, 4 }.Select(n => n * Graphics.MinimumWorldScale).ToList();
         while (worldScaleNotches.Last() < Graphics.MaximumWorldScale)
         {
             worldScaleNotches.Add(worldScaleNotches.Last() * 2);
         }
 
-        if (Options.IsLoaded)
-        {
-            _worldScale.IsDisabled = false;
-            _worldScale.SetToolTipText(null);
-
-            Globals.Database.WorldZoom = (float)MathHelper.Clamp(
-                Globals.Database.WorldZoom,
-                worldScaleNotches.Min(),
-                worldScaleNotches.Max()
-            );
-        }
-        else
-        {
-            _worldScale.SetToolTipText(Strings.Settings.WorldScaleTooltip);
-            _worldScale.IsDisabled = true;
-        }
+        Globals.Database.WorldZoom = (float)MathHelper.Clamp(
+            Globals.Database.WorldZoom,
+            worldScaleNotches.Min(),
+            worldScaleNotches.Max()
+        );
 
         _worldScale.SetRange(worldScaleNotches.Min(), worldScaleNotches.Max());
         _worldScale.Notches = worldScaleNotches.ToArray();
@@ -1175,7 +1174,10 @@ public partial class SettingsWindow : Window
 
         // Video Settings.
         Globals.Database.EnableScrollingWorldZoom = _enableScrollingWorldZoomCheckbox.IsChecked;
-        Globals.Database.WorldZoom = (float)_worldScale.Value;
+        if (!_worldScale.IsHidden)
+        {
+            Globals.Database.WorldZoom = (float)_worldScale.Value;
+        }
 
         var resolutionItem = _resolutionList.SelectedItem;
         var targetResolution = resolutionItem?.UserData as int? ?? -1;


### PR DESCRIPTION
Fixes #2750 

The available world scale values cannot be determined until the client has a copy of the server/map config.

Therefore we cannot show or allow updating of the world scale until that config is present.

This PR hides the world scale slider if settings are opened before we have the game config.

If we have the game config AND the saved scale is out of bounds this also fixes it instead of crashing.