### PR TITLE
Add icon selector feature to Intersect Editor

### DIFF
--- a/Intersect.Editor/Forms/Editors/frmIconSelector.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/frmIconSelector.Designer.cs
@@ -1,0 +1,165 @@
+using System.ComponentModel;
+using System.Windows.Forms;
+using DarkUI.Controls;
+
+namespace Intersect.Editor.Forms.Editors
+{
+    partial class FrmIconSelector
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                if (_pictureBoxPool != null)
+                {
+                    foreach (var pb in _pictureBoxPool)
+                    {
+                        pb.Image?.Dispose();
+                        pb.Dispose();
+                    }
+                    _pictureBoxPool.Clear();
+                }
+
+                if (components != null)
+                {
+                    components.Dispose();
+                }
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.pnlMain = new System.Windows.Forms.Panel();
+            this.flowIconPanel = new System.Windows.Forms.FlowLayoutPanel();
+            this.pnlBottom = new System.Windows.Forms.Panel();
+            this.lblPageInfo = new System.Windows.Forms.Label();
+            this.btnOK = new DarkUI.Controls.DarkButton();
+            this.btnNextPage = new DarkUI.Controls.DarkButton();
+            this.btnPrevPage = new DarkUI.Controls.DarkButton();
+            this.pnlMain.SuspendLayout();
+            this.pnlBottom.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // pnlMain
+            // 
+            this.pnlMain.AutoScroll = true;
+            this.pnlMain.Controls.Add(this.flowIconPanel);
+            this.pnlMain.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.pnlMain.Location = new System.Drawing.Point(0, 0);
+            this.pnlMain.Name = "pnlMain";
+            this.pnlMain.Size = new System.Drawing.Size(600, 380);
+            this.pnlMain.TabIndex = 0;
+            // 
+            // flowIconPanel
+            // 
+            this.flowIconPanel.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
+            this.flowIconPanel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flowIconPanel.Location = new System.Drawing.Point(0, 0);
+            this.flowIconPanel.Name = "flowIconPanel";
+            this.flowIconPanel.Padding = new System.Windows.Forms.Padding(10);
+            this.flowIconPanel.Size = new System.Drawing.Size(600, 380);
+            this.flowIconPanel.TabIndex = 0;
+            // 
+            // pnlBottom
+            // 
+            this.pnlBottom.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
+            this.pnlBottom.Controls.Add(this.lblPageInfo);
+            this.pnlBottom.Controls.Add(this.btnOK);
+            this.pnlBottom.Controls.Add(this.btnNextPage);
+            this.pnlBottom.Controls.Add(this.btnPrevPage);
+            this.pnlBottom.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.pnlBottom.Location = new System.Drawing.Point(0, 380);
+            this.pnlBottom.Name = "pnlBottom";
+            this.pnlBottom.Size = new System.Drawing.Size(600, 40);
+            this.pnlBottom.TabIndex = 3;
+            // 
+            // lblPageInfo
+            // 
+            this.lblPageInfo.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            this.lblPageInfo.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
+            this.lblPageInfo.Location = new System.Drawing.Point(10, 10);
+            this.lblPageInfo.Name = "lblPageInfo";
+            this.lblPageInfo.Size = new System.Drawing.Size(150, 20);
+            this.lblPageInfo.TabIndex = 4;
+            this.lblPageInfo.Text = "Page 1 of 1";
+            this.lblPageInfo.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // btnPrevPage
+            // 
+            this.btnPrevPage.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnPrevPage.Location = new System.Drawing.Point(380, 8);
+            this.btnPrevPage.Name = "btnPrevPage";
+            this.btnPrevPage.Padding = new System.Windows.Forms.Padding(5);
+            this.btnPrevPage.Size = new System.Drawing.Size(60, 24);
+            this.btnPrevPage.TabIndex = 0;
+            this.btnPrevPage.Text = "Prev";
+            this.btnPrevPage.Click += new System.EventHandler(this.btnPrevPage_Click);
+            // 
+            // btnNextPage
+            // 
+            this.btnNextPage.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnNextPage.Location = new System.Drawing.Point(445, 8);
+            this.btnNextPage.Name = "btnNextPage";
+            this.btnNextPage.Padding = new System.Windows.Forms.Padding(5);
+            this.btnNextPage.Size = new System.Drawing.Size(60, 24);
+            this.btnNextPage.TabIndex = 1;
+            this.btnNextPage.Text = "Next";
+            this.btnNextPage.Click += new System.EventHandler(this.btnNextPage_Click);
+            // 
+            // btnOK
+            // 
+            this.btnOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnOK.Location = new System.Drawing.Point(510, 8);
+            this.btnOK.Name = "btnOK";
+            this.btnOK.Padding = new System.Windows.Forms.Padding(5);
+            this.btnOK.Size = new System.Drawing.Size(80, 24);
+            this.btnOK.TabIndex = 2;
+            this.btnOK.Text = "OK";
+            this.btnOK.Click += new System.EventHandler(this.btnOK_Click);
+            // 
+            // FrmIconSelector
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(600, 420);
+            this.Controls.Add(this.pnlMain);
+            this.Controls.Add(this.pnlBottom);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "FrmIconSelector";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "Icon Selector";
+            this.pnlMain.ResumeLayout(false);
+            this.pnlBottom.ResumeLayout(false);
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Panel pnlMain;
+        private System.Windows.Forms.FlowLayoutPanel flowIconPanel;
+        private System.Windows.Forms.Panel pnlBottom;
+        private System.Windows.Forms.Label lblPageInfo;
+        private DarkUI.Controls.DarkButton btnPrevPage;
+        private DarkUI.Controls.DarkButton btnNextPage;
+        private DarkUI.Controls.DarkButton btnOK;
+    }
+}

