### PR TITLE
performance: editor's graphics

### DIFF
--- a/Intersect.Editor/Core/Graphics.cs
+++ b/Intersect.Editor/Core/Graphics.cs
@@ -6,7 +6,6 @@ using Intersect.Editor.Forms.DockingElements;
 using Intersect.Editor.Forms.Helpers;
 using Intersect.Editor.General;
 using Intersect.Editor.Maps;
-using Intersect.Enums;
 using Intersect.Framework.Core;
 using Intersect.Framework.Core.GameObjects.Animations;
 using Intersect.Framework.Core.GameObjects.Events;
@@ -15,7 +14,6 @@ using Intersect.Framework.Core.GameObjects.Mapping.Tilesets;
 using Intersect.Framework.Core.GameObjects.Maps;
 using Intersect.Framework.Core.GameObjects.Maps.Attributes;
 using Intersect.Framework.Core.GameObjects.Resources;
-using Intersect.GameObjects;
 using Intersect.Utilities;
 using Microsoft.Extensions.Logging;
 using Microsoft.Xna.Framework;
@@ -34,6 +32,8 @@ public static partial class Graphics
     public static System.Drawing.Rectangle CurrentView;
 
     public static RenderTarget2D DarknessTexture;
+
+    private static Texture2D _transparentGridTexture;
 
     public static object GraphicsLock = new object();
 
@@ -60,8 +60,6 @@ public static partial class Graphics
     public static BlendState MultiplyState;
 
     //Overlay Stuff
-    public static System.Drawing.Color OverlayColor = System.Drawing.Color.Transparent;
-
     private static BlendState sCurrentBlendmode = BlendState.NonPremultiplied;
 
     private static Effect sCurrentShader;
@@ -147,6 +145,13 @@ public static partial class Graphics
         }
     }
 
+    private static void DrawAllMapAttributes(MapInstance map, int gridX, int gridY, bool screenShotting, RenderTarget2D target)
+    {
+        DrawMapAttributes(map, gridX, gridY, screenShotting, target, false, false);
+        DrawMapAttributes(map, gridX, gridY, screenShotting, target, false, true);
+        DrawMapAttributes(map, gridX, gridY, screenShotting, target, true, true);
+    }
+    
     public static GraphicsDevice GetGraphicsDevice()
     {
         return sGraphicsDevice;
@@ -231,129 +236,35 @@ public static partial class Graphics
 
                                 if (map != null)
                                 {
+                                    var relX = x - Globals.CurrentMap.MapGridX;
+                                    var relY = y - Globals.CurrentMap.MapGridY;
+
                                     lock (map.MapLock)
                                     {
-                                        //Draw this map
-                                        DrawMap(
-                                            map, x - Globals.CurrentMap.MapGridX, y - Globals.CurrentMap.MapGridY,
-                                            false, 0, null
-                                        );
+                                        // Lower layers
+                                        DrawMap(map, relX, relY, false, 0, null);
+
+                                        // Attributes - consolidate 3 calls into 1
+                                        DrawAllMapAttributes(map, relX, relY, false, null);
+
+                                        // Events
+                                        DrawMapEvents(map, relX, relY, false, null);
+
+                                        // Upper layers
+                                        DrawMap(map, relX, relY, false, 1, null);
+
+                                        // Upper attributes
+                                        DrawMapAttributes(map, relX, relY, false, null, true, false);
                                     }
                                 }
-                                else
+                                else // Empty Map, fill it with checkered transparent texture
                                 {
-                                    DrawTransparentBorders(
-                                        x - Globals.CurrentMap.MapGridX, y - Globals.CurrentMap.MapGridY
-                                    );
+                                    DrawTransparentBorders(x - Globals.CurrentMap.MapGridX, y - Globals.CurrentMap.MapGridY);
                                 }
                             }
