### PR TITLE
fix: stop drag-drop from reparenting item icons

### DIFF
--- a/Intersect.Client.Core/Entities/Player.cs
+++ b/Intersect.Client.Core/Entities/Player.cs
@@ -415,7 +415,8 @@ public partial class Player : Entity, IPlayer
         }
 
         var quantity = inventorySlot.Quantity;
-        var canDropMultiple = quantity > 1;
+        var maxQuantity = GetQuantityOfItemInInventory(itemDescriptor.Id);
+        var canDropMultiple = maxQuantity > 1;
         var inputType = canDropMultiple ? InputType.NumericSliderInput : InputType.YesNo;
         var prompt = canDropMultiple ? Strings.Inventory.DropItemPrompt : Strings.Inventory.DropPrompt;
         _ = new InputBox(
@@ -423,7 +424,7 @@ public partial class Player : Entity, IPlayer
             prompt: prompt.ToString(itemDescriptor.Name),
             inputType: inputType,
             quantity: quantity,
-            maximumQuantity: GetQuantityOfItemInInventory(itemDescriptor.Id),
+            maximumQuantity: maxQuantity,
             userData: inventorySlotIndex,
             onSubmit: (sender, args) =>
             {
@@ -1120,41 +1121,32 @@ public partial class Player : Entity, IPlayer
         }
 
         var quantity = inventorySlot.Quantity;
-        var maxQuantity = quantity;
-
-        if (maxQuantity < 2)
-        {
-            PacketSender.SendStoreBagItem(inventorySlotIndex, 1, bagSlotIndex);
-            return;
-        }
 
         _ = new InputBox(
             title: Strings.Bags.StoreItem,
             prompt: Strings.Bags.StoreItemPrompt.ToString(itemDescriptor.Name),
-            inputType: InputType.NumericSliderInput,
+            inputType: InputType.YesNo,
             quantity: quantity,
-            maximumQuantity: maxQuantity,
-            userData: new Tuple<int, int>(inventorySlotIndex, bagSlotIndex),
+            userData: new Tuple<int, int, int>(inventorySlotIndex, bagSlotIndex, quantity),
             onSubmit: TryStoreItemInBagOnSubmit
         );
     }
 
     private static void TryStoreItemInBagOnSubmit(Base sender, InputSubmissionEventArgs args)
     {
-        if (sender is not InputBox { UserData: (int inventorySlotIndex, int bagSlotIndex) })
+        if (sender is not InputBox { UserData: (int inventorySlotIndex, int bagSlotIndex, int quantity) })
         {
             return;
         }
 
-        if (args.Value is not NumericalSubmissionValue submissionValue)
+        if (args.Value is not BooleanSubmissionValue submissionValue)
         {
             return;
         }
 
-        var value = (int)Math.Round(submissionValue.Value);
-        if (value > 0)
+        if (submissionValue.Value)
         {
-            PacketSender.SendStoreBagItem(inventorySlotIndex, value, bagSlotIndex);
+            PacketSender.SendStoreBagItem(inventorySlotIndex, quantity, bagSlotIndex);
         }
     }
 
@@ -1444,11 +1436,16 @@ public partial class Player : Entity, IPlayer
         PacketSender.SendHotbarUpdate(hotbarSlot, itemType, itemSlot);
     }
 
-    public void HotbarSwap(int index, int swapIndex)
+    public bool HotbarSwap(int index, int swapIndex)
     {
         var itemId = Hotbar[index].ItemOrSpellId;
         var bagId = Hotbar[index].BagId;
         var stats = Hotbar[index].PreferredStatBuffs;
+
+        if (Hotbar[swapIndex].ItemOrSpellId == itemId)
+        {
+            return false;
+        }
 
         Hotbar[index].ItemOrSpellId = Hotbar[swapIndex].ItemOrSpellId;
         Hotbar[index].BagId = Hotbar[swapIndex].BagId;
@@ -1459,6 +1456,7 @@ public partial class Player : Entity, IPlayer
         Hotbar[swapIndex].PreferredStatBuffs = stats;
 
         PacketSender.SendHotbarSwap(index, swapIndex);
+        return true;
     }
 
     // Change the dimension if the player is on a gateway