--- a/Intersect.Editor/Forms/Editors/frmIconSelector.cs
+++ b/Intersect.Editor/Forms/Editors/frmIconSelector.cs
@@ -1,0 +1,191 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.IO;
+using System.Linq;
+using System.Windows.Forms;
+
+namespace Intersect.Editor.Forms.Editors
+{
+    public partial class FrmIconSelector : Form
+    {
+        private const int IconsPerPage = 160; // Perfect fit for 16 columns x 10 rows
+        private const int IconSize = 32;
+
+        private readonly string _iconDirectory;
+
+        private List<string> _allIcons = new List<string>();
+        private List<string> _filteredIcons = new List<string>();
+        private int _currentPage = 0;
+        private PictureBox _selectedPictureBox;
+        private List<PictureBox> _pictureBoxPool = new List<PictureBox>();
+
+        public string SelectedIcon { get; private set; }
+
+        public FrmIconSelector(string iconDirectory, string currentIcon = null)
+        {
+            InitializeComponent();
+            
+            _iconDirectory = iconDirectory;
+            SelectedIcon = currentIcon;
+
+            LoadIcons();
+            UpdatePagination();
+            LoadCurrentPage();
+        }
+
+        private void LoadIcons()
+        {
+            if (!Directory.Exists(_iconDirectory)) return;
+
+            _allIcons = Directory.GetFiles(_iconDirectory, "*.png")
+                .Concat(Directory.GetFiles(_iconDirectory, "*.jpg"))
+                .Concat(Directory.GetFiles(_iconDirectory, "*.jpeg"))
+                .ToList();
+
+            _filteredIcons = new List<string>(_allIcons);
+        }
+
+        private void LoadCurrentPage()
+        {
+            flowIconPanel.SuspendLayout();
+
+            var startIndex = _currentPage * IconsPerPage;
+            var endIndex = Math.Min(startIndex + IconsPerPage, _filteredIcons.Count);
+            var itemsToDisplay = endIndex - startIndex;
+
+            // Dispose old images to prevent memory leaks and lag
+            foreach (var picBox in _pictureBoxPool)
+            {
+                if (picBox.Image != null)
+                {
+                    var img = picBox.Image;
+                    picBox.Image = null;
+                    img.Dispose();
+                }
+            }
+
+            // Ensure we have enough controls in the pool
+            while (_pictureBoxPool.Count < itemsToDisplay)
+            {
+                var picBox = new PictureBox
+                {
+                    Width = IconSize,
+                    Height = IconSize,
+                    SizeMode = PictureBoxSizeMode.StretchImage,
+                    Margin = new Padding(2),
+                    Cursor = Cursors.Hand,
+                    BackColor = System.Drawing.Color.FromArgb(60, 63, 65)
+                };
+                picBox.Click += IconButton_Click;
+                _pictureBoxPool.Add(picBox);
+                flowIconPanel.Controls.Add(picBox);
+            }
+
+            int poolIndex = 0;
+            for (int i = startIndex; i < endIndex; i++)
+            {
+                var iconPath = _filteredIcons[i];
+                
+                Image img = null;
+                try
+                {
+                    // Use MemoryStream to avoid file locking on disk
+                    if (File.Exists(iconPath))
+                    {
+                        var bytes = File.ReadAllBytes(iconPath);
+                        using (var ms = new MemoryStream(bytes))
+                        {
+                            img = Image.FromStream(ms);
+                        }
+                    }
+                }
+                catch
+                {
+                    continue;
+                }
+
+                if (img == null) continue;
+
+                var picBox = _pictureBoxPool[poolIndex];
+                picBox.Image = img;
+                picBox.Tag = iconPath;
+                picBox.Visible = true;
+                
+                // Clear selection visuals if not selected
+                if (SelectedIcon == Path.GetFileName(iconPath))
+                {
+                    picBox.BorderStyle = BorderStyle.FixedSingle;
+                    picBox.BackColor = System.Drawing.Color.FromArgb(100, 100, 100);
+                    _selectedPictureBox = picBox;
+                }
+                else
+                {
+                    picBox.BorderStyle = BorderStyle.None;
+                    picBox.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+                }
+
+                poolIndex++;
+            }
+
+            // Hide unused controls in the pool
+            for (int i = poolIndex; i < _pictureBoxPool.Count; i++)
+            {
+                _pictureBoxPool[i].Visible = false;
+            }
+
+            flowIconPanel.ResumeLayout();
+        }
+
+        private void UpdatePagination()
+        {
+            int totalPages = Math.Max(1, (int)Math.Ceiling(_filteredIcons.Count / (double)IconsPerPage));
+            
+            lblPageInfo.Text = $"Page {_currentPage + 1} / {totalPages}";
+            btnPrevPage.Enabled = _currentPage > 0;
+            btnNextPage.Enabled = _currentPage < totalPages - 1;
+        }
+
+        private void IconButton_Click(object sender, EventArgs e)
+        {
+            if (sender is PictureBox picBox && picBox.Tag is string iconPath)
+            {
+                // Clear previous selection
+                if (_selectedPictureBox != null)
+                {
+                    _selectedPictureBox.BorderStyle = BorderStyle.None;
+                    _selectedPictureBox.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+                }
+
+                // Set new selection with visual feedback
+                _selectedPictureBox = picBox;
+                picBox.BorderStyle = BorderStyle.FixedSingle;
+                picBox.BackColor = System.Drawing.Color.FromArgb(100, 100, 100);
+                SelectedIcon = Path.GetFileName(iconPath);
+            }
+        }
+
+        private void btnPrevPage_Click(object sender, EventArgs e)
+        {
+            _currentPage--;
+            UpdatePagination();
+            LoadCurrentPage();
+        }
+
+        private void btnNextPage_Click(object sender, EventArgs e)
+        {
+            _currentPage++;
+            UpdatePagination();
+            LoadCurrentPage();
+        }
+
+        private void btnOK_Click(object sender, EventArgs e)
+        {
+            if (!string.IsNullOrEmpty(SelectedIcon))
+            {
+                DialogResult = DialogResult.OK;
+                Close();
+            }
+        }
+    }
+}

