### PR TITLE
Fix: RichLabels improvements + Restores EventWindow

### DIFF
--- a/Framework/Intersect.Framework.Core/Configuration/ClientConfiguration.cs
+++ b/Framework/Intersect.Framework.Core/Configuration/ClientConfiguration.cs
@@ -90,6 +90,8 @@ public sealed partial class ClientConfiguration : IConfiguration<ClientConfigura
 
     public static List<string> DefaultTypewriterSounds => ["octave-beep-tapped.wav"];
 
+    private const bool DefaultDimmedEventWindowBackground = true;
+
     #endregion
 
     #region Static Properties and Methods
@@ -257,6 +259,11 @@ public sealed partial class ClientConfiguration : IConfiguration<ClientConfigura
     public int TypewriterSoundFrequency { get; set; } = DefaultTypewriterSoundFrequency;
 
     public List<string> TypewriterSounds { get; set; } = DefaultTypewriterSounds;
+
+    /// <summary>
+    ///     Adds dimmed background to EventWindow.
+    /// </summary>
+    public bool DimmedEventWindowBackground { get; set; } = DefaultDimmedEventWindowBackground;
 
     #region Hidden Properties
 


### PR DESCRIPTION
Fixes #2768

~~(Already merged)
[Previously required: merge assets into main_full branch](https://github.com/AscensionGameDev/Intersect-Assets/pull/71)~~

(Fix: wrap RichLabels when single word it's too long)
<img width="818" height="659" alt="Image" src="https://github.com/user-attachments/assets/e2107bd0-f6f5-4349-8c7e-5eb71bbc98ac" />


<img width="887" height="606" alt="Image" src="https://github.com/user-attachments/assets/629d1b36-b847-42c2-a093-81ff9397f889" />

<img width="716" height="488" alt="{924AE11D-F78A-4132-858B-69B30FF364C5}" src="https://github.com/user-attachments/assets/a6c3393c-cb65-4d96-b6bc-0090d68ab385" />

<img width="736" height="448" alt="{013C80BF-21D3-4E21-843B-04B0A1304914}" src="https://github.com/user-attachments/assets/6ee9b2a1-acc2-480e-bec9-5aa6f7b358f8" />

<img width="738" height="470" alt="{2793577D-5E20-4B13-AFB7-81CD7E103A01}" src="https://github.com/user-attachments/assets/48095fda-ad77-4903-99c9-d72569c7fb2d" />
