### PR TITLE
fix: combobox menu items width

### DIFF
--- a/Intersect.Client.Framework/Gwen/Control/ComboBox.cs
+++ b/Intersect.Client.Framework/Gwen/Control/ComboBox.cs
@@ -422,10 +422,8 @@ public partial class ComboBox : Button
         var menuItems = @this._menu.Children.OfType<MenuItem>().ToArray();
         foreach (var menuItem in menuItems)
         {
-            menuItem.SizeToContents();
+            menuItem.AutoSizeToContents = false;
             totalChildHeight += menuItem.OuterHeight;
-            // TODO(2553): I thought this was the solution, it isn't. Results in menu growing each time it's opened.
-            // width = Math.Max(width, menuItem.OuterWidth + menuPaddingH);
         }
 
         var offset = @this.ToCanvas(default);

--- a/Intersect.Client.Framework/Gwen/Control/ContextMenu.cs
+++ b/Intersect.Client.Framework/Gwen/Control/ContextMenu.cs
@@ -1,23 +1,3 @@
 namespace Intersect.Client.Framework.Gwen.Control;
 
-public class ContextMenu : Menu
-{
-    public ContextMenu(Base parent, string? name = default) : base(parent, name)
-    {
-
-    }
-
-    protected override void OnPositioningBeforeOpen()
-    {
-        base.OnPositioningBeforeOpen();
-
-        SizeToChildren(recursive: true);
-    }
-
-    protected override void OnOpen()
-    {
-        base.OnOpen();
-
-        PostLayout.Enqueue(contextMenu => contextMenu.SizeToChildren(recursive: true), this);
-    }
-}
+public class ContextMenu(Base parent, string? name = default) : Menu(parent, name);

--- a/Intersect.Client.Framework/Gwen/Control/Menu.cs
+++ b/Intersect.Client.Framework/Gwen/Control/Menu.cs
@@ -193,7 +193,13 @@ public partial class Menu : ScrollControl
 
     protected virtual void OnPositioningBeforeOpen()
     {
+        var menuItems = Children.OfType<MenuItem>().ToArray();
+        foreach (var menuItem in menuItems)
+        {
+            menuItem.AutoSizeToContents = false;
+        }
 
+        SizeToChildren(recursive: true);
     }
 
     protected virtual void OnOpen()


### PR DESCRIPTION
fixes #2553

<img width="120" height="236" alt="image" src="https://github.com/user-attachments/assets/e25bb258-10e3-4ca6-93ee-dd3820506bdd" /> <img width="95" height="199" alt="image" src="https://github.com/user-attachments/assets/c78eb12c-6f5d-4856-9fe0-a27608a499ba" /> <img width="64" height="168" alt="image" src="https://github.com/user-attachments/assets/523c7a30-e56d-4f02-af63-0a5c9d93eded" />

<img width="255" height="237" alt="{2795D6E9-227E-48F5-B23E-200E581776B6}" src="https://github.com/user-attachments/assets/c1e1a779-35d3-4075-8226-67b87d8ac313" /> <img width="281" height="244" alt="image" src="https://github.com/user-attachments/assets/3f25d58e-897c-4dfd-83f3-e793a9741426" /> <img width="239" height="117" alt="{006FFB6D-C31D-4C53-9D84-721318F6174A}" src="https://github.com/user-attachments/assets/b5382774-cbc8-49d7-9d92-9cb14f730e52" />


<img width="193" height="255" alt="image" src="https://github.com/user-attachments/assets/3467524a-8047-4913-861c-cbc348dfdf36" />
<img width="292" height="217" alt="image" src="https://github.com/user-attachments/assets/6f094609-f598-4dc5-a3f6-0c627b35578d" />
<img width="131" height="199" alt="image" src="https://github.com/user-attachments/assets/7ed2d07a-4ebd-4097-9954-5f87d1845318" />
<img width="117" height="94" alt="image" src="https://github.com/user-attachments/assets/abc7f221-df3c-45a6-a4b1-2e75caee9d44" />
<img width="179" height="87" alt="image" src="https://github.com/user-attachments/assets/aaee03f0-a1f8-43ed-837d-c1079dda5661" />
<img width="246" height="172" alt="image" src="https://github.com/user-attachments/assets/e366c894-bc56-48bc-8fa5-12fd39854ed1" />