--- a/Intersect.Editor/Forms/Editors/frmItem.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/frmItem.Designer.cs
@@ -92,7 +92,8 @@ namespace Intersect.Editor.Forms.Editors
             cmbAnimation = new DarkComboBox();
             lblDesc = new Label();
             txtDesc = new DarkTextBox();
-            cmbPic = new DarkComboBox();
+            btnSelectIcon = new DarkButton();
+            txtSelectedIcon = new DarkTextBox();
             lblAnim = new Label();
             lblPrice = new Label();
             lblPic = new Label();
@@ -417,7 +418,8 @@ namespace Intersect.Editor.Forms.Editors
             grpGeneral.Controls.Add(cmbAnimation);
             grpGeneral.Controls.Add(lblDesc);
             grpGeneral.Controls.Add(txtDesc);
-            grpGeneral.Controls.Add(cmbPic);
+            grpGeneral.Controls.Add(btnSelectIcon);
+            grpGeneral.Controls.Add(txtSelectedIcon);
             grpGeneral.Controls.Add(lblAnim);
             grpGeneral.Controls.Add(lblPrice);
             grpGeneral.Controls.Add(lblPic);
@@ -1108,28 +1110,29 @@ namespace Intersect.Editor.Forms.Editors
             txtDesc.TabIndex = 12;
             txtDesc.TextChanged += txtDesc_TextChanged;
             // 
