### PR TITLE
fix: Ban/Mute game client DC

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Admin/BanMuteBox.cs
+++ b/Intersect.Client.Core/Interface/Game/Admin/BanMuteBox.cs
@@ -103,14 +103,14 @@ public partial class BanMuteBox : WindowControl
         buttonOkay.Clicked += (s, e) =>
         {
             okayHandler?.Invoke(this, EventArgs.Empty);
-            Dispose();
+            DelayedDelete();
         };
 
         var buttonCancel = new Button(this, "ButtonCancel")
         {
             Text = Strings.BanMute.Cancel,
         };
-        buttonCancel.Clicked += (s, e) => Dispose();
+        buttonCancel.Clicked += (s, e) => DelayedDelete();
 
         LoadJsonUi(UI.InGame, Graphics.Renderer?.GetResolutionString(), true);
 


### PR DESCRIPTION
Fixes #2782

<img width="393" height="118" alt="{2DA523FC-1DF1-4E40-BDDD-F40CC13C1B71}" src="https://github.com/user-attachments/assets/71afc131-6ec6-4109-8c0c-7fbbd3c8d4c4" />


Fixes a critical crash that occurred when UI controls (in this case, controls within BanMuteBox)
attempted to dispose themselves from within their own event handlers.

Changes:
- BanMuteBox: Use DelayedDelete() instead of Dispose() in button click
  handlers to defer disposal until after event processing completes
- Canvas: Fix ProcessDelayedDeletes() to iterate over a copy of the
  disposal queue, preventing "Collection was modified" exceptions when
  nested DelayedDelete() calls occur during disposal
- Canvas: Add error handling to catch and log disposal exceptions
  instead of crashing the entire client

The root cause was a double-disposal race condition where:
1. Control.Dispose() was called directly from an event handler
2. The GWEN event system would then try to access the disposed control
3. Additionally, ProcessDelayedDeletes() could throw when the disposal
   queue was modified during iteration

This fix ensures controls are disposed safely between frames using the
delayed deletion queue, and that nested deletion requests don't cause
collection modification exceptions.