### PR TITLE
update: NPC and Critter movement

### DIFF
--- a/Intersect (Core)/Enums/NpcMovement.cs
+++ b/Intersect (Core)/Enums/NpcMovement.cs
@@ -9,4 +9,12 @@ public enum NpcMovement
     StandStill,
 
     Static,
+
+    HorizontalPatrol,
+
+    VerticalPatrol,
+
+    BackslashPatrol,
+
+    ForwardslashPatrol,
 }

--- a/Intersect.Editor/Localization/Strings.cs
+++ b/Intersect.Editor/Localization/Strings.cs
@@ -4582,6 +4582,10 @@ Tick timer saved in server config.json.";
             {1, @"Turn Randomly"},
             {2, @"Stand Still"},
             {3, @"Static"},
+            {4, @"Horizontal Patrol"},
+            {5, @"Vertical Patrol"},
+            {6, @"Backslash Patrol (\)"},
+            {7, @"Forwardslash Patrol (/)"},
         };
 
         public static LocalizedString mpregen = @"MP (%):";

--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -1118,6 +1118,19 @@ public partial class Player : Entity
     {
         CastTime = 0;
         CastTarget = null;
+        
+        // Remove player from ALL threat lists.
+        foreach (var instance in MapController.GetSurroundingMapInstances(Map.Id, MapInstanceId, true))
+        {
+            foreach (var entity in instance.GetCachedEntities())
+            {
+                if (entity is Npc npc)
+                {
+                    npc.RemoveTarget();
+                    npc.RemoveFromDamageMap(this);
+                }
+            }
+        }
 
         //Flag death to the client
         PacketSender.SendPlayerDeath(this);
@@ -1128,23 +1141,10 @@ public partial class Player : Entity
             evt.Value.PlayerHasDied = true;
         }
 
-        // Remove player from ALL threat lists.
-        foreach (var instance in MapController.GetSurroundingMapInstances(Map.Id, MapInstanceId, true))
-        {
-            foreach (var entity in instance.GetCachedEntities())
-            {
-                if (entity is Npc npc)
-                {
-                    npc.RemoveFromDamageMap(this);
-                }
-            }
-        }
-
         lock (EntityLock)
         {
             base.Die(dropItems, killer);
         }
-
 
         // EXP Loss - don't lose in shared instance, or in an Arena zone
         if (InstanceType != MapInstanceType.Shared || Options.Instance.Instancing.LoseExpOnInstanceDeath)


### PR DESCRIPTION
NPC and Critter movement:
- Refactors how both, NPCs and Critters randomly move around, replacing the boring single-tile-paused movement with a more natural, range-based path logic.
- NPCs now intelligently navigate around obstacles and other entities
- Collision detection overhead with optimized valid direction finding
- Prevents movement patterns from messing with current path finder's target
- Code chore: cached status check consolidation
- Code chore: updated naming conventions for movement variables
- Code chore: TODOs - soft reset (walk) to spawn point and hard reset (warp) when pathfinder is unable to lead back to spawnpoint

(New) NPC Patrol Patterns:
- Horizontal patrol (left/right from spawn)
- Vertical patrol (up/down from spawn)
- Diagonal backslash patrol (UpLeft <-> DownRight)
- Diagonal forwardslash patrol (UpRight <-> DownLeft)
- Patrolling NPCs return to their spawn/patrol point when there's no target left to smack or out of former map

All patrol modes use NPC sight range as patrol distance and keep track of their spawn position for reseting purposes.

<img width="261" height="250" alt="image" src="https://github.com/user-attachments/assets/0bb67cda-6ed3-4958-83e8-8e335dd2a181" />


https://github.com/user-attachments/assets/43539be1-8990-4679-8e67-a3a412bbf6d7


https://github.com/user-attachments/assets/141de477-45a4-4a0e-9af1-cbd69694db67


https://github.com/user-attachments/assets/88c481c9-c799-4eea-8b36-5f812b7f061f


https://github.com/user-attachments/assets/49fc9f01-2e89-4f2a-be5a-3263d490d366


https://github.com/user-attachments/assets/4f5c5df4-411f-4695-a931-6f470f87da2d