-            // cmbPic
+            // btnSelectIcon
             // 
-            cmbPic.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
-            cmbPic.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
-            cmbPic.BorderStyle = ButtonBorderStyle.Solid;
-            cmbPic.ButtonColor = System.Drawing.Color.FromArgb(43, 43, 43);
-            cmbPic.DrawDropdownHoverOutline = false;
-            cmbPic.DrawFocusRectangle = false;
-            cmbPic.DrawMode = DrawMode.OwnerDrawFixed;
-            cmbPic.DropDownStyle = ComboBoxStyle.DropDownList;
-            cmbPic.FlatStyle = FlatStyle.Flat;
-            cmbPic.ForeColor = System.Drawing.Color.Gainsboro;
-            cmbPic.FormattingEnabled = true;
-            cmbPic.Items.AddRange(new object[] { "None" });
-            cmbPic.Location = new System.Drawing.Point(327, 45);
-            cmbPic.Margin = new Padding(4, 3, 4, 3);
-            cmbPic.Name = "cmbPic";
-            cmbPic.Size = new Size(184, 24);
-            cmbPic.TabIndex = 11;
-            cmbPic.Text = "None";
-            cmbPic.TextPadding = new Padding(2);
-            cmbPic.SelectedIndexChanged += cmbPic_SelectedIndexChanged;
+            btnSelectIcon.Location = new System.Drawing.Point(327, 45);
+            btnSelectIcon.Margin = new Padding(4, 3, 4, 3);
+            btnSelectIcon.Name = "btnSelectIcon";
+            btnSelectIcon.Padding = new Padding(5);
+            btnSelectIcon.Size = new Size(100, 24);
+            btnSelectIcon.TabIndex = 11;
+            btnSelectIcon.Text = "Select Icon";
+            btnSelectIcon.Click += btnSelectIcon_Click;
+            // 
+            // txtSelectedIcon
+            // 
+            txtSelectedIcon.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            txtSelectedIcon.BorderStyle = BorderStyle.FixedSingle;
+            txtSelectedIcon.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            txtSelectedIcon.Location = new System.Drawing.Point(434, 45);
+            txtSelectedIcon.Margin = new Padding(4, 3, 4, 3);
+            txtSelectedIcon.Name = "txtSelectedIcon";
+            txtSelectedIcon.ReadOnly = true;
+            txtSelectedIcon.Size = new Size(77, 23);
+            txtSelectedIcon.TabIndex = 12;
+            txtSelectedIcon.Text = "None";
             // 
             // lblAnim
             // 
@@ -3116,7 +3119,8 @@ namespace Intersect.Editor.Forms.Editors
         private DarkComboBox cmbConsume;
         private DarkGroupBox grpSpell;
         private DarkButton btnCancel;
-        private DarkComboBox cmbPic;
+        private DarkButton btnSelectIcon;
+        private DarkTextBox txtSelectedIcon;
         private DarkComboBox cmbMalePaperdoll;
         private DarkTextBox txtDesc;
         private DarkCheckBox chk2Hand;

