### PR TITLE
Fix: #2762 + OnExiting Updates V2

### DIFF
--- a/Intersect.Client.Core/Interface/Game/SimplifiedEscapeMenu.cs
+++ b/Intersect.Client.Core/Interface/Game/SimplifiedEscapeMenu.cs
@@ -35,7 +35,7 @@ public sealed partial class SimplifiedEscapeMenu : Framework.Gwen.Control.Menu
         _settings.Clicked += OpenSettingsWindow;
         _character.Clicked += LogoutToCharacterSelectSelectClicked;
         _logout.Clicked += LogoutToMainToMainMenuClicked;
-        _exit.Clicked += ExitToDesktopToDesktopClicked;
+        _exit.Clicked += ExitToDesktopClicked;
 
         LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer?.GetResolutionString());
     }
@@ -80,7 +80,13 @@ public sealed partial class SimplifiedEscapeMenu : Framework.Gwen.Control.Menu
     {
         if (Globals.Me?.CombatTimer > Timing.Global.Milliseconds)
         {
-            ShowCombatWarning();
+            AlertWindow.Open(
+                Strings.Combat.WarningCharacterSelect,
+                Strings.Combat.WarningTitle,
+                AlertType.Warning,
+                handleSubmit: LogoutToCharacterSelect,
+                inputType: InputType.YesNo
+            );
         }
         else
         {
@@ -92,7 +98,13 @@ public sealed partial class SimplifiedEscapeMenu : Framework.Gwen.Control.Menu
     {
         if (Globals.Me?.CombatTimer > Timing.Global.Milliseconds)
         {
-            ShowCombatWarning();
+            AlertWindow.Open(
+                Strings.Combat.WarningLogout,
+                Strings.Combat.WarningTitle,
+                AlertType.Warning,
+                handleSubmit: LogoutToMainMenu,
+                inputType: InputType.YesNo
+            );
         }
         else
         {
@@ -100,27 +112,35 @@ public sealed partial class SimplifiedEscapeMenu : Framework.Gwen.Control.Menu
         }
     }
 
-    private void ExitToDesktopToDesktopClicked(Base sender, MouseButtonState arguments)
+    private void ExitToDesktopClicked(Base sender, MouseButtonState arguments)
     {
-        if (Globals.Me?.CombatTimer > Timing.Global.Milliseconds)
+        if (Globals.Me?.CombatTimer > Timing.Global?.Milliseconds)
         {
-            ShowCombatWarning();
+            AlertWindow.Open(
+                Strings.Combat.WarningExitDesktop,
+                Strings.Combat.WarningTitle,
+                AlertType.Warning,
+                inputType: InputType.YesNo,
+                handleSubmit: (_, _) =>
+                {
+                    Globals.Me.CombatTimer = 0;
+                    Globals.IsRunning = false;
+                }
+            );
         }
         else
         {
-            ExitToDesktop(null, null);
+            AlertWindow.Open(
+                Strings.General.QuitPrompt,
+                Strings.General.QuitTitle,
+                AlertType.Warning,
+                inputType: InputType.YesNo,
+                handleSubmit: (_, _) =>
+                {
+                    Globals.IsRunning = false;
+                }
+            );
         }
-    }
-
-    private static void ShowCombatWarning()
-    {
-        AlertWindow.Open(
-            Strings.Combat.WarningCharacterSelect,
-            Strings.Combat.WarningTitle,
-            AlertType.Warning,
-            handleSubmit: LogoutToCharacterSelect,
-            inputType: InputType.YesNo
-        );
     }
 
     private void OpenSettingsWindow(object? sender, EventArgs? e)
@@ -152,24 +172,5 @@ public sealed partial class SimplifiedEscapeMenu : Framework.Gwen.Control.Menu
         }
 
         Main.Logout(false);
-    }
-
-    private static void ExitToDesktop(object? sender, EventArgs? e)
-    {
-        AlertWindow.Open(
-            Strings.General.QuitPrompt,
-            Strings.General.QuitTitle,
-            AlertType.Warning,
-            inputType: InputType.YesNo,
-            handleSubmit: (_, _) =>
-            {
-                if (Globals.Me != null)
-                {
-                    Globals.Me.CombatTimer = 0;
-                }
-
-                Globals.IsRunning = false;
-            }
-        );
     }
 }

--- a/Intersect.Client.Framework/Gwen/Control/Base.cs
+++ b/Intersect.Client.Framework/Gwen/Control/Base.cs
@@ -861,6 +861,12 @@ public partial class Base : IDisposable
 
     private static void SetVisible(Base @this, bool value)
     {
+        // Check if already disposed
+        if (@this._disposed)
+        {
+            return;
+        }
+
         var wasVisibleInParent = @this._visible;
 
         if (@this.GetType().Name == "VersionPanel")

--- a/Intersect.Client.Framework/Gwen/Control/WindowControl.cs
+++ b/Intersect.Client.Framework/Gwen/Control/WindowControl.cs
@@ -273,7 +273,14 @@ public partial class WindowControl : ResizableControl
             return;
         }
 
-        IsHidden = true;
+        try
+        {
+            IsHidden = true;
+        }
+        catch (ObjectDisposedException)
+        {
+            // Canvas already disposed during shutdown, this is fine
+        }
 
         if (_modal != null)
         {


### PR DESCRIPTION
(PR #2788 was not finished)
This Commit finishes the job and fixes #2762 as well
- No more SDL hack for Linux, args.Cancel = true should be sufficient for all platforms (MonoGame).
- Improved logic working for: simplified and regular game menus desktop/logout buttons, Alt+F4 and X close button
- Improved logic works either in game and mainmenu
- Prevents game crash due to canvas handling of already disposed UI elements

<img width="823" height="612" alt="{67A9E158-A8B5-4501-9E34-9FA53D63CC73}" src="https://github.com/user-attachments/assets/edc934ff-db85-46d9-81af-1b62d215c9ac" />

<img width="784" height="669" alt="{149C87AD-3C0C-436F-89EA-D1732DD75359}" src="https://github.com/user-attachments/assets/8a958775-b276-4b21-ad4c-5cddf0f5d508" />

<img width="679" height="431" alt="{1CBEE88F-0543-422B-A51C-AA25029F0F08}" src="https://github.com/user-attachments/assets/24e610f7-d8c0-4117-8f0f-3b633d55decb" />

<img width="436" height="183" alt="{B252AD3E-B61E-46CC-B502-C07D37E55981}" src="https://github.com/user-attachments/assets/61eb13ef-1b1a-4ba3-940d-c6a23d443b4b" />

