### PR TITLE
fix: Input focus handling for hotbar

### DIFF
--- a/Intersect.Client.Core/Entities/Player.cs
+++ b/Intersect.Client.Core/Entities/Player.cs
@@ -1591,6 +1591,11 @@ public partial class Player : Entity, IPlayer
             return;
         }
 
+        if (Interface.Interface.HasInputFocus())
+        {
+            return;
+        }
+
         var inputDirection = GetInputDirection();
         if (TryTurnAround(inputDirection))
         {


### PR DESCRIPTION
Resolves #2767 

In Player.HandleInput(), hotbar key processing occurred witout checking if any text input field had focus. Directional movement input already checked focus via GetInputDirection(), but hotbar processing did not...

The check is placed early in HandleInput() to exit before any input processing occurs. This will block hotbar activation when chat's input has focus, and any input text field - with whatever is all is in HasInputFocus ... We can define specific interfaces if needed, but this would be prob the best take on this.