--- a/Intersect.Editor/Forms/Editors/frmItem.cs
+++ b/Intersect.Editor/Forms/Editors/frmItem.cs
@@ -1,4 +1,5 @@
 using System.Drawing.Imaging;
+using System.IO;
 using DarkUI.Forms;
 using Intersect.Editor.Content;
 using Intersect.Editor.Core;
@@ -107,12 +108,6 @@ public partial class FrmItem : EditorForm
 
     private void frmItem_Load(object sender, EventArgs e)
     {
-        cmbPic.Items.Clear();
-        cmbPic.Items.Add(Strings.General.None);
-
-        var itemnames = GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Item);
-        cmbPic.Items.AddRange(itemnames);
-
         cmbWeaponSprite.Items.Clear();
         cmbWeaponSprite.Items.Add(Strings.General.None);
         cmbWeaponSprite.Items.AddRange(
@@ -341,7 +336,7 @@ public partial class FrmItem : EditorForm
             cmbFolder.Text = mEditorItem.Folder;
             txtDesc.Text = mEditorItem.Description;
             cmbType.SelectedIndex = (int)mEditorItem.ItemType;
-            cmbPic.SelectedIndex = cmbPic.FindString(TextUtils.NullToNone(mEditorItem.Icon));
+            txtSelectedIcon.Text = TextUtils.NullToNone(mEditorItem.Icon);
             nudRgbaR.Value = mEditorItem.Color.R;
             nudRgbaG.Value = mEditorItem.Color.G;
             nudRgbaB.Value = mEditorItem.Color.B;
@@ -421,7 +416,7 @@ public partial class FrmItem : EditorForm
 
             picItem.BackgroundImage?.Dispose();
             picItem.BackgroundImage = null;
-            if (cmbPic.SelectedIndex > 0)
+            if (!string.IsNullOrEmpty(txtSelectedIcon.Text) && txtSelectedIcon.Text != Strings.General.None)
             {
                 DrawItemIcon();
             }
@@ -613,14 +608,24 @@ public partial class FrmItem : EditorForm
         lstGameObjects.UpdateText(txtName.Text);
     }
 
-    private void cmbPic_SelectedIndexChanged(object sender, EventArgs e)
+    private void btnSelectIcon_Click(object sender, EventArgs e)
     {
-        mEditorItem.Icon = cmbPic.SelectedIndex < 1 ? null : cmbPic.Text;
-        picItem.BackgroundImage?.Dispose();
-        picItem.BackgroundImage = null;
-        if (cmbPic.SelectedIndex > 0)
+        var currentIcon = mEditorItem.Icon;
+        var iconDirectory = Path.Combine("resources", "items");
+        var iconSelector = new FrmIconSelector(iconDirectory, currentIcon);
+
+        if (iconSelector.ShowDialog() == DialogResult.OK)
         {
-            DrawItemIcon();
+            mEditorItem.Icon = iconSelector.SelectedIcon;
+            txtSelectedIcon.Text = TextUtils.NullToNone(mEditorItem.Icon);
+
+            picItem.BackgroundImage?.Dispose();
+            picItem.BackgroundImage = null;
+
+            if (!string.IsNullOrEmpty(mEditorItem.Icon))
+            {
+                DrawItemIcon();
+            }
         }
     }
 
@@ -1154,9 +1159,9 @@ public partial class FrmItem : EditorForm
         var picItemBmp = new Bitmap(picItem.Width, picItem.Height);
         var gfx = Graphics.FromImage(picItemBmp);
         gfx.FillRectangle(Brushes.Black, new Rectangle(0, 0, picItem.Width, picItem.Height));
