### PR TITLE
enhancement: confirmation dialogues when closing the client

### DIFF
--- a/Intersect.Client.Core/Interface/Game/SimplifiedEscapeMenu.cs
+++ b/Intersect.Client.Core/Interface/Game/SimplifiedEscapeMenu.cs
@@ -156,11 +156,20 @@ public sealed partial class SimplifiedEscapeMenu : Framework.Gwen.Control.Menu
 
     private static void ExitToDesktop(object? sender, EventArgs? e)
     {
-        if (Globals.Me != null)
-        {
-            Globals.Me.CombatTimer = 0;
-        }
+        AlertWindow.Open(
+            Strings.General.QuitPrompt,
+            Strings.General.QuitTitle,
+            AlertType.Warning,
+            inputType: InputType.YesNo,
+            handleSubmit: (_, _) =>
+            {
+                if (Globals.Me != null)
+                {
+                    Globals.Me.CombatTimer = 0;
+                }
 
-        Globals.IsRunning = false;
+                Globals.IsRunning = false;
+            }
+        );
     }
 }

--- a/Intersect.Client.Core/Interface/Menu/EscapeMenuWindow.cs
+++ b/Intersect.Client.Core/Interface/Menu/EscapeMenuWindow.cs
@@ -217,11 +217,20 @@ public partial class EscapeMenuWindow : Window
 
     private void ExitToDesktop(object? sender, EventArgs? e)
     {
-        if (Globals.Me != null)
-        {
-            Globals.Me.CombatTimer = 0;
-        }
+        AlertWindow.Open(
+            Strings.General.QuitPrompt,
+            Strings.General.QuitTitle,
+            AlertType.Warning,
+            inputType: InputType.YesNo,
+            handleSubmit: (_, _) =>
+            {
+                if (Globals.Me != null)
+                {
+                    Globals.Me.CombatTimer = 0;
+                }
 
-        Globals.IsRunning = false;
+                Globals.IsRunning = false;
+            }
+        );
     }
 }

--- a/Intersect.Client.Core/Localization/Strings.cs
+++ b/Intersect.Client.Core/Localization/Strings.cs
@@ -1273,6 +1273,12 @@ public static partial class Strings
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public static LocalizedString PingLabelFormat = @"{0}ms";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString QuitTitle { get; set; } = @"Quit Game";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString QuitPrompt { get; set; } = @"Are you sure you want to quit the game?";
     }
 
     public partial struct Guilds


### PR DESCRIPTION
This commit restores some of the original engine behavior that prevented accidental game exits and ensures players don't lose progress by accidentally pressing Alt+F4 or clicking the window close button, especially during combat situations.

- Intercept OnExiting event to prevent immediate closure when player is in-game
- Show combat warning dialog if player is in combat, requiring confirmation to exit
- Show standard quit confirmation dialog if player is not in combat
- Add _isShowingExitConfirmation flag to prevent infinite OnExiting event loop
- Makes InputBox.Closed event to handle X button clicks on dialogs
- Add QuitTitle and QuitPrompt strings to General localization
- Normal cleanup continues if player is not logged in or not in-game

While not in combat - (press either Alt+F4 or the X window close button)
<img width="853" height="602" alt="{E268CBC0-3E8E-4152-B1F2-EB8EDF8BFC95}" src="https://github.com/user-attachments/assets/cb210f8d-4a4c-4473-a4ac-e891fc81c366" />

While in combat - (press either Alt+F4 or the X window close button)
<img width="1142" height="522" alt="{FB63C52A-BCAB-4746-9695-417832CCAF5F}" src="https://github.com/user-attachments/assets/1ebb4a6a-9833-420a-9166-56592ad22cde" />

While not in combat - (from game menu / simplified menu desktop button)
<img width="461" height="211" alt="{CDFE70FC-E2BF-40B9-B83C-0E06FF8FA95A}" src="https://github.com/user-attachments/assets/175f52ca-5f7d-40dc-b7ed-182cdcc37203" />

While in combat - (from game menu / simplified menu desktop button) (not changed at all)
<img width="419" height="173" alt="{17FCA23D-0404-4586-8476-7A42409F4F8A}" src="https://github.com/user-attachments/assets/c7d4ce0f-5d53-4cc1-a10c-e9f0f263e7ad" />