### PR TITLE
fix: settings window crash after changing tile dimensions

### DIFF
--- a/Intersect.Client.Framework/Gwen/Control/LabeledSlider.cs
+++ b/Intersect.Client.Framework/Gwen/Control/LabeledSlider.cs
@@ -388,6 +388,11 @@ public partial class LabeledSlider : Base, ISmartAutoSizeToContents, INumericInp
             Maximum = actualMax;
             Minimum = actualMin;
         }
+        else if (actualMax < Minimum)
+        {
+            Minimum = actualMin;
+            Maximum = actualMax;
+        }
         else
         {
             Minimum = actualMin;

--- a/Intersect.Client.Framework/Gwen/Control/Slider.cs
+++ b/Intersect.Client.Framework/Gwen/Control/Slider.cs
@@ -461,10 +461,15 @@ public partial class Slider : Base
         var actualMin = Math.Min(min, max);
         var actualMax = Math.Max(min, max);
 
-        if (actualMin > Maximum)
+        if (actualMin > _maximumValue)
         {
             _maximumValue = actualMax;
             _minimumValue = actualMin;
+        }
+        else if (actualMax < _minimumValue)
+        {
+            _minimumValue = actualMin;
+            _maximumValue = actualMax;
         }
         else
         {


### PR DESCRIPTION
Fixes #2795
This fix ensures that when updating value ranges within Sliders and LabeledSliders:
- If the new minimum is greater than the current maximum, we set the maximum first to avoid the validation error
- If the new maximum is less than the current minimum, we set the minimum first
- Otherwise, we can safely set them in the original order

This prevents the intermediate state where minimum temporarily exceeds maximum, which was causing the crash when opening the settings window after changing tile dimensions.

Note: Tested by decreasing dimensions from 32x32 to 16x16, leading to no more crashes at settings windows
<img width="1370" height="763" alt="{860FFCF6-ECC1-4B10-8EBF-6DAADC636395}" src="https://github.com/user-attachments/assets/3732a435-e3fa-4e24-bb18-d3242705f3c7" />