-        if (cmbPic.SelectedIndex > 0)
+        if (!string.IsNullOrEmpty(txtSelectedIcon.Text) && txtSelectedIcon.Text != Strings.General.None)
         {
-            var img = Image.FromFile("resources/items/" + cmbPic.Text);
+            var img = Image.FromFile("resources/items/" + txtSelectedIcon.Text);
             var imgAttributes = new ImageAttributes();
 
             // Microsoft, what the heck is this crap?

--- a/Intersect.Editor/Forms/Editors/frmSpell.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/frmSpell.Designer.cs
@@ -47,7 +47,7 @@ namespace Intersect.Editor.Forms.Editors
             this.picSpell = new System.Windows.Forms.PictureBox();
             this.lblHitAnimation = new System.Windows.Forms.Label();
             this.lblCastAnimation = new System.Windows.Forms.Label();
-            this.cmbSprite = new DarkUI.Controls.DarkComboBox();
+            this.btnSelectIcon = new DarkUI.Controls.DarkButton();
             this.lblIcon = new System.Windows.Forms.Label();
             this.lblType = new System.Windows.Forms.Label();
             this.cmbType = new DarkUI.Controls.DarkComboBox();
@@ -258,7 +258,7 @@ namespace Intersect.Editor.Forms.Editors
             this.grpGeneral.Controls.Add(this.picSpell);
             this.grpGeneral.Controls.Add(this.lblHitAnimation);
             this.grpGeneral.Controls.Add(this.lblCastAnimation);
-            this.grpGeneral.Controls.Add(this.cmbSprite);
+            this.grpGeneral.Controls.Add(this.btnSelectIcon);
             this.grpGeneral.Controls.Add(this.lblIcon);
             this.grpGeneral.Controls.Add(this.lblType);
             this.grpGeneral.Controls.Add(this.cmbType);
@@ -444,28 +444,15 @@ namespace Intersect.Editor.Forms.Editors
             this.lblCastAnimation.TabIndex = 14;
             this.lblCastAnimation.Text = "Extra Cast Anim.:";
             // 
-            // cmbSprite
+            // btnSelectIcon
             // 
-            this.cmbSprite.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.cmbSprite.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-            this.cmbSprite.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
-            this.cmbSprite.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
-            this.cmbSprite.DrawDropdownHoverOutline = false;
-            this.cmbSprite.DrawFocusRectangle = false;
-            this.cmbSprite.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
-            this.cmbSprite.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cmbSprite.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.cmbSprite.ForeColor = System.Drawing.Color.Gainsboro;
-            this.cmbSprite.FormattingEnabled = true;
-            this.cmbSprite.Items.AddRange(new object[] {
-            "None"});
-            this.cmbSprite.Location = new System.Drawing.Point(60, 111);
-            this.cmbSprite.Name = "cmbSprite";
-            this.cmbSprite.Size = new System.Drawing.Size(161, 21);
-            this.cmbSprite.TabIndex = 11;
-            this.cmbSprite.Text = "None";
-            this.cmbSprite.TextPadding = new System.Windows.Forms.Padding(2);
-            this.cmbSprite.SelectedIndexChanged += new System.EventHandler(this.cmbSprite_SelectedIndexChanged);
+            this.btnSelectIcon.Location = new System.Drawing.Point(60, 111);
+            this.btnSelectIcon.Name = "btnSelectIcon";
+            this.btnSelectIcon.Padding = new System.Windows.Forms.Padding(5);
+            this.btnSelectIcon.Size = new System.Drawing.Size(161, 23);
+            this.btnSelectIcon.TabIndex = 11;
+            this.btnSelectIcon.Text = "Select Icon";
+            this.btnSelectIcon.Click += new System.EventHandler(this.btnSelectIcon_Click);
             // 
             // lblIcon
             // 
@@ -2465,7 +2452,7 @@ namespace Intersect.Editor.Forms.Editors
         private DarkGroupBox grpSpells;
         private DarkGroupBox grpGeneral;
         private System.Windows.Forms.Label lblCooldownDuration;
-        private DarkComboBox cmbSprite;
+        private DarkButton btnSelectIcon;
         private System.Windows.Forms.Label lblCastDuration;
         private System.Windows.Forms.Label lblIcon;
         private System.Windows.Forms.PictureBox picSpell;

--- a/Intersect.Editor/Forms/Editors/frmSpell.cs
+++ b/Intersect.Editor/Forms/Editors/frmSpell.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using DarkUI.Controls;
 using DarkUI.Forms;
 using Intersect.Editor.Content;
@@ -108,11 +109,6 @@ public partial class FrmSpell : EditorForm
         cmbTickAnimation.Items.Clear();
         cmbTickAnimation.Items.Add(Strings.General.None);
         cmbTickAnimation.Items.AddRange(AnimationDescriptor.Names);
-
-        cmbSprite.Items.Clear();
-        cmbSprite.Items.Add(Strings.General.None);
-        var spellNames = GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Spell);
-        cmbSprite.Items.AddRange(spellNames);
 
         cmbTransform.Items.Clear();
         cmbTransform.Items.Add(Strings.General.None);
