### PR TITLE
Add VariableValueHelper and improve variable value handling

### DIFF
--- a/Intersect.Server/Web/Controllers/Api/V1/GuildController.cs
+++ b/Intersect.Server/Web/Controllers/Api/V1/GuildController.cs
@@ -369,19 +369,19 @@ namespace Intersect.Server.Web.Controllers.Api.V1
 
             var variable = guild.GetVariable(variableDescriptor.Id, true);
 
-            var changed = false;
-            if (variable?.Value != null)
+            if (variable?.Value == null)
             {
-                if (variable.Value.Value != valueBody.Value)
-                {
-                    variable.Value.Value = valueBody.Value;
-                    changed = true;
-                }
+                return InternalServerError("Variable value storage is missing.");
             }
 
-            // ReSharper disable once InvertIf
-            if (changed)
+            if (!VariableValueHelper.TryConvertValue(variableDescriptor.DataType, valueBody.Value, out object convertedValue, out string error))
             {
+                return BadRequest(error);
+            }
+
+            if (!VariableValueHelper.Equals(variableDescriptor.DataType, variable.Value, convertedValue))
+            {
+                variable.Value.Value = convertedValue;
                 guild.StartCommonEventsWithTriggerForAll(CommonEventTrigger.GuildVariableChange, string.Empty, variableId.ToString());
                 _ = guild.UpdatedVariables.AddOrUpdate(
                     variableId,

--- a/Intersect.Server/Web/Controllers/Api/V1/UserController.cs
+++ b/Intersect.Server/Web/Controllers/Api/V1/UserController.cs
@@ -626,19 +626,19 @@ namespace Intersect.Server.Web.Controllers.Api.V1
 
             var variable = user.GetVariable(variableDescriptor.Id, true);
 
-            var changed = false;
-            if (variable?.Value != null)
+            if (variable?.Value == null)
             {
-                if (variable.Value.Value != valueBody.Value)
-                {
-                    variable.Value.Value = valueBody.Value;
-                    changed = true;
-                }
+                return InternalServerError("Variable value storage is missing.");
             }
 
-            // ReSharper disable once InvertIf
-            if (changed)
+            if (!VariableValueHelper.TryConvertValue(variableDescriptor.DataType, valueBody.Value, out object convertedValue, out string error))
             {
+                return BadRequest(error);
+            }
+
+            if (!VariableValueHelper.Equals(variableDescriptor.DataType, variable.Value, convertedValue))
+            {
+                variable.Value.Value = convertedValue;
                 user.StartCommonEventsWithTriggerForAll(CommonEventTrigger.UserVariableChange, string.Empty, variableId.ToString());
                 _ = user.UpdatedVariables.AddOrUpdate(
                     variableId,

--- a/Intersect.Server/Web/Controllers/Api/V1/VariableValueHelper.cs
+++ b/Intersect.Server/Web/Controllers/Api/V1/VariableValueHelper.cs
@@ -1,0 +1,101 @@
+using System.Globalization;
+using Intersect.Enums;
+using Intersect.Framework.Core.GameObjects.Variables;
+
+namespace Intersect.Server.Web.Controllers.Api.V1;
+
+internal static class VariableValueHelper
+{
+    private const string InvalidValueErrorFormat = "Invalid value for variable of type {0}. Received: {1}";
+
+    public static bool Equals(VariableDataType dataType, VariableValue variableValue, object? value)
+    {
+        if (value == null)
+        {
+            return variableValue.Value == null;
+        }
+
+        return dataType switch
+        {
+            VariableDataType.Boolean => value is bool booleanValue && variableValue.Boolean == booleanValue,
+            VariableDataType.Integer => value is long longValue && variableValue.Integer == longValue,
+            VariableDataType.Number => value is double doubleValue && variableValue.Number.Equals(doubleValue),
+            VariableDataType.String => value is string stringValue && string.Equals(variableValue.String ?? string.Empty, stringValue, StringComparison.Ordinal),
+            _ => Equals(variableValue.Value, value),
+        };
+    }
+
+    public static bool TryConvertValue(
+        VariableDataType dataType,
+        object? value,
+        out object convertedValue,
+        out string? error
+    )
+    {
+        convertedValue = string.Empty;
+        error = null;
+
+        if (value == null)
+        {
+            if (dataType == VariableDataType.String)
+            {
+                return true;
+            }
+
+            error = FormatError(dataType, "null");
+            return false;
+        }
+
+        switch (dataType)
+        {
+            case VariableDataType.Boolean:
+                if (value is bool booleanValue)
+                {
+                    convertedValue = booleanValue;
+                    return true;
+                }
+
+                error = FormatError(dataType, value?.GetType()?.Name ?? "null");
+                return false;
+
+            case VariableDataType.Integer:
+                if (long.TryParse(value.ToString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedInt))
+                {
+                    convertedValue = parsedInt;
+                    return true;
+                }
+
+                error = FormatError(dataType, value?.GetType()?.Name ?? "null");
+                return false;
+
+            case VariableDataType.Number:
+                if (double.TryParse(value.ToString(), NumberStyles.Float, CultureInfo.InvariantCulture, out var parsedDouble))
+                {
+                    convertedValue = parsedDouble;
+                    return true;
+                }
+
+                error = FormatError(dataType, value?.GetType()?.Name ?? "null");
+                return false;
+
+            case VariableDataType.String:
+                if (value is string stringValue)
+                {
+                    convertedValue = stringValue;
+                    return true;
+                }
+
+                error = FormatError(dataType, value?.GetType()?.Name ?? "null");
+                return false;
+
+            default:
+                error = FormatError(dataType, value?.GetType()?.Name ?? "null");
+                return false;
+        }
+    }
+
+    private static string FormatError(VariableDataType dataType, string received)
+    {
+        return string.Format(CultureInfo.InvariantCulture, InvalidValueErrorFormat, dataType, received);
+    }
+}


### PR DESCRIPTION
resolves #2785 
I've been testing the API these past few days in the Naziozeno game, which is updated with the latest version of Intersect and has no changes in the API files. I found inconsistencies in setting variable values, mostly because the variable's DataType is ignored. So I'm strengthening the variable setting routes a bit more by adding a helper to consider the type of the value coming from the body in relation to the datatype of the variable whose value you want to change. This way, you no longer need to send all values ​​as strings to the API.

In this case, the API will now consider the variable's type and return error messages if the value coming from the body is not of the same type or not be converted to the expected type