### PR TITLE
fix: prevents cursor drift when using gamepads

### DIFF
--- a/Intersect.Client.Core/MonoGame/Input/MonoInput.cs
+++ b/Intersect.Client.Core/MonoGame/Input/MonoInput.cs
@@ -315,8 +315,13 @@ public partial class MonoInput : GameInput
 
             if (gamePadState.IsConnected)
             {
-                var deltaX = (int)(gamePadState.ThumbSticks.Right.X * elapsed.TotalSeconds * 1000);
-                var deltaY = (int)(-gamePadState.ThumbSticks.Right.Y * elapsed.TotalSeconds * 1000);
+                const float DEADZONE = 0.15f; // deadzone threshold
+
+                var rightStickX = Math.Abs(gamePadState.ThumbSticks.Right.X) > DEADZONE ? gamePadState.ThumbSticks.Right.X : 0f;
+                var rightStickY = Math.Abs(gamePadState.ThumbSticks.Right.Y) > DEADZONE ? gamePadState.ThumbSticks.Right.Y : 0f;
+
+                var deltaX = (int)(rightStickX * elapsed.TotalSeconds * 1000);
+                var deltaY = (int)(-rightStickY * elapsed.TotalSeconds * 1000);
 
                 if (deltaX != 0 || deltaY != 0)
                 {


### PR DESCRIPTION
This commit should fix the following issue:

https://github.com/user-attachments/assets/13171579-b326-4785-ba93-7cc18a233f32

**Explanation**

Controllers commonly experience "stick drift" where analog sticks don't return perfectly to center (0.0, 0.0) and instead hover at small values like 0.01-0.05. Without a deadzone check, even tiny thumbstick movements cause deltaX to be non-zero, resulting in the cursor constantly drifting to the right (or other directions) pixel by pixel. With this commit, gamepads will only move the cursor when the thumbstick is pushed beyond a deadzone threshold (0.15f), effectively filtering out controller drift while still allowing intentional cursor movement with the gamepad.

