### PR TITLE
fix 2633: Do not send entity packet unless sprite actually changes

### DIFF
--- a/Intersect.Server.Core/Entities/Events/CommandProcessing.cs
+++ b/Intersect.Server.Core/Entities/Events/CommandProcessing.cs
@@ -640,7 +640,7 @@ public static partial class CommandProcessing
         Stack<CommandInstance> callStack
     )
     {
-        if (player.Sprite != command.Sprite)
+        if (!string.Equals(player.Sprite, command.Sprite, StringComparison.OrdinalIgnoreCase))
         {
             player.Sprite = command.Sprite;
             PacketSender.SendEntityDataToProximity(player);


### PR DESCRIPTION
Fixes #2633 

If you have an autorun event that is repeatedly trying to update a sprite for a player it will send entity update packets non-stop which include a position update. If the player is in movement than the position update can make them snap back to their previous location.

This only sends the entity update packet if the sprite actually changes, saving on bandwidth and resolving this behavior.

Better event design is recommended, but at least we can help out from the code angle as well.