--- a/Intersect.Client.Core/Interface/Game/Bag/BagItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Bag/BagItem.cs
@@ -19,15 +19,13 @@ public partial class BagItem : SlotItem
 {
     // Controls
     private readonly Label _quantityLabel;
-    private readonly BagWindow _bagWindow;
 
     // Context Menu Handling
     private readonly MenuItem _withdrawContextItem;
 
-    public BagItem(BagWindow bagWindow, Base parent, int index, ContextMenu contextMenu)
+    public BagItem(Base parent, int index, ContextMenu contextMenu)
         : base(parent, nameof(BagItem), index, contextMenu)
     {
-        _bagWindow = bagWindow;
         TextureFilename = "bagitem.png";
 
         Icon.HoverEnter += Icon_HoverEnter;
@@ -157,6 +155,16 @@ public partial class BagItem : SlotItem
 
     public override bool DragAndDrop_HandleDrop(Package package, int x, int y)
     {
+        if (Globals.Me is not { } player)
+        {
+            return false;
+        }
+
+        if (Globals.BagSlots is not { Length: > 0 } bagSlots)
+        {
+            return false;
+        }
+
         var targetNode = Interface.FindComponentUnderCursor();
 
         // Find the first parent acceptable in that tree that can accept the package
@@ -166,11 +174,11 @@ public partial class BagItem : SlotItem
             {
                 case BagItem bagItem:
                     PacketSender.SendMoveBagItems(SlotIndex, bagItem.SlotIndex);
-                    return true;
+                    return bagSlots[bagItem.SlotIndex] is not { Quantity: > 0 };
 
                 case InventoryItem inventoryItem:
-                    Globals.Me?.TryRetrieveItemFromBag(SlotIndex, inventoryItem.SlotIndex);
-                    return true;
+                    player.TryRetrieveItemFromBag(SlotIndex, inventoryItem.SlotIndex);
+                    return bagSlots[inventoryItem.SlotIndex] is not { Quantity: > 0 };
 
                 default:
                     targetNode = targetNode.Parent;
@@ -206,7 +214,7 @@ public partial class BagItem : SlotItem
         var bagSlot = bagSlots[SlotIndex];
         var descriptor = bagSlot.Descriptor;
 
-        _quantityLabel.IsVisibleInParent = !Icon.IsDragging && descriptor.IsStackable && bagSlot.Quantity > 1;
+        _quantityLabel.IsVisibleInParent = !Icon.IsHidden && descriptor.IsStackable && bagSlot.Quantity > 1;
         if (_quantityLabel.IsVisibleInParent)
         {
             _quantityLabel.Text = Strings.FormatQuantityAbbreviated(bagSlot.Quantity);

--- a/Intersect.Client.Core/Interface/Game/Bag/BagWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Bag/BagWindow.cs
@@ -58,7 +58,7 @@ public partial class BagWindow : Window
 
         for (var slotIndex = 0; slotIndex < bagSlots.Length; slotIndex++)
         {
-            Items.Add(new BagItem(this, _slotContainer, slotIndex, _contextMenu));
+            Items.Add(new BagItem(_slotContainer, slotIndex, _contextMenu));
         }
 
         PopulateSlotContainer.Populate(_slotContainer, Items);

--- a/Intersect.Client.Core/Interface/Game/Bank/BankItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Bank/BankItem.cs
@@ -22,15 +22,12 @@ public partial class BankItem : SlotItem
 {
     // Controls
     private readonly Label _quantityLabel;
-    private BankWindow _bankWindow;
 
     // Context Menu Handling
     private MenuItem _withdrawContextItem;
 
-    public BankItem(BankWindow bankWindow, Base parent, int index, ContextMenu contextMenu) :
-        base(parent, nameof(BankItem), index, contextMenu)
+    public BankItem(Base parent, int index, ContextMenu contextMenu) : base(parent, nameof(BankItem), index, contextMenu)
     {
-        _bankWindow = bankWindow;
         TextureFilename = "bankitem.png";
 
         Icon.HoverEnter += Icon_HoverEnter;
@@ -117,6 +114,7 @@ public partial class BankItem : SlotItem
 
         if (bankSlots[SlotIndex] is not { Descriptor: not null } or { Quantity: <= 0 })
         {
+             _quantityLabel.IsVisibleInParent = false;
             return;
         }
 
@@ -206,29 +204,28 @@ public partial class BankItem : SlotItem
             }
         }
 
+        if (Globals.BankSlots is not { Length: > 0 } bankSlots)
+        {
+            return false;
+        }
+
         var targetNode = Interface.FindComponentUnderCursor();
 
         // Find the first parent acceptable in that tree that can accept the package
         while (targetNode != default)
         {
+            if (bankSlots[SlotIndex] is not { Quantity: > 0 } slot)
+            {
+                return false;
+            }
+
             switch (targetNode)
             {
                 case BankItem bankItem:
                     PacketSender.SendMoveBankItems(SlotIndex, bankItem.SlotIndex);
-                    return true;
+                    return bankSlots[bankItem.SlotIndex] is not { Quantity: > 0 };
 
                 case InventoryItem inventoryItem:
-
-                    if (Globals.BankSlots is not { Length: > 0 } bankSlots)
-                    {
-                        return false;
-                    }
-
-                    if (bankSlots[SlotIndex] is not { Quantity: > 0 } slot)
-                    {
-                        return false;
-                    }
-
                     player.TryRetrieveItemFromBank(
                         SlotIndex,
                         inventorySlotIndex: inventoryItem.SlotIndex,
@@ -271,7 +268,7 @@ public partial class BankItem : SlotItem
         var bankSlot = bankSlots[SlotIndex];
         var descriptor = bankSlot.Descriptor;
 
-        _quantityLabel.IsVisibleInParent = !Icon.IsDragging && descriptor.IsStackable && bankSlot.Quantity > 1;
+        _quantityLabel.IsVisibleInParent = descriptor.IsStackable && bankSlot.Quantity > 1 && !Icon.IsHidden;
         if (_quantityLabel.IsVisibleInParent)
         {
             _quantityLabel.Text = Strings.FormatQuantityAbbreviated(bankSlot.Quantity);
@@ -295,6 +292,7 @@ public partial class BankItem : SlotItem
             {
                 Icon.Texture = default;
                 Icon.IsVisibleInParent = false;
+                _quantityLabel.IsVisibleInParent = false;
             }
         }
     }

--- a/Intersect.Client.Core/Interface/Game/Bank/BankWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Bank/BankWindow.cs
@@ -67,7 +67,7 @@ public partial class BankWindow : Window
     {
         for (var slotIndex = 0; slotIndex < Globals.BankSlotCount; slotIndex++)
         {
-            Items.Add(new BankItem(this, _slotContainer, slotIndex, _contextMenu));
+            Items.Add(new BankItem(_slotContainer, slotIndex, _contextMenu));
         }
 
         PopulateSlotContainer.Populate(_slotContainer, Items);

--- a/Intersect.Client.Core/Interface/Game/Crafting/RecipeItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Crafting/RecipeItem.cs
@@ -4,7 +4,6 @@ using Intersect.Client.Framework.Input;
 using Intersect.Client.General;
 using Intersect.Framework.Core.GameObjects.Crafting;
 using Intersect.Framework.Core.GameObjects.Items;
-using Intersect.GameObjects;
 
 namespace Intersect.Client.Interface.Game.Crafting;
 
@@ -13,8 +12,6 @@ public partial class RecipeItem
 {
 
     public ImagePanel? Container;
-
-    public bool IsDragging;
 
     //Dragging
     private bool mCanDrag;

--- a/Intersect.Client.Core/Interface/Game/Draggable.cs
+++ b/Intersect.Client.Core/Interface/Game/Draggable.cs
@@ -16,6 +16,7 @@ public partial class Draggable(Base parent, string name) : ImagePanel(parent, na
 
     public override bool DragAndDrop_CanAcceptPackage(Package package)
     {
+        // Important: Icon is the topmost hovered control, so it must be allowed to "receive" the drop, BUT: we forward handling to SlotItem.
         return true;
     }
 
@@ -27,6 +28,7 @@ public partial class Draggable(Base parent, string name) : ImagePanel(parent, na
             DrawControl = this,
             Name = Name,
             HoldOffset = ToLocal(InputHandler.MousePosition.X, InputHandler.MousePosition.Y),
+            UserData = Parent, // Expected to be SlotItem (InventoryItem/BankItem/etc)
         };
     }
 
@@ -37,6 +39,24 @@ public partial class Draggable(Base parent, string name) : ImagePanel(parent, na
 
     public override void DragAndDrop_EndDragging(bool success, int x, int y)
     {
-        IsVisibleInParent = true;
+        IsVisibleInParent = !success;
+    }
+
+    public override bool DragAndDrop_HandleDrop(Package package, int x, int y)
+    {
+        // Never allow Base.DragAndDrop_HandleDrop() to run on the icon because it reparents SourceControl (Base.cs)
+        // Forward drop handling to the slot (or nearest SlotItem ancestor).
+        var node = Parent;
+        while (node != null)
+        {
+            if (node is SlotItem)
+            {
+                return node.DragAndDrop_HandleDrop(package, x, y);
+            }
+
+            node = node.Parent;
+        }
+
+        return false;
     }
 }

--- a/Intersect.Client.Core/Interface/Game/Hotbar/HotbarItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Hotbar/HotbarItem.cs
@@ -217,12 +217,9 @@ public partial class HotbarItem : SlotItem
             if (targetNode is HotbarItem hotbarItem)
             {
                 player.HotbarSwap(SlotIndex, hotbarItem.SlotIndex);
-                return true;
             }
-            else
-            {
-                targetNode = targetNode.Parent;
-            }
+
+            targetNode = targetNode.Parent;
         }
 
         // If we've reached the top of the tree, we can't drop here, so cancel drop

--- a/Intersect.Client.Core/Interface/Game/Shop/ShopItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Shop/ShopItem.cs
@@ -16,13 +16,11 @@ namespace Intersect.Client.Interface.Game.Shop;
 public partial class ShopItem : SlotItem
 {
     private readonly int _mySlot;
-    private readonly ShopWindow _shopWindow;
     private readonly MenuItem _buyMenuItem;
 
-    public ShopItem(ShopWindow shopWindow, Base parent, int index, ContextMenu contextMenu)
+    public ShopItem(Base parent, int index, ContextMenu contextMenu)
         : base(parent, nameof(ShopItem), index, contextMenu)
     {
-        _shopWindow = shopWindow;
         _mySlot = index;
         TextureFilename = "shopitem.png";
 
@@ -106,7 +104,7 @@ public partial class ShopItem : SlotItem
         Globals.Me?.TryBuyItem(_mySlot);
     }
 
-    private void _buyMenuItem_Clicked(Base sender, Framework.Gwen.Control.EventArguments.MouseButtonState arguments)
+    private void _buyMenuItem_Clicked(Base sender, MouseButtonState arguments)
     {
         Globals.Me?.TryBuyItem(_mySlot);
     }

--- a/Intersect.Client.Core/Interface/Game/Shop/ShopWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Shop/ShopWindow.cs
@@ -58,7 +58,7 @@ public partial class ShopWindow : Window
 
         for (var slotIndex = 0; slotIndex < gameShop.SellingItems.Count; slotIndex++)
         {
-            _items.Add(new ShopItem(this, _slotContainer, slotIndex, _contextMenu));
+            _items.Add(new ShopItem(_slotContainer, slotIndex, _contextMenu));
         }
 
         PopulateSlotContainer.Populate(_slotContainer, _items);

--- a/Intersect.Client.Core/Interface/Game/Spells/SpellItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Spells/SpellItem.cs
@@ -173,7 +173,7 @@ public partial class SpellItem : SlotItem
 
                 case HotbarItem hotbarItem:
                     player.AddToHotbar(hotbarItem.SlotIndex, 1, SlotIndex);
-                    return true;
+                    return false;
 
                 default:
                     targetNode = targetNode.Parent;
@@ -207,7 +207,7 @@ public partial class SpellItem : SlotItem
             return;
         }
 
-        _cooldownLabel.IsVisibleInParent = !Icon.IsDragging && Globals.Me.IsSpellOnCooldown(SlotIndex);
+        _cooldownLabel.IsVisibleInParent = !Icon.IsHidden && Globals.Me.IsSpellOnCooldown(SlotIndex);
         if (_cooldownLabel.IsVisibleInParent)
         {
             var itemCooldownRemaining = Globals.Me.GetSpellRemainingCooldown(SlotIndex);
@@ -219,22 +219,24 @@ public partial class SpellItem : SlotItem
             Icon.RenderColor.A = 255;
         }
 
-        if (Path.GetFileName(Icon.Texture?.Name) != spell.Icon)
+        if (Icon.TextureFilename == spell.Icon)
         {
-            var spellIconTexture = GameContentManager.Current.GetTexture(TextureType.Spell, spell.Icon);
-            if (spellIconTexture != null)
+            return;
+        }
+
+        var spellTexture = GameContentManager.Current.GetTexture(TextureType.Spell, spell.Icon);
+        if (spellTexture != default)
+        {
+            Icon.Texture = spellTexture;
+            Icon.RenderColor.A = (byte)(_cooldownLabel.IsVisibleInParent ? 100 : 255);
+            Icon.IsVisibleInParent = true;
+        }
+        else
+        {
+            if (Icon.Texture != null)
             {
-                Icon.Texture = spellIconTexture;
-                Icon.RenderColor.A = (byte)(_cooldownLabel.IsVisibleInParent ? 100 : 255);
-                Icon.IsVisibleInParent = true;
-            }
-            else
-            {
-                if (Icon.Texture != null)
-                {
-                    Icon.Texture = null;
-                    Icon.IsVisibleInParent = false;
-                }
+                Icon.Texture = null;
+                Icon.IsVisibleInParent = false;
             }
         }
     }

--- a/Intersect.Client.Core/Interface/Game/Trades/TradeItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Trades/TradeItem.cs
@@ -6,7 +6,6 @@ using Intersect.Client.Framework.Input;
 using Intersect.Client.General;
 using Intersect.Configuration;
 using Intersect.Framework.Core.GameObjects.Items;
-using Intersect.GameObjects;
 
 namespace Intersect.Client.Interface.Game.Trades;
 

--- a/Intersect.Client.Core/Localization/Strings.cs
+++ b/Intersect.Client.Core/Localization/Strings.cs
@@ -541,7 +541,10 @@ public static partial class Strings
         public static LocalizedString StoreItem = @"Store Item";
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-        public static LocalizedString StoreItemPrompt = @"How many/much {00} would you like to store?";
+        public static LocalizedString StoreMultipleItemPrompt = @"How many/much {00} would you like to store?";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString StoreItemPrompt = @"Do you wish to store the item: {00} ?";
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public static LocalizedString Title = @"Bag";

--- a/Intersect.Client.Framework/Entities/IPlayer.cs
+++ b/Intersect.Client.Framework/Entities/IPlayer.cs
@@ -34,7 +34,7 @@ public interface IPlayer : IEntity
     void AddToHotbar(int hotbarSlot, sbyte itemType, int itemSlot);
     int FindHotbarItem(IHotbarInstance hotbarInstance);
     int FindHotbarSpell(IHotbarInstance hotbarInstance);
-    void HotbarSwap(int index, int swapIndex);
+    bool HotbarSwap(int index, int swapIndex);
     int FindItem(Guid itemId, int itemVal = 1);
     void SwapItems(int item1, int item2);
     long GetItemCooldown(Guid id);

--- a/Intersect.Client.Framework/Gwen/DragDrop/DragAndDrop.cs
+++ b/Intersect.Client.Framework/Gwen/DragDrop/DragAndDrop.cs
@@ -58,7 +58,7 @@ public static partial class DragAndDrop
 
         // Not been dragged far enough
         var length = Math.Abs(x - sLastPressedPos.X) + Math.Abs(y - sLastPressedPos.Y);
-        if (length < 5)
+        if (length <= 1)
         {
             return false;
         }


### PR DESCRIPTION
Fixes #2793

Prevent Gwen's default drop handler from reparenting the dragged icon into the hovered control, which could place the icon into the wrong slot/container. Draggable now forwards DragAndDrop_HandleDrop to its SlotItem parent, and the drag package stores the source SlotItem in Package.UserData to make slot handlers deterministic.


https://github.com/user-attachments/assets/304afac6-46d8-4d58-affa-1eabbed8ffbe

