### PR TITLE
fix: character creation and selection flow

### DIFF
--- a/Intersect.Client.Core/Interface/Menu/CharacterCreationWindow.cs
+++ b/Intersect.Client.Core/Interface/Menu/CharacterCreationWindow.cs
@@ -251,7 +251,7 @@ public partial class CharacterCreationWindow : Window
 
     public void Show(bool force)
     {
-        _backButton.IsVisibleInTree = !force;
+        _backButton.IsVisibleInTree = true;
         _createButton.Alignment = force ? [Alignments.Center] : [Alignments.Left];
 
         _renderLayers = new ImagePanel[Options.Instance.Equipment.Paperdoll.Down.Count];

--- a/Intersect.Client.Core/Interface/Menu/SelectCharacterWindow.cs
+++ b/Intersect.Client.Core/Interface/Menu/SelectCharacterWindow.cs
@@ -198,6 +198,7 @@ public partial class SelectCharacterWindow : Window
 
         LoadJsonUi(GameContentManager.UI.Menu, Graphics.Renderer?.GetResolutionString());
         EnsureArrowsVisibility();
+        UpdateDisplay();
     }
 
     //Methods


### PR DESCRIPTION
- Bug fix: Back button should always be visible on character creation window
- Bug fix: Play button was shown despite of having no characters created, this commit fixes that by properly updating character selection window buttons and display during initializing


Before:
<img width="1282" height="800" alt="image" src="https://github.com/user-attachments/assets/ea357a2d-77a5-457e-9ae5-72c5c195f50c" />

After (with max chars 1, back logs account out):
<img width="619" height="279" alt="{0C230371-336E-4EAD-9700-86C8959A4E2B}" src="https://github.com/user-attachments/assets/b84b84e7-c408-4060-b867-5495135342ff" />

After (with max chars >1, back sends to character select window, with proper display update):
<img width="639" height="285" alt="{8BD4314D-66EE-4763-A6E9-32B92C2D334E}" src="https://github.com/user-attachments/assets/e8773758-c03b-48a0-800f-8bba0d26d430" />

<img width="718" height="286" alt="{FE0BF14A-AA43-4D95-8C7E-E0A5F74C9F89}" src="https://github.com/user-attachments/assets/f5a9d360-8538-4fd3-ba64-c37d68ee84a0" />
