### PR TITLE
fixes controls

### DIFF
--- a/Intersect.Client.Core/Core/Controls/Controls.cs
+++ b/Intersect.Client.Core/Core/Controls/Controls.cs
@@ -224,6 +224,16 @@ public partial class Controls : IControlSet
                 }
             }
 
+            // Check for corrupted controls bug (all bindings are None/None)
+            if (AreAllControlsBroken())
+            {
+                ApplicationContext.Context.Value?.Logger.LogWarning(
+                    "Detected broken control bindings (all None/None), resetting to defaults"
+                );
+                ResetDefaults();
+                TrySave();
+            }
+
             return success;
         }
         catch (Exception exception)
@@ -231,6 +241,25 @@ public partial class Controls : IControlSet
             ApplicationContext.Context.Value?.Logger.LogError(exception, "Error while getting controls");
             return false;
         }
+    }
+
+    private bool AreAllControlsBroken()
+    {
+        // Check if all controls have all bindings set to None/None (broken state from old bug)
+        foreach (var (control, mapping) in Mappings)
+        {
+            foreach (var binding in mapping.Bindings)
+            {
+                // If we find any binding that's not None/None, controls are not broken
+                if (binding.Modifier != Keys.None || binding.Key != Keys.None)
+                {
+                    return false;
+                }
+            }
+        }
+
+        // All bindings are None/None, this is the broken state
+        return true;
     }
 
     private bool TryLoadBindingFor(Control control, int bindingIndex, [NotNullWhen(true)] out ControlBinding? binding)

--- a/Intersect.Client.Framework/Input/BuiltinControlsProvider.cs
+++ b/Intersect.Client.Framework/Input/BuiltinControlsProvider.cs
@@ -53,8 +53,17 @@ internal sealed class BuiltinControlsProvider : IControlsProvider
 
     public Control[] Controls { get; } = Enum.GetValues<Control>().Where(control => control.IsValid()).ToArray();
 
-    public bool TryGetDefaultMapping(Control control, [NotNullWhen(true)] out ControlMapping? defaultMapping) =>
-        _defaultMappings.TryGetValue(control, out defaultMapping);
+    public bool TryGetDefaultMapping(Control control, [NotNullWhen(true)] out ControlMapping? defaultMapping)
+    {
+        if (_defaultMappings.TryGetValue(control, out var mapping))
+        {
+            defaultMapping = new ControlMapping(mapping);
+            return true;
+        }
+
+        defaultMapping = null;
+        return false;
+    }
 
     public void ReloadFromOptions(Options? options)
     {


### PR DESCRIPTION
1. Previous versions of Intersect had a bug where, when launched, control key mappings would not populate, leaving every control set as None/None. This looks for clients with that problem and automatically restores proper defaults.

2. This fixes a bug where the 'Restore Defaults' button didn't work.