-                            else
+                            else // Outside grid bounds: fill it with checkered transparent texture
                             {
-                                DrawTransparentBorders(
-                                    x - Globals.CurrentMap.MapGridX, y - Globals.CurrentMap.MapGridY
-                                );
-                            }
-                        }
-                    }
-
-                    //Draw the lower resources/animations
-                    for (var y = Globals.CurrentMap.MapGridY - 1; y <= Globals.CurrentMap.MapGridY + 1; y++)
-                    {
-                        for (var x = Globals.CurrentMap.MapGridX - 1; x <= Globals.CurrentMap.MapGridX + 1; x++)
-                        {
-                            if (x >= 0 && x < Globals.MapGrid.GridWidth && y >= 0 && y < Globals.MapGrid.GridHeight)
-                            {
-                                var mapGridItem = Globals.MapGrid.Grid[x, y];
-                                var map = MapInstance.Get(mapGridItem.MapId);
-                                if (map == null)
-                                {
-                                    continue;
-                                }
-
-                                lock (map.MapLock)
-                                {
-                                    DrawMapAttributes(
-                                        map, x - Globals.CurrentMap.MapGridX, y - Globals.CurrentMap.MapGridY,
-                                        false, null, false, false
-                                    );
-
-                                    DrawMapAttributes(
-                                        map, x - Globals.CurrentMap.MapGridX, y - Globals.CurrentMap.MapGridY,
-                                        false, null, false, true
-                                    );
-
-                                    DrawMapAttributes(
-                                        map, x - Globals.CurrentMap.MapGridX, y - Globals.CurrentMap.MapGridY,
-                                        false, null, true, true
-                                    );
-                                }
-                            }
-                        }
-                    }
-
-                    // Draw events
-                    for (var y = Globals.CurrentMap.MapGridY - 1; y <= Globals.CurrentMap.MapGridY + 1; y++)
-                    {
-                        for (var x = Globals.CurrentMap.MapGridX - 1; x <= Globals.CurrentMap.MapGridX + 1; x++)
-                        {
-                            if (x >= 0 && x < Globals.MapGrid.GridWidth && y >= 0 && y < Globals.MapGrid.GridHeight)
-                            {
-                                var map = MapInstance.Get(Globals.MapGrid.Grid[x, y].MapId);
-                                if (map != null)
-                                {
-                                    lock (map.MapLock)
-                                    {
-                                        DrawMapEvents(
-                                            map, x - Globals.CurrentMap.MapGridX, y - Globals.CurrentMap.MapGridY,
-                                            false, null
-                                        );
-                                    }
-                                }
-                            }
-                        }
-                    }
-
-                    //Draw The upper maps
-                    for (var y = Globals.CurrentMap.MapGridY - 1; y <= Globals.CurrentMap.MapGridY + 1; y++)
-                    {
-                        for (var x = Globals.CurrentMap.MapGridX - 1; x <= Globals.CurrentMap.MapGridX + 1; x++)
-                        {
-                            if (x >= 0 && x < Globals.MapGrid.GridWidth && y >= 0 && y < Globals.MapGrid.GridHeight)
-                            {
-                                var map = MapInstance.Get(Globals.MapGrid.Grid[x, y].MapId);
-                                if (map != null)
-                                {
-                                    lock (map.MapLock)
-                                    {
-                                        //Draw this map
-                                        DrawMap(
-                                            map, x - Globals.CurrentMap.MapGridX, y - Globals.CurrentMap.MapGridY,
-                                            false, 1, null
-                                        );
-                                    }
-                                }
-                            }
-                        }
-                    }
-
-                    //Draw the upper resources/animations
-                    for (var y = Globals.CurrentMap.MapGridY - 1; y <= Globals.CurrentMap.MapGridY + 1; y++)
-                    {
-                        for (var x = Globals.CurrentMap.MapGridX - 1; x <= Globals.CurrentMap.MapGridX + 1; x++)
-                        {
-                            if (x >= 0 && x < Globals.MapGrid.GridWidth && y >= 0 && y < Globals.MapGrid.GridHeight)
-                            {
-                                var map = MapInstance.Get(Globals.MapGrid.Grid[x, y].MapId);
-                                if (map != null)
-                                {
-                                    lock (map.MapLock)
-                                    {
-                                        DrawMapAttributes(
-                                            map, x - Globals.CurrentMap.MapGridX, y - Globals.CurrentMap.MapGridY,
-                                            false, null, true, false
-                                        );
-                                    }
-                                }
+                                DrawTransparentBorders(x - Globals.CurrentMap.MapGridX, y - Globals.CurrentMap.MapGridY);
                             }
                         }
                     }
