### PR TITLE
fix: NPCs disappearing when targets enter different map instances

### DIFF
--- a/Intersect.Server.Core/Entities/Npc.cs
+++ b/Intersect.Server.Core/Entities/Npc.cs
@@ -837,6 +837,24 @@ public partial class Npc : Entity
                     var targetY = 0;
                     var targetZ = 0;
 
+                    // If target is on a different instance, clear it immediately
+                    if (tempTarget != null && tempTarget.MapInstanceId != MapInstanceId)
+                    {
+                        RemoveTarget();
+                        tempTarget = null;
+
+                        // Also clear aggro center since target is unreachable
+                        if (AggroCenterMap != null)
+                        {
+                            AggroCenterMap = null;
+                            AggroCenterX = 0;
+                            AggroCenterY = 0;
+                            AggroCenterZ = 0;
+                            mPathFinder?.SetTarget(null);
+                            mResetting = false;
+                        }
+                    }
+
                     if (tempTarget != null && (tempTarget.IsDead || !InRangeOf(tempTarget, Options.Instance.Map.MapWidth * 2) || !CanTarget(tempTarget)))
                     {
                         _ = TryFindNewTarget(Timing.Global.Milliseconds, tempTarget.Id, !CanTarget(tempTarget));


### PR DESCRIPTION
When a player aggros an NPC and then enters a different map instance (dungeon, dies, etc.), the NPC would attempt to reset and chase an unreachable target. This caused NPCs to become stuck in a reset loop or disappear from their spawn map entirely.

The fix clears the NPC's target and aggro center immediately when the target switches to a different MapInstanceId, preventing the NPC from attempting to path to or reset towards an unreachable location.

(Hopefully) Fixes #2769