@@ -302,12 +298,15 @@ public partial class FrmSpell : EditorForm
 
             chkBound.Checked = mEditorItem.Bound;
 
-            cmbSprite.SelectedIndex = cmbSprite.FindString(TextUtils.NullToNone(mEditorItem.Icon));
             picSpell.BackgroundImage?.Dispose();
             picSpell.BackgroundImage = null;
-            if (cmbSprite.SelectedIndex > 0)
+            if (!string.IsNullOrEmpty(mEditorItem.Icon) && mEditorItem.Icon != "None")
             {
-                picSpell.BackgroundImage = Image.FromFile("resources/spells/" + cmbSprite.Text);
+                var iconPath = Path.Combine("resources", "spells", mEditorItem.Icon);
+                if (File.Exists(iconPath))
+                {
+                    picSpell.BackgroundImage = Image.FromFile(iconPath);
+                }
             }
 
             nudHPCost.Value = mEditorItem.VitalCost[(int)Vital.Health];
@@ -502,14 +501,24 @@ public partial class FrmSpell : EditorForm
         }
     }
 
-    private void cmbSprite_SelectedIndexChanged(object sender, EventArgs e)
+    private void btnSelectIcon_Click(object sender, EventArgs e)
     {
-        mEditorItem.Icon = cmbSprite.Text;
-        picSpell.BackgroundImage?.Dispose();
-        picSpell.BackgroundImage = null;
-        picSpell.BackgroundImage = cmbSprite.SelectedIndex > 0
-            ? Image.FromFile("resources/spells/" + cmbSprite.Text)
-            : null;
+        var frm = new FrmIconSelector(Path.Combine("resources", "spells"), mEditorItem.Icon);
+        frm.ShowDialog();
+        if (frm.DialogResult == DialogResult.OK)
+        {
+            mEditorItem.Icon = frm.SelectedIcon;
+            picSpell.BackgroundImage?.Dispose();
+            picSpell.BackgroundImage = null;
+            if (!string.IsNullOrEmpty(mEditorItem.Icon))
+            {
+                var iconPath = Path.Combine("resources", "spells", mEditorItem.Icon);
+                if (File.Exists(iconPath))
+                {
+                    picSpell.BackgroundImage = Image.FromFile(iconPath);
+                }
+            }
+        }
     }
 
     private void cmbTargetType_SelectedIndexChanged(object sender, EventArgs e)

--- a/Intersect.Editor/Intersect.Editor.csproj
+++ b/Intersect.Editor/Intersect.Editor.csproj
@@ -453,6 +453,12 @@
     <Compile Update="Forms\Editors\Events\frmEvent.Designer.cs">
       <DependentUpon>frmEvent.cs</DependentUpon>
     </Compile>
+    <Compile Update="Forms\Editors\frmIconSelector.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\Editors\frmIconSelector.Designer.cs">
+      <DependentUpon>frmIconSelector.cs</DependentUpon>
+    </Compile>
     <Compile Update="Forms\Editors\frmItem.cs">
       <SubType>Form</SubType>
     </Compile>


### PR DESCRIPTION
Replaces the ComboBox icon selection in Item and Spell editors with a visual icon selector dialog.

- Add FrmIconSelector form with paginated icon grid (160/page, 32px thumbnails)
- Replace cmbPic dropdown in Item editor with Select Icon button + icon selector
- Replace cmbSprite dropdown in Spell editor with Select Icon button + icon selector
- Uses DarkUI controls, MemoryStream for file-lock-free image loading