@@ -390,54 +301,71 @@ public static partial class Graphics
 
     private static void DrawGridOverlay()
     {
-        for (var x = 0; x < Options.Instance.Map.MapWidth; x++)
+        var tileWidth = Options.Instance.Map.TileWidth;
+        var tileHeight = Options.Instance.Map.TileHeight;
+        var mapWidth = Options.Instance.Map.MapWidth;
+        var mapHeight = Options.Instance.Map.MapHeight;
+        var leftPos = CurrentView.Left;
+        var topPos = CurrentView.Top;
+        var totalWidth = mapWidth * tileWidth;
+        var totalHeight = mapHeight * tileHeight;
+
+        // Draw vertical lines
+        for (var x = 0; x <= mapWidth; x++)
         {
             DrawTexture(
-                sWhiteTex, new RectangleF(0, 0, 1, 1),
-                new RectangleF(
-                    CurrentView.Left + x * Options.Instance.Map.TileWidth, CurrentView.Top, 1,
-                    Options.Instance.Map.MapHeight * Options.Instance.Map.TileHeight
-                ), null
+                sWhiteTex,
+                new RectangleF(0, 0, 1, 1),
+                new RectangleF(leftPos + x * tileWidth, topPos, 1, totalHeight),
+                null
             );
         }
 
-        for (var y = 0; y < Options.Instance.Map.MapHeight; y++)
+        // Draw horizontal lines
+        for (var y = 0; y <= mapHeight; y++)
         {
             DrawTexture(
-                sWhiteTex, new RectangleF(0, 0, 1, 1),
-                new RectangleF(
-                    CurrentView.Left, CurrentView.Top + y * Options.Instance.Map.TileHeight,
-                    Options.Instance.Map.MapWidth * Options.Instance.Map.TileWidth, 1
-                ), null
+                sWhiteTex,
+                new RectangleF(0, 0, 1, 1),
+                new RectangleF(leftPos, topPos + y * tileHeight, totalWidth, 1),
+                null
             );
         }
     }
 
     private static void DrawTransparentBorders(int gridX, int gridY)
     {
-        var transTex = GameContentManager.GetTexture(GameContentManager.TextureType.Misc, "transtile.png");
-        if (transTex == null)
+        if (_transparentGridTexture?.IsDisposed != false)
+        {
+            _transparentGridTexture = GameContentManager.GetTexture(GameContentManager.TextureType.Misc, "transtile.png");
+        }
+
+        if (_transparentGridTexture == null)
         {
             return;
         }
 
-        var xoffset = CurrentView.Left + gridX * Options.Instance.Map.TileWidth * Options.Instance.Map.MapWidth;
-        var yoffset = CurrentView.Top + gridY * Options.Instance.Map.TileHeight * Options.Instance.Map.MapHeight;
-        for (var x = 0; x < Options.Instance.Map.MapWidth; x++)
+        var tileWidth = Options.Instance.Map.TileWidth;
+        var tileHeight = Options.Instance.Map.TileHeight;
+        var mapWidth = Options.Instance.Map.MapWidth;
+        var mapHeight = Options.Instance.Map.MapHeight;
+        var xoffset = CurrentView.Left + gridX * tileWidth * mapWidth;
+        var yoffset = CurrentView.Top + gridY * tileHeight * mapHeight;
+        var texRect = new RectangleF(0, 0, _transparentGridTexture.Width, _transparentGridTexture.Height);
+        var viewRect = new System.Drawing.Rectangle(0, 0, CurrentView.Width, CurrentView.Height);
+        
+        for (var x = 0; x < mapWidth; x++)
         {
-            for (var y = 0; y < Options.Instance.Map.MapHeight; y++)
+            for (var y = 0; y < mapHeight; y++)
             {
-                if (new System.Drawing.Rectangle(
-                    x * Options.Instance.Map.TileWidth + xoffset, y * Options.Instance.Map.TileHeight + yoffset, Options.Instance.Map.TileWidth,
-                    Options.Instance.Map.TileHeight
-                ).IntersectsWith(new System.Drawing.Rectangle(0, 0, CurrentView.Width, CurrentView.Height)))
+                if (new System.Drawing.Rectangle(x * tileWidth + xoffset, y * tileHeight + yoffset, tileWidth, tileHeight).IntersectsWith(viewRect))
                 {
                     DrawTexture(
-                        transTex, new RectangleF(0, 0, transTex.Width, transTex.Height),
-                        new RectangleF(
-                            xoffset + x * Options.Instance.Map.TileWidth, yoffset + y * Options.Instance.Map.TileHeight, Options.Instance.Map.TileWidth,
-                            Options.Instance.Map.TileHeight
-                        ), System.Drawing.Color.White, null
+                        _transparentGridTexture,
+                        texRect,
+                        new RectangleF(xoffset + x * tileWidth, yoffset + y * tileHeight, tileWidth, tileHeight),
+                        System.Drawing.Color.White,
+                        null
                     );
                 }
             }
@@ -1079,7 +1007,7 @@ public static partial class Graphics
         DrawTexture(sWhiteTex, new RectangleF(0, 0, 1, 1), new RectangleF(x + w, y, 1, h), clr, target);
     }
 
-    public static void DrawMapGrid()
+    private static void DrawMapGrid()
     {
         if (sMapGridChain == null ||
             sMapGridChain.IsContentLost ||
@@ -1092,109 +1020,105 @@ public static partial class Graphics
         EndSpriteBatch();
         SetRenderTarget(sMapGridChain);
         sGraphicsDevice.Clear(Microsoft.Xna.Framework.Color.FromNonPremultiplied(60, 63, 65, 255));
-        var rand = new Random();
+
         var grid = Globals.MapGrid;
         lock (Globals.MapGrid.GetMapGridLock())
         {
             grid.Update(sMapGridChain.Bounds);
+
+            // Pre-calculate colors and textures
+            var whiteTex = GetWhiteTex();
+            var paddingColor = System.Drawing.Color.FromArgb(45, 45, 48);
+            var emptySlotColor = System.Drawing.Color.Transparent;
+
             for (var x = 0; x < grid.GridWidth + 2; x++)
             {
                 for (var y = 0; y < grid.GridHeight + 2; y++)
                 {
-                    var renderRect = new System.Drawing.Rectangle(
-                        grid.ContentRect.X + x * grid.TileWidth, grid.ContentRect.Y + y * grid.TileHeight,
-                        grid.TileWidth, grid.TileHeight
-                    );
+                    float drawX = grid.ContentRect.X + x * grid.TileWidth;
+                    float drawY = grid.ContentRect.Y + y * grid.TileHeight;
+                    var renderRect = new System.Drawing.Rectangle((int)drawX, (int)drawY, grid.TileWidth, grid.TileHeight);
 
-                    if (grid.ViewRect.IntersectsWith(renderRect))
+                    // View Culling: Skip drawing if outside the visible area
+                    if (!grid.ViewRect.IntersectsWith(renderRect))
                     {
-                        if (x == 0 ||
-                            y == 0 ||
-                            x == grid.GridWidth + 1 ||
-                            y == grid.GridHeight + 1 ||
-                            grid.Grid[x - 1, y - 1].MapId == Guid.Empty)
+                        continue;
+                    }
+
+                    // We need a RectangleF for the drawing calls
+                    var destRect = new RectangleF(drawX, drawY, grid.TileWidth, grid.TileHeight);
+                    bool isPadding = x == 0 || y == 0 || x == grid.GridWidth + 1 || y == grid.GridHeight + 1;
+
+                    if (isPadding)
+                    {
+                        // Draw Border/Padding Background
+                        DrawTexture(
+                            whiteTex,
+                            new RectangleF(0, 0, 1, 1),
+                            destRect,
+                            paddingColor,
+                            sMapGridChain
+                        );
+                    }
+                    else
+                    {
+                        var tile = grid.Grid[x - 1, y - 1];
+
+                        if (tile.MapId == Guid.Empty || tile.Tex == null)
                         {
                             DrawTexture(
-                                GetWhiteTex(), new RectangleF(0, 0, 1, 1),
-                                new RectangleF(
-                                    grid.ContentRect.X + x * grid.TileWidth,
-                                    grid.ContentRect.Y + y * grid.TileHeight, grid.TileWidth, grid.TileHeight
-                                ), System.Drawing.Color.FromArgb(45, 45, 48), sMapGridChain
+                                whiteTex,
+                                new RectangleF(0, 0, 1, 1),
+                                destRect,
+                                emptySlotColor,
+                                sMapGridChain
                             );
                         }
                         else
                         {
-                            if (grid.Grid[x - 1, y - 1].MapId != Guid.Empty)
-                            {
-                                if (grid.Grid[x - 1, y - 1].Tex != null &&
-                                    grid.Grid[x - 1, y - 1].Tex.Width == grid.TileWidth &&
-                                    grid.Grid[x - 1, y - 1].Tex.Height == grid.TileHeight)
-                                {
-                                    DrawTexture(
-                                        grid.Grid[x - 1, y - 1].Tex, grid.ContentRect.X + x * grid.TileWidth,
-                                        grid.ContentRect.Y + y * grid.TileHeight, sMapGridChain
-                                    );
-                                }
-                                else
-                                {
-                                    DrawTexture(
-                                        GetWhiteTex(), new RectangleF(0, 0, 1, 1),
-                                        new RectangleF(
-                                            grid.ContentRect.X + x * grid.TileWidth,
-                                            grid.ContentRect.Y + y * grid.TileHeight, grid.TileWidth,
-                                            grid.TileHeight
-                                        ), System.Drawing.Color.Green, sMapGridChain
-                                    );
-                                }
-                            }
-                            else
-                            {
-                                DrawTexture(
-                                    GetWhiteTex(), new RectangleF(0, 0, 1, 1),
-                                    new RectangleF(
-                                        grid.ContentRect.X + x * grid.TileWidth,
-                                        grid.ContentRect.Y + y * grid.TileHeight, grid.TileWidth, grid.TileHeight
-                                    ), System.Drawing.Color.Gray, sMapGridChain
-                                );
-                            }
-                        }
-
-                        if (Globals.MapGrid.ShowLines)
-                        {
                             DrawTexture(
-                                GetWhiteTex(), new RectangleF(0, 0, 1, 1),
-                                new RectangleF(
-                                    grid.ContentRect.X + x * grid.TileWidth,
-                                    grid.ContentRect.Y + y * grid.TileHeight, grid.TileWidth, 1
-                                ), System.Drawing.Color.DarkGray, sMapGridChain
-                            );
-
-                            DrawTexture(
-                                GetWhiteTex(), new RectangleF(0, 0, 1, 1),
-                                new RectangleF(
-                                    grid.ContentRect.X + x * grid.TileWidth,
-                                    grid.ContentRect.Y + y * grid.TileHeight, 1, grid.TileHeight
-                                ), System.Drawing.Color.DarkGray, sMapGridChain
-                            );
-
-                            DrawTexture(
-                                GetWhiteTex(), new RectangleF(0, 0, 1, 1),
-                                new RectangleF(
-                                    grid.ContentRect.X + x * grid.TileWidth + grid.TileWidth,
-                                    grid.ContentRect.Y + y * grid.TileHeight, 1, grid.TileHeight
-                                ), System.Drawing.Color.DarkGray, sMapGridChain
-                            );
-
-                            DrawTexture(
-                                GetWhiteTex(), new RectangleF(0, 0, 1, 1),
-                                new RectangleF(
-                                    grid.ContentRect.X + x * grid.TileWidth,
-                                    grid.ContentRect.Y + y * grid.TileHeight + grid.TileHeight, grid.TileWidth, 1
-                                ), System.Drawing.Color.DarkGray, sMapGridChain
+                                tile.Tex,
+                                new RectangleF(0, 0, tile.Tex.Width, tile.Tex.Height),
+                                destRect,
+                                Color.White,
+                                sMapGridChain
                             );
                         }
                     }
                 }
+            }
+        }
+
+        if (Globals.MapGrid.ShowLines)
+        {
+            var srcRect = new RectangleF(0, 0, 1, 1);
+            var whiteTex = GetWhiteTex();
+            var gridLineColor = System.Drawing.Color.White;
+
+            // Draw all vertical lines
+            for (var x = 0; x <= grid.GridWidth + 2; x++)
+            {
+                float lineX = grid.ContentRect.X + x * grid.TileWidth;
+                DrawTexture(
+                    whiteTex,
+                    srcRect,
+                    new RectangleF(lineX, grid.ContentRect.Y, 1, (grid.GridHeight + 2) * grid.TileHeight),
+                    gridLineColor,
+                    sMapGridChain
+                );
+            }
+
+            // Draw all horizontal lines
+            for (var y = 0; y <= grid.GridHeight + 2; y++)
+            {
+                float lineY = grid.ContentRect.Y + y * grid.TileHeight;
+                DrawTexture(
+                    whiteTex,
+                    srcRect,
+                    new RectangleF(grid.ContentRect.X, lineY, (grid.GridWidth + 2) * grid.TileWidth, 1),
+                    gridLineColor,
+                    sMapGridChain
+                );
             }
         }
 
@@ -1259,62 +1183,39 @@ public static partial class Graphics
 
     private static void DrawMapBorders()
     {
-        //Horizontal Top
+        var borderColor = System.Drawing.Color.DimGray;
+        var srcRect = new RectangleF(0, 0, 1, 1);
+        var mapWidth = Options.Instance.Map.TileWidth * Options.Instance.Map.MapWidth;
+        var mapHeight = Options.Instance.Map.TileHeight * Options.Instance.Map.MapHeight;
+
+        // Horizontal borders (Top and Bottom)
         DrawTexture(
-            sWhiteTex, new RectangleF(0, 0, 1, 1), new RectangleF(0, CurrentView.Y - 1, CurrentView.Width, 3),
-            System.Drawing.Color.DimGray
+            sWhiteTex,
+            srcRect,
+            new RectangleF(0, CurrentView.Y - 1, CurrentView.Width, 3),
+            borderColor
         );
 
-        //Horizontal Buttom
         DrawTexture(
-            sWhiteTex, new RectangleF(0, 0, 1, 1),
-            new RectangleF(0, CurrentView.Y + Options.Instance.Map.TileHeight * Options.Instance.Map.MapHeight - 1, CurrentView.Width, 3),
-            System.Drawing.Color.DimGray
+            sWhiteTex,
+            srcRect,
+            new RectangleF(0, CurrentView.Y + mapHeight - 1, CurrentView.Width, 3),
+            borderColor
         );
 
-        //Vertical Left
+        // Vertical borders (Left and Right)
         DrawTexture(
-            sWhiteTex, new RectangleF(0, 0, 1, 1), new RectangleF(CurrentView.Left - 1, 0, 3, CurrentView.Height),
-            System.Drawing.Color.DimGray
+            sWhiteTex,
+            srcRect,
+            new RectangleF(CurrentView.Left - 1, 0, 3, CurrentView.Height),
+            borderColor
         );
 
-        //Vertical Right
         DrawTexture(
-            sWhiteTex, new RectangleF(0, 0, 1, 1),
-            new RectangleF(CurrentView.Left + Options.Instance.Map.TileWidth * Options.Instance.Map.MapWidth - 1, 0, 3, CurrentView.Height),
-            System.Drawing.Color.DimGray
-        );
-
-        //Horizontal Top
-        DrawTexture(
-            sWhiteTex, new RectangleF(0, 0, 1, 1),
-            new RectangleF(CurrentView.Left, CurrentView.Y - 1, Options.Instance.Map.TileWidth * Options.Instance.Map.MapWidth, 3),
-            System.Drawing.Color.DimGray
-        );
-
-        //Horizontal Buttom
-        DrawTexture(
-            sWhiteTex, new RectangleF(0, 0, 1, 1),
-            new RectangleF(
-                CurrentView.Left, CurrentView.Y + Options.Instance.Map.TileHeight * Options.Instance.Map.MapHeight - 1,
-                Options.Instance.Map.TileWidth * Options.Instance.Map.MapWidth, 3
-            ), System.Drawing.Color.DimGray
-        );
-
-        //Vertical Left
-        DrawTexture(
-            sWhiteTex, new RectangleF(0, 0, 1, 1),
-            new RectangleF(CurrentView.Left - 1, CurrentView.Y, 3, Options.Instance.Map.MapHeight * Options.Instance.Map.TileHeight),
-            System.Drawing.Color.DimGray
-        );
-
-        //Vertical Right
-        DrawTexture(
-            sWhiteTex, new RectangleF(0, 0, 1, 1),
-            new RectangleF(
-                CurrentView.Left + Options.Instance.Map.TileWidth * Options.Instance.Map.MapWidth - 1, CurrentView.Y, 3,
-                Options.Instance.Map.MapHeight * Options.Instance.Map.TileHeight
-            ), System.Drawing.Color.DimGray
+            sWhiteTex,
+            srcRect,
+            new RectangleF(CurrentView.Left + mapWidth - 1, 0, 3, CurrentView.Height),
+            borderColor
         );
     }
 


### PR DESCRIPTION
### [Editor]
- We were iterating over the same 9 maps (3x3 grid) 6 separate times for different layers/attributes. This fix consolidates the whole thing into a single pass.
- Add DrawAllMapAttributes() to consolidate 3 attribute draw calls
- Cached property lookups in DrawGridOverlay, DrawTransparentBorders, and DrawMapBorders to avoid repeated access
- Cache textures and property lookups
- Move DrawMapGrid lines outside nested loop, reduction in draw calls
- Reduce DrawMapBorders from 8 to 4 calls, pre-calculates values
- Optimized DrawTransparentBorders with texture caching and IsDisposed check
- Add view culling to skip off-screen rendering
- Removes unused imports and variables.

### Before:

https://github.com/user-attachments/assets/c0dd90eb-3655-4174-8af9-7b07851962bc

### After:

https://github.com/user-attachments/assets/3a6a07fe-e82a-4d21-845c-2592060337ad

<img width="887" height="682" alt="{67814741-5E5B-4896-A1C3-9E38EF56603A}" src="https://github.com/user-attachments/assets/30b0ccf6-1c02-42f5-ba0a-c8a99eee3826" />

<img width="1148" height="672" alt="{FA976E53-EFDA-4F27-BCF5-0A5A5BD0C6C8}" src="https://github.com/user-attachments/assets/acd6cb28-52fe-4622-b245-97f4fbee5dfe" />

<img width="751" height="545" alt="{BB229254-A4E5-4099-AE5E-FC57B8BAECC0}" src="https://github.com/user-attachments/assets/2035e2fa-8a8e-4eac-a964-a2f06c66e33f" />

<img width="1259" height="924" alt="{0C08205C-60D1-4C14-AB22-A1484980F049}" src="https://github.com/user-attachments/assets/da58e1da-9d8f-4b29-833f-8da0e39e8d01" />

<img width="1278" height="921" alt="{65C82D90-0D46-4FC2-98A9-85085A2A8398}" src="https://github.com/user-attachments/assets/63f446ef-acb3-4d12-8743-729054f